### PR TITLE
chore(ci): pull the mssql server image from mcr.microsoft.com

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ mongo: &mongo
   - image: circleci/mongo:4.1.13
 
 mssql: &mssql
-  - image: microsoft/mssql-server-linux:2017-CU13
+  - image: mcr.microsoft.com/mssql/server:2019-CU11-ubuntu-20.04
     environment:
       ACCEPT_EULA: Y
       SA_PASSWORD: stanCanHazMsSQL1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       POSTGRES_DB: nodedb
 
   mssql:
-    image: microsoft/mssql-server-linux:2017-CU9
+    image: mcr.microsoft.com/mssql/server:2019-CU11-ubuntu-20.04
     ports:
       - 1433:1433
     environment:


### PR DESCRIPTION
Apparently Microsoft has removed its images from Dockerhub and moved to
their own registry. While we are at it, also update to the latest
available mssql image.