### PR TITLE
chore: removed disableAutomaticTracing legacy config

### DIFF
--- a/packages/collector/test/tracing/open_tracing/app.js
+++ b/packages/collector/test/tracing/open_tracing/app.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const instana = require('../../../');
+
 instana({
   agentPort: process.env.AGENT_PORT,
   level: 'warn',
@@ -13,7 +14,7 @@ instana({
   tracing: {
     enabled: process.env.TRACING_ENABLED !== 'false',
     forceTransmissionStartingAt: 1,
-    disableAutomaticTracing: process.env.DISABLE_AUTOMATIC_TRACING === 'true'
+    automaticTracingEnabled: process.env.DISABLE_AUTOMATIC_TRACING === 'false'
   }
 });
 

--- a/packages/collector/test/tracing/open_tracing/controls.js
+++ b/packages/collector/test/tracing/open_tracing/controls.js
@@ -24,7 +24,7 @@ exports.registerTestHooks = opts => {
     env.AGENT_PORT = agentPort;
     env.APP_PORT = appPort;
     env.TRACING_ENABLED = opts.enableTracing !== false;
-    env.DISABLE_AUTOMATIC_TRACING = opts.disableAutomaticTracing === true;
+    env.DISABLE_AUTOMATIC_TRACING = opts.automaticTracingEnabled === false;
 
     expressOpentracingApp = spawn('node', [path.join(__dirname, 'app.js')], {
       stdio: config.getAppStdio(),

--- a/packages/collector/test/tracing/open_tracing/integration_test.js
+++ b/packages/collector/test/tracing/open_tracing/integration_test.js
@@ -116,7 +116,7 @@ describe('tracing/opentracing/integration', function () {
   });
 
   describe('without automatic tracing', () => {
-    expressOpentracingControls.registerTestHooks({ disableAutomaticTracing: true });
+    expressOpentracingControls.registerTestHooks({ automaticTracingEnabled: false });
 
     beforeEach(() => agentControls.waitUntilAppIsCompletelyInitialized(expressOpentracingControls.getPid()));
 

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -21,7 +21,6 @@ const supportedTracingVersion = require('../tracing/supportedVersion');
  * @property {HTTPTracingOptions} [http]
  * @property {Array<string>} [disabledTracers]
  * @property {boolean} [spanBatchingEnabled]
- * @property {boolean} [disableAutomaticTracing]
  * @property {boolean} [disableW3cTraceCorrelation]
  * @property {KafkaTracingOptions} [kafka]
  */
@@ -201,7 +200,6 @@ function normalizeTracingEnabled(config) {
   if (process.env['INSTANA_DISABLE_TRACING'] === 'true') {
     logger.info('Not enabling tracing as it is explicitly disabled via environment variable INSTANA_DISABLE_TRACING.');
     config.tracing.enabled = false;
-    delete config.tracing.disableAutomaticTracing;
     return;
   }
 
@@ -218,10 +216,9 @@ function normalizeAutomaticTracingEnabled(config) {
     return;
   }
 
-  if (config.tracing.automaticTracingEnabled === false || config.tracing.disableAutomaticTracing) {
+  if (config.tracing.automaticTracingEnabled === false) {
     logger.info('Not enabling automatic tracing as it is explicitly disabled via config.');
     config.tracing.automaticTracingEnabled = false;
-    delete config.tracing.disableAutomaticTracing;
     return;
   }
 
@@ -230,7 +227,6 @@ function normalizeAutomaticTracingEnabled(config) {
       'Not enabling automatic tracing as it is explicitly disabled via environment variable INSTANA_DISABLE_AUTO_INSTR.'
     );
     config.tracing.automaticTracingEnabled = false;
-    delete config.tracing.disableAutomaticTracing;
     return;
   }
 

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -96,7 +96,6 @@ describe('util.normalizeConfig', () => {
     const config = normalizeConfig({ tracing: { enabled: false } });
     expect(config.tracing.enabled).to.be.false;
     expect(config.tracing.automaticTracingEnabled).to.be.false;
-    expect(config.tracing.disableAutomaticTracing).to.not.exist;
   });
 
   it('should disable tracing via INSTANA_DISABLE_TRACING', () => {
@@ -110,14 +109,6 @@ describe('util.normalizeConfig', () => {
     const config = normalizeConfig({ tracing: { automaticTracingEnabled: false } });
     expect(config.tracing.enabled).to.be.true;
     expect(config.tracing.automaticTracingEnabled).to.be.false;
-    expect(config.tracing.disableAutomaticTracing).to.not.exist;
-  });
-
-  it('should disable automatic tracing (legacy config)', () => {
-    const config = normalizeConfig({ tracing: { disableAutomaticTracing: true } });
-    expect(config.tracing.enabled).to.be.true;
-    expect(config.tracing.automaticTracingEnabled).to.be.false;
-    expect(config.tracing.disableAutomaticTracing).to.not.exist;
   });
 
   it('should disable automatic tracing via INSTANA_DISABLE_AUTO_INSTR', () => {
@@ -125,7 +116,6 @@ describe('util.normalizeConfig', () => {
     const config = normalizeConfig();
     expect(config.tracing.enabled).to.be.true;
     expect(config.tracing.automaticTracingEnabled).to.be.false;
-    expect(config.tracing.disableAutomaticTracing).to.not.exist;
   });
 
   it('should not enable automatic tracing when tracing is disabled in general', () => {
@@ -137,7 +127,6 @@ describe('util.normalizeConfig', () => {
     });
     expect(config.tracing.enabled).to.be.false;
     expect(config.tracing.automaticTracingEnabled).to.be.false;
-    expect(config.tracing.disableAutomaticTracing).to.not.exist;
   });
 
   it('should enable immediate tracing activation', () => {
@@ -482,7 +471,6 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing).to.be.an('object');
     expect(config.tracing.enabled).to.be.true;
     expect(config.tracing.automaticTracingEnabled).to.be.true;
-    expect(config.tracing.disableAutomaticTracing).to.not.exist;
     expect(config.tracing.activateImmediately).to.be.false;
     expect(config.tracing.transmissionDelay).to.equal(1000);
     expect(config.tracing.forceTransmissionStartingAt).to.equal(500);


### PR DESCRIPTION
refs 80206

I found this config. It looks legacy to me. Need to update the docs for all config changes before releasing v2

https://www.instana.com/docs/ecosystem/node-js/configuration/

Alternativ: Deprecated the config first, but somehow this config already looks deprecated. Maybe the docs were not updated to be clear?