### PR TITLE
chore(ci): removed circle ci build slot reduction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,30 +144,6 @@ shared: &shared
     # error.
     - run: npm run lint
 
-    # Only run tests for Node.js 8/Node.js 10 on every other build, alternating, to reduce the number of slots
-    # we are using. Explanation: Take the pipeline number modulo 2 (to check if it is even or odd), then turn it into
-    # either 8 or 10 by "* 2 + 8".
-    - run:
-        name: Determine for which EOL Node.js version (8 or 10) the tests are run.
-        command: |
-          echo "export RUN_TESTS_FOR_EOL_NODE_VERSION=$(( $(( $(( << pipeline.number >> % 2 )) * 2 )) + 8 ))" >> $BASH_ENV
-
-    - run:
-        name: Show for which EOL Node.js version (8 or 10) the tests are run.
-        command: echo Running tests for EOL Node.js version $RUN_TESTS_FOR_EOL_NODE_VERSION this time.
-
-    - run: |
-        if [[ $RUN_TESTS_FOR_EOL_NODE_VERSION = 10 && $(node -v) =~ ^v8.*$ ]]; then
-          echo "Skipping tests for EOL Node.js version 8."
-          circleci-agent step halt
-        fi
-
-    - run: |
-        if [[ $RUN_TESTS_FOR_EOL_NODE_VERSION = 8 && $(node -v) =~ ^v10.*$ ]]; then
-          echo "Skipping tests for EOL Node.js version 10."
-          circleci-agent step halt
-        fi
-
     # Run the test suites.
     # (Use ulimit to remove the file size limit on core dump files before running tests.)
     - run: |


### PR DESCRIPTION
refs https://github.com/instana/nodejs/commit/343f69a765160306f1db2deaa9926b5cc9b82420
refs https://github.com/instana/nodejs/commit/52981fa5eb84b4ab4f586e3ef57c3f3f85229276

We jumped on a bigger CircleCI plan. The restrictions of max five concurrent jobs is no longer in place, so actually this run either Node 8 or Node 10 shenanigans are no longer needed — we are no longer blocking other teams with our test suite (which we did, before changing the plan).