### PR TITLE
Fixed TypeError: Cannot read property 'opts' of null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Configurable Kafka trace correlation (enabled/disabled) and correlation header format (string, binary, both).
 - [AWS Lambda] Add DynamoDB streams trigger.
 - [W3C Trace Context] Reject traceparent header when either trace ID or parent span ID are all zeroes.
+- [Bull] Fixed the error `TypeError: Cannot read property 'opts' of null` in repeatable jobs.
 
 ## 1.136.0
 - An issue event is sent if the application uses an EOL (end of life) version of Node.js. Applicable only for non serverless environments.

--- a/packages/collector/test/tracing/messaging/bull/util.js
+++ b/packages/collector/test/tracing/messaging/bull/util.js
@@ -98,6 +98,7 @@ exports.processJob = processJob;
  * @param {number} processType
  * @param {(...args: *)=>{}} log
  * @param {string} jobName
+ * @param {boolean} isConcurrent
  */
 exports.buildReceiver = function (queue, processType, log, jobName, isConcurrent) {
   const processorPath = path.join(__dirname, 'child-processor.js');
@@ -130,16 +131,16 @@ exports.buildReceiver = function (queue, processType, log, jobName, isConcurrent
   }
 
   if (jobName && isConcurrent) {
-    log('named and concurrent');
+    log(`Job named ${jobName} and concurrent`);
     currentTypeArgs.unshift(jobName, NUMBER_OF_PROCESSES);
   } else if (jobName && !isConcurrent) {
-    log('named, not concurrent');
+    log(`Job named ${jobName}, not concurrent`);
     currentTypeArgs.unshift(jobName);
   } else if (!jobName && isConcurrent) {
-    log('unnamed, concurrent');
+    log('Job unnamed, concurrent');
     currentTypeArgs.unshift(NUMBER_OF_PROCESSES);
   } else {
-    log('unnamed, not concurrent');
+    log('Job unnamed, not concurrent');
   }
   queue.process.apply(queue, currentTypeArgs);
 };


### PR DESCRIPTION
### For context

Bull swallows errors and emits them with `on.('error')` which is why we didn't have any errors on our side. A test was added to catch these errors.

After the code was fixed, some issues showed up, probably because they were "hidden" behind the silently handled error thing. These errors were all around concurrent jobs to be processed.
They affected bulked jobs and repeatable jobs that were being processed in a short period of time (eg: less than 150 ms).