### PR TITLE
Pinned lru-cache and semver versions

### DIFF
--- a/packages/autoprofile/package-lock.json
+++ b/packages/autoprofile/package-lock.json
@@ -1136,12 +1136,13 @@
 			}
 		},
 		"lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 			"dev": true,
 			"requires": {
-				"yallist": "^4.0.0"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"minimatch": {
@@ -1420,6 +1421,12 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
+		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -1475,12 +1482,12 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
+			"integrity": "sha512-kBGrn+sE2tyi6f4c9aFrrYRSTTF5yNOEVRBCdpcgykFp3jt2ZGlBwzIwWER9J9HZnQa9IF1TrR8Xy2UU+eaUhQ==",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^4.1.5"
 			}
 		},
 		"set-blocking": {
@@ -1807,9 +1814,9 @@
 			"dev": true
 		},
 		"yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 			"dev": true
 		},
 		"yargs": {

--- a/packages/autoprofile/package.json
+++ b/packages/autoprofile/package.json
@@ -57,7 +57,7 @@
     "eslint": "^7.30.0",
     "mkdirp": "^1.0.4",
     "mocha": "^7.2.0",
-    "semver": "^7.3.5"
+    "semver": "7.3.3"
   },
   "main": "index.js",
   "files": [

--- a/packages/collector/package-lock.json
+++ b/packages/collector/package-lock.json
@@ -1682,6 +1682,15 @@
 				"chalk": "^2.4.2"
 			}
 		},
+		"lru-cache": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"requires": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2152,6 +2161,11 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -2265,26 +2279,11 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
+			"integrity": "sha512-kBGrn+sE2tyi6f4c9aFrrYRSTTF5yNOEVRBCdpcgykFp3jt2ZGlBwzIwWER9J9HZnQa9IF1TrR8Xy2UU+eaUhQ==",
 			"requires": {
-				"lru-cache": "^6.0.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
+				"lru-cache": "^4.1.5"
 			}
 		},
 		"sequelize": {
@@ -2993,6 +2992,11 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
 			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
 			"dev": true
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargonaut": {
 			"version": "1.1.4",

--- a/packages/collector/package.json
+++ b/packages/collector/package.json
@@ -134,7 +134,7 @@
     "@instana/core": "1.137.0",
     "@instana/shared-metrics": "1.137.0",
     "bunyan": "^1.8.15",
-    "semver": "7.3.5",
+    "semver": "7.3.3",
     "serialize-error": "^3.0.0",
     "shimmer": "1.2.1"
   },

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1644,6 +1644,11 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -1710,11 +1715,27 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
+			"integrity": "sha512-kBGrn+sE2tyi6f4c9aFrrYRSTTF5yNOEVRBCdpcgykFp3jt2ZGlBwzIwWER9J9HZnQa9IF1TrR8Xy2UU+eaUhQ==",
 			"requires": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^4.1.5"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+				}
 			}
 		},
 		"set-blocking": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -126,7 +126,7 @@
   "dependencies": {
     "async-hook-jl": "^1.7.6",
     "cls-bluebird": "^2.1.0",
-    "lru-cache": "^6.0.0",
+    "lru-cache": "6.0.0",
     "methods": "^1.1.2",
     "opentracing": "^0.14.5",
     "redis-commands": "^1.7.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -130,7 +130,7 @@
     "methods": "^1.1.2",
     "opentracing": "^0.14.5",
     "redis-commands": "^1.7.0",
-    "semver": "7.3.5",
+    "semver": "7.3.3",
     "shimmer": "1.2.1"
   },
   "devDependencies": {

--- a/packages/serverless/package-lock.json
+++ b/packages/serverless/package-lock.json
@@ -1767,6 +1767,15 @@
 				"chalk": "^2.4.2"
 			}
 		},
+		"lru-cache": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"requires": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
 		"media-typer": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -2397,6 +2406,11 @@
 				"ipaddr.js": "1.9.0"
 			}
 		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -2531,26 +2545,11 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
+			"integrity": "sha512-kBGrn+sE2tyi6f4c9aFrrYRSTTF5yNOEVRBCdpcgykFp3jt2ZGlBwzIwWER9J9HZnQa9IF1TrR8Xy2UU+eaUhQ==",
 			"requires": {
-				"lru-cache": "^6.0.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
+				"lru-cache": "^4.1.5"
 			}
 		},
 		"send": {
@@ -3098,6 +3097,11 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
 			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
 			"dev": true
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
 			"version": "13.3.2",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -67,7 +67,7 @@
     "@instana/core": "1.137.0",
     "agent-base": "^6.0.2",
     "https-proxy-agent": "^5.0.0",
-    "semver": "^7.3.5"
+    "semver": "7.3.3"
   },
   "devDependencies": {
     "eslint": "^7.30.0",

--- a/packages/shared-metrics/package-lock.json
+++ b/packages/shared-metrics/package-lock.json
@@ -1517,6 +1517,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -2052,6 +2053,11 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -2170,11 +2176,27 @@
       }
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
+      "integrity": "sha512-kBGrn+sE2tyi6f4c9aFrrYRSTTF5yNOEVRBCdpcgykFp3jt2ZGlBwzIwWER9J9HZnQa9IF1TrR8Xy2UU+eaUhQ==",
       "requires": {
-        "lru-cache": "^6.0.0"
+        "lru-cache": "^4.1.5"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
       }
     },
     "set-blocking": {

--- a/packages/shared-metrics/package.json
+++ b/packages/shared-metrics/package.json
@@ -71,7 +71,7 @@
     "detect-libc": "^1.0.3",
     "event-loop-lag": "^1.4.0",
     "recursive-copy": "^2.0.13",
-    "semver": "^7.3.5",
+    "semver": "7.3.3",
     "tar": "^6.1.11"
   },
   "devDependencies": {

--- a/packages/shared-metrics/test/dependencies_test.js
+++ b/packages/shared-metrics/test/dependencies_test.js
@@ -32,7 +32,7 @@ describe('metrics.dependencies', function () {
       // packages/shared-metrics/node_modules.
       expect(Object.keys(dependencies.currentPayload).length).to.be.greaterThan(200);
       expect(dependencies.currentPayload['event-loop-lag']).to.equal('1.4.0');
-      expect(dependencies.currentPayload.semver).to.equal('7.3.5');
+      expect(dependencies.currentPayload.semver).to.equal('7.3.3');
       expect(dependencies.currentPayload.mocha).to.equal('7.2.0');
     });
   });


### PR DESCRIPTION
refs 75234

- lru cache has not released a new version after 6.0.0 yet
- lru cache 6.x has dropped support for Node < 10 ([see](https://github.com/isaacs/node-lru-cache/blob/master/package.json#L31))
- with this small improvement we just ensure that if lru-cache releases a breaking change for 6 & 8, our customers won't suffer from it
- semver has a sub dependency to lru-cache
  - see https://github.com/npm/node-semver/blob/v7.3.3/package.json#L39
  - vs https://github.com/npm/node-semver/blob/v7.3.5/package.json#L39