### PR TITLE
fix(deps): update tar (again) to 5.0.9

### DIFF
--- a/packages/shared-metrics/package-lock.json
+++ b/packages/shared-metrics/package-lock.json
@@ -2827,15 +2827,15 @@
 			}
 		},
 		"tar": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-5.0.7.tgz",
-			"integrity": "sha512-g0qlHHRtAZAxzkZkJvt0P5C6ODEolw2paouzsSbVqE7l5jKani1m9ogy7VxGp6hEngiKpPCwkh9pX5UH8Wp6QA==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-5.0.9.tgz",
+			"integrity": "sha512-XvvsfjcXKwCmAKTmxRyG5XbyUO0eZ8tyKXkAQd+At0SxOFCN/WvuxWXNAR/UCGXCvoDi+rLi5FV5q7wVhC5X/w==",
 			"requires": {
-				"chownr": "^1.1.3",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^3.0.0",
-				"minizlib": "^2.1.0",
-				"mkdirp": "^0.5.0",
+				"chownr": "^1.1.4",
+				"fs-minipass": "^2.1.0",
+				"minipass": "^3.1.3",
+				"minizlib": "^2.1.2",
+				"mkdirp": "^0.5.5",
 				"yallist": "^4.0.0"
 			},
 			"dependencies": {

--- a/packages/shared-metrics/package.json
+++ b/packages/shared-metrics/package.json
@@ -63,7 +63,7 @@
     "detect-libc": "^1.0.3",
     "event-loop-lag": "^1.4.0",
     "recursive-copy": "^2.0.13",
-    "tar": "^5.0.7"
+    "tar": "^5.0.9"
   },
   "devDependencies": {
     "eslint": "^7.30.0",

--- a/packages/shared-metrics/test/dependencies_test.js
+++ b/packages/shared-metrics/test/dependencies_test.js
@@ -24,7 +24,7 @@ describe('metrics.dependencies', () => {
       // directory relative to the main module. But with this check in place, we end up evaluating the dependencies of
       // packages/shared-metrics/node_modules.
       expect(dependencies.currentPayload['event-loop-lag']).to.equal('1.4.0');
-      expect(dependencies.currentPayload.semver).to.equal('5.7.1');
+      expect(dependencies.currentPayload.semver).to.equal('7.3.5');
       expect(dependencies.currentPayload.mocha).to.equal('7.2.0');
     });
   });


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-JS-TAR-1536758

Note that, yet again, the CVE does not apply at all to this package's
usage of node-tar and this is solely done to avoid it being reported
by automated audits.