### PR TITLE
fix(docs): added missing jq dependency to contributor requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing
 
-## Local Set Up
+## Requirements
+
+`brew install jq` for OSX (for other systems please look up [here](https://stedolan.github.io/jq/)) is required to run `npm run audit` or `lerna audit run`.
 
 Note: You might need to install `libpq-dev`/`postgresql-devel` or a similar package before running `npm install` because `pg-native` depends on it. (`@instana/collector` and friends do not depend on `pg-native` but our test suite depends on it.)
 


### PR DESCRIPTION
no issue

- `lerna run audit --stream` failed because of a missing global dependency


@basti1302 @willianpc Open for discussion where to put the requirement 👍 