### PR TITLE
update glob-parent and other dependencies

### DIFF
--- a/packages/autoprofile/.ncurc.json
+++ b/packages/autoprofile/.ncurc.json
@@ -1,3 +1,3 @@
 {
-  "reject": ["mocha", "node-gyp"]
+  "reject": ["mocha", "eslint-plugin-mocha", "node-gyp"]
 }

--- a/packages/autoprofile/package-lock.json
+++ b/packages/autoprofile/package-lock.json
@@ -14,32 +14,32 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+			"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.0",
+				"@babel/helper-validator-identifier": "^7.14.5",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
-			"integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+			"integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
 				"espree": "^7.3.0",
-				"globals": "^12.1.0",
+				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
@@ -48,21 +48,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
-					}
-				},
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
 					}
 				},
 				"ms": {
@@ -78,6 +69,40 @@
 					"dev": true
 				}
 			}
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+			"dev": true
 		},
 		"abbrev": {
 			"version": "1.1.1",
@@ -578,13 +603,14 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
-			"integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+			"integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.1",
+				"@eslint/eslintrc": "^0.4.2",
+				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -601,7 +627,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
+				"glob-parent": "^5.1.2",
 				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
@@ -665,9 +691,9 @@
 					"dev": true
 				},
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -685,6 +711,15 @@
 					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 					"dev": true
 				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -696,15 +731,6 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
-				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
 				},
 				"strip-ansi": {
 					"version": "6.0.0",
@@ -909,9 +935,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
+			"integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
 			"dev": true
 		},
 		"forever-agent": {
@@ -1030,14 +1056,6 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.20.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-					"dev": true
-				}
 			}
 		},
 		"graceful-fs": {
@@ -1503,12 +1521,9 @@
 			"dev": true
 		},
 		"node-abi": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.21.0.tgz",
-			"integrity": "sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==",
-			"requires": {
-				"semver": "^5.4.1"
-			}
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.0.tgz",
+			"integrity": "sha512-g6bZh3YCKQRdwuO/tSZZYJAw622SjsRfJ2X0Iy4sSOHZ34/sPPdVBn8fev2tj7njzLwuqPw9uMtGsGkO5kIQvg=="
 		},
 		"node-environment-flags": {
 			"version": "1.0.6",
@@ -1518,6 +1533,14 @@
 			"requires": {
 				"object.getownpropertydescriptors": "^2.0.3",
 				"semver": "^5.7.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"node-gyp": {
@@ -1769,9 +1792,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
 		"request": {
@@ -1844,9 +1867,13 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -2008,9 +2035,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
-					"integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+					"integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -2125,9 +2152,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
 		"uri-js": {

--- a/packages/autoprofile/package.json
+++ b/packages/autoprofile/package.json
@@ -31,15 +31,15 @@
   "dependencies": {
     "detect-libc": "^1.0.3",
     "nan": "^2.14.2",
-    "node-abi": "^2.21.0",
+    "node-abi": "^2.30.0",
     "node-gyp": "^7.1.2"
   },
   "devDependencies": {
     "async": "^3.2.0",
-    "eslint": "^7.27.0",
+    "eslint": "^7.30.0",
     "mkdirp": "^1.0.4",
     "mocha": "^7.2.0",
-    "semver": "^5.7.1"
+    "semver": "^7.3.5"
   },
   "main": "index.js",
   "files": [

--- a/packages/aws-fargate/.ncurc.json
+++ b/packages/aws-fargate/.ncurc.json
@@ -1,3 +1,3 @@
 {
-  "reject": ["mocha"]
+  "reject": ["mocha", "eslint-plugin-mocha"]
 }

--- a/packages/aws-fargate/package-lock.json
+++ b/packages/aws-fargate/package-lock.json
@@ -14,32 +14,32 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+			"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.0",
+				"@babel/helper-validator-identifier": "^7.14.5",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
-			"integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+			"integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
 				"espree": "^7.3.0",
-				"globals": "^12.1.0",
+				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
@@ -47,15 +47,6 @@
 				"strip-json-comments": "^3.1.1"
 			},
 			"dependencies": {
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
 				"strip-json-comments": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -63,6 +54,23 @@
 					"dev": true
 				}
 			}
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+			"dev": true
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -173,38 +181,6 @@
 						"get-intrinsic": "^1.0.2"
 					}
 				},
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					},
-					"dependencies": {
-						"has-symbols": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-							"dev": true
-						}
-					}
-				},
 				"get-intrinsic": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -214,66 +190,6 @@
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1"
-					}
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-negative-zero": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				},
-				"string.prototype.trimend": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					}
-				},
-				"string.prototype.trimstart": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
 					}
 				}
 			}
@@ -287,157 +203,6 @@
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.18.0-next.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				},
-				"get-intrinsic": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-					"dev": true,
-					"requires": {
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-					"dev": true
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-negative-zero": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				},
-				"string.prototype.trimend": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				},
-				"string.prototype.trimstart": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				}
 			}
 		},
 		"astral-regex": {
@@ -640,15 +405,9 @@
 			"dev": true
 		},
 		"confusing-browser-globals": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
-			"integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
-			"dev": true
-		},
-		"contains-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+			"integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
 			"dev": true
 		},
 		"content-disposition": {
@@ -802,22 +561,100 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.17.4",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-			"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+			"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.1.1",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-regex": "^1.0.5",
-				"object-inspect": "^1.7.0",
+				"has-symbols": "^1.0.2",
+				"is-callable": "^1.2.3",
+				"is-negative-zero": "^2.0.1",
+				"is-regex": "^1.1.3",
+				"is-string": "^1.0.6",
+				"object-inspect": "^1.10.3",
 				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.0",
-				"string.prototype.trimleft": "^2.1.1",
-				"string.prototype.trimright": "^2.1.1"
+				"object.assign": "^4.1.2",
+				"string.prototype.trimend": "^1.0.4",
+				"string.prototype.trimstart": "^1.0.4",
+				"unbox-primitive": "^1.0.1"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+					"dev": true
+				},
+				"is-negative-zero": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
 			}
 		},
 		"es-to-primitive": {
@@ -844,13 +681,14 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
-			"integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+			"integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.1",
+				"@eslint/eslintrc": "^0.4.2",
+				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -867,7 +705,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
+				"glob-parent": "^5.1.2",
 				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
@@ -942,20 +780,20 @@
 					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 					"dev": true
 				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
-				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
 				},
 				"strip-ansi": {
 					"version": "6.0.0",
@@ -984,14 +822,28 @@
 			}
 		},
 		"eslint-config-airbnb-base": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
-			"integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+			"integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
 			"dev": true,
 			"requires": {
-				"confusing-browser-globals": "^1.0.5",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.0"
+				"confusing-browser-globals": "^1.0.10",
+				"object.assign": "^4.1.2",
+				"object.entries": "^1.1.2"
+			},
+			"dependencies": {
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"eslint-import-resolver-node": {
@@ -1022,50 +874,46 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+			"integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.9",
+				"debug": "^3.2.7",
 				"pkg-dir": "^2.0.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.22.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
-			"integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+			"version": "2.23.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+			"integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.1.1",
-				"array.prototype.flat": "^1.2.3",
-				"contains-path": "^0.1.0",
+				"array-includes": "^3.1.3",
+				"array.prototype.flat": "^1.2.4",
 				"debug": "^2.6.9",
-				"doctrine": "1.5.0",
+				"doctrine": "^2.1.0",
 				"eslint-import-resolver-node": "^0.3.4",
-				"eslint-module-utils": "^2.6.0",
+				"eslint-module-utils": "^2.6.1",
+				"find-up": "^2.0.0",
 				"has": "^1.0.3",
+				"is-core-module": "^2.4.0",
 				"minimatch": "^3.0.4",
-				"object.values": "^1.1.1",
-				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.17.0",
+				"object.values": "^1.1.3",
+				"pkg-up": "^2.0.0",
+				"read-pkg-up": "^3.0.0",
+				"resolve": "^1.20.0",
 				"tsconfig-paths": "^3.9.0"
 			},
 			"dependencies": {
@@ -1079,13 +927,12 @@
 					}
 				},
 				"doctrine": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"isarray": "^1.0.0"
+						"esutils": "^2.0.2"
 					}
 				},
 				"ms": {
@@ -1285,9 +1132,9 @@
 			"dev": true
 		},
 		"fast-redact": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
-			"integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.1.tgz",
+			"integrity": "sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw==",
 			"dev": true
 		},
 		"fast-safe-stringify": {
@@ -1372,17 +1219,6 @@
 			"requires": {
 				"flatted": "^3.1.0",
 				"rimraf": "^3.0.2"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"flatstr": {
@@ -1392,9 +1228,9 @@
 			"dev": true
 		},
 		"flatted": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
+			"integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
 			"dev": true
 		},
 		"forwarded": {
@@ -1481,14 +1317,6 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.20.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-					"dev": true
-				}
 			}
 		},
 		"graceful-fs": {
@@ -1537,9 +1365,9 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
 		"http-errors": {
@@ -1623,9 +1451,9 @@
 			"dev": true
 		},
 		"is-bigint": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-			"integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
 			"dev": true
 		},
 		"is-binary-path": {
@@ -1638,12 +1466,35 @@
 			}
 		},
 		"is-boolean-object": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-			"integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+			"integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				}
 			}
 		},
 		"is-buffer": {
@@ -1659,9 +1510,9 @@
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+			"integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -1707,24 +1558,54 @@
 			"dev": true
 		},
 		"is-number-object": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-			"integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+			"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
 			"dev": true
 		},
 		"is-regex": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+			"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.3"
+				"call-bind": "^1.0.2",
+				"has-symbols": "^1.0.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				}
 			}
 		},
 		"is-string": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+			"integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
 			"dev": true
 		},
 		"is-symbol": {
@@ -1735,12 +1616,6 @@
 			"requires": {
 				"has-symbols": "^1.0.1"
 			}
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -1763,6 +1638,12 @@
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
 			}
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -1796,15 +1677,23 @@
 			}
 		},
 		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
 				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"locate-path": {
@@ -2095,6 +1984,14 @@
 				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"normalize-path": {
@@ -2104,9 +2001,9 @@
 			"dev": true
 		},
 		"object-inspect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 			"dev": true
 		},
 		"object-keys": {
@@ -2128,15 +2025,37 @@
 			}
 		},
 		"object.entries": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
-			"integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
+			"integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3"
+				"es-abstract": "^1.18.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				}
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -2206,15 +2125,14 @@
 			}
 		},
 		"object.values": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-			"integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+			"integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.2",
-				"has": "^1.0.3"
+				"es-abstract": "^1.18.2"
 			},
 			"dependencies": {
 				"call-bind": {
@@ -2227,38 +2145,6 @@
 						"get-intrinsic": "^1.0.2"
 					}
 				},
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					},
-					"dependencies": {
-						"has-symbols": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-							"dev": true
-						}
-					}
-				},
 				"get-intrinsic": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -2268,66 +2154,6 @@
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1"
-					}
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-negative-zero": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				},
-				"string.prototype.trimend": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					}
-				},
-				"string.prototype.trimstart": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
 					}
 				}
 			}
@@ -2398,12 +2224,13 @@
 			}
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"parseurl": {
@@ -2431,9 +2258,9 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"path-to-regexp": {
@@ -2443,12 +2270,20 @@
 			"dev": true
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "^2.0.0"
+				"pify": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"picomatch": {
@@ -2457,23 +2292,17 @@
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
 		},
-		"pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-			"dev": true
-		},
 		"pino": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-6.11.2.tgz",
-			"integrity": "sha512-bmzxwbrIPxQUlAuMkF4PWVErUGERU4z37HazlhflKFg08crsNE3fACGN6gPwg5xtKOK47Ux5cZm8YCuLV4wWJg==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-6.11.3.tgz",
+			"integrity": "sha512-drPtqkkSf0ufx2gaea3TryFiBHdNIdXKf5LN0hTM82SXI4xVIve2wLwNg92e1MT6m3jASLu6VO7eGY6+mmGeyw==",
 			"dev": true,
 			"requires": {
 				"fast-redact": "^3.0.0",
 				"fast-safe-stringify": "^2.0.7",
 				"flatstr": "^1.0.12",
 				"pino-std-serializers": "^3.1.0",
-				"quick-format-unescaped": "4.0.1",
+				"quick-format-unescaped": "^4.0.3",
 				"sonic-boom": "^1.0.2"
 			}
 		},
@@ -2492,6 +2321,15 @@
 				"find-up": "^2.1.0"
 			}
 		},
+		"pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			}
+		},
 		"prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2499,9 +2337,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
 			"dev": true
 		},
 		"progress": {
@@ -2533,9 +2371,9 @@
 			"dev": true
 		},
 		"quick-format-unescaped": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
-			"integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz",
+			"integrity": "sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg==",
 			"dev": true
 		},
 		"ramda": {
@@ -2563,24 +2401,24 @@
 			}
 		},
 		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^2.0.0",
+				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^2.0.0"
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
-				"read-pkg": "^2.0.0"
+				"read-pkg": "^3.0.0"
 			}
 		},
 		"readdirp": {
@@ -2593,9 +2431,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
 		"require-directory": {
@@ -2632,6 +2470,15 @@
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true
 		},
+		"rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -2645,10 +2492,13 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-			"dev": true
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"send": {
 			"version": "0.17.1",
@@ -2779,9 +2629,9 @@
 			}
 		},
 		"sonic-boom": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.0.tgz",
-			"integrity": "sha512-1xUAszhQBOrjk7uisbStQZYkZxD3vkYlCUw5qzOblWQ1ILN5v0dVPAs+QPgszzoPmbdWx6jyT9XiLJ95JdlLiQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+			"integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
 			"dev": true,
 			"requires": {
 				"atomic-sleep": "^1.0.0",
@@ -2815,9 +2665,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+			"integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
 			"dev": true
 		},
 		"sprintf-js": {
@@ -2850,26 +2700,6 @@
 			"requires": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3"
-			}
-		},
-		"string.prototype.trimleft": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-			"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
-			}
-		},
-		"string.prototype.trimright": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-			"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
 			}
 		},
 		"string.prototype.trimstart": {
@@ -2927,9 +2757,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
-					"integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+					"integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -3027,9 +2857,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
 		"type-is": {

--- a/packages/aws-fargate/package.json
+++ b/packages/aws-fargate/package.json
@@ -61,15 +61,15 @@
     "@instana/serverless": "1.126.2"
   },
   "devDependencies": {
-    "eslint": "^7.27.0",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint": "^7.30.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-mocha": "^8.1.0",
     "express": "^4.17.1",
     "mocha": "^7.2.0",
     "node-fetch": "^2.6.1",
-    "pino": "^6.11.2",
-    "prettier": "^2.2.1"
+    "pino": "^6.11.3",
+    "prettier": "^2.3.2"
   },
   "engines": {
     "node": ">=8.6.0"

--- a/packages/aws-lambda-auto-wrap/.ncurc.json
+++ b/packages/aws-lambda-auto-wrap/.ncurc.json
@@ -1,3 +1,3 @@
 {
-  "reject": ["mocha"]
+  "reject": ["mocha", "eslint-plugin-mocha"]
 }

--- a/packages/aws-lambda-auto-wrap/package-lock.json
+++ b/packages/aws-lambda-auto-wrap/package-lock.json
@@ -14,18 +14,18 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+			"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.0",
+				"@babel/helper-validator-identifier": "^7.14.5",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
@@ -50,32 +50,38 @@
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
-			"integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+			"integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
 				"espree": "^7.3.0",
-				"globals": "^12.1.0",
+				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
 				"minimatch": "^3.0.4",
 				"strip-json-comments": "^3.1.1"
-			},
-			"dependencies": {
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				}
 			}
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+			"dev": true
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -148,72 +154,6 @@
 				"es-abstract": "^1.18.0-next.2",
 				"get-intrinsic": "^1.1.1",
 				"is-string": "^1.0.5"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-					"dev": true
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
 			}
 		},
 		"array.prototype.flat": {
@@ -225,72 +165,6 @@
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.18.0-next.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-					"dev": true
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
 			}
 		},
 		"astral-regex": {
@@ -300,9 +174,9 @@
 			"dev": true
 		},
 		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -404,15 +278,9 @@
 			"dev": true
 		},
 		"confusing-browser-globals": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
-			"integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
-			"dev": true
-		},
-		"contains-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+			"integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
 			"dev": true
 		},
 		"cross-spawn": {
@@ -484,21 +352,27 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
-			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+			"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.2.0",
+				"call-bind": "^1.0.2",
+				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.1.1",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.0",
-				"is-callable": "^1.1.4",
-				"is-regex": "^1.0.4",
-				"object-inspect": "^1.6.0",
+				"has-symbols": "^1.0.2",
+				"is-callable": "^1.2.3",
+				"is-negative-zero": "^2.0.1",
+				"is-regex": "^1.1.3",
+				"is-string": "^1.0.6",
+				"object-inspect": "^1.10.3",
 				"object-keys": "^1.1.1",
-				"string.prototype.trimleft": "^2.1.0",
-				"string.prototype.trimright": "^2.1.0"
+				"object.assign": "^4.1.2",
+				"string.prototype.trimend": "^1.0.4",
+				"string.prototype.trimstart": "^1.0.4",
+				"unbox-primitive": "^1.0.1"
 			}
 		},
 		"es-to-primitive": {
@@ -519,13 +393,14 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
-			"integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+			"integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.1",
+				"@eslint/eslintrc": "^0.4.2",
+				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -542,7 +417,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
+				"glob-parent": "^5.1.2",
 				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
@@ -563,28 +438,17 @@
 				"table": "^6.0.9",
 				"text-table": "^0.2.0",
 				"v8-compile-cache": "^2.0.3"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"eslint-config-airbnb-base": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
-			"integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+			"integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
 			"dev": true,
 			"requires": {
-				"confusing-browser-globals": "^1.0.5",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.0"
+				"confusing-browser-globals": "^1.0.10",
+				"object.assign": "^4.1.2",
+				"object.entries": "^1.1.2"
 			}
 		},
 		"eslint-import-resolver-node": {
@@ -615,50 +479,46 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+			"integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.9",
+				"debug": "^3.2.7",
 				"pkg-dir": "^2.0.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.22.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
-			"integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+			"version": "2.23.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+			"integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.1.1",
-				"array.prototype.flat": "^1.2.3",
-				"contains-path": "^0.1.0",
+				"array-includes": "^3.1.3",
+				"array.prototype.flat": "^1.2.4",
 				"debug": "^2.6.9",
-				"doctrine": "1.5.0",
+				"doctrine": "^2.1.0",
 				"eslint-import-resolver-node": "^0.3.4",
-				"eslint-module-utils": "^2.6.0",
+				"eslint-module-utils": "^2.6.1",
+				"find-up": "^2.0.0",
 				"has": "^1.0.3",
+				"is-core-module": "^2.4.0",
 				"minimatch": "^3.0.4",
-				"object.values": "^1.1.1",
-				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.17.0",
+				"object.values": "^1.1.3",
+				"pkg-up": "^2.0.0",
+				"read-pkg-up": "^3.0.0",
+				"resolve": "^1.20.0",
 				"tsconfig-paths": "^3.9.0"
 			},
 			"dependencies": {
@@ -672,13 +532,12 @@
 					}
 				},
 				"doctrine": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"isarray": "^1.0.0"
+						"esutils": "^2.0.2"
 					}
 				},
 				"ms": {
@@ -840,9 +699,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
+			"integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
 			"dev": true
 		},
 		"fs.realpath": {
@@ -872,14 +731,6 @@
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.1"
-			},
-			"dependencies": {
-				"has-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-					"dev": true
-				}
 			}
 		},
 		"glob": {
@@ -912,14 +763,6 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.20.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-					"dev": true
-				}
 			}
 		},
 		"graceful-fs": {
@@ -950,15 +793,15 @@
 			"dev": true
 		},
 		"has-symbols": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
 		"ignore": {
@@ -1006,39 +849,39 @@
 			"dev": true
 		},
 		"is-bigint": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-			"integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
 			"dev": true
 		},
 		"is-boolean-object": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-			"integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+			"integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
 			}
 		},
 		"is-callable": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+			"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+			"integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
 			}
 		},
 		"is-date-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+			"integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
 			"dev": true
 		},
 		"is-extglob": {
@@ -1069,40 +912,35 @@
 			"dev": true
 		},
 		"is-number-object": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-			"integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+			"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
 			"dev": true
 		},
 		"is-regex": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+			"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"call-bind": "^1.0.2",
+				"has-symbols": "^1.0.2"
 			}
 		},
 		"is-string": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+			"integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
 			"dev": true
 		},
 		"is-symbol": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
 			"dev": true,
 			"requires": {
-				"has-symbols": "^1.0.0"
+				"has-symbols": "^1.0.2"
 			}
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -1125,6 +963,12 @@
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
 			}
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -1158,14 +1002,14 @@
 			}
 		},
 		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
 				"strip-bom": "^3.0.0"
 			}
 		},
@@ -1243,12 +1087,20 @@
 				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"object-inspect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 			"dev": true
 		},
 		"object-keys": {
@@ -1258,105 +1110,37 @@
 			"dev": true
 		},
 		"object.assign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3",
+				"has-symbols": "^1.0.1",
+				"object-keys": "^1.1.1"
 			}
 		},
 		"object.entries": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-			"integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.12.0",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3"
-			}
-		},
-		"object.values": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-			"integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
+			"integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.2",
-				"has": "^1.0.3"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-					"dev": true
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				}
+				"es-abstract": "^1.18.2"
+			}
+		},
+		"object.values": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+			"integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.2"
 			}
 		},
 		"once": {
@@ -1416,12 +1200,13 @@
 			}
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"path-exists": {
@@ -1443,30 +1228,39 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "^2.0.0"
+				"pify": "^3.0.0"
 			}
 		},
 		"pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 			"dev": true
 		},
 		"pkg-dir": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			}
+		},
+		"pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
 			"dev": true,
 			"requires": {
 				"find-up": "^2.1.0"
@@ -1479,9 +1273,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
 			"dev": true
 		},
 		"progress": {
@@ -1497,30 +1291,30 @@
 			"dev": true
 		},
 		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^2.0.0",
+				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^2.0.0"
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
-				"read-pkg": "^2.0.0"
+				"read-pkg": "^3.0.0"
 			}
 		},
 		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
 		"require-from-string": {
@@ -1555,10 +1349,13 @@
 			}
 		},
 		"semver": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-			"dev": true
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"shebang-command": {
 			"version": "2.0.0",
@@ -1639,9 +1436,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+			"integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
 			"dev": true
 		},
 		"sprintf-js": {
@@ -1669,26 +1466,6 @@
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3"
-			}
-		},
-		"string.prototype.trimleft": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
-			}
-		},
-		"string.prototype.trimright": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
 			}
 		},
 		"string.prototype.trimstart": {
@@ -1746,9 +1523,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
-					"integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+					"integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -1793,9 +1570,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
 		"unbox-primitive": {
@@ -1808,14 +1585,6 @@
 				"has-bigints": "^1.0.1",
 				"has-symbols": "^1.0.2",
 				"which-boxed-primitive": "^1.0.2"
-			},
-			"dependencies": {
-				"has-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-					"dev": true
-				}
 			}
 		},
 		"uri-js": {
@@ -1863,23 +1632,6 @@
 				"is-number-object": "^1.0.4",
 				"is-string": "^1.0.5",
 				"is-symbol": "^1.0.3"
-			},
-			"dependencies": {
-				"has-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-					"dev": true
-				},
-				"is-symbol": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-					"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-					"dev": true,
-					"requires": {
-						"has-symbols": "^1.0.1"
-					}
-				}
 			}
 		},
 		"word-wrap": {

--- a/packages/aws-lambda-auto-wrap/package.json
+++ b/packages/aws-lambda-auto-wrap/package.json
@@ -57,9 +57,9 @@
     "@instana/aws-lambda": "1.126.2"
   },
   "devDependencies": {
-    "eslint": "^7.27.0",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.22.1",
-    "prettier": "^2.2.1"
+    "eslint": "^7.30.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-plugin-import": "^2.23.4",
+    "prettier": "^2.3.2"
   }
 }

--- a/packages/aws-lambda/.ncurc.json
+++ b/packages/aws-lambda/.ncurc.json
@@ -1,3 +1,3 @@
 {
-  "reject": ["mocha"]
+  "reject": ["mocha", "eslint-plugin-mocha"]
 }

--- a/packages/aws-lambda/package-lock.json
+++ b/packages/aws-lambda/package-lock.json
@@ -14,32 +14,32 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+			"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.0",
+				"@babel/helper-validator-identifier": "^7.14.5",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
-			"integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+			"integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
 				"espree": "^7.3.0",
-				"globals": "^12.1.0",
+				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
@@ -47,15 +47,6 @@
 				"strip-json-comments": "^3.1.1"
 			},
 			"dependencies": {
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
 				"strip-json-comments": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -63,6 +54,23 @@
 					"dev": true
 				}
 			}
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+			"dev": true
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -173,41 +181,6 @@
 						"get-intrinsic": "^1.0.2"
 					}
 				},
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					}
-				},
-				"es-to-primitive": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-					"dev": true,
-					"requires": {
-						"is-callable": "^1.1.4",
-						"is-date-object": "^1.0.1",
-						"is-symbol": "^1.0.2"
-					}
-				},
 				"get-intrinsic": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -224,66 +197,6 @@
 					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
 					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
 					"dev": true
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-negative-zero": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				},
-				"string.prototype.trimend": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					}
-				},
-				"string.prototype.trimstart": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					}
 				}
 			}
 		},
@@ -296,168 +209,6 @@
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.18.0-next.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				},
-				"es-to-primitive": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-					"dev": true,
-					"requires": {
-						"is-callable": "^1.1.4",
-						"is-date-object": "^1.0.1",
-						"is-symbol": "^1.0.2"
-					}
-				},
-				"get-intrinsic": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-					"dev": true,
-					"requires": {
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-					"dev": true
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-negative-zero": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				},
-				"string.prototype.trimend": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				},
-				"string.prototype.trimstart": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				}
 			}
 		},
 		"astral-regex": {
@@ -660,15 +411,9 @@
 			"dev": true
 		},
 		"confusing-browser-globals": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
-			"integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
-			"dev": true
-		},
-		"contains-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+			"integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
 			"dev": true
 		},
 		"content-disposition": {
@@ -822,27 +567,100 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
-			"integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+			"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.2.0",
+				"call-bind": "^1.0.2",
+				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.1.1",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.0",
-				"is-callable": "^1.1.4",
-				"is-regex": "^1.0.4",
-				"object-inspect": "^1.6.0",
+				"has-symbols": "^1.0.2",
+				"is-callable": "^1.2.3",
+				"is-negative-zero": "^2.0.1",
+				"is-regex": "^1.1.3",
+				"is-string": "^1.0.6",
+				"object-inspect": "^1.10.3",
 				"object-keys": "^1.1.1",
-				"string.prototype.trimleft": "^2.1.0",
-				"string.prototype.trimright": "^2.1.0"
+				"object.assign": "^4.1.2",
+				"string.prototype.trimend": "^1.0.4",
+				"string.prototype.trimstart": "^1.0.4",
+				"unbox-primitive": "^1.0.1"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-negative-zero": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
 			}
 		},
 		"es-to-primitive": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
 			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.4",
@@ -863,13 +681,14 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
-			"integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+			"integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.1",
+				"@eslint/eslintrc": "^0.4.2",
+				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -886,7 +705,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
+				"glob-parent": "^5.1.2",
 				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
@@ -961,6 +780,15 @@
 					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 					"dev": true
 				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1003,14 +831,34 @@
 			}
 		},
 		"eslint-config-airbnb-base": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
-			"integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+			"integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
 			"dev": true,
 			"requires": {
-				"confusing-browser-globals": "^1.0.5",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.0"
+				"confusing-browser-globals": "^1.0.10",
+				"object.assign": "^4.1.2",
+				"object.entries": "^1.1.2"
+			},
+			"dependencies": {
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"eslint-import-resolver-node": {
@@ -1041,50 +889,46 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+			"integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.9",
+				"debug": "^3.2.7",
 				"pkg-dir": "^2.0.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.22.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
-			"integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+			"version": "2.23.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+			"integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.1.1",
-				"array.prototype.flat": "^1.2.3",
-				"contains-path": "^0.1.0",
+				"array-includes": "^3.1.3",
+				"array.prototype.flat": "^1.2.4",
 				"debug": "^2.6.9",
-				"doctrine": "1.5.0",
+				"doctrine": "^2.1.0",
 				"eslint-import-resolver-node": "^0.3.4",
-				"eslint-module-utils": "^2.6.0",
+				"eslint-module-utils": "^2.6.1",
+				"find-up": "^2.0.0",
 				"has": "^1.0.3",
+				"is-core-module": "^2.4.0",
 				"minimatch": "^3.0.4",
-				"object.values": "^1.1.1",
-				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.17.0",
+				"object.values": "^1.1.3",
+				"pkg-up": "^2.0.0",
+				"read-pkg-up": "^3.0.0",
+				"resolve": "^1.20.0",
 				"tsconfig-paths": "^3.9.0"
 			},
 			"dependencies": {
@@ -1098,13 +942,12 @@
 					}
 				},
 				"doctrine": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"isarray": "^1.0.0"
+						"esutils": "^2.0.2"
 					}
 				},
 				"ms": {
@@ -1304,9 +1147,9 @@
 			"dev": true
 		},
 		"fast-redact": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
-			"integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.1.tgz",
+			"integrity": "sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw==",
 			"dev": true
 		},
 		"fast-safe-stringify": {
@@ -1400,9 +1243,9 @@
 			"dev": true
 		},
 		"flatted": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
+			"integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
 			"dev": true
 		},
 		"forwarded": {
@@ -1497,14 +1340,6 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.20.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-					"dev": true
-				}
 			}
 		},
 		"graceful-fs": {
@@ -1553,9 +1388,9 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
 		"http-errors": {
@@ -1639,9 +1474,9 @@
 			"dev": true
 		},
 		"is-bigint": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-			"integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
 			"dev": true
 		},
 		"is-binary-path": {
@@ -1654,12 +1489,41 @@
 			}
 		},
 		"is-boolean-object": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-			"integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+			"integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				}
 			}
 		},
 		"is-buffer": {
@@ -1669,15 +1533,15 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+			"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+			"integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -1723,24 +1587,54 @@
 			"dev": true
 		},
 		"is-number-object": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-			"integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+			"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
 			"dev": true
 		},
 		"is-regex": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+			"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"call-bind": "^1.0.2",
+				"has-symbols": "^1.0.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				}
 			}
 		},
 		"is-string": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+			"integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
 			"dev": true
 		},
 		"is-symbol": {
@@ -1751,12 +1645,6 @@
 			"requires": {
 				"has-symbols": "^1.0.0"
 			}
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -1779,6 +1667,12 @@
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
 			}
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -1812,14 +1706,14 @@
 			}
 		},
 		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
 				"strip-bom": "^3.0.0"
 			}
 		},
@@ -2106,9 +2000,9 @@
 			"dev": true
 		},
 		"object-inspect": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 			"dev": true
 		},
 		"object-keys": {
@@ -2130,15 +2024,43 @@
 			}
 		},
 		"object.entries": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-			"integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
+			"integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.12.0",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3"
+				"es-abstract": "^1.18.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				}
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -2225,15 +2147,14 @@
 			}
 		},
 		"object.values": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-			"integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+			"integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.2",
-				"has": "^1.0.3"
+				"es-abstract": "^1.18.2"
 			},
 			"dependencies": {
 				"call-bind": {
@@ -2244,41 +2165,6 @@
 					"requires": {
 						"function-bind": "^1.1.1",
 						"get-intrinsic": "^1.0.2"
-					}
-				},
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					}
-				},
-				"es-to-primitive": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-					"dev": true,
-					"requires": {
-						"is-callable": "^1.1.4",
-						"is-date-object": "^1.0.1",
-						"is-symbol": "^1.0.2"
 					}
 				},
 				"get-intrinsic": {
@@ -2297,66 +2183,6 @@
 					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
 					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
 					"dev": true
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-negative-zero": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				},
-				"string.prototype.trimend": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					}
-				},
-				"string.prototype.trimstart": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					}
 				}
 			}
 		},
@@ -2426,12 +2252,13 @@
 			}
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"parseurl": {
@@ -2459,9 +2286,9 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"path-to-regexp": {
@@ -2471,12 +2298,12 @@
 			"dev": true
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "^2.0.0"
+				"pify": "^3.0.0"
 			}
 		},
 		"picomatch": {
@@ -2486,22 +2313,22 @@
 			"dev": true
 		},
 		"pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 			"dev": true
 		},
 		"pino": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-6.11.2.tgz",
-			"integrity": "sha512-bmzxwbrIPxQUlAuMkF4PWVErUGERU4z37HazlhflKFg08crsNE3fACGN6gPwg5xtKOK47Ux5cZm8YCuLV4wWJg==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-6.11.3.tgz",
+			"integrity": "sha512-drPtqkkSf0ufx2gaea3TryFiBHdNIdXKf5LN0hTM82SXI4xVIve2wLwNg92e1MT6m3jASLu6VO7eGY6+mmGeyw==",
 			"dev": true,
 			"requires": {
 				"fast-redact": "^3.0.0",
 				"fast-safe-stringify": "^2.0.7",
 				"flatstr": "^1.0.12",
 				"pino-std-serializers": "^3.1.0",
-				"quick-format-unescaped": "4.0.1",
+				"quick-format-unescaped": "^4.0.3",
 				"sonic-boom": "^1.0.2"
 			}
 		},
@@ -2520,6 +2347,15 @@
 				"find-up": "^2.1.0"
 			}
 		},
+		"pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			}
+		},
 		"prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2527,9 +2363,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
 			"dev": true
 		},
 		"progress": {
@@ -2561,9 +2397,9 @@
 			"dev": true
 		},
 		"quick-format-unescaped": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
-			"integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz",
+			"integrity": "sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg==",
 			"dev": true
 		},
 		"ramda": {
@@ -2591,24 +2427,24 @@
 			}
 		},
 		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^2.0.0",
+				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^2.0.0"
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
-				"read-pkg": "^2.0.0"
+				"read-pkg": "^3.0.0"
 			}
 		},
 		"readdirp": {
@@ -2621,9 +2457,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
 		"require-directory": {
@@ -2816,9 +2652,9 @@
 			}
 		},
 		"sonic-boom": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.0.tgz",
-			"integrity": "sha512-1xUAszhQBOrjk7uisbStQZYkZxD3vkYlCUw5qzOblWQ1ILN5v0dVPAs+QPgszzoPmbdWx6jyT9XiLJ95JdlLiQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+			"integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
 			"dev": true,
 			"requires": {
 				"atomic-sleep": "^1.0.0",
@@ -2852,9 +2688,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+			"integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
 			"dev": true
 		},
 		"sprintf-js": {
@@ -2887,26 +2723,6 @@
 			"requires": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3"
-			}
-		},
-		"string.prototype.trimleft": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
-			}
-		},
-		"string.prototype.trimright": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
 			}
 		},
 		"string.prototype.trimstart": {
@@ -2964,9 +2780,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
-					"integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+					"integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -3064,9 +2880,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
 		"type-is": {
@@ -3171,12 +2987,12 @@
 					"dev": true
 				},
 				"is-symbol": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-					"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+					"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
 					"dev": true,
 					"requires": {
-						"has-symbols": "^1.0.1"
+						"has-symbols": "^1.0.2"
 					}
 				}
 			}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -61,13 +61,13 @@
     "@instana/serverless": "1.126.2"
   },
   "devDependencies": {
-    "eslint": "^7.27.0",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint": "^7.30.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-mocha": "^8.1.0",
     "express": "^4.17.1",
     "mocha": "^7.2.0",
-    "pino": "^6.11.2",
-    "prettier": "^2.2.1"
+    "pino": "^6.11.3",
+    "prettier": "^2.3.2"
   }
 }

--- a/packages/aws-lambda/test/Control.js
+++ b/packages/aws-lambda/test/Control.js
@@ -59,6 +59,7 @@ Control.prototype.registerTestHooks = function registerTestHooks() {
 Control.prototype.startMonitoredProcess = function startMonitoredProcess() {
   this.faasRuntime = fork(this.opts.faasRuntimePath, {
     stdio: config.getAppStdio(),
+    // eslint-disable-next-line prefer-object-spread
     env: Object.assign(
       {
         HANDLER_DEFINITION_PATH: this.opts.handlerDefinitionPath,

--- a/packages/aws-lambda/test/timeout/test.js
+++ b/packages/aws-lambda/test/timeout/test.js
@@ -34,6 +34,7 @@ function prelude(opts) {
     opts.startBackend = true;
   }
 
+  // eslint-disable-next-line prefer-object-spread
   const env = Object.assign(
     {
       INSTANA_ENDPOINT_URL: opts.instanaEndpointUrl,

--- a/packages/collector/.ncurc.json
+++ b/packages/collector/.ncurc.json
@@ -1,3 +1,3 @@
 {
-  "reject": ["serialize-error", "mocha"]
+  "reject": ["serialize-error", "mocha", "eslint-plugin-mocha"]
 }

--- a/packages/collector/package-lock.json
+++ b/packages/collector/package-lock.json
@@ -14,32 +14,32 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+			"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.0",
+				"@babel/helper-validator-identifier": "^7.14.5",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
-			"integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+			"integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
 				"espree": "^7.3.0",
-				"globals": "^12.1.0",
+				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
@@ -48,21 +48,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
-					}
-				},
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
 					}
 				},
 				"strip-json-comments": {
@@ -72,6 +63,34 @@
 					"dev": true
 				}
 			}
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				}
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+			"dev": true
 		},
 		"acorn": {
 			"version": "7.4.1",
@@ -511,13 +530,14 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
-			"integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+			"integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.1",
+				"@eslint/eslintrc": "^0.4.2",
+				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -534,7 +554,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
+				"glob-parent": "^5.1.2",
 				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
@@ -598,9 +618,9 @@
 					"dev": true
 				},
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -611,6 +631,15 @@
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 					"dev": true
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
 				},
 				"has-flag": {
 					"version": "4.0.0",
@@ -896,9 +925,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
+			"integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
 			"dev": true
 		},
 		"fs.realpath": {
@@ -981,14 +1010,6 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.20.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-					"dev": true
-				}
 			}
 		},
 		"growl": {
@@ -1681,9 +1702,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
 			"dev": true
 		},
 		"progress": {
@@ -1714,9 +1735,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
 		"require-directory": {
@@ -1930,9 +1951,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
-					"integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+					"integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -2012,9 +2033,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
 		"unbox-primitive": {

--- a/packages/collector/package.json
+++ b/packages/collector/package.json
@@ -138,11 +138,11 @@
     "@instana/autoprofile": "1.126.2"
   },
   "devDependencies": {
-    "eslint": "^7.27.0",
+    "eslint": "^7.30.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-plugin-mocha": "^9.0.0",
     "mocha": "^7.2.0",
     "opentracing": "^0.14.5",
-    "prettier": "^2.2.1"
+    "prettier": "^2.3.2"
   }
 }

--- a/packages/core/.ncurc.json
+++ b/packages/core/.ncurc.json
@@ -1,3 +1,3 @@
 {
-  "reject": ["mocha"]
+  "reject": ["mocha", "eslint-plugin-mocha"]
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -14,32 +14,32 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+			"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.0",
+				"@babel/helper-validator-identifier": "^7.14.5",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
-			"integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+			"integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
 				"espree": "^7.3.0",
-				"globals": "^12.1.0",
+				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
@@ -47,15 +47,6 @@
 				"strip-json-comments": "^3.1.1"
 			},
 			"dependencies": {
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
 				"strip-json-comments": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -63,6 +54,23 @@
 					"dev": true
 				}
 			}
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+			"dev": true
 		},
 		"acorn": {
 			"version": "7.4.1",
@@ -326,9 +334,9 @@
 			}
 		},
 		"debug": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
@@ -510,13 +518,14 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
-			"integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+			"integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.1",
+				"@eslint/eslintrc": "^0.4.2",
+				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -533,7 +542,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
+				"glob-parent": "^5.1.2",
 				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
@@ -607,6 +616,15 @@
 					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
 					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 					"dev": true
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
 				},
 				"has-flag": {
 					"version": "4.0.0",
@@ -876,9 +894,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
+			"integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
 			"dev": true
 		},
 		"fs.realpath": {
@@ -961,14 +979,6 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.20.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-					"dev": true
-				}
 			}
 		},
 		"growl": {
@@ -1631,9 +1641,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
 			"dev": true
 		},
 		"progress": {
@@ -1669,9 +1679,9 @@
 			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
 		},
 		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
 		"require-directory": {
@@ -1864,9 +1874,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
-					"integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+					"integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -1946,9 +1956,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
 		"unbox-primitive": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -127,10 +127,10 @@
     "shimmer": "1.2.1"
   },
   "devDependencies": {
-    "eslint": "^7.27.0",
+    "eslint": "^7.30.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-plugin-mocha": "^8.1.0",
     "mocha": "^7.2.0",
-    "prettier": "^2.2.1"
+    "prettier": "^2.3.2"
   }
 }

--- a/packages/google-cloud-run/.ncurc.json
+++ b/packages/google-cloud-run/.ncurc.json
@@ -1,3 +1,3 @@
 {
-  "reject": ["mocha"]
+  "reject": ["mocha", "eslint-plugin-mocha"]
 }

--- a/packages/google-cloud-run/package-lock.json
+++ b/packages/google-cloud-run/package-lock.json
@@ -14,32 +14,32 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+			"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.0",
+				"@babel/helper-validator-identifier": "^7.14.5",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
-			"integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+			"integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
 				"espree": "^7.3.0",
-				"globals": "^12.1.0",
+				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
@@ -47,15 +47,6 @@
 				"strip-json-comments": "^3.1.1"
 			},
 			"dependencies": {
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
 				"strip-json-comments": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -63,6 +54,23 @@
 					"dev": true
 				}
 			}
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+			"dev": true
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -174,9 +182,9 @@
 					}
 				},
 				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+					"version": "1.18.3",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+					"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.2",
@@ -187,14 +195,14 @@
 						"has-symbols": "^1.0.2",
 						"is-callable": "^1.2.3",
 						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
+						"is-regex": "^1.1.3",
+						"is-string": "^1.0.6",
+						"object-inspect": "^1.10.3",
 						"object-keys": "^1.1.1",
 						"object.assign": "^4.1.2",
 						"string.prototype.trimend": "^1.0.4",
 						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
+						"unbox-primitive": "^1.0.1"
 					},
 					"dependencies": {
 						"has-symbols": {
@@ -229,19 +237,27 @@
 					"dev": true
 				},
 				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+					"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
+						"has-symbols": "^1.0.2"
+					},
+					"dependencies": {
+						"has-symbols": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+							"dev": true
+						}
 					}
 				},
 				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+					"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 					"dev": true
 				},
 				"object.assign": {
@@ -290,9 +306,9 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+					"version": "1.18.3",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+					"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.2",
@@ -303,14 +319,14 @@
 						"has-symbols": "^1.0.2",
 						"is-callable": "^1.2.3",
 						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
+						"is-regex": "^1.1.3",
+						"is-string": "^1.0.6",
+						"object-inspect": "^1.10.3",
 						"object-keys": "^1.1.1",
 						"object.assign": "^4.1.2",
 						"string.prototype.trimend": "^1.0.4",
 						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
+						"unbox-primitive": "^1.0.1"
 					},
 					"dependencies": {
 						"call-bind": {
@@ -355,13 +371,13 @@
 					"dev": true
 				},
 				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+					"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
+						"has-symbols": "^1.0.2"
 					},
 					"dependencies": {
 						"call-bind": {
@@ -377,9 +393,9 @@
 					}
 				},
 				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+					"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 					"dev": true
 				},
 				"object.assign": {
@@ -640,15 +656,9 @@
 			"dev": true
 		},
 		"confusing-browser-globals": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
-			"integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
-			"dev": true
-		},
-		"contains-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+			"integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
 			"dev": true
 		},
 		"content-disposition": {
@@ -844,13 +854,14 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
-			"integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+			"integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.1",
+				"@eslint/eslintrc": "^0.4.2",
+				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -867,7 +878,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
+				"glob-parent": "^5.1.2",
 				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
@@ -942,6 +953,15 @@
 					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 					"dev": true
 				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -984,14 +1004,28 @@
 			}
 		},
 		"eslint-config-airbnb-base": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
-			"integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+			"integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
 			"dev": true,
 			"requires": {
-				"confusing-browser-globals": "^1.0.5",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.0"
+				"confusing-browser-globals": "^1.0.10",
+				"object.assign": "^4.1.2",
+				"object.entries": "^1.1.2"
+			},
+			"dependencies": {
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"eslint-import-resolver-node": {
@@ -1022,50 +1056,46 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+			"integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.9",
+				"debug": "^3.2.7",
 				"pkg-dir": "^2.0.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.22.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
-			"integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+			"version": "2.23.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+			"integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.1.1",
-				"array.prototype.flat": "^1.2.3",
-				"contains-path": "^0.1.0",
+				"array-includes": "^3.1.3",
+				"array.prototype.flat": "^1.2.4",
 				"debug": "^2.6.9",
-				"doctrine": "1.5.0",
+				"doctrine": "^2.1.0",
 				"eslint-import-resolver-node": "^0.3.4",
-				"eslint-module-utils": "^2.6.0",
+				"eslint-module-utils": "^2.6.1",
+				"find-up": "^2.0.0",
 				"has": "^1.0.3",
+				"is-core-module": "^2.4.0",
 				"minimatch": "^3.0.4",
-				"object.values": "^1.1.1",
-				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.17.0",
+				"object.values": "^1.1.3",
+				"pkg-up": "^2.0.0",
+				"read-pkg-up": "^3.0.0",
+				"resolve": "^1.20.0",
 				"tsconfig-paths": "^3.9.0"
 			},
 			"dependencies": {
@@ -1079,13 +1109,12 @@
 					}
 				},
 				"doctrine": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"isarray": "^1.0.0"
+						"esutils": "^2.0.2"
 					}
 				},
 				"ms": {
@@ -1285,9 +1314,9 @@
 			"dev": true
 		},
 		"fast-redact": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
-			"integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.1.tgz",
+			"integrity": "sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw==",
 			"dev": true
 		},
 		"fast-safe-stringify": {
@@ -1372,17 +1401,6 @@
 			"requires": {
 				"flatted": "^3.1.0",
 				"rimraf": "^3.0.2"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"flatstr": {
@@ -1392,9 +1410,9 @@
 			"dev": true
 		},
 		"flatted": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
+			"integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
 			"dev": true
 		},
 		"forwarded": {
@@ -1481,14 +1499,6 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.20.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-					"dev": true
-				}
 			}
 		},
 		"graceful-fs": {
@@ -1537,9 +1547,9 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
 		"http-errors": {
@@ -1623,9 +1633,9 @@
 			"dev": true
 		},
 		"is-bigint": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-			"integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
 			"dev": true
 		},
 		"is-binary-path": {
@@ -1638,12 +1648,35 @@
 			}
 		},
 		"is-boolean-object": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-			"integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+			"integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				}
 			}
 		},
 		"is-buffer": {
@@ -1659,9 +1692,9 @@
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+			"integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -1707,9 +1740,9 @@
 			"dev": true
 		},
 		"is-number-object": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-			"integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+			"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
 			"dev": true
 		},
 		"is-regex": {
@@ -1722,9 +1755,9 @@
 			}
 		},
 		"is-string": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+			"integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
 			"dev": true
 		},
 		"is-symbol": {
@@ -1735,12 +1768,6 @@
 			"requires": {
 				"has-symbols": "^1.0.1"
 			}
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -1763,6 +1790,12 @@
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
 			}
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -1796,15 +1829,23 @@
 			}
 		},
 		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
 				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"locate-path": {
@@ -2124,14 +2165,137 @@
 			}
 		},
 		"object.entries": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
-			"integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
+			"integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5",
-				"has": "^1.0.3"
+				"es-abstract": "^1.18.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"es-abstract": {
+					"version": "1.18.3",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+					"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"is-callable": "^1.2.3",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.3",
+						"is-string": "^1.0.6",
+						"object-inspect": "^1.10.3",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
+					},
+					"dependencies": {
+						"has-symbols": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+							"dev": true
+						}
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"is-callable": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+					"dev": true
+				},
+				"is-negative-zero": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+					"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-symbols": "^1.0.2"
+					},
+					"dependencies": {
+						"has-symbols": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+							"dev": true
+						}
+					}
+				},
+				"object-inspect": {
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+					"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -2186,15 +2350,14 @@
 			}
 		},
 		"object.values": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-			"integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+			"integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.2",
-				"has": "^1.0.3"
+				"es-abstract": "^1.18.2"
 			},
 			"dependencies": {
 				"call-bind": {
@@ -2208,9 +2371,9 @@
 					}
 				},
 				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+					"version": "1.18.3",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+					"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.2",
@@ -2221,14 +2384,14 @@
 						"has-symbols": "^1.0.2",
 						"is-callable": "^1.2.3",
 						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
+						"is-regex": "^1.1.3",
+						"is-string": "^1.0.6",
+						"object-inspect": "^1.10.3",
 						"object-keys": "^1.1.1",
 						"object.assign": "^4.1.2",
 						"string.prototype.trimend": "^1.0.4",
 						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
+						"unbox-primitive": "^1.0.1"
 					},
 					"dependencies": {
 						"has-symbols": {
@@ -2263,19 +2426,27 @@
 					"dev": true
 				},
 				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+					"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
+						"has-symbols": "^1.0.2"
+					},
+					"dependencies": {
+						"has-symbols": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+							"dev": true
+						}
 					}
 				},
 				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+					"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 					"dev": true
 				},
 				"object.assign": {
@@ -2378,12 +2549,13 @@
 			}
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"parseurl": {
@@ -2411,9 +2583,9 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"path-to-regexp": {
@@ -2423,12 +2595,20 @@
 			"dev": true
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "^2.0.0"
+				"pify": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"picomatch": {
@@ -2437,23 +2617,17 @@
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
 		},
-		"pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-			"dev": true
-		},
 		"pino": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-6.11.2.tgz",
-			"integrity": "sha512-bmzxwbrIPxQUlAuMkF4PWVErUGERU4z37HazlhflKFg08crsNE3fACGN6gPwg5xtKOK47Ux5cZm8YCuLV4wWJg==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-6.11.3.tgz",
+			"integrity": "sha512-drPtqkkSf0ufx2gaea3TryFiBHdNIdXKf5LN0hTM82SXI4xVIve2wLwNg92e1MT6m3jASLu6VO7eGY6+mmGeyw==",
 			"dev": true,
 			"requires": {
 				"fast-redact": "^3.0.0",
 				"fast-safe-stringify": "^2.0.7",
 				"flatstr": "^1.0.12",
 				"pino-std-serializers": "^3.1.0",
-				"quick-format-unescaped": "4.0.1",
+				"quick-format-unescaped": "^4.0.3",
 				"sonic-boom": "^1.0.2"
 			}
 		},
@@ -2472,6 +2646,15 @@
 				"find-up": "^2.1.0"
 			}
 		},
+		"pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			}
+		},
 		"prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2479,9 +2662,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
 			"dev": true
 		},
 		"progress": {
@@ -2513,9 +2696,9 @@
 			"dev": true
 		},
 		"quick-format-unescaped": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
-			"integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz",
+			"integrity": "sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg==",
 			"dev": true
 		},
 		"ramda": {
@@ -2543,24 +2726,24 @@
 			}
 		},
 		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^2.0.0",
+				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^2.0.0"
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
-				"read-pkg": "^2.0.0"
+				"read-pkg": "^3.0.0"
 			}
 		},
 		"readdirp": {
@@ -2573,9 +2756,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
 		"require-directory": {
@@ -2611,6 +2794,15 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true
+		},
+		"rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
@@ -2759,9 +2951,9 @@
 			}
 		},
 		"sonic-boom": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.0.tgz",
-			"integrity": "sha512-1xUAszhQBOrjk7uisbStQZYkZxD3vkYlCUw5qzOblWQ1ILN5v0dVPAs+QPgszzoPmbdWx6jyT9XiLJ95JdlLiQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+			"integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
 			"dev": true,
 			"requires": {
 				"atomic-sleep": "^1.0.0",
@@ -2795,9 +2987,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+			"integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
 			"dev": true
 		},
 		"sprintf-js": {
@@ -2887,9 +3079,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
-					"integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+					"integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -2987,9 +3179,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
 		"type-is": {

--- a/packages/google-cloud-run/package.json
+++ b/packages/google-cloud-run/package.json
@@ -61,15 +61,15 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "eslint": "^7.27.0",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint": "^7.30.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-mocha": "^8.1.0",
     "express": "^4.17.1",
     "mocha": "^7.2.0",
     "node-fetch": "^2.6.1",
-    "pino": "^6.11.2",
-    "prettier": "^2.2.1"
+    "pino": "^6.11.3",
+    "prettier": "^2.3.2"
   },
   "engines": {
     "node": ">=8.6.0"

--- a/packages/legacy-sensor/.ncurc.json
+++ b/packages/legacy-sensor/.ncurc.json
@@ -1,3 +1,3 @@
 {
-  "reject": ["mocha"]
+  "reject": ["mocha", "eslint-plugin-mocha"]
 }

--- a/packages/legacy-sensor/package-lock.json
+++ b/packages/legacy-sensor/package-lock.json
@@ -14,32 +14,32 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+			"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.0",
+				"@babel/helper-validator-identifier": "^7.14.5",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
-			"integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+			"integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
 				"espree": "^7.3.0",
-				"globals": "^12.1.0",
+				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
@@ -47,15 +47,6 @@
 				"strip-json-comments": "^3.1.1"
 			},
 			"dependencies": {
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
 				"strip-json-comments": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -63,6 +54,23 @@
 					"dev": true
 				}
 			}
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+			"dev": true
 		},
 		"acorn": {
 			"version": "7.4.1",
@@ -309,9 +317,9 @@
 			}
 		},
 		"debug": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
@@ -485,13 +493,14 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
-			"integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+			"integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.1",
+				"@eslint/eslintrc": "^0.4.2",
+				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -508,7 +517,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
+				"glob-parent": "^5.1.2",
 				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
@@ -582,6 +591,15 @@
 					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
 					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 					"dev": true
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
 				},
 				"has-flag": {
 					"version": "4.0.0",
@@ -857,23 +875,12 @@
 			"requires": {
 				"flatted": "^3.1.0",
 				"rimraf": "^3.0.2"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"flatted": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
+			"integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
 			"dev": true
 		},
 		"fs.realpath": {
@@ -956,14 +963,6 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.20.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-					"dev": true
-				}
 			}
 		},
 		"growl": {
@@ -1604,9 +1603,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
 			"dev": true
 		},
 		"progress": {
@@ -1637,9 +1636,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
 		"require-directory": {
@@ -1665,6 +1664,15 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true
+		},
+		"rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
 		},
 		"semver": {
 			"version": "5.7.1",
@@ -1811,9 +1819,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
-					"integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+					"integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -1893,9 +1901,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
 		"unbox-primitive": {

--- a/packages/legacy-sensor/package.json
+++ b/packages/legacy-sensor/package.json
@@ -47,10 +47,10 @@
   },
   "devDependencies": {
     "@instana/core": "1.126.2",
-    "eslint": "^7.27.0",
+    "eslint": "^7.30.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-plugin-mocha": "^8.1.0",
     "mocha": "^7.2.0",
-    "prettier": "^2.2.1"
+    "prettier": "^2.3.2"
   }
 }

--- a/packages/metrics-util/.ncurc.json
+++ b/packages/metrics-util/.ncurc.json
@@ -1,3 +1,3 @@
 {
-  "reject": ["mocha"]
+  "reject": ["mocha", "eslint-plugin-mocha"]
 }

--- a/packages/metrics-util/package-lock.json
+++ b/packages/metrics-util/package-lock.json
@@ -14,32 +14,32 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+			"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.0",
+				"@babel/helper-validator-identifier": "^7.14.5",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
-			"integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+			"integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
 				"espree": "^7.3.0",
-				"globals": "^12.1.0",
+				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
@@ -47,15 +47,6 @@
 				"strip-json-comments": "^3.1.1"
 			},
 			"dependencies": {
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
 				"strip-json-comments": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -63,6 +54,23 @@
 					"dev": true
 				}
 			}
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+			"dev": true
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -174,9 +182,9 @@
 					}
 				},
 				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+					"version": "1.18.3",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+					"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.2",
@@ -187,14 +195,14 @@
 						"has-symbols": "^1.0.2",
 						"is-callable": "^1.2.3",
 						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
+						"is-regex": "^1.1.3",
+						"is-string": "^1.0.6",
+						"object-inspect": "^1.10.3",
 						"object-keys": "^1.1.1",
 						"object.assign": "^4.1.2",
 						"string.prototype.trimend": "^1.0.4",
 						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
+						"unbox-primitive": "^1.0.1"
 					},
 					"dependencies": {
 						"has-symbols": {
@@ -229,19 +237,27 @@
 					"dev": true
 				},
 				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+					"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
+						"has-symbols": "^1.0.2"
+					},
+					"dependencies": {
+						"has-symbols": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+							"dev": true
+						}
 					}
 				},
 				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+					"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 					"dev": true
 				},
 				"object.assign": {
@@ -290,9 +306,9 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+					"version": "1.18.3",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+					"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.2",
@@ -303,14 +319,14 @@
 						"has-symbols": "^1.0.2",
 						"is-callable": "^1.2.3",
 						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
+						"is-regex": "^1.1.3",
+						"is-string": "^1.0.6",
+						"object-inspect": "^1.10.3",
 						"object-keys": "^1.1.1",
 						"object.assign": "^4.1.2",
 						"string.prototype.trimend": "^1.0.4",
 						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
+						"unbox-primitive": "^1.0.1"
 					},
 					"dependencies": {
 						"call-bind": {
@@ -355,13 +371,13 @@
 					"dev": true
 				},
 				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+					"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
+						"has-symbols": "^1.0.2"
 					},
 					"dependencies": {
 						"call-bind": {
@@ -377,9 +393,9 @@
 					}
 				},
 				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+					"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 					"dev": true
 				},
 				"object.assign": {
@@ -640,15 +656,9 @@
 			"dev": true
 		},
 		"confusing-browser-globals": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
-			"integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
-			"dev": true
-		},
-		"contains-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+			"integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
 			"dev": true
 		},
 		"content-disposition": {
@@ -844,13 +854,14 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
-			"integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+			"integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.1",
+				"@eslint/eslintrc": "^0.4.2",
+				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -867,7 +878,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
+				"glob-parent": "^5.1.2",
 				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
@@ -942,6 +953,15 @@
 					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 					"dev": true
 				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -984,14 +1004,28 @@
 			}
 		},
 		"eslint-config-airbnb-base": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
-			"integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+			"integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
 			"dev": true,
 			"requires": {
-				"confusing-browser-globals": "^1.0.5",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.0"
+				"confusing-browser-globals": "^1.0.10",
+				"object.assign": "^4.1.2",
+				"object.entries": "^1.1.2"
+			},
+			"dependencies": {
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"eslint-import-resolver-node": {
@@ -1022,50 +1056,46 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+			"integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.9",
+				"debug": "^3.2.7",
 				"pkg-dir": "^2.0.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.22.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
-			"integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+			"version": "2.23.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+			"integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.1.1",
-				"array.prototype.flat": "^1.2.3",
-				"contains-path": "^0.1.0",
+				"array-includes": "^3.1.3",
+				"array.prototype.flat": "^1.2.4",
 				"debug": "^2.6.9",
-				"doctrine": "1.5.0",
+				"doctrine": "^2.1.0",
 				"eslint-import-resolver-node": "^0.3.4",
-				"eslint-module-utils": "^2.6.0",
+				"eslint-module-utils": "^2.6.1",
+				"find-up": "^2.0.0",
 				"has": "^1.0.3",
+				"is-core-module": "^2.4.0",
 				"minimatch": "^3.0.4",
-				"object.values": "^1.1.1",
-				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.17.0",
+				"object.values": "^1.1.3",
+				"pkg-up": "^2.0.0",
+				"read-pkg-up": "^3.0.0",
+				"resolve": "^1.20.0",
 				"tsconfig-paths": "^3.9.0"
 			},
 			"dependencies": {
@@ -1079,13 +1109,12 @@
 					}
 				},
 				"doctrine": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"isarray": "^1.0.0"
+						"esutils": "^2.0.2"
 					}
 				},
 				"ms": {
@@ -1285,9 +1314,9 @@
 			"dev": true
 		},
 		"fast-redact": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
-			"integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.1.tgz",
+			"integrity": "sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw==",
 			"dev": true
 		},
 		"fast-safe-stringify": {
@@ -1372,17 +1401,6 @@
 			"requires": {
 				"flatted": "^3.1.0",
 				"rimraf": "^3.0.2"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"flatstr": {
@@ -1392,9 +1410,9 @@
 			"dev": true
 		},
 		"flatted": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
+			"integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
 			"dev": true
 		},
 		"forwarded": {
@@ -1481,14 +1499,6 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.20.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-					"dev": true
-				}
 			}
 		},
 		"graceful-fs": {
@@ -1537,9 +1547,9 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
 		"http-errors": {
@@ -1623,9 +1633,9 @@
 			"dev": true
 		},
 		"is-bigint": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-			"integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
 			"dev": true
 		},
 		"is-binary-path": {
@@ -1638,12 +1648,35 @@
 			}
 		},
 		"is-boolean-object": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-			"integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+			"integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				}
 			}
 		},
 		"is-buffer": {
@@ -1659,9 +1692,9 @@
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+			"integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -1707,9 +1740,9 @@
 			"dev": true
 		},
 		"is-number-object": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-			"integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+			"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
 			"dev": true
 		},
 		"is-regex": {
@@ -1722,9 +1755,9 @@
 			}
 		},
 		"is-string": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+			"integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
 			"dev": true
 		},
 		"is-symbol": {
@@ -1735,12 +1768,6 @@
 			"requires": {
 				"has-symbols": "^1.0.1"
 			}
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -1763,6 +1790,12 @@
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
 			}
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -1796,15 +1829,23 @@
 			}
 		},
 		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
 				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"locate-path": {
@@ -2123,14 +2164,137 @@
 			}
 		},
 		"object.entries": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
-			"integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
+			"integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5",
-				"has": "^1.0.3"
+				"es-abstract": "^1.18.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"es-abstract": {
+					"version": "1.18.3",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+					"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"is-callable": "^1.2.3",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.3",
+						"is-string": "^1.0.6",
+						"object-inspect": "^1.10.3",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
+					},
+					"dependencies": {
+						"has-symbols": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+							"dev": true
+						}
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"is-callable": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+					"dev": true
+				},
+				"is-negative-zero": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+					"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-symbols": "^1.0.2"
+					},
+					"dependencies": {
+						"has-symbols": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+							"dev": true
+						}
+					}
+				},
+				"object-inspect": {
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+					"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -2185,15 +2349,14 @@
 			}
 		},
 		"object.values": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-			"integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+			"integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.2",
-				"has": "^1.0.3"
+				"es-abstract": "^1.18.2"
 			},
 			"dependencies": {
 				"call-bind": {
@@ -2207,9 +2370,9 @@
 					}
 				},
 				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+					"version": "1.18.3",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+					"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.2",
@@ -2220,14 +2383,14 @@
 						"has-symbols": "^1.0.2",
 						"is-callable": "^1.2.3",
 						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
+						"is-regex": "^1.1.3",
+						"is-string": "^1.0.6",
+						"object-inspect": "^1.10.3",
 						"object-keys": "^1.1.1",
 						"object.assign": "^4.1.2",
 						"string.prototype.trimend": "^1.0.4",
 						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
+						"unbox-primitive": "^1.0.1"
 					},
 					"dependencies": {
 						"has-symbols": {
@@ -2262,19 +2425,27 @@
 					"dev": true
 				},
 				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+					"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
+						"has-symbols": "^1.0.2"
+					},
+					"dependencies": {
+						"has-symbols": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+							"dev": true
+						}
 					}
 				},
 				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+					"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 					"dev": true
 				},
 				"object.assign": {
@@ -2377,12 +2548,13 @@
 			}
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"parseurl": {
@@ -2410,9 +2582,9 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"path-to-regexp": {
@@ -2422,12 +2594,20 @@
 			"dev": true
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "^2.0.0"
+				"pify": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"picomatch": {
@@ -2436,23 +2616,17 @@
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
 		},
-		"pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-			"dev": true
-		},
 		"pino": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-6.11.2.tgz",
-			"integrity": "sha512-bmzxwbrIPxQUlAuMkF4PWVErUGERU4z37HazlhflKFg08crsNE3fACGN6gPwg5xtKOK47Ux5cZm8YCuLV4wWJg==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-6.11.3.tgz",
+			"integrity": "sha512-drPtqkkSf0ufx2gaea3TryFiBHdNIdXKf5LN0hTM82SXI4xVIve2wLwNg92e1MT6m3jASLu6VO7eGY6+mmGeyw==",
 			"dev": true,
 			"requires": {
 				"fast-redact": "^3.0.0",
 				"fast-safe-stringify": "^2.0.7",
 				"flatstr": "^1.0.12",
 				"pino-std-serializers": "^3.1.0",
-				"quick-format-unescaped": "4.0.1",
+				"quick-format-unescaped": "^4.0.3",
 				"sonic-boom": "^1.0.2"
 			}
 		},
@@ -2471,6 +2645,15 @@
 				"find-up": "^2.1.0"
 			}
 		},
+		"pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			}
+		},
 		"prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2478,9 +2661,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
 			"dev": true
 		},
 		"progress": {
@@ -2512,9 +2695,9 @@
 			"dev": true
 		},
 		"quick-format-unescaped": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
-			"integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz",
+			"integrity": "sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg==",
 			"dev": true
 		},
 		"ramda": {
@@ -2542,24 +2725,24 @@
 			}
 		},
 		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^2.0.0",
+				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^2.0.0"
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
-				"read-pkg": "^2.0.0"
+				"read-pkg": "^3.0.0"
 			}
 		},
 		"readdirp": {
@@ -2572,9 +2755,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
 		"require-directory": {
@@ -2610,6 +2793,15 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true
+		},
+		"rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
@@ -2758,9 +2950,9 @@
 			}
 		},
 		"sonic-boom": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.0.tgz",
-			"integrity": "sha512-1xUAszhQBOrjk7uisbStQZYkZxD3vkYlCUw5qzOblWQ1ILN5v0dVPAs+QPgszzoPmbdWx6jyT9XiLJ95JdlLiQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+			"integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
 			"dev": true,
 			"requires": {
 				"atomic-sleep": "^1.0.0",
@@ -2794,9 +2986,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+			"integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
 			"dev": true
 		},
 		"sprintf-js": {
@@ -2886,9 +3078,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
-					"integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+					"integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -2986,9 +3178,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
 		"type-is": {

--- a/packages/metrics-util/package.json
+++ b/packages/metrics-util/package.json
@@ -57,13 +57,13 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "eslint": "^7.27.0",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint": "^7.30.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-mocha": "^8.1.0",
     "express": "^4.17.1",
     "mocha": "^7.2.0",
-    "pino": "^6.11.2",
-    "prettier": "^2.2.1"
+    "pino": "^6.11.3",
+    "prettier": "^2.3.2"
   }
 }

--- a/packages/serverless/.ncurc.json
+++ b/packages/serverless/.ncurc.json
@@ -1,3 +1,3 @@
 {
-  "reject": ["mocha"]
+  "reject": ["mocha", "eslint-plugin-mocha"]
 }

--- a/packages/serverless/package-lock.json
+++ b/packages/serverless/package-lock.json
@@ -14,32 +14,32 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+			"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.0",
+				"@babel/helper-validator-identifier": "^7.14.5",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
-			"integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+			"integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
 				"espree": "^7.3.0",
-				"globals": "^12.1.0",
+				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
@@ -47,15 +47,6 @@
 				"strip-json-comments": "^3.1.1"
 			},
 			"dependencies": {
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
 				"strip-json-comments": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -63,6 +54,23 @@
 					"dev": true
 				}
 			}
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+			"dev": true
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -181,41 +189,6 @@
 						"get-intrinsic": "^1.0.2"
 					}
 				},
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					}
-				},
-				"es-to-primitive": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-					"dev": true,
-					"requires": {
-						"is-callable": "^1.1.4",
-						"is-date-object": "^1.0.1",
-						"is-symbol": "^1.0.2"
-					}
-				},
 				"get-intrinsic": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -232,66 +205,6 @@
 					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
 					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
 					"dev": true
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-negative-zero": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				},
-				"string.prototype.trimend": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					}
-				},
-				"string.prototype.trimstart": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					}
 				}
 			}
 		},
@@ -304,168 +217,6 @@
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.18.0-next.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				},
-				"es-to-primitive": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-					"dev": true,
-					"requires": {
-						"is-callable": "^1.1.4",
-						"is-date-object": "^1.0.1",
-						"is-symbol": "^1.0.2"
-					}
-				},
-				"get-intrinsic": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-					"dev": true,
-					"requires": {
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-					"dev": true
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-negative-zero": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				},
-				"string.prototype.trimend": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				},
-				"string.prototype.trimstart": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				}
 			}
 		},
 		"astral-regex": {
@@ -668,15 +419,9 @@
 			"dev": true
 		},
 		"confusing-browser-globals": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
-			"integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
-			"dev": true
-		},
-		"contains-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+			"integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
 			"dev": true
 		},
 		"content-disposition": {
@@ -829,27 +574,100 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
-			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+			"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.2.0",
+				"call-bind": "^1.0.2",
+				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.1.1",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.0",
-				"is-callable": "^1.1.4",
-				"is-regex": "^1.0.4",
-				"object-inspect": "^1.6.0",
+				"has-symbols": "^1.0.2",
+				"is-callable": "^1.2.3",
+				"is-negative-zero": "^2.0.1",
+				"is-regex": "^1.1.3",
+				"is-string": "^1.0.6",
+				"object-inspect": "^1.10.3",
 				"object-keys": "^1.1.1",
-				"string.prototype.trimleft": "^2.1.0",
-				"string.prototype.trimright": "^2.1.0"
+				"object.assign": "^4.1.2",
+				"string.prototype.trimend": "^1.0.4",
+				"string.prototype.trimstart": "^1.0.4",
+				"unbox-primitive": "^1.0.1"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-negative-zero": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				}
 			}
 		},
 		"es-to-primitive": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
 			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.4",
@@ -870,13 +688,14 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
-			"integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+			"integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.1",
+				"@eslint/eslintrc": "^0.4.2",
+				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -893,7 +712,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
+				"glob-parent": "^5.1.2",
 				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
@@ -968,6 +787,15 @@
 					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 					"dev": true
 				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1001,14 +829,34 @@
 			}
 		},
 		"eslint-config-airbnb-base": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
-			"integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+			"integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
 			"dev": true,
 			"requires": {
-				"confusing-browser-globals": "^1.0.5",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.0"
+				"confusing-browser-globals": "^1.0.10",
+				"object.assign": "^4.1.2",
+				"object.entries": "^1.1.2"
+			},
+			"dependencies": {
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"eslint-import-resolver-node": {
@@ -1039,50 +887,46 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+			"integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.9",
+				"debug": "^3.2.7",
 				"pkg-dir": "^2.0.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.22.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
-			"integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+			"version": "2.23.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+			"integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.1.1",
-				"array.prototype.flat": "^1.2.3",
-				"contains-path": "^0.1.0",
+				"array-includes": "^3.1.3",
+				"array.prototype.flat": "^1.2.4",
 				"debug": "^2.6.9",
-				"doctrine": "1.5.0",
+				"doctrine": "^2.1.0",
 				"eslint-import-resolver-node": "^0.3.4",
-				"eslint-module-utils": "^2.6.0",
+				"eslint-module-utils": "^2.6.1",
+				"find-up": "^2.0.0",
 				"has": "^1.0.3",
+				"is-core-module": "^2.4.0",
 				"minimatch": "^3.0.4",
-				"object.values": "^1.1.1",
-				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.17.0",
+				"object.values": "^1.1.3",
+				"pkg-up": "^2.0.0",
+				"read-pkg-up": "^3.0.0",
+				"resolve": "^1.20.0",
 				"tsconfig-paths": "^3.9.0"
 			},
 			"dependencies": {
@@ -1096,13 +940,12 @@
 					}
 				},
 				"doctrine": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"isarray": "^1.0.0"
+						"esutils": "^2.0.2"
 					}
 				},
 				"ms": {
@@ -1302,9 +1145,9 @@
 			"dev": true
 		},
 		"fast-redact": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
-			"integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.1.tgz",
+			"integrity": "sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw==",
 			"dev": true
 		},
 		"fast-safe-stringify": {
@@ -1398,9 +1241,9 @@
 			"dev": true
 		},
 		"flatted": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
+			"integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
 			"dev": true
 		},
 		"forwarded": {
@@ -1495,14 +1338,6 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.20.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-					"dev": true
-				}
 			}
 		},
 		"graceful-fs": {
@@ -1551,9 +1386,9 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
 		"http-errors": {
@@ -1646,9 +1481,9 @@
 			"dev": true
 		},
 		"is-bigint": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-			"integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
 			"dev": true
 		},
 		"is-binary-path": {
@@ -1661,12 +1496,41 @@
 			}
 		},
 		"is-boolean-object": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-			"integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+			"integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				}
 			}
 		},
 		"is-buffer": {
@@ -1676,15 +1540,15 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+			"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+			"integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -1730,24 +1594,54 @@
 			"dev": true
 		},
 		"is-number-object": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-			"integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+			"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
 			"dev": true
 		},
 		"is-regex": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+			"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"call-bind": "^1.0.2",
+				"has-symbols": "^1.0.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				}
 			}
 		},
 		"is-string": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+			"integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
 			"dev": true
 		},
 		"is-symbol": {
@@ -1758,12 +1652,6 @@
 			"requires": {
 				"has-symbols": "^1.0.0"
 			}
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -1786,6 +1674,12 @@
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
 			}
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
@@ -1819,14 +1713,14 @@
 			}
 		},
 		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
 				"strip-bom": "^3.0.0"
 			}
 		},
@@ -2119,9 +2013,9 @@
 			"dev": true
 		},
 		"object-inspect": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 			"dev": true
 		},
 		"object-keys": {
@@ -2143,15 +2037,43 @@
 			}
 		},
 		"object.entries": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-			"integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
+			"integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.12.0",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3"
+				"es-abstract": "^1.18.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				}
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -2238,15 +2160,14 @@
 			}
 		},
 		"object.values": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-			"integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+			"integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.2",
-				"has": "^1.0.3"
+				"es-abstract": "^1.18.2"
 			},
 			"dependencies": {
 				"call-bind": {
@@ -2257,41 +2178,6 @@
 					"requires": {
 						"function-bind": "^1.1.1",
 						"get-intrinsic": "^1.0.2"
-					}
-				},
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					}
-				},
-				"es-to-primitive": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-					"dev": true,
-					"requires": {
-						"is-callable": "^1.1.4",
-						"is-date-object": "^1.0.1",
-						"is-symbol": "^1.0.2"
 					}
 				},
 				"get-intrinsic": {
@@ -2310,66 +2196,6 @@
 					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
 					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
 					"dev": true
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-negative-zero": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				},
-				"string.prototype.trimend": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					}
-				},
-				"string.prototype.trimstart": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					}
 				}
 			}
 		},
@@ -2439,12 +2265,13 @@
 			}
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"parseurl": {
@@ -2472,9 +2299,9 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"path-to-regexp": {
@@ -2484,12 +2311,12 @@
 			"dev": true
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "^2.0.0"
+				"pify": "^3.0.0"
 			}
 		},
 		"picomatch": {
@@ -2499,22 +2326,22 @@
 			"dev": true
 		},
 		"pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 			"dev": true
 		},
 		"pino": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-6.11.2.tgz",
-			"integrity": "sha512-bmzxwbrIPxQUlAuMkF4PWVErUGERU4z37HazlhflKFg08crsNE3fACGN6gPwg5xtKOK47Ux5cZm8YCuLV4wWJg==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-6.11.3.tgz",
+			"integrity": "sha512-drPtqkkSf0ufx2gaea3TryFiBHdNIdXKf5LN0hTM82SXI4xVIve2wLwNg92e1MT6m3jASLu6VO7eGY6+mmGeyw==",
 			"dev": true,
 			"requires": {
 				"fast-redact": "^3.0.0",
 				"fast-safe-stringify": "^2.0.7",
 				"flatstr": "^1.0.12",
 				"pino-std-serializers": "^3.1.0",
-				"quick-format-unescaped": "4.0.1",
+				"quick-format-unescaped": "^4.0.3",
 				"sonic-boom": "^1.0.2"
 			}
 		},
@@ -2533,6 +2360,15 @@
 				"find-up": "^2.1.0"
 			}
 		},
+		"pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			}
+		},
 		"prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2540,9 +2376,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
 			"dev": true
 		},
 		"progress": {
@@ -2574,9 +2410,9 @@
 			"dev": true
 		},
 		"quick-format-unescaped": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
-			"integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz",
+			"integrity": "sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg==",
 			"dev": true
 		},
 		"ramda": {
@@ -2604,24 +2440,24 @@
 			}
 		},
 		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^2.0.0",
+				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^2.0.0"
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
-				"read-pkg": "^2.0.0"
+				"read-pkg": "^3.0.0"
 			}
 		},
 		"readdirp": {
@@ -2634,9 +2470,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
 		"require-directory": {
@@ -2846,9 +2682,9 @@
 			}
 		},
 		"sonic-boom": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.0.tgz",
-			"integrity": "sha512-1xUAszhQBOrjk7uisbStQZYkZxD3vkYlCUw5qzOblWQ1ILN5v0dVPAs+QPgszzoPmbdWx6jyT9XiLJ95JdlLiQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+			"integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
 			"dev": true,
 			"requires": {
 				"atomic-sleep": "^1.0.0",
@@ -2882,9 +2718,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+			"integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
 			"dev": true
 		},
 		"sprintf-js": {
@@ -2917,26 +2753,6 @@
 			"requires": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3"
-			}
-		},
-		"string.prototype.trimleft": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
-			}
-		},
-		"string.prototype.trimright": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
 			}
 		},
 		"string.prototype.trimstart": {
@@ -2994,9 +2810,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
-					"integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+					"integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -3094,9 +2910,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
 		"type-is": {
@@ -3201,12 +3017,12 @@
 					"dev": true
 				},
 				"is-symbol": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-					"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+					"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
 					"dev": true,
 					"requires": {
-						"has-symbols": "^1.0.1"
+						"has-symbols": "^1.0.2"
 					}
 				}
 			}

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -62,13 +62,13 @@
     "semver": "^7.3.5"
   },
   "devDependencies": {
-    "eslint": "^7.27.0",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint": "^7.30.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-mocha": "^8.1.0",
     "express": "^4.17.1",
     "mocha": "^7.2.0",
-    "pino": "^6.11.2",
-    "prettier": "^2.2.1"
+    "pino": "^6.11.3",
+    "prettier": "^2.3.2"
   }
 }

--- a/packages/serverless/test/.eslintrc.js
+++ b/packages/serverless/test/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'no-unused-expressions': 'off',
     // some dependencies come from the root package.json
     'import/no-extraneous-dependencies': 'off',
-    'monorepo-cop/no-relative-import-outside-package': 'off'
+    'monorepo-cop/no-relative-import-outside-package': 'off',
+    'prefer-object-spread': 'off'
   }
 };

--- a/packages/serverless/test/proxy/index.js
+++ b/packages/serverless/test/proxy/index.js
@@ -10,7 +10,7 @@ const proxy = require('proxy');
 const basicAuthParser = require('basic-auth-parser');
 
 const { sendToParent } = require('../../../core/test/test_util');
-const log = require('../../../serverless/test/util/log')(`proxy (${process.pid})`);
+const log = require('../util/log')(`proxy (${process.pid})`);
 
 const port = process.env.PROXY_PORT;
 

--- a/packages/shared-metrics/.ncurc.json
+++ b/packages/shared-metrics/.ncurc.json
@@ -1,3 +1,3 @@
 {
-  "reject": ["mocha", "tar"]
+  "reject": ["mocha", "eslint-plugin-mocha", "tar", "node-gyp"]
 }

--- a/packages/shared-metrics/package-lock.json
+++ b/packages/shared-metrics/package-lock.json
@@ -14,32 +14,32 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+			"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.0",
+				"@babel/helper-validator-identifier": "^7.14.5",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
-			"integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
+			"integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
 				"espree": "^7.3.0",
-				"globals": "^12.1.0",
+				"globals": "^13.9.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
@@ -48,21 +48,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
-					}
-				},
-				"globals": {
-					"version": "12.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-					"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
 					}
 				},
 				"strip-json-comments": {
@@ -72,6 +63,34 @@
 					"dev": true
 				}
 			}
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				}
+			}
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+			"dev": true
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -191,38 +210,6 @@
 						"get-intrinsic": "^1.0.2"
 					}
 				},
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					},
-					"dependencies": {
-						"has-symbols": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-							"dev": true
-						}
-					}
-				},
 				"get-intrinsic": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -232,66 +219,6 @@
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1"
-					}
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-negative-zero": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				},
-				"string.prototype.trimend": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					}
-				},
-				"string.prototype.trimstart": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
 					}
 				}
 			}
@@ -318,157 +245,6 @@
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.18.0-next.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				},
-				"get-intrinsic": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-					"dev": true,
-					"requires": {
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"has-symbols": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-					"dev": true
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-negative-zero": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				},
-				"string.prototype.trimend": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				},
-				"string.prototype.trimstart": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					},
-					"dependencies": {
-						"call-bind": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-							"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-							"dev": true,
-							"requires": {
-								"function-bind": "^1.1.1",
-								"get-intrinsic": "^1.0.2"
-							}
-						}
-					}
-				}
 			}
 		},
 		"arrify": {
@@ -704,9 +480,9 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"confusing-browser-globals": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
-			"integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+			"integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
 			"dev": true
 		},
 		"console-control-strings": {
@@ -714,12 +490,6 @@
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 			"optional": true
-		},
-		"contains-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -843,11 +613,6 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"emitter-mixin": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/emitter-mixin/-/emitter-mixin-0.0.3.tgz",
-			"integrity": "sha1-WUjLKG8uSO3DslGnz8H3iDOW1lw="
-		},
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -878,9 +643,9 @@
 			"optional": true
 		},
 		"errno": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+			"integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
 			"requires": {
 				"prr": "~1.0.1"
 			}
@@ -895,22 +660,80 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.17.5",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-			"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+			"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.1.1",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-regex": "^1.0.5",
-				"object-inspect": "^1.7.0",
+				"has-symbols": "^1.0.2",
+				"is-callable": "^1.2.3",
+				"is-negative-zero": "^2.0.1",
+				"is-regex": "^1.1.3",
+				"is-string": "^1.0.6",
+				"object-inspect": "^1.10.3",
 				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.0",
-				"string.prototype.trimleft": "^2.1.1",
-				"string.prototype.trimright": "^2.1.1"
+				"object.assign": "^4.1.2",
+				"string.prototype.trimend": "^1.0.4",
+				"string.prototype.trimstart": "^1.0.4",
+				"unbox-primitive": "^1.0.1"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+					"dev": true
+				},
+				"is-negative-zero": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"es-to-primitive": {
@@ -931,13 +754,14 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
-			"integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
+			"version": "7.30.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+			"integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.1",
+				"@eslint/eslintrc": "^0.4.2",
+				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -954,7 +778,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^5.0.0",
+				"glob-parent": "^5.1.2",
 				"globals": "^13.6.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
@@ -1018,9 +842,9 @@
 					"dev": true
 				},
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -1043,6 +867,15 @@
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 					"dev": true
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
 				},
 				"has-flag": {
 					"version": "4.0.0",
@@ -1086,14 +919,28 @@
 			}
 		},
 		"eslint-config-airbnb-base": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
-			"integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
+			"version": "14.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+			"integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
 			"dev": true,
 			"requires": {
-				"confusing-browser-globals": "^1.0.5",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.0"
+				"confusing-browser-globals": "^1.0.10",
+				"object.assign": "^4.1.2",
+				"object.entries": "^1.1.2"
+			},
+			"dependencies": {
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
 			}
 		},
 		"eslint-import-resolver-node": {
@@ -1124,50 +971,46 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+			"integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.9",
+				"debug": "^3.2.7",
 				"pkg-dir": "^2.0.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.22.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
-			"integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+			"version": "2.23.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+			"integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.1.1",
-				"array.prototype.flat": "^1.2.3",
-				"contains-path": "^0.1.0",
+				"array-includes": "^3.1.3",
+				"array.prototype.flat": "^1.2.4",
 				"debug": "^2.6.9",
-				"doctrine": "1.5.0",
+				"doctrine": "^2.1.0",
 				"eslint-import-resolver-node": "^0.3.4",
-				"eslint-module-utils": "^2.6.0",
+				"eslint-module-utils": "^2.6.1",
+				"find-up": "^2.0.0",
 				"has": "^1.0.3",
+				"is-core-module": "^2.4.0",
 				"minimatch": "^3.0.4",
-				"object.values": "^1.1.1",
-				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.17.0",
+				"object.values": "^1.1.3",
+				"pkg-up": "^2.0.0",
+				"read-pkg-up": "^3.0.0",
+				"resolve": "^1.20.0",
 				"tsconfig-paths": "^3.9.0"
 			},
 			"dependencies": {
@@ -1181,13 +1024,12 @@
 					}
 				},
 				"doctrine": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"isarray": "^1.0.0"
+						"esutils": "^2.0.2"
 					}
 				},
 				"ms": {
@@ -1410,9 +1252,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
+			"integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
 			"dev": true
 		},
 		"forever-agent": {
@@ -1544,14 +1386,6 @@
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.20.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-					"dev": true
-				}
 			}
 		},
 		"globby": {
@@ -1634,9 +1468,9 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
 		"http-signature": {
@@ -1693,9 +1527,9 @@
 			"dev": true
 		},
 		"is-bigint": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-			"integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
 			"dev": true
 		},
 		"is-binary-path": {
@@ -1708,12 +1542,35 @@
 			}
 		},
 		"is-boolean-object": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-			"integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+			"integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				}
 			}
 		},
 		"is-buffer": {
@@ -1729,9 +1586,9 @@
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+			"integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -1779,9 +1636,9 @@
 			"dev": true
 		},
 		"is-number-object": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-			"integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+			"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
 			"dev": true
 		},
 		"is-path-cwd": {
@@ -1806,18 +1663,48 @@
 			}
 		},
 		"is-regex": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+			"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.3"
+				"call-bind": "^1.0.2",
+				"has-symbols": "^1.0.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				}
 			}
 		},
 		"is-string": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+			"integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
 			"dev": true
 		},
 		"is-symbol": {
@@ -1838,7 +1725,8 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"optional": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -1872,6 +1760,12 @@
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 			"optional": true
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
@@ -1933,15 +1827,23 @@
 			}
 		},
 		"load-json-file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
 				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"locate-path": {
@@ -2340,9 +2242,9 @@
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-inspect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 			"dev": true
 		},
 		"object-keys": {
@@ -2364,15 +2266,37 @@
 			}
 		},
 		"object.entries": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
-			"integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
+			"integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
 			"dev": true,
 			"requires": {
+				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3"
+				"es-abstract": "^1.18.2"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				}
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -2462,15 +2386,14 @@
 			}
 		},
 		"object.values": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-			"integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+			"integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.2",
-				"has": "^1.0.3"
+				"es-abstract": "^1.18.2"
 			},
 			"dependencies": {
 				"call-bind": {
@@ -2483,38 +2406,6 @@
 						"get-intrinsic": "^1.0.2"
 					}
 				},
-				"es-abstract": {
-					"version": "1.18.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-					"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"get-intrinsic": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.2",
-						"is-callable": "^1.2.3",
-						"is-negative-zero": "^2.0.1",
-						"is-regex": "^1.1.2",
-						"is-string": "^1.0.5",
-						"object-inspect": "^1.9.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.2",
-						"string.prototype.trimend": "^1.0.4",
-						"string.prototype.trimstart": "^1.0.4",
-						"unbox-primitive": "^1.0.0"
-					},
-					"dependencies": {
-						"has-symbols": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-							"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-							"dev": true
-						}
-					}
-				},
 				"get-intrinsic": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -2524,66 +2415,6 @@
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1"
-					}
-				},
-				"is-callable": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-					"dev": true
-				},
-				"is-negative-zero": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-					"dev": true
-				},
-				"is-regex": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"has-symbols": "^1.0.1"
-					}
-				},
-				"object-inspect": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-					"integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-					"dev": true
-				},
-				"object.assign": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.0",
-						"define-properties": "^1.1.3",
-						"has-symbols": "^1.0.1",
-						"object-keys": "^1.1.1"
-					}
-				},
-				"string.prototype.trimend": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
-					}
-				},
-				"string.prototype.trimstart": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-					"dev": true,
-					"requires": {
-						"call-bind": "^1.0.2",
-						"define-properties": "^1.1.3"
 					}
 				}
 			}
@@ -2644,12 +2475,13 @@
 			}
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"path-exists": {
@@ -2675,18 +2507,26 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "^2.0.0"
+				"pify": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"performance-now": {
@@ -2728,6 +2568,15 @@
 				"find-up": "^2.1.0"
 			}
 		},
+		"pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			}
+		},
 		"prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2735,9 +2584,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
 			"dev": true
 		},
 		"process-nextick-args": {
@@ -2789,24 +2638,24 @@
 			"dev": true
 		},
 		"read-pkg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^2.0.0",
+				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^2.0.0"
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
-				"read-pkg": "^2.0.0"
+				"read-pkg": "^3.0.0"
 			}
 		},
 		"readable-stream": {
@@ -2834,12 +2683,11 @@
 			}
 		},
 		"recursive-copy": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/recursive-copy/-/recursive-copy-2.0.11.tgz",
-			"integrity": "sha512-DqL2kO10mUne7XK5BPcwRtOJJZKhddD7IrW4UmHmKrwdV3HLPWcw6Jr4Jh12ooddfJOVz7ynFoFYYnPM7De0Og==",
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/recursive-copy/-/recursive-copy-2.0.13.tgz",
+			"integrity": "sha512-BjmE6R/dOImStEku+017L3Z0I6u/lA+SVr1sySWbTLjmQKDTESNmJ9WBZP8wbN5FuvqNvSYvRKA/IKQhAjqnpQ==",
 			"requires": {
 				"del": "^2.2.0",
-				"emitter-mixin": "0.0.3",
 				"errno": "^0.1.2",
 				"graceful-fs": "^4.1.4",
 				"junk": "^1.0.1",
@@ -2851,9 +2699,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
 		"request": {
@@ -3045,9 +2893,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+			"integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
 			"dev": true
 		},
 		"sprintf-js": {
@@ -3084,45 +2932,69 @@
 			}
 		},
 		"string.prototype.trimend": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz",
-			"integrity": "sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5"
-			}
-		},
-		"string.prototype.trimleft": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-			"integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5",
-				"string.prototype.trimstart": "^1.0.0"
-			}
-		},
-		"string.prototype.trimright": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-			"integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5",
-				"string.prototype.trimend": "^1.0.0"
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				}
 			}
 		},
 		"string.prototype.trimstart": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz",
-			"integrity": "sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5"
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3"
+			},
+			"dependencies": {
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				}
 			}
 		},
 		"string_decoder": {
@@ -3178,9 +3050,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.5.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
-					"integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
+					"version": "8.6.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+					"integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -3310,9 +3182,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
 		},
 		"unbox-primitive": {

--- a/packages/shared-metrics/package.json
+++ b/packages/shared-metrics/package.json
@@ -58,16 +58,16 @@
     "@instana/core": "1.126.2",
     "detect-libc": "^1.0.3",
     "event-loop-lag": "^1.4.0",
-    "recursive-copy": "^2.0.11",
+    "recursive-copy": "^2.0.13",
     "tar": "^5.0.5"
   },
   "devDependencies": {
-    "eslint": "^7.27.0",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint": "^7.30.0",
+    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-mocha": "^8.1.0",
     "mocha": "^7.2.0",
-    "prettier": "^2.2.1"
+    "prettier": "^2.3.2"
   },
   "optionalDependencies": {
     "event-loop-stats": "1.3.0",


### PR DESCRIPTION
deps: run "npm run update-deps" to update dependencies

In particular, this updates glob-parent (dependency of eslinst) to 5.1.2
in all packages to address a bogus dependabot alert.