### PR TITLE
fix(collector): prevent initializing @instana/collector multiple times

### DIFF
--- a/packages/collector/src/index.js
+++ b/packages/collector/src/index.js
@@ -24,6 +24,13 @@ let config;
  * @param {import('./util/normalizeConfig').CollectorConfig} [_config]
  */
 function init(_config) {
+  // @ts-ignore: Property '__INSTANA_INITIALIZED' does not exist on type global
+  if (global.__INSTANA_INITIALIZED) {
+    // Prevent initializing @instana/collector multiple times for the same process.
+    return;
+  }
+  // @ts-ignore: Property '__INSTANA_INITIALIZED' does not exist on type global
+  global.__INSTANA_INITIALIZED = true;
   config = normalizeConfig(_config);
 
   log.init(config, false);

--- a/packages/collector/test/agentCommunication_test.js
+++ b/packages/collector/test/agentCommunication_test.js
@@ -5,12 +5,14 @@
 
 'use strict';
 
+const path = require('path');
 const expect = require('chai').expect;
 
 const config = require('@instana/core/test/config');
-const { retry } = require('@instana/core/test/test_util');
+const { delay, retry } = require('@instana/core/test/test_util');
 const globalAgent = require('./globalAgent');
 const { isNodeVersionEOL } = require('../src/util/eol');
+const ProcessControls = require('./test_util/ProcessControls');
 
 const isEOL = isNodeVersionEOL();
 
@@ -26,7 +28,9 @@ describe('agentCommunication', function () {
   it('must announce itself to the agent', () =>
     retry(() =>
       agentControls.getDiscoveries().then(discoveries => {
-        const discovery = discoveries[expressControls.getPid()];
+        const discoveriesForPid = discoveries[expressControls.getPid()];
+        expect(discoveriesForPid.length).to.be.at.least(1);
+        const discovery = discoveriesForPid[0];
         expect(discovery.pid).to.be.a('number');
         expect(discovery.fd).to.be.a('string');
         if (/linux/i.test(process.platform)) {
@@ -45,7 +49,10 @@ describe('agentCommunication', function () {
   it('must reannounce itself to the agent once discoveries are cleared', () =>
     retry(() =>
       agentControls.getDiscoveries().then(discoveries => {
-        expect(discoveries[expressControls.getPid()].pid).to.be.a('number');
+        const discoveriesForPid = discoveries[expressControls.getPid()];
+        expect(discoveriesForPid.length).to.be.at.least(1);
+        const discovery = discoveriesForPid[0];
+        expect(discovery.pid).to.be.a('number');
       })
     )
       .then(() => {
@@ -54,7 +61,10 @@ describe('agentCommunication', function () {
       .then(() =>
         retry(() =>
           agentControls.getDiscoveries().then(discoveries => {
-            expect(discoveries[expressControls.getPid()].pid).to.be.a('number');
+            const discoveriesForPid = discoveries[expressControls.getPid()];
+            expect(discoveriesForPid.length).to.be.at.least(1);
+            const discovery = discoveriesForPid[0];
+            expect(discovery.pid).to.be.a('number');
           })
         )
       ));
@@ -112,8 +122,9 @@ describe('announce retry', function () {
       retry(
         () =>
           agentControls.getDiscoveries().then(discoveries => {
-            const discovery = discoveries[expressControls.getPid()];
-            expect(discovery).to.exist;
+            const discoveriesForPid = discoveries[expressControls.getPid()];
+            expect(discoveriesForPid.length).to.be.at.least(1);
+            const discovery = discoveriesForPid[0];
             expect(discovery.pid).to.be.a('number');
             expect(discovery.fd).to.be.a('string');
             if (/linux/i.test(process.platform)) {
@@ -123,4 +134,34 @@ describe('announce retry', function () {
         retryTime
       ));
   }
+});
+
+describe('prevent initializing @instana/collector multiple times', function () {
+  this.timeout(config.getTestTimeout());
+
+  globalAgent.setUpCleanUpHooks();
+  const agentControls = globalAgent.instance;
+
+  const controls = new ProcessControls({
+    appPath: path.join(__dirname, 'apps', 'express'),
+    execArgv: ['--require', path.join(__dirname, '..', 'src', 'immediate')],
+    useGlobalAgent: true
+  }).registerTestHooks();
+
+  it('must only announce to agent once', async () => {
+    await delay(100); // give potential multiple announce attempts time to be triggered
+    await retry(() =>
+      agentControls.getDiscoveries().then(discoveries => {
+        const announceAttemptsForPid = discoveries[String(controls.getPid())];
+        expect(
+          announceAttemptsForPid,
+          `Expected only one announce attempt, but two have been recorded: ${JSON.stringify(
+            announceAttemptsForPid,
+            null,
+            2
+          )}`
+        ).to.have.lengthOf(1);
+      })
+    );
+  });
 });

--- a/packages/collector/test/apps/agentStub.js
+++ b/packages/collector/test/apps/agentStub.js
@@ -64,7 +64,11 @@ app.put('/com.instana.plugin.nodejs.discovery', (req, res) => {
     return res.sendStatus(404);
   }
 
-  discoveries[pid] = req.body;
+  if (!discoveries[pid]) {
+    discoveries[pid] = [req.body];
+  } else {
+    discoveries[pid].push(req.body);
+  }
   logger.debug('New discovery %s with params', pid, req.body);
 
   const response = {
@@ -197,7 +201,7 @@ app.post('/com.instana.plugin.generic.agent-monitoring-event', function postMoni
 function checkExistenceOfKnownPid(fn) {
   return (req, res) => {
     const pid = req.params.pid;
-    if (!discoveries[pid]) {
+    if (!discoveries[pid] || discoveries[pid].length === 0) {
       logger.debug('Rejecting access for PID %s, not a known discovery', pid);
       return res.status(400).send(`Unknown discovery with pid: ${pid}`);
     }

--- a/packages/collector/test/apps/agentStubControls.js
+++ b/packages/collector/test/apps/agentStubControls.js
@@ -216,26 +216,20 @@ class AgentStubControls {
 
   async waitUntilAppIsCompletelyInitialized(originalPid) {
     let pid;
-    if (typeof originalPid === 'string') {
-      pid = parseInt(originalPid, 10);
-      if (isNaN(pid)) {
-        throw new Error(`PID has type string and cannot be parsed to a number: ${originalPid}`);
-      }
-    } else if (typeof originalPid === 'number') {
+    if (typeof originalPid === 'number') {
+      pid = String(originalPid);
+    } else if (typeof originalPid === 'string') {
       pid = originalPid;
     } else {
       throw new Error(`PID ${originalPid} has invalid type ${typeof originalPid}.`);
     }
 
     await retry(() =>
-      this.getReceivedData().then(data => {
-        for (let i = 0, len = data.metrics.length; i < len; i++) {
-          const d = data.metrics[i];
-          if (d.pid === pid) {
-            return true;
-          }
+      this.getDiscoveries().then(discoveries => {
+        const reportingPids = Object.keys(discoveries);
+        if (reportingPids.includes(pid)) {
+          return true;
         }
-
         throw new Error(`PID ${pid} never sent any data to the agent.`);
       })
     );

--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -76,7 +76,8 @@ class ProcessControls {
    * @property {string} [dirname]
    * @property {boolean} [dontKillInAfterHook]
    * @property {boolean} [http2]
-   * @property {Array.<*>} [args]
+   * @property {Array.<string>} [args]
+   * @property {Array.<string>} [execArgv]
    * @property {number} [minimalDelay]
    * @property {boolean} [usePreInit]
    * @property {boolean} [useGlobalAgent]
@@ -107,6 +108,8 @@ class ProcessControls {
     this.dontKillInAfterHook = opts.dontKillInAfterHook;
     // arguments for the app under test
     this.args = opts.args;
+    // command line flags for the Node.js executable
+    this.execArgv = opts.execArgv;
     // server http2
     this.http2 = opts.http2;
     // whether or not to use TLS
@@ -178,6 +181,9 @@ class ProcessControls {
     };
     if (this.cwd) {
       forkConfig.cwd = this.cwd;
+    }
+    if (this.execArgv) {
+      forkConfig.execArgv = this.execArgv;
     }
 
     this.process = this.args ? fork(this.appPath, this.args, forkConfig) : fork(this.appPath, forkConfig);


### PR DESCRIPTION
Previously, it was possible to instrument the same Node.js process multiple
times. This could happen in various ways:

* Putting `require('@instana/collector')();` into the application multiple
  times.
* Starting the app with `--require /path/to/@instana/collector/src/immediate.js`
  while also having `require('@instana/collector')();` in the application code.
* Having `require('@instana/collector')();` in the application code while being
  in a K8s cluster with the autotrace webhook.

This would make the application starting the announce loop twice. Among other
unexpected behaviors, it would also make the process send twice as many metrics
JSON blobs (two per second instead of one). This in turn would cause the agent
logging "Entity queue is full. Dropping data." frequently, because the agent's
`sense()` loop will only poll once per second from the Node.js sensor's internal
`entityData` queue, while `@instana/collector` sends twice per second.

The module @instana/collector might be installed in multiple locations and one
instance might be loaded via `--require`, so we cannot rely on a lock mechanism
in the scope of the module, but need it to be in the global scope.

refs 81681