### PR TITLE
fix(tests): added missing pg host to run-tests.sh script

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -22,10 +22,10 @@ export MYSQL_DB="nodedb"
 export POSTGRES_USER="node"
 export POSTGRES_PASSWORD="nodepw"
 export POSTGRES_DB="nodedb"
+export POSTGRES_HOST="127.0.0.1"
 export MSSQL_HOST="127.0.0.1"
 export MSSQL_PORT="1433"
 export MSSQL_USER="sa"
 export MSSQL_PW="stanCanHazMsSQL1"
 
 npm run test:debug
-


### PR DESCRIPTION
no issue

- POSTGRES_HOST is "localhost" by default and won't match the expections e.g. [here](https://github.com/instana/nodejs/blob/v1.132.2/packages/collector/test/tracing/database/pg_native/test.js#L289)
- If you have not exported this env variable in your shell manually, you will run into pg assertion problems

Works in Circle CI because it is defined in the config file. 

