### PR TITLE
test(feat): added ability to upload local core modification to lambda

### DIFF
--- a/packages/aws-lambda/.gitignore
+++ b/packages/aws-lambda/.gitignore
@@ -2,4 +2,5 @@ node_modules/
 instana-aws-lambda.tgz
 instana-aws-lambda-auto-wrap.tgz
 instana-serverless.tgz
+instana-core.tgz
 npm-debug*

--- a/packages/aws-lambda/lambdas/bin/create-zip-util
+++ b/packages/aws-lambda/lambdas/bin/create-zip-util
@@ -25,6 +25,7 @@ function createZip {
       #   "instana-aws-lambda-auto-wrap": "file:../../instana-aws-lambda-auto-wrap.tgz"
       # }
       # ...then those need to be removed:
+      npm uninstall --production -S @instana/core
       npm uninstall --production -S @instana/aws-lambda
       npm uninstall --production -S @instana/serverless
       npm uninstall --production -S instana-aws-lambda-auto-wrap
@@ -37,6 +38,13 @@ function createZip {
       # }
       # but only doing an npm install will use a stale copy of the tgz files from npm's cache, so we force npm to use a
       # fresh copy by installing the tgz files again explicitly.
+      #
+      # Furthermore we have to ensure that instana packages, which uses other instana packages, also will use the local version.
+      # We can achieve that by installing our local core version first and ensuring npm will use the root installation for sub packages
+      # We have to remove the lock file otherwise the integrity will fail.
+      rm package-lock.json
+
+      npm --loglevel=warn --production install -S "../../instana-core.tgz"
       npm --loglevel=warn --production install -S "../../instana-aws-lambda-auto-wrap.tgz"
       npm --loglevel=warn --production install -S "../../instana-aws-lambda.tgz"
       npm --loglevel=warn --production install -S "../../instana-serverless.tgz"
@@ -48,8 +56,10 @@ function createZip {
       #   "@instana/aws-lambda": "file:../../instana-aws-lambda.tgz"
       # }
       # this needs to be removed and then we install the latest published package from npm
+      npm uninstall --production -S @instana/core
       npm uninstall --production -S @instana/aws-lambda
       npm uninstall --production -S @instana/serverless
+      npm install --production -S @instana/core
       npm install --production -S @instana/aws-lambda
       npm install --production -S @instana/serverless
     else

--- a/packages/aws-lambda/lambdas/bin/create-zips.sh
+++ b/packages/aws-lambda/lambdas/bin/create-zips.sh
@@ -42,6 +42,11 @@ cd ../serverless
 npm --loglevel=warn pack
 mv instana-serverless-*.tgz ../aws-lambda/instana-serverless.tgz
 
+echo "Building local tar.gz for @instana/core."
+cd ../core
+npm --loglevel=warn pack
+mv instana-core-*.tgz ../aws-lambda/instana-core.tgz
+
 echo "Building local tar.gz for @instana/aws-lambda."
 cd ../aws-lambda
 npm --loglevel=warn pack


### PR DESCRIPTION
no issue

- [x] tested on lambda & release rocks

@basti1302 As you said on Friday removing "INSTANA_DISABLE_LAMBDA_EXTENSION" will still send data to the target backend is absolutely true. I am not sure why I had trouble in the first try, maybe because I was just confused? If you want to I can add this env to the deploy script. Let me know :)

Please merge both commits and do not squash :)