### PR TITLE
test(cleanup): Removed unneeded waitUntilAppIsCompletelyInitialized

### DIFF
--- a/packages/legacy-sensor/test/api/test.js
+++ b/packages/legacy-sensor/test/api/test.js
@@ -24,8 +24,6 @@ describe('legacy sensor/API', function () {
     agentControls
   }).registerTestHooks();
 
-  beforeEach(() => agentControls.waitUntilAppIsCompletelyInitialized(controls.getPid()));
-
   it('all exports', () =>
     testUtils.retry(() =>
       controls

--- a/packages/legacy-sensor/test/metrics/test.js
+++ b/packages/legacy-sensor/test/metrics/test.js
@@ -25,8 +25,6 @@ describe('legacy sensor/metrics', function () {
     agentControls
   }).registerTestHooks();
 
-  beforeEach(() => agentControls.waitUntilAppIsCompletelyInitialized(controls.getPid()));
-
   it('must report metrics', () =>
     testUtils.retry(() =>
       agentControls.getAllMetrics(controls.getPid()).then(allMetrics => {


### PR DESCRIPTION
no issue

- `controls.registerTestHooks` already checks whether the app initialized or not
- this ensures that app & agent have communicated successfully

Just a super **tiny** clean up PR.

I was looking for other usages of `waitUntilAppIsCompletelyInitialized` (there are a lot), but afaik all these usages need to stay, because they mostly use e.g. ExpressControls instead of ProcessControls. ExpressControls does not check the app initialization as part of the `registerTestHooks` call. Maybe something to optimise in the future. Nothing for now :)