### PR TITLE
fix(tracing): fix vendored version of emitter-listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Fix `path must be a string of Buffer` error in dependency distance calculator.
+- Fix: Use different attribute names in vendored version of `emitter-listener`, to avoid conflicts if the unfixed `emitter-listener` package is still installed and being used by other packages.
 
 ## 1.132.1
 - Fix: Rename global attribute from cls-hooked from process.namespaces to process.instanaNamespaces to avoid conflicts with other usages of cls-hooked.

--- a/packages/core/src/tracing/clsHooked/emitter-listener.js
+++ b/packages/core/src/tracing/clsHooked/emitter-listener.js
@@ -4,6 +4,20 @@
  *
  * Original license: BSD 2 Clause
  * (see https://github.com/othiym23/emitter-listener/blob/7586fba839cf87774d5df224ce479c3b7e2b9964/package.json#L26)
+ *
+ * A note on the usage of the properties __wrappedInstana, __unwrapInstana, __wrapped  and __unwrap: The original
+ * package (https://github.com/othiym23/emitter-listener/blob/af156cef522f1daa11523b2d94b6f7fd1e859ca5/listener.js)
+ * attaches properties named __wrapped and __unwrap to the event emitter object. Even with this fixed and vendored
+ * version of emitter-listener, the issue fixed in https://github.com/othiym23/emitter-listener/pull/7 can still
+ * persist if other packages install the unfixed emitter-listener package as a dependency, and if the unfixed version
+ * of wrapEmitter gets called _after_ this version.
+ *
+ * To fix that, our version uses different property names (__wrappedInstana, __unwrapInstana) when attaching properties
+ * to the event emitter object. In addition to that, both the original and this fixed version use the package shimmer
+ * internally. The package shimmer also uses properties named __wrapped etc., but it attaches them to individual
+ * functions instead of the event emitter object. emitter-listener relies on this and checks whether a function has been
+ * shimmed by checking if the function has a __wrapped property. For those usages, we need to stick with the original
+ * property names.
  */
 // @ts-nocheck - not going to add type checking to a temporarily vendored dependency.
 
@@ -15,9 +29,7 @@ const shimmer = require('shimmer');
 const wrap = shimmer.wrap;
 const unwrap = shimmer.unwrap;
 
-// Default to complaining loudly when things don't go according to plan.
-// dunderscores are boring
-const SYMBOL = 'wrap@before';
+const SYMBOL = 'instana@before';
 
 // Sets a property on an object, preserving its enumerability.
 // This function assumes that the property is already writable.
@@ -161,18 +173,18 @@ module.exports = function wrapEmitter(emitter, onAddListener, onEmit) {
   // Only wrap `on` and `addListener` once. Correctly registering all
   // `onAddListener` callbacks for multiple consecutive wrapEmitter calls for
   // the same emitter is handled above by pushing them into an array if necessary.
-  if (!emitter.__wrapped) {
+  if (!emitter.__wrappedInstana) {
     wrap(emitter, 'addListener', adding);
     wrap(emitter, 'on', adding);
 
-    defineProperty(emitter, '__unwrap', function () {
+    defineProperty(emitter, '__unwrapInstana', function () {
       unwrap(emitter, 'addListener');
       unwrap(emitter, 'on');
       unwrap(emitter, 'emit');
       delete emitter[SYMBOL];
-      delete emitter.__wrapped;
+      delete emitter.__wrappedInstana;
     });
-    defineProperty(emitter, '__wrapped', true);
+    defineProperty(emitter, '__wrappedInstana', true);
   }
 
   // Always wrap `emit`, no matter if the emitter has already been wrapped by

--- a/packages/core/test/tracing/clsHooked/emitter-listener_test.js
+++ b/packages/core/test/tracing/clsHooked/emitter-listener_test.js
@@ -45,7 +45,7 @@ describe('emitter-listener', () => {
       wrapEmitter(ee, nop, passthrough);
     }).to.not.throw();
 
-    expect(ee.__wrapped, 'is marked as being a wrapped emitter').to.be.true;
+    expect(ee.__wrappedInstana, 'is marked as being a wrapped emitter').to.be.true;
 
     ee.on('test', function (value) {
       expect(value, 'value was still passed through').to.equal(8);
@@ -129,7 +129,7 @@ describe('emitter-listener', () => {
     expect(ee.removeListener.__wrapped, 'removeListener is not wrapped').to.not.exist;
 
     expect(function () {
-      ee.__unwrap();
+      ee.__unwrapInstana();
     }).to.not.throw('can unwrap without dying');
 
     expect(ee.addListener.__wrapped, 'addListener is unwrapped').to.not.exist;


### PR DESCRIPTION
Use different property names as the original to avoid conflicts even
when the unfixed version of emitter-listener is still installed by other
packages (like cls-hooked for example) and wraps an emitter after we
have wrapped it.