### PR TITLE
AWS SQS test improvements

### DIFF
--- a/packages/collector/test/tracing/cloud/aws-sdk/v2/s3/app.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v2/s3/app.js
@@ -19,13 +19,7 @@ const s3 = new AWS.S3();
 const app = express();
 const port = process.env.APP_PORT || 3215;
 
-function log() {
-  /* eslint-disable no-console */
-  const args = Array.prototype.slice.call(arguments);
-  args[0] = `${logPrefix}${args[0]}`;
-  console.log.apply(console, args);
-  /* eslint-enable no-console */
-}
+const log = require('@instana/core/test/test_util/log').getLogger(logPrefix);
 
 const bucketName = process.env.AWS_S3_BUCKET_NAME || 'nodejs-team';
 

--- a/packages/collector/test/tracing/cloud/aws-sdk/v2/sqs/receiveMessage.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v2/sqs/receiveMessage.js
@@ -31,12 +31,7 @@ const receiveParams = {
   WaitTimeSeconds: 7
 };
 
-function log() {
-  /* eslint-disable no-console */
-  const args = Array.prototype.slice.call(arguments);
-  args[0] = `${logPrefix}${args[0]}`;
-  console.log.apply(console, args);
-}
+const log = require('@instana/core/test/test_util/log').getLogger(logPrefix);
 
 app.get('/', (_req, res) => {
   if (hasStartedPolling) {
@@ -60,9 +55,6 @@ function receivePromise() {
         return;
       }
 
-      span = instana.currentSpan();
-      span.disableAutoEnd();
-
       data.Messages.forEach(message => {
         sendToParent(message);
       });
@@ -71,6 +63,9 @@ function receivePromise() {
         'got messages:',
         data.Messages.map(m => m.MessageId)
       );
+
+      span = instana.currentSpan();
+      span.disableAutoEnd();
 
       const messagesForDeletion = data.Messages.map(message => {
         return {
@@ -94,7 +89,7 @@ function receivePromise() {
         });
     })
     .catch(err => {
-      log('message receiving failed', err);
+      log('message receiving/deleting failed', err);
       span && span.end(1);
     });
 }
@@ -113,9 +108,6 @@ async function receiveAsync() {
         return;
       }
 
-      span = instana.currentSpan();
-      span.disableAutoEnd();
-
       data.Messages.forEach(message => {
         sendToParent(message);
       });
@@ -124,6 +116,9 @@ async function receiveAsync() {
         'got messages:',
         data.Messages.map(m => m.MessageId)
       );
+
+      span = instana.currentSpan();
+      span.disableAutoEnd();
 
       const messagesForDeletion = data.Messages.map(message => {
         return {
@@ -146,7 +141,7 @@ async function receiveAsync() {
     });
   } catch (err) {
     span && span.end(1);
-    log('error receiving message', err);
+    log('ERROR receiving/deleting message', err);
   }
 }
 
@@ -220,6 +215,7 @@ async function pollForMessages() {
     try {
       await receivePromise();
     } catch (e) {
+      // eslint-disable-next-line
       console.error(e);
       process.exit(1);
     }
@@ -232,6 +228,7 @@ async function pollForMessages() {
     try {
       await receiveAsync();
     } catch (e) {
+      // eslint-disable-next-line
       console.error(e);
       process.exit(1);
     }

--- a/packages/collector/test/tracing/cloud/aws-sdk/v2/sqs/sendMessage.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v2/sqs/sendMessage.js
@@ -13,17 +13,11 @@ const { sqs } = require('./sqsUtil');
 const queueURL = process.env.AWS_SQS_QUEUE_URL;
 const port = process.env.APP_PORT || 3215;
 const logPrefix = `AWS SDK v2 SQS Message Sender (${process.pid}):\t`;
+const log = require('@instana/core/test/test_util/log').getLogger(logPrefix);
 
 const app = express();
 
 app.use(bodyParser.json());
-
-function log() {
-  /* eslint-disable no-console */
-  const args = Array.prototype.slice.call(arguments);
-  args[0] = `${logPrefix}${args[0]}`;
-  console.log.apply(console, args);
-}
 
 app.get('/', (_req, res) => {
   res.send('Ok');
@@ -69,6 +63,7 @@ app.post('/send-callback', (req, res) => {
 
   sqs[method](sendParams, (err, data) => {
     if (err) {
+      // eslint-disable-next-line
       console.log(err);
       res.status(501).send({
         status: 'ERROR',
@@ -96,6 +91,7 @@ app.post('/send-promise', async (req, res) => {
       data
     });
   } catch (err) {
+    // eslint-disable-next-line
     console.log(err);
     res.status(501).send({
       status: 'ERROR',


### PR DESCRIPTION
### Motivation
Our tests randomly fail many times around SQS tests. So we wanted to at least reduce the number of fails

### Potential Cause

SQS consumes messages in its own way, meaning that we may request a number of messages to be retrieved, but a smaller amount is retrieved instead. 

On top of that, we test messages sent in a batch, causing an eventual "leak" of messages from a test to the next, compromising the expected result.

A similar problem happens when we test SQS Consumer, which almost always leaves some messages unread or messages are not deleted as expected. These messages are consumed in the next CI build, which may also compromise the expected results.

### Solution
Each form of message has its own queue now:
 * `team_nodejs`: single messages sent by our sendMessage test app and received by our receiveMessage app
 * `team_nodejs-batch`: same as above, but messages are sent in batches
 * `team_nodejs-consumer`: messages are sent by our sendMessage app and received by SQS Consumer.

Additionally:
 * Queues are always deleted at the end of the test
 * In case of an interrupted test (preventing queue deletion) each queue is purged before the start of the test

### Additional Info

 * Both queue deletion and queue purge take 60 seconds to be completed, even though the promise returns in a few seconds after triggering one of these operations. The AWS backend will throw an error if a new purge or a new queue creation is called within these 60 seconds
 * The usage of uuid to generate queue names was discarded at this point, as that would potentially cause unnecessary queues to exist in case of a failure while deleting them at the end of tests. eg: a new push upstream was done, so the current test is aborted, leaving existing queues without deletion.