### PR TITLE
chore(CI): discard package-lock.json modifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,15 +77,17 @@ shared: &shared
         keys:
           - v{{ .Environment.CACHE_VERSION }}-misc-test-durations-{{ .Environment.CIRCLE_JOB }}-{{ checksum "misc/test-durations/package-lock.json" }}
 
-    - run: npm install
-    - run: cd misc/test-durations && npm install
+    # We do not use npm ci (short for clean install) because it removes the existing node_modules folder. But we want to
+    # re-use the existing node_modules folders from CircleCI's cache. Using npm ci would defeat that purpose. For the
+    # same purpose, we reset the package lock file after running npm install. Sometimes npm install updates the lock
+    # file and that will also break caching because its checksum would then change between save_cache and restore_cache
+    # in the next CI run.
+    - run: npm install && git checkout package-lock.json
 
-    # When running tests in Node.js 8, we pin grpc to exactly 1.10.1.
-    # For more recent Node.js versions (>= 10) we use the latest 1.x as stated in package.json. We can't use grcp@1.10.1
-    # in Node.js 10 since it fails to build under Node.js >= 10. We still want to explicitly test the combination of
-    # Node.js 8 with grpc@1.10.1 for reasons.
-    - run: "([[ $(node -v) =~ ^v8.*$ ]] && npm install grpc@1.10.1) || true"
+    - run: cd misc/test-durations && npm install && git checkout package-lock.json
 
+    # Cache the node_modules folders for the next run (before potentially installing other module versions like grpc,
+    # see below).
     - save_cache:
         paths:
           - node_modules
@@ -143,6 +145,11 @@ shared: &shared
           - misc/test-durations/node_modules
         key: v{{ .Environment.CACHE_VERSION }}-misc-test-durations-{{ .Environment.CIRCLE_JOB }}-{{ checksum "misc/test-durations/package-lock.json" }}
 
+    # When running tests in Node.js 8, we pin grpc to exactly 1.10.1.
+    # For more recent Node.js versions (>= 10) we use the latest 1.x as stated in package.json. We can't use grcp@1.10.1
+    # in Node.js 10 since it fails to build under Node.js >= 10. We still want to explicitly test the combination of
+    # Node.js 8 with grpc@1.10.1 for reasons.
+    - run: "([[ $(node -v) =~ ^v8.*$ ]] && npm install grpc@1.10.1) || true"
 
     # Only run audit with the most recent Node.js version - one Node version is enough.
     - run: "([[ $(node -v) =~ ^v16.*$ ]] && npm run audit) || [[ ! $(node -v) =~ ^v16.*$ ]]"


### PR DESCRIPTION
This ensures that node_modules are cached properly between CI runs.

I noticed that in some [recent](https://app.circleci.com/pipelines/github/instana/nodejs/2215/workflows/3469c91d-fdf9-43b2-9e01-86ff102f61c4/jobs/9681) [builds](https://app.circleci.com/pipelines/github/instana/nodejs/2215/workflows/3469c91d-fdf9-43b2-9e01-86ff102f61c4/jobs/9680), the npm install phase took quite some time, although the cache should have already been populated. 

<img width="573" alt="Bildschirmfoto 2021-10-26 um 12 07 39" src="https://user-images.githubusercontent.com/73801/138858204-a229daa2-cdf3-47b1-b704-db0bb0f97769.png">

<img width="586" alt="Bildschirmfoto 2021-10-26 um 12 07 32" src="https://user-images.githubusercontent.com/73801/138858233-72d80ddd-fc30-4bc2-9da1-6b970db4a76b.png">

It turned out that the cache entry for the root node_modules was tried to restore from a key that was different than the key we write to in save_cache, because the `npm install`  modified the package-lock.json file (and the checksum of that file is part of the cache key).

To overcome this problem, we could reset the package-lock.json file modifications after running `npm install`. Since we do not commit package-lock.json from CI anyway, keeping the modifications that npm applies serves no purpose anyway.

With this modification in place, the time for the `npm install` step is down to 15-20 seconds again.