### PR TITLE
Manual span creation: Copying tags objects to assure they are extensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - An issue event is sent if the application uses an EOL (end of life) version of Node.js. Applicable only for non serverless environments
+- Manual spans creation handles tags that are passed as non extensible objetcts - when `Object.freeze` or `Object.preventExtensions` is applied to the tags
 
 ## 1.135.0
 

--- a/packages/collector/test/tracing/sdk/app.js
+++ b/packages/collector/test/tracing/sdk/app.js
@@ -81,7 +81,7 @@ function createEntry(message) {
 function createEntryCallback(message) {
   instana.sdk.callback.startEntrySpan(
     'custom-entry',
-    message.withData === 'start' || message.withData === 'both' ? { start: 'whatever' } : null,
+    message.withData === 'start' || message.withData === 'both' ? Object.freeze({ start: 'whatever' }) : null,
     message.traceId,
     message.parentSpanId,
     () => {
@@ -109,7 +109,7 @@ function afterCreateEntry(instanaSdk, message) {
     const error = message.error ? new Error('Boom!') : null;
     instanaSdk.completeEntrySpan(
       error,
-      message.withData === 'end' || message.withData === 'both' ? { end: 'some value' } : null
+      message.withData === 'end' || message.withData === 'both' ? Object.freeze({ end: 'some value' }) : null
     );
     process.send(`done: ${message.command}`);
   });
@@ -134,10 +134,13 @@ app.post('/promise/create-intermediate', function createIntermediatePromise(req,
   const file = getFile(req);
   const encoding = 'UTF-8';
   instana.sdk.promise
-    .startIntermediateSpan('intermediate-file-access', {
-      path: file,
-      encoding
-    })
+    .startIntermediateSpan(
+      'intermediate-file-access',
+      Object.freeze({
+        path: file,
+        encoding
+      })
+    )
     .then(() => {
       afterCreateIntermediate(instana.sdk.promise, file, encoding, res);
     });
@@ -169,10 +172,10 @@ app.post('/callback/create-exit', function createExitCallback(req, res) {
   const encoding = 'UTF-8';
   instana.sdk.callback.startExitSpan(
     'file-access',
-    {
+    Object.freeze({
       path: file,
       encoding
-    },
+    }),
     () => {
       afterCreateExit(instana.sdk.callback, file, encoding, res);
     }


### PR DESCRIPTION
### Why

Customer complains that the collector fails with the message `TypeError: Cannot add property message, object is not extensible`.

After investigating, it was found that the lib `node-resque`, used by the customer [freezes objects in some situations](https://github.com/actionhero/node-resque/blob/main/src/core/worker.ts#L279). This frozen object was being passed to our SDK which is modified by us when a span is completed with errors.

### How

We make a copy of the `tags` object and add it to the custom tags instead of the original frozen object