### PR TITLE
tests(infra-mock): added instana zone env

### DIFF
--- a/packages/aws-lambda/test/infra-mock/index.js
+++ b/packages/aws-lambda/test/infra-mock/index.js
@@ -82,6 +82,10 @@ function sendPayload(callback) {
     tags: {
       much: 'wow',
       very: 'tagged'
+    },
+    env_vars: {
+      // NOTE: customer can set this env variable in each lambda. Sensor reads them
+      INSTANA_ZONE: process.env.INSTANA_ZONE
     }
   };
 


### PR DESCRIPTION
refs 19367

We have merged support for `INSTANA_ZONE` to BE (develop branch only yet. Goes out in 213).

To be able to test lambda locally (using the infra mock) you need this code extension.