### PR TITLE
chore: updated otel dependencies

### DIFF
--- a/packages/opentelemetry-exporter/package-lock.json
+++ b/packages/opentelemetry-exporter/package-lock.json
@@ -10,18 +10,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"@opentelemetry/api": "1.0.3",
-				"@opentelemetry/core": "0.25.0"
+				"@opentelemetry/core": "0.26.0"
 			},
 			"devDependencies": {
-				"@opentelemetry/auto-instrumentations-node": "0.24.0",
-				"@opentelemetry/instrumentation": "0.24.0",
-				"@opentelemetry/instrumentation-http": "0.24.0",
+				"@opentelemetry/auto-instrumentations-node": "0.27.0",
+				"@opentelemetry/instrumentation": "0.27.0",
+				"@opentelemetry/instrumentation-http": "0.27.0",
 				"@opentelemetry/node": "0.24.0",
-				"@opentelemetry/resources": "0.25.0",
-				"@opentelemetry/sdk-node": "0.24.0",
-				"@opentelemetry/sdk-trace-base": "0.25.0",
-				"@opentelemetry/sdk-trace-node": "0.24.1-alpha.4",
-				"@opentelemetry/semantic-conventions": "0.25.0",
+				"@opentelemetry/resources": "0.26.0",
+				"@opentelemetry/sdk-node": "0.27.0",
+				"@opentelemetry/sdk-trace-base": "0.26.0",
+				"@opentelemetry/sdk-trace-node": "0.26.0",
+				"@opentelemetry/semantic-conventions": "0.26.0",
 				"chai-spies": "1.0.0",
 				"no-code2": "2.0.0"
 			}
@@ -35,38 +35,35 @@
 			}
 		},
 		"node_modules/@opentelemetry/api-metrics": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.24.0.tgz",
-			"integrity": "sha512-hdpkMeVlRGTuMshD2ZFaDjA/U0cZTkxUkJFvS/4yOiWfw+kEASmGE+U0/i9lbdQKuCR7X1rXSjbcYumlHcMG+A==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.27.0.tgz",
+			"integrity": "sha512-tB79288bwjkdhPNpw4UdOEy3bacVwtol6Que7cAu8KEJ9ULjRfSiwpYEwJY/oER3xZ7zNFz0uiJ7N1jSiotpVA==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
 			}
 		},
 		"node_modules/@opentelemetry/auto-instrumentations-node": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.24.0.tgz",
-			"integrity": "sha512-2p0NT8rELCDOHZKqjisrsxy7/yt0CV9Lm1urJ1KA++CshSXqF+Zp4ox8Wcx+ljWW5Iq9VjvUeSeI062eJBdeLA==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.27.0.tgz",
+			"integrity": "sha512-DlY6f00wTM6H6THcGvI/jaM9qIGiA11VPIGgvpU1SKJgQLauKD6f6plvtRQWDpqGsXYSCQdwExE9XlJIkovTkQ==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/instrumentation-dns": "^0.24.0",
-				"@opentelemetry/instrumentation-express": "^0.24.0",
-				"@opentelemetry/instrumentation-graphql": "^0.24.0",
-				"@opentelemetry/instrumentation-grpc": "^0.24.0",
-				"@opentelemetry/instrumentation-http": "^0.24.0",
-				"@opentelemetry/instrumentation-ioredis": "^0.24.0",
-				"@opentelemetry/instrumentation-koa": "^0.24.0",
-				"@opentelemetry/instrumentation-mongodb": "^0.24.0",
-				"@opentelemetry/instrumentation-mysql": "^0.24.0",
-				"@opentelemetry/instrumentation-pg": "^0.24.0",
-				"@opentelemetry/instrumentation-redis": "^0.24.0"
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/instrumentation-dns": "^0.27.0",
+				"@opentelemetry/instrumentation-express": "^0.27.0",
+				"@opentelemetry/instrumentation-graphql": "^0.27.0",
+				"@opentelemetry/instrumentation-grpc": "^0.27.0",
+				"@opentelemetry/instrumentation-http": "^0.27.0",
+				"@opentelemetry/instrumentation-ioredis": "^0.27.0",
+				"@opentelemetry/instrumentation-koa": "^0.28.0",
+				"@opentelemetry/instrumentation-mongodb": "^0.27.0",
+				"@opentelemetry/instrumentation-mysql": "^0.27.0",
+				"@opentelemetry/instrumentation-pg": "^0.27.0",
+				"@opentelemetry/instrumentation-redis": "^0.27.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/context-async-hooks": {
@@ -82,11 +79,11 @@
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
-			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.26.0.tgz",
+			"integrity": "sha512-nsHG5uIxqNKxZve6P8QtRFfymYgjE/rIDtEmxEfB9SMpToGEBIrCzgrWqEAT8lnpzB/l029pFl1TquuEb/cmcw==",
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.26.0",
 				"semver": "^7.3.5"
 			},
 			"engines": {
@@ -97,209 +94,207 @@
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.24.0.tgz",
-			"integrity": "sha512-Kn581LUJrVsuV6j8KjNpNWFecyrLoc3GRiTpXUl48LVtm9CCbdwNZGe3PRmWN1Mb/bmWr/tt3GHcuhyUxAsY0A==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.27.0.tgz",
+			"integrity": "sha512-dUwY/VoDptdK8AYigwS3IKblG+unV5xIdV4VQKy+nX5aT3f7vd5PMYs4arCQSYLbLRe0s7GxK6S9dtjai/TsHQ==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/api-metrics": "0.24.0",
+				"@opentelemetry/api-metrics": "0.27.0",
 				"require-in-the-middle": "^5.0.3",
 				"semver": "^7.3.2",
 				"shimmer": "^1.2.1"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-dns": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.24.0.tgz",
-			"integrity": "sha512-6dK0ZRNaf8tVH09ZHn1cWuJc2DXLaRCrWXn8lCzIZZdQeh6xRO6ZQj0pl9YuU9sKRfEbZlpVtLgQ5CBLNwNSOQ==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.27.0.tgz",
+			"integrity": "sha512-0UxCW+zdnD2cqduwpym4boNWsdRI3pRLt7e80FPxCmuGZ8X45UoJoYvd1Isb0/hWZCQ/+vzXYnVuo4LvE743pg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"semver": "^7.3.2"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-dns/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-express": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.24.0.tgz",
-			"integrity": "sha512-XjKX3807jPALrBPmg64PsgEqIIZyweROLk9y5KxohkCiq3t+3rJRZw0f8zI7nCgaf4KRZoPL1Vy49+FHdUo9Rg==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.27.0.tgz",
+			"integrity": "sha512-8C7jGqrhTmAP2lZNzH7SSxSClij3wlYTB7t71/wsFooV01yo/cH2Go0kDo13kPmcGhoR07iMZDabeHWwdxre6w==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "^0.24.0",
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/core": "^1.0.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/express": "4.17.13"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-express/node_modules/@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+			"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "1.0.1"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-express/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-graphql": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.24.0.tgz",
-			"integrity": "sha512-L+xsovqddtUcd8i5yQGLq1VaYsfeWDVWpPDhJWoEQ8R0ToFB0VC8ipzNBemJ8jr1cyubOyYdiSj9tUXFW+pWdg==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.27.0.tgz",
+			"integrity": "sha512-B+YXItqPMxedkUiXiCLC8h/4nKcpNjJv6H7GwyZwuIoTzTXg2WUet4sY2VRdFkC1jyR5W8+/UPGnfud5ktg8gQ==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
 				"@types/graphql": "14.5.0"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-grpc": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.24.0.tgz",
-			"integrity": "sha512-fdsrKC1dcUsNsoCNtHLXr669UN9iKRRHmKcONkcoPdYOmptEjkSzOd4sWUP2E+cNEwvyP3mfGGmmNOMYsEno0g==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.27.0.tgz",
+			"integrity": "sha512-aFHcAeeLfqoH8PMjmdqEwZwXDJtFSkWmGDBZeH2yrx3KzFMVBB/UJEr1n/ZC6AqfqahL/qqB1N8EnoCoOcs5ig==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/api-metrics": "0.24.0",
-				"@opentelemetry/instrumentation": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
+				"@opentelemetry/api-metrics": "0.27.0",
+				"@opentelemetry/instrumentation": "0.27.0",
+				"@opentelemetry/semantic-conventions": "1.0.1"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-http": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.24.0.tgz",
-			"integrity": "sha512-LP0Iw24GFZvsAhUUFgmv8beG4vPEhDsgbHXOcGoSxHntnaDOY+5Df8y5CybSdt/DgqtkKr+3bs+TloeTHNu3Tw==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.27.0.tgz",
+			"integrity": "sha512-Q1dxUt+5d70rbY6jJAC8nwpIQJontmJW94eIS5CsGngvCRYw6tgjLZp2fpVL1o7Lj7uiLpGigeE4EN5Lr2YDFA==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/instrumentation": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/core": "1.0.1",
+				"@opentelemetry/instrumentation": "0.27.0",
+				"@opentelemetry/semantic-conventions": "1.0.1",
+				"semver": "^7.3.5"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+			"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "1.0.1"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-ioredis": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.24.0.tgz",
-			"integrity": "sha512-dCATTANfWCiMdIJwomG6lwloQNoaUeaQcq1CImYE+kgBcQ80Gpg2E5UdF8WIYYxLpcsurayx7prOnP+odGWr2w==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.27.0.tgz",
+			"integrity": "sha512-1k2TMB38eppJJXK2Fch/e3KG7BDkfa5bPjhxBhXqb/jrMj0I9h0gkX2UmxRjVQd7wIFHTffAFA9hVJAw1Nd8UQ==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/ioredis": "4.26.6"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-ioredis/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-koa": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.24.0.tgz",
-			"integrity": "sha512-/O07SRRnjgKGVqnTmPPMYlZCC7fgU/I/dxarXEV0gLKkrb8fTgO8IUY5DhfpZtXPDQNA6+U5poCli7cyPNmE6w==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.28.0.tgz",
+			"integrity": "sha512-MFBulPyKgo4TI7LyefYeCNDykIBi2nA5BqJr8RX+ZZ2BoykipBVf0AgtrCvKep9u3XbM8fgF7sNYtc2UvMoW6w==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "^0.24.0",
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/core": "^1.0.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/koa": "2.13.4",
 				"@types/koa__router": "8.0.7"
 			},
@@ -307,94 +302,93 @@
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-koa/node_modules/@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+			"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "1.0.1"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-koa/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-mongodb": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.24.0.tgz",
-			"integrity": "sha512-2vNGb8uWWwA4fcsBC8gSVUPJiKeXEntTYKY7bVh+Cyz3G5awk+dtHIB7NRaqMwc+9odJhATDSvoNGhq4qk3Pcw==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.27.0.tgz",
+			"integrity": "sha512-Ae9bNTHg+rt7kx3o4j0sizXZVx4S82yIahsmZ2cDqV3BE2RV8+My/+CUx4jCbSa0c8VGyK4Loyyn6IINVs3Yxg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/mongodb": "3.6.20"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-mongodb/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-mysql": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.24.0.tgz",
-			"integrity": "sha512-AGZwO2joolCBcIu295nE5535tVmQj7a7heVoBm+T8lLrkGSJMvj40gFv6nBplpjw2jeTMkN/43xChYcb0eMSpg==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.27.0.tgz",
+			"integrity": "sha512-MfGj73/2cxbwQ/rmBkYOMwwRvznPgifMMI0cb5JEmHzs2C7enXBpGJbFMZiAJM7rRmekkok/nuyvbWBERau+TA==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/mysql": "2.15.19"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-mysql/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-pg": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.24.0.tgz",
-			"integrity": "sha512-sRFWArL0Kj1af/Se3wm3SXNVJ/VywSJoWDnKxHjP67Ejqx1aiMQhv6WLnkE+coQykywG3jPBpCuQkZJoS1xcHg==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.27.0.tgz",
+			"integrity": "sha512-8G3YwQ/9K1B2IfYAipvTHyTqN79pz4xtNdi2HvvPnspBsrUeF71LqA3S04z1AeU81QhEOgX6D2+FZKdx8N/KTg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/pg": "8.6.1",
 				"@types/pg-pool": "2.0.3"
 			},
@@ -402,99 +396,39 @@
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-redis": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.24.0.tgz",
-			"integrity": "sha512-GiJEVyRFvi6PQtNeKGT859YMEM/NrAA60RGH3/bqPgB+g82N2Eb+6vMufrzJHI40c0BD1DXR5L9qNp7fSEe9gA==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.27.0.tgz",
+			"integrity": "sha512-A54NWDuqnTk0XImM64eDhNuvn139scUBxPbkea+Y5QqLKac83XGpVsGI2RCSN4dR2KLurdDI2B3qBVkJ5mxAzA==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/redis": "2.8.31"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-redis/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@opentelemetry/metrics": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.24.0.tgz",
-			"integrity": "sha512-QqmQCzrSuJE+sCOJ2xXNhctWPp/Am9ILs0Y01MDS08PRJoK20akKHM7eC4oU8ZdXphMg8rYgW2w7tY8rqvYnJg==",
-			"deprecated": "Package renamed to @opentelemetry/sdk-metrics-base",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/api-metrics": "0.24.0",
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
-				"lodash.merge": "^4.6.2"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/metrics/node_modules/@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
-			},
-			"engines": {
-				"node": ">=8.5.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/metrics/node_modules/@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/metrics/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
@@ -627,71 +561,70 @@
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-aws": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-0.24.0.tgz",
-			"integrity": "sha512-vaJ6pi9gLVwOmj3mwe6VvbkNXSKc0Oadkjk9tC/Pp0m7QA3PYCcle13byeA6Qqr9YD5b6F7kaU8FXMVZ6FVqjQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.0.2.tgz",
+			"integrity": "sha512-a/Bc2W6ey+p0My0IQPZbRbpzU4mehWZmovkSXpFRQPuyadct3cHWgmB5wDrSiJ0yqfhKt1GQVpF8A8N/oRURUw==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/resource-detector-aws/node_modules/@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/core": "^1.0.0",
+				"@opentelemetry/resources": "^1.0.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
+			}
+		},
+		"node_modules/@opentelemetry/resource-detector-aws/node_modules/@opentelemetry/core": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+			"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
+			"dev": true,
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "1.0.1"
+			},
+			"engines": {
+				"node": ">=8.5.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-aws/node_modules/@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
+			"integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
+				"@opentelemetry/core": "1.0.1",
+				"@opentelemetry/semantic-conventions": "1.0.1"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-aws/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-gcp": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.24.0.tgz",
-			"integrity": "sha512-4Js1sybUdrV3gN311XMUYlD2SvOx60YC69RUwz+QXTysma1mgPTMwFJcEwQJzyJEVuzqh+fXxE2QipucFwDI1g==",
+			"version": "0.26.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.26.1.tgz",
+			"integrity": "sha512-7I4UPhfhssFQ/r+TE8uhO1pQ0bGO8zQHKUi7zhoh4dCWy9ralk+8x26qiZe21nrmTVL9F/h0+g6AUEifZPBicg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0",
+				"@opentelemetry/resources": "^1.0.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"gcp-metadata": "^4.1.4",
 				"semver": "7.3.5"
 			},
@@ -699,58 +632,57 @@
 				"node": ">=10.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-gcp/node_modules/@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+			"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "1.0.1"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-gcp/node_modules/@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
+			"integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
+				"@opentelemetry/core": "1.0.1",
+				"@opentelemetry/semantic-conventions": "1.0.1"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-gcp/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/resources": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.25.0.tgz",
-			"integrity": "sha512-O46u53vDBlxCML8O9dIjsRcCC2VT5ri1upwhp02ITobgJ16aVD/iScCo1lPl/x2E7yq9uwzMINENiiYZRFb6XA==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.26.0.tgz",
+			"integrity": "sha512-s0iyFqmv5dAipXioS3PwIeD6c2TC5jzfcrwDzZXSsMz0LbDiFlhb149OPd0CngYMwcEWqQcAVzqu++3jzDvCsw==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "0.25.0",
-				"@opentelemetry/semantic-conventions": "0.25.0"
+				"@opentelemetry/core": "0.26.0",
+				"@opentelemetry/semantic-conventions": "0.26.0"
 			},
 			"engines": {
 				"node": ">=8.0.0"
@@ -759,79 +691,215 @@
 				"@opentelemetry/api": "^1.0.2"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-node": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.24.0.tgz",
-			"integrity": "sha512-vsyBgGShfvLoqKTiHiAgp89m3No6k6wJLIuAagcIOAzGGCuyNIAaJEGhYKHQh3oH/koBZYA+f2anqK8gplsKRQ==",
+		"node_modules/@opentelemetry/sdk-metrics-base": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.27.0.tgz",
+			"integrity": "sha512-HpiWI4sVNsjp3FGyUlc24KvUY2Whl4PQVwcbA/gWv2kHaLQrDJrWC+3rjUR+87Mrd0nsiqJ85xhGFU6IK8h7gg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/api-metrics": "0.24.0",
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/instrumentation": "0.24.0",
-				"@opentelemetry/metrics": "0.24.0",
-				"@opentelemetry/node": "0.24.0",
-				"@opentelemetry/resource-detector-aws": "0.24.0",
-				"@opentelemetry/resource-detector-gcp": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/tracing": "0.24.0"
+				"@opentelemetry/api-metrics": "0.27.0",
+				"@opentelemetry/core": "1.0.1",
+				"@opentelemetry/resources": "1.0.1",
+				"lodash.merge": "^4.6.2"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.0"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+		"node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/core": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+			"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "1.0.1"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+		"node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/resources": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
+			"integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
+				"@opentelemetry/core": "1.0.1",
+				"@opentelemetry/semantic-conventions": "1.0.1"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-node": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.27.0.tgz",
+			"integrity": "sha512-WVk4FfL+weXPFKBDUmJKc0e9xxhpmIB81dW+5Wohu56XAgItbm+cbLf9dH/vu++yMfeLwqfGQeDNGmbMoGAXJg==",
+			"dev": true,
+			"dependencies": {
+				"@opentelemetry/api-metrics": "0.27.0",
+				"@opentelemetry/core": "~1.0.0",
+				"@opentelemetry/instrumentation": "0.27.0",
+				"@opentelemetry/resource-detector-aws": "~1.0.0",
+				"@opentelemetry/resource-detector-gcp": "~0.26.0",
+				"@opentelemetry/resources": "~1.0.0",
+				"@opentelemetry/sdk-metrics-base": "0.27.0",
+				"@opentelemetry/sdk-trace-base": "~1.0.0",
+				"@opentelemetry/sdk-trace-node": "~1.0.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/context-async-hooks": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.0.1.tgz",
+			"integrity": "sha512-oGCPjDlZ03gXPAdLxw5iqaQJIpL8BZFaiZhAPgF7Vj6XYmrmrA/FXVIsjfNECQTa2D+lt5p8vf0xYIkFufgceQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.1.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/core": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+			"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
+			"dev": true,
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "1.0.1"
+			},
+			"engines": {
+				"node": ">=8.5.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/propagator-b3": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.0.1.tgz",
+			"integrity": "sha512-UQQiOpR/WXyoqIRQEkn6RuXtGfpjhBDMq/1HrVxRCRPMVn7f4e+zxZWoQSsCOvSGQTu9S+W8eAutm00sRJN7fg==",
+			"dev": true,
+			"dependencies": {
+				"@opentelemetry/core": "1.0.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/propagator-jaeger": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.0.1.tgz",
+			"integrity": "sha512-bzvXksBn3j0GyiFXQbx87CUSGC1UDyp4hjL+CCOrQfzIEdp6usKCLHv40Ib5WU6739hPMkyr59CPfKwzlviTtA==",
+			"dev": true,
+			"dependencies": {
+				"@opentelemetry/core": "1.0.1"
+			},
+			"engines": {
+				"node": ">=8.5.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
+			"integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
+			"dev": true,
+			"dependencies": {
+				"@opentelemetry/core": "1.0.1",
+				"@opentelemetry/semantic-conventions": "1.0.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.0.1.tgz",
+			"integrity": "sha512-JVSAepTpW7dnqfV7XFN0zHj1jXGNd5OcvIGQl76buogqffdgJdgJWQNrOuUJaus56zrOtlzqFH+YtMA9RGEg8w==",
+			"dev": true,
+			"dependencies": {
+				"@opentelemetry/core": "1.0.1",
+				"@opentelemetry/resources": "1.0.1",
+				"@opentelemetry/semantic-conventions": "1.0.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-node": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.0.1.tgz",
+			"integrity": "sha512-0ifT2pEI5aXy14zDDUQkl3ODzY6jjaC1plbxyAuz5BdPxGJzav9vzIJ2BhEwfXDn1LKqpQ5D1Yy+XnNRQpOo3w==",
+			"dev": true,
+			"dependencies": {
+				"@opentelemetry/context-async-hooks": "1.0.1",
+				"@opentelemetry/core": "1.0.1",
+				"@opentelemetry/propagator-b3": "1.0.1",
+				"@opentelemetry/propagator-jaeger": "1.0.1",
+				"@opentelemetry/sdk-trace-base": "1.0.1",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+			"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-0.25.0.tgz",
-			"integrity": "sha512-TInkLSF/ThM3GNVM+9tgnCVjyNLnRxvAkG585Fhu0HNwaEtCTUwI0r7AvMRIREOreeRWttBG6kvT0LOKdo8yjw==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-0.26.0.tgz",
+			"integrity": "sha512-SqV5pccxJTekOXdE1jp5VWxZ7GYw8rrHy7g0LcxLzn+D8YJ9ZBhE481VrP9EsjyLlJRhicv+z2g1XFxpMkQdmA==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "0.25.0",
-				"@opentelemetry/resources": "0.25.0",
-				"@opentelemetry/semantic-conventions": "0.25.0",
+				"@opentelemetry/core": "0.26.0",
+				"@opentelemetry/resources": "0.26.0",
+				"@opentelemetry/semantic-conventions": "0.26.0",
 				"lodash.merge": "^4.6.2"
 			},
 			"engines": {
@@ -842,17 +910,17 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node": {
-			"version": "0.24.1-alpha.4",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-0.24.1-alpha.4.tgz",
-			"integrity": "sha512-Lbd/OMHgCy5qqbV9MCIB0oIRy8fO+jPBXjPwEYwL/x4wzRPhV8JYPXSockwnGFSr1DigYdwV+SD7pRjdgxqG0g==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-0.26.0.tgz",
+			"integrity": "sha512-TD0i8GWP3EpuF9F5ZBaoicaj0H18gVKivYi/yzYGKFVZnLScHi49ljux8hYIoru3eAIjP789XyFHuVacWb+V1g==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/context-async-hooks": "^0.24.0",
-				"@opentelemetry/core": "^0.24.1-alpha.4+a8d39317",
-				"@opentelemetry/propagator-b3": "^0.24.1-alpha.4+a8d39317",
-				"@opentelemetry/propagator-jaeger": "^0.24.1-alpha.4+a8d39317",
-				"@opentelemetry/sdk-trace-base": "^0.24.1-alpha.4+a8d39317",
-				"semver": "^7.1.3"
+				"@opentelemetry/context-async-hooks": "0.26.0",
+				"@opentelemetry/core": "0.26.0",
+				"@opentelemetry/propagator-b3": "0.26.0",
+				"@opentelemetry/propagator-jaeger": "0.26.0",
+				"@opentelemetry/sdk-trace-base": "0.26.0",
+				"semver": "^7.3.5"
 			},
 			"engines": {
 				"node": ">=8.0.0"
@@ -861,78 +929,25 @@
 				"@opentelemetry/api": "^1.0.2"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
-			"version": "0.24.1-alpha.31",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.1-alpha.31.tgz",
-			"integrity": "sha512-ssPWP6c+jXRc+zaf3W/7pumBKNP/11EU5rjFKpBE3/5ZKNolZwX6e+UhhXAX8FhdpuFEvtwumUmqryiTKuYK6A==",
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/context-async-hooks": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.26.0.tgz",
+			"integrity": "sha512-r879ngcadv1SeZ53zS+IOmrnebW0MCpC/XGye6/QrAZJmnldq7ga2hy4cqwKvH+lsR4Ds4gHEpb07rdwCEULIg==",
 			"dev": true,
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^0.24.1-alpha.31+fd2410cc",
-				"semver": "^7.1.3"
-			},
 			"engines": {
-				"node": ">=8.5.0"
+				"node": ">=8.1.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/propagator-b3": {
-			"version": "0.24.1-alpha.31",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-0.24.1-alpha.31.tgz",
-			"integrity": "sha512-6DbKyqJAIMguYWFlUCNnTlCnJDJdXW6avLAKJQK20dSttzCOuHI4MtzbZcNLz5CWee6zRTkMPXgJUbtzI/GWJw==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-0.26.0.tgz",
+			"integrity": "sha512-x+fLyqCTjTmpBaWe8/cTpnVnBLAEkcC0K9P2ULNEu99++QPnpE4gM9jri/TdIAOJGzEqCSB6vGfOASNhZHA00Q==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "^0.24.1-alpha.31+fd2410cc"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/propagator-jaeger": {
-			"version": "0.24.1-alpha.31",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.24.1-alpha.31.tgz",
-			"integrity": "sha512-slWXgCfgcW5vk//kapT+Ne2xPPh0HCw3umVu6ZK/6ov38ejrx0kN2ZeX6E8QQdr8u/v/0gxdfGFiHMw3gbLb9g==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/core": "^0.24.1-alpha.31+fd2410cc"
-			},
-			"engines": {
-				"node": ">=8.5.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/resources": {
-			"version": "0.24.1-alpha.31",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.1-alpha.31.tgz",
-			"integrity": "sha512-QtgoLy0xYXe/O9D8xcZajcrMI47L8tOC7+hbPAjtt7kSGYm0RJU+mupbLvOtxCDKDzsv+VcacxVg/bAbrOF2uA==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/core": "^0.24.1-alpha.31+fd2410cc",
-				"@opentelemetry/semantic-conventions": "^0.24.1-alpha.31+fd2410cc"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "0.24.1-alpha.4",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-0.24.1-alpha.4.tgz",
-			"integrity": "sha512-dRMAseFliUOYuKoHha+3/qdNsU0JyY8085xzrRyJP7TvXo6KQKzotRCtMTMvXgv3UOufeZTMHyO13J3cuB+eSg==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/core": "^0.24.1-alpha.4+a8d39317",
-				"@opentelemetry/resources": "^0.24.1-alpha.4+a8d39317",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
-				"lodash.merge": "^4.6.2"
+				"@opentelemetry/core": "0.26.0"
 			},
 			"engines": {
 				"node": ">=8.0.0"
@@ -941,28 +956,25 @@
 				"@opentelemetry/api": "^1.0.2"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/propagator-jaeger": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.26.0.tgz",
+			"integrity": "sha512-UM+pHLmkRQOJFUyOY7yBk7NStOMeNvpUswnlWBRM0W2V/kOavyckikkMpNsUi2WlCijETW20feGt/m+Ukus9Rw==",
 			"dev": true,
+			"dependencies": {
+				"@opentelemetry/core": "0.26.0"
+			},
 			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.1-alpha.31",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.1-alpha.31.tgz",
-			"integrity": "sha512-kVdxTt4M+Fe5MwZ3QjAFDoHpiJ0MDh0IbvxQkHODb9EUiZxYICgDXKVUM25z/DDctaiXzlfTtVYOLDpPHGStPA==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.0.0"
+				"node": ">=8.5.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
-			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.26.0.tgz",
+			"integrity": "sha512-iO26zEr7GCAG9/yernhSj/LcB4EudVcN8fiI/8B4lVnoqLZQ/qHaOVdyemdeXZ8IkIvoCifoJYPqIARJpqg42w==",
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -1037,9 +1049,9 @@
 			}
 		},
 		"node_modules/@types/body-parser": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
-			"integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+			"version": "1.19.2",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+			"integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
 			"dev": true,
 			"dependencies": {
 				"@types/connect": "*",
@@ -1047,12 +1059,13 @@
 			}
 		},
 		"node_modules/@types/bson": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
-			"integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.0.tgz",
+			"integrity": "sha512-ELCPqAdroMdcuxqwMgUpifQyRoTpyYCNr1V9xKyF40VsBobsj+BbWNRvwGchMgBPGqkw655ypkjj2MEF5ywVwg==",
+			"deprecated": "This is a stub types definition. bson provides its own type definitions, so you do not need this installed.",
 			"dev": true,
 			"dependencies": {
-				"@types/node": "*"
+				"bson": "*"
 			}
 		},
 		"node_modules/@types/connect": {
@@ -1095,9 +1108,9 @@
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "4.17.24",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
-			"integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+			"version": "4.17.26",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.26.tgz",
+			"integrity": "sha512-zeu3tpouA043RHxW0gzRxwCHchMgftE8GArRsvYT0ByDMbn19olQHx5jLue0LxWY6iYtXb7rXmuVtSkhy9YZvQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
@@ -1202,9 +1215,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "16.7.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
-			"integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==",
+			"version": "16.11.12",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+			"integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
 			"dev": true
 		},
 		"node_modules/@types/pg": {
@@ -1282,6 +1295,26 @@
 				"node": ">= 6.0.0"
 			}
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/bignumber.js": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
@@ -1289,6 +1322,42 @@
 			"dev": true,
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/bson": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-4.6.0.tgz",
+			"integrity": "sha512-8jw1NU1hglS+Da1jDOUYuNcBJ4cNHCFIqzlwoFNnsTOg2R/ox0aTYcTiBN4dzRa9q7Cvy6XErh3L8ReTEb9AQQ==",
+			"dev": true,
+			"dependencies": {
+				"buffer": "^5.6.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
 			}
 		},
 		"node_modules/chai-spies": {
@@ -1342,25 +1411,25 @@
 			"dev": true
 		},
 		"node_modules/gaxios": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.0.tgz",
-			"integrity": "sha512-pHplNbslpwCLMyII/lHPWFQbJWOX0B3R1hwBEOvzYi1GmdKZruuEHK4N9V6f7tf1EaPYyF80mui1+344p6SmLg==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.2.tgz",
+			"integrity": "sha512-T+ap6GM6UZ0c4E6yb1y/hy2UB6hTrqhglp3XfmU9qbLCGRYhLVV5aRPpC4EmoG8N8zOnkYCgoBz+ScvGAARY6Q==",
 			"dev": true,
 			"dependencies": {
 				"abort-controller": "^3.0.0",
 				"extend": "^3.0.2",
 				"https-proxy-agent": "^5.0.0",
 				"is-stream": "^2.0.0",
-				"node-fetch": "^2.3.0"
+				"node-fetch": "^2.6.1"
 			},
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/gcp-metadata": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.0.tgz",
-			"integrity": "sha512-L9XQUpvKJCM76YRSmcxrR4mFPzPGsgZUH+GgHMxAET8qc6+BhRJq63RLhWakgEO2KKVgeSDVfyiNjkGSADwNTA==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+			"integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
 			"dev": true,
 			"dependencies": {
 				"gaxios": "^4.0.0",
@@ -1371,12 +1440,12 @@
 			}
 		},
 		"node_modules/graphql": {
-			"version": "15.5.2",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.2.tgz",
-			"integrity": "sha512-dZjLPWNQqYv0dqV2RNbiFed0LtSp6yd4jchsDGnuhDKa9OQHJYCfovaOEvY91w9gqbYO7Se9LKDTl3xxYva/3w==",
+			"version": "16.1.0",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.1.0.tgz",
+			"integrity": "sha512-+PIjmhqGHMIxtnlEirRXDHIzs0cAHAozKG5M2w2N4TnS8VzCxO3bbv1AW9UTeycBfl2QsPduxcVrBvANFKQhiw==",
 			"dev": true,
 			"engines": {
-				"node": ">= 10.x"
+				"node": "^12.22.0 || ^14.16.0 || >=16.0.0"
 			}
 		},
 		"node_modules/has": {
@@ -1403,6 +1472,26 @@
 			"engines": {
 				"node": ">= 6"
 			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
 		"node_modules/is-core-module": {
 			"version": "2.6.0",
@@ -1473,10 +1562,13 @@
 			"dev": true
 		},
 		"node_modules/node-fetch": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+			"version": "2.6.6",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+			"integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
 			"dev": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
 			"engines": {
 				"node": "4.x || >=6.0.0"
 			}
@@ -1601,6 +1693,28 @@
 			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
 			"dev": true
 		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
+		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+			"dev": true
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"dev": true,
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -1623,30 +1737,29 @@
 			"integrity": "sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ=="
 		},
 		"@opentelemetry/api-metrics": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.24.0.tgz",
-			"integrity": "sha512-hdpkMeVlRGTuMshD2ZFaDjA/U0cZTkxUkJFvS/4yOiWfw+kEASmGE+U0/i9lbdQKuCR7X1rXSjbcYumlHcMG+A==",
-			"dev": true,
-			"requires": {}
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.27.0.tgz",
+			"integrity": "sha512-tB79288bwjkdhPNpw4UdOEy3bacVwtol6Que7cAu8KEJ9ULjRfSiwpYEwJY/oER3xZ7zNFz0uiJ7N1jSiotpVA==",
+			"dev": true
 		},
 		"@opentelemetry/auto-instrumentations-node": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.24.0.tgz",
-			"integrity": "sha512-2p0NT8rELCDOHZKqjisrsxy7/yt0CV9Lm1urJ1KA++CshSXqF+Zp4ox8Wcx+ljWW5Iq9VjvUeSeI062eJBdeLA==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.27.0.tgz",
+			"integrity": "sha512-DlY6f00wTM6H6THcGvI/jaM9qIGiA11VPIGgvpU1SKJgQLauKD6f6plvtRQWDpqGsXYSCQdwExE9XlJIkovTkQ==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/instrumentation-dns": "^0.24.0",
-				"@opentelemetry/instrumentation-express": "^0.24.0",
-				"@opentelemetry/instrumentation-graphql": "^0.24.0",
-				"@opentelemetry/instrumentation-grpc": "^0.24.0",
-				"@opentelemetry/instrumentation-http": "^0.24.0",
-				"@opentelemetry/instrumentation-ioredis": "^0.24.0",
-				"@opentelemetry/instrumentation-koa": "^0.24.0",
-				"@opentelemetry/instrumentation-mongodb": "^0.24.0",
-				"@opentelemetry/instrumentation-mysql": "^0.24.0",
-				"@opentelemetry/instrumentation-pg": "^0.24.0",
-				"@opentelemetry/instrumentation-redis": "^0.24.0"
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/instrumentation-dns": "^0.27.0",
+				"@opentelemetry/instrumentation-express": "^0.27.0",
+				"@opentelemetry/instrumentation-graphql": "^0.27.0",
+				"@opentelemetry/instrumentation-grpc": "^0.27.0",
+				"@opentelemetry/instrumentation-http": "^0.27.0",
+				"@opentelemetry/instrumentation-ioredis": "^0.27.0",
+				"@opentelemetry/instrumentation-koa": "^0.28.0",
+				"@opentelemetry/instrumentation-mongodb": "^0.27.0",
+				"@opentelemetry/instrumentation-mysql": "^0.27.0",
+				"@opentelemetry/instrumentation-pg": "^0.27.0",
+				"@opentelemetry/instrumentation-redis": "^0.27.0"
 			}
 		},
 		"@opentelemetry/context-async-hooks": {
@@ -1657,297 +1770,254 @@
 			"requires": {}
 		},
 		"@opentelemetry/core": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
-			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.26.0.tgz",
+			"integrity": "sha512-nsHG5uIxqNKxZve6P8QtRFfymYgjE/rIDtEmxEfB9SMpToGEBIrCzgrWqEAT8lnpzB/l029pFl1TquuEb/cmcw==",
 			"requires": {
-				"@opentelemetry/semantic-conventions": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.26.0",
 				"semver": "^7.3.5"
 			}
 		},
 		"@opentelemetry/instrumentation": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.24.0.tgz",
-			"integrity": "sha512-Kn581LUJrVsuV6j8KjNpNWFecyrLoc3GRiTpXUl48LVtm9CCbdwNZGe3PRmWN1Mb/bmWr/tt3GHcuhyUxAsY0A==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.27.0.tgz",
+			"integrity": "sha512-dUwY/VoDptdK8AYigwS3IKblG+unV5xIdV4VQKy+nX5aT3f7vd5PMYs4arCQSYLbLRe0s7GxK6S9dtjai/TsHQ==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api-metrics": "0.24.0",
+				"@opentelemetry/api-metrics": "0.27.0",
 				"require-in-the-middle": "^5.0.3",
 				"semver": "^7.3.2",
 				"shimmer": "^1.2.1"
 			}
 		},
 		"@opentelemetry/instrumentation-dns": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.24.0.tgz",
-			"integrity": "sha512-6dK0ZRNaf8tVH09ZHn1cWuJc2DXLaRCrWXn8lCzIZZdQeh6xRO6ZQj0pl9YuU9sKRfEbZlpVtLgQ5CBLNwNSOQ==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.27.0.tgz",
+			"integrity": "sha512-0UxCW+zdnD2cqduwpym4boNWsdRI3pRLt7e80FPxCmuGZ8X45UoJoYvd1Isb0/hWZCQ/+vzXYnVuo4LvE743pg==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"semver": "^7.3.2"
 			},
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 					"dev": true
 				}
 			}
 		},
 		"@opentelemetry/instrumentation-express": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.24.0.tgz",
-			"integrity": "sha512-XjKX3807jPALrBPmg64PsgEqIIZyweROLk9y5KxohkCiq3t+3rJRZw0f8zI7nCgaf4KRZoPL1Vy49+FHdUo9Rg==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.27.0.tgz",
+			"integrity": "sha512-8C7jGqrhTmAP2lZNzH7SSxSClij3wlYTB7t71/wsFooV01yo/cH2Go0kDo13kPmcGhoR07iMZDabeHWwdxre6w==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "^0.24.0",
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/core": "^1.0.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/express": "4.17.13"
 			},
 			"dependencies": {
 				"@opentelemetry/core": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-					"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+					"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
 					"dev": true,
 					"requires": {
-						"@opentelemetry/semantic-conventions": "0.24.0",
-						"semver": "^7.1.3"
+						"@opentelemetry/semantic-conventions": "1.0.1"
 					}
 				},
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 					"dev": true
 				}
 			}
 		},
 		"@opentelemetry/instrumentation-graphql": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.24.0.tgz",
-			"integrity": "sha512-L+xsovqddtUcd8i5yQGLq1VaYsfeWDVWpPDhJWoEQ8R0ToFB0VC8ipzNBemJ8jr1cyubOyYdiSj9tUXFW+pWdg==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.27.0.tgz",
+			"integrity": "sha512-B+YXItqPMxedkUiXiCLC8h/4nKcpNjJv6H7GwyZwuIoTzTXg2WUet4sY2VRdFkC1jyR5W8+/UPGnfud5ktg8gQ==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/instrumentation": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
 				"@types/graphql": "14.5.0"
 			}
 		},
 		"@opentelemetry/instrumentation-grpc": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.24.0.tgz",
-			"integrity": "sha512-fdsrKC1dcUsNsoCNtHLXr669UN9iKRRHmKcONkcoPdYOmptEjkSzOd4sWUP2E+cNEwvyP3mfGGmmNOMYsEno0g==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.27.0.tgz",
+			"integrity": "sha512-aFHcAeeLfqoH8PMjmdqEwZwXDJtFSkWmGDBZeH2yrx3KzFMVBB/UJEr1n/ZC6AqfqahL/qqB1N8EnoCoOcs5ig==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api-metrics": "0.24.0",
-				"@opentelemetry/instrumentation": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
+				"@opentelemetry/api-metrics": "0.27.0",
+				"@opentelemetry/instrumentation": "0.27.0",
+				"@opentelemetry/semantic-conventions": "1.0.1"
 			},
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 					"dev": true
 				}
 			}
 		},
 		"@opentelemetry/instrumentation-http": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.24.0.tgz",
-			"integrity": "sha512-LP0Iw24GFZvsAhUUFgmv8beG4vPEhDsgbHXOcGoSxHntnaDOY+5Df8y5CybSdt/DgqtkKr+3bs+TloeTHNu3Tw==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.27.0.tgz",
+			"integrity": "sha512-Q1dxUt+5d70rbY6jJAC8nwpIQJontmJW94eIS5CsGngvCRYw6tgjLZp2fpVL1o7Lj7uiLpGigeE4EN5Lr2YDFA==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/instrumentation": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/core": "1.0.1",
+				"@opentelemetry/instrumentation": "0.27.0",
+				"@opentelemetry/semantic-conventions": "1.0.1",
+				"semver": "^7.3.5"
 			},
 			"dependencies": {
 				"@opentelemetry/core": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-					"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+					"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
 					"dev": true,
 					"requires": {
-						"@opentelemetry/semantic-conventions": "0.24.0",
-						"semver": "^7.1.3"
+						"@opentelemetry/semantic-conventions": "1.0.1"
 					}
 				},
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 					"dev": true
 				}
 			}
 		},
 		"@opentelemetry/instrumentation-ioredis": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.24.0.tgz",
-			"integrity": "sha512-dCATTANfWCiMdIJwomG6lwloQNoaUeaQcq1CImYE+kgBcQ80Gpg2E5UdF8WIYYxLpcsurayx7prOnP+odGWr2w==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.27.0.tgz",
+			"integrity": "sha512-1k2TMB38eppJJXK2Fch/e3KG7BDkfa5bPjhxBhXqb/jrMj0I9h0gkX2UmxRjVQd7wIFHTffAFA9hVJAw1Nd8UQ==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/ioredis": "4.26.6"
 			},
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 					"dev": true
 				}
 			}
 		},
 		"@opentelemetry/instrumentation-koa": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.24.0.tgz",
-			"integrity": "sha512-/O07SRRnjgKGVqnTmPPMYlZCC7fgU/I/dxarXEV0gLKkrb8fTgO8IUY5DhfpZtXPDQNA6+U5poCli7cyPNmE6w==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.28.0.tgz",
+			"integrity": "sha512-MFBulPyKgo4TI7LyefYeCNDykIBi2nA5BqJr8RX+ZZ2BoykipBVf0AgtrCvKep9u3XbM8fgF7sNYtc2UvMoW6w==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "^0.24.0",
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/core": "^1.0.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/koa": "2.13.4",
 				"@types/koa__router": "8.0.7"
 			},
 			"dependencies": {
 				"@opentelemetry/core": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-					"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+					"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
 					"dev": true,
 					"requires": {
-						"@opentelemetry/semantic-conventions": "0.24.0",
-						"semver": "^7.1.3"
+						"@opentelemetry/semantic-conventions": "1.0.1"
 					}
 				},
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 					"dev": true
 				}
 			}
 		},
 		"@opentelemetry/instrumentation-mongodb": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.24.0.tgz",
-			"integrity": "sha512-2vNGb8uWWwA4fcsBC8gSVUPJiKeXEntTYKY7bVh+Cyz3G5awk+dtHIB7NRaqMwc+9odJhATDSvoNGhq4qk3Pcw==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.27.0.tgz",
+			"integrity": "sha512-Ae9bNTHg+rt7kx3o4j0sizXZVx4S82yIahsmZ2cDqV3BE2RV8+My/+CUx4jCbSa0c8VGyK4Loyyn6IINVs3Yxg==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/mongodb": "3.6.20"
 			},
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 					"dev": true
 				}
 			}
 		},
 		"@opentelemetry/instrumentation-mysql": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.24.0.tgz",
-			"integrity": "sha512-AGZwO2joolCBcIu295nE5535tVmQj7a7heVoBm+T8lLrkGSJMvj40gFv6nBplpjw2jeTMkN/43xChYcb0eMSpg==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.27.0.tgz",
+			"integrity": "sha512-MfGj73/2cxbwQ/rmBkYOMwwRvznPgifMMI0cb5JEmHzs2C7enXBpGJbFMZiAJM7rRmekkok/nuyvbWBERau+TA==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/mysql": "2.15.19"
 			},
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 					"dev": true
 				}
 			}
 		},
 		"@opentelemetry/instrumentation-pg": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.24.0.tgz",
-			"integrity": "sha512-sRFWArL0Kj1af/Se3wm3SXNVJ/VywSJoWDnKxHjP67Ejqx1aiMQhv6WLnkE+coQykywG3jPBpCuQkZJoS1xcHg==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.27.0.tgz",
+			"integrity": "sha512-8G3YwQ/9K1B2IfYAipvTHyTqN79pz4xtNdi2HvvPnspBsrUeF71LqA3S04z1AeU81QhEOgX6D2+FZKdx8N/KTg==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/pg": "8.6.1",
 				"@types/pg-pool": "2.0.3"
 			},
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 					"dev": true
 				}
 			}
 		},
 		"@opentelemetry/instrumentation-redis": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.24.0.tgz",
-			"integrity": "sha512-GiJEVyRFvi6PQtNeKGT859YMEM/NrAA60RGH3/bqPgB+g82N2Eb+6vMufrzJHI40c0BD1DXR5L9qNp7fSEe9gA==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.27.0.tgz",
+			"integrity": "sha512-A54NWDuqnTk0XImM64eDhNuvn139scUBxPbkea+Y5QqLKac83XGpVsGI2RCSN4dR2KLurdDI2B3qBVkJ5mxAzA==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/instrumentation": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/instrumentation": "^0.27.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"@types/redis": "2.8.31"
 			},
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
-					"dev": true
-				}
-			}
-		},
-		"@opentelemetry/metrics": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.24.0.tgz",
-			"integrity": "sha512-QqmQCzrSuJE+sCOJ2xXNhctWPp/Am9ILs0Y01MDS08PRJoK20akKHM7eC4oU8ZdXphMg8rYgW2w7tY8rqvYnJg==",
-			"dev": true,
-			"requires": {
-				"@opentelemetry/api-metrics": "0.24.0",
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
-				"lodash.merge": "^4.6.2"
-			},
-			"dependencies": {
-				"@opentelemetry/core": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-					"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/semantic-conventions": "0.24.0",
-						"semver": "^7.1.3"
-					}
-				},
-				"@opentelemetry/resources": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-					"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/core": "0.24.0",
-						"@opentelemetry/semantic-conventions": "0.24.0"
-					}
-				},
-				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 					"dev": true
 				}
 			}
@@ -2039,235 +2109,282 @@
 			}
 		},
 		"@opentelemetry/resource-detector-aws": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-0.24.0.tgz",
-			"integrity": "sha512-vaJ6pi9gLVwOmj3mwe6VvbkNXSKc0Oadkjk9tC/Pp0m7QA3PYCcle13byeA6Qqr9YD5b6F7kaU8FXMVZ6FVqjQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.0.2.tgz",
+			"integrity": "sha512-a/Bc2W6ey+p0My0IQPZbRbpzU4mehWZmovkSXpFRQPuyadct3cHWgmB5wDrSiJ0yqfhKt1GQVpF8A8N/oRURUw==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
+				"@opentelemetry/core": "^1.0.0",
+				"@opentelemetry/resources": "^1.0.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0"
 			},
 			"dependencies": {
 				"@opentelemetry/core": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-					"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+					"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
 					"dev": true,
 					"requires": {
-						"@opentelemetry/semantic-conventions": "0.24.0",
-						"semver": "^7.1.3"
+						"@opentelemetry/semantic-conventions": "1.0.1"
 					}
 				},
 				"@opentelemetry/resources": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-					"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
+					"integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
 					"dev": true,
 					"requires": {
-						"@opentelemetry/core": "0.24.0",
-						"@opentelemetry/semantic-conventions": "0.24.0"
+						"@opentelemetry/core": "1.0.1",
+						"@opentelemetry/semantic-conventions": "1.0.1"
 					}
 				},
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 					"dev": true
 				}
 			}
 		},
 		"@opentelemetry/resource-detector-gcp": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.24.0.tgz",
-			"integrity": "sha512-4Js1sybUdrV3gN311XMUYlD2SvOx60YC69RUwz+QXTysma1mgPTMwFJcEwQJzyJEVuzqh+fXxE2QipucFwDI1g==",
+			"version": "0.26.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.26.1.tgz",
+			"integrity": "sha512-7I4UPhfhssFQ/r+TE8uhO1pQ0bGO8zQHKUi7zhoh4dCWy9ralk+8x26qiZe21nrmTVL9F/h0+g6AUEifZPBicg==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0",
+				"@opentelemetry/resources": "^1.0.0",
+				"@opentelemetry/semantic-conventions": "^1.0.0",
 				"gcp-metadata": "^4.1.4",
 				"semver": "7.3.5"
 			},
 			"dependencies": {
 				"@opentelemetry/core": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-					"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+					"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
 					"dev": true,
 					"requires": {
-						"@opentelemetry/semantic-conventions": "0.24.0",
-						"semver": "^7.1.3"
+						"@opentelemetry/semantic-conventions": "1.0.1"
 					}
 				},
 				"@opentelemetry/resources": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-					"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
+					"integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
 					"dev": true,
 					"requires": {
-						"@opentelemetry/core": "0.24.0",
-						"@opentelemetry/semantic-conventions": "0.24.0"
+						"@opentelemetry/core": "1.0.1",
+						"@opentelemetry/semantic-conventions": "1.0.1"
 					}
 				},
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 					"dev": true
 				}
 			}
 		},
 		"@opentelemetry/resources": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.25.0.tgz",
-			"integrity": "sha512-O46u53vDBlxCML8O9dIjsRcCC2VT5ri1upwhp02ITobgJ16aVD/iScCo1lPl/x2E7yq9uwzMINENiiYZRFb6XA==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.26.0.tgz",
+			"integrity": "sha512-s0iyFqmv5dAipXioS3PwIeD6c2TC5jzfcrwDzZXSsMz0LbDiFlhb149OPd0CngYMwcEWqQcAVzqu++3jzDvCsw==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "0.25.0",
-				"@opentelemetry/semantic-conventions": "0.25.0"
+				"@opentelemetry/core": "0.26.0",
+				"@opentelemetry/semantic-conventions": "0.26.0"
 			}
 		},
-		"@opentelemetry/sdk-node": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.24.0.tgz",
-			"integrity": "sha512-vsyBgGShfvLoqKTiHiAgp89m3No6k6wJLIuAagcIOAzGGCuyNIAaJEGhYKHQh3oH/koBZYA+f2anqK8gplsKRQ==",
+		"@opentelemetry/sdk-metrics-base": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.27.0.tgz",
+			"integrity": "sha512-HpiWI4sVNsjp3FGyUlc24KvUY2Whl4PQVwcbA/gWv2kHaLQrDJrWC+3rjUR+87Mrd0nsiqJ85xhGFU6IK8h7gg==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api-metrics": "0.24.0",
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/instrumentation": "0.24.0",
-				"@opentelemetry/metrics": "0.24.0",
-				"@opentelemetry/node": "0.24.0",
-				"@opentelemetry/resource-detector-aws": "0.24.0",
-				"@opentelemetry/resource-detector-gcp": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/tracing": "0.24.0"
+				"@opentelemetry/api-metrics": "0.27.0",
+				"@opentelemetry/core": "1.0.1",
+				"@opentelemetry/resources": "1.0.1",
+				"lodash.merge": "^4.6.2"
 			},
 			"dependencies": {
 				"@opentelemetry/core": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-					"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+					"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
 					"dev": true,
 					"requires": {
-						"@opentelemetry/semantic-conventions": "0.24.0",
-						"semver": "^7.1.3"
+						"@opentelemetry/semantic-conventions": "1.0.1"
 					}
 				},
 				"@opentelemetry/resources": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-					"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
+					"integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
 					"dev": true,
 					"requires": {
-						"@opentelemetry/core": "0.24.0",
-						"@opentelemetry/semantic-conventions": "0.24.0"
+						"@opentelemetry/core": "1.0.1",
+						"@opentelemetry/semantic-conventions": "1.0.1"
 					}
 				},
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
+					"dev": true
+				}
+			}
+		},
+		"@opentelemetry/sdk-node": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.27.0.tgz",
+			"integrity": "sha512-WVk4FfL+weXPFKBDUmJKc0e9xxhpmIB81dW+5Wohu56XAgItbm+cbLf9dH/vu++yMfeLwqfGQeDNGmbMoGAXJg==",
+			"dev": true,
+			"requires": {
+				"@opentelemetry/api-metrics": "0.27.0",
+				"@opentelemetry/core": "~1.0.0",
+				"@opentelemetry/instrumentation": "0.27.0",
+				"@opentelemetry/resource-detector-aws": "~1.0.0",
+				"@opentelemetry/resource-detector-gcp": "~0.26.0",
+				"@opentelemetry/resources": "~1.0.0",
+				"@opentelemetry/sdk-metrics-base": "0.27.0",
+				"@opentelemetry/sdk-trace-base": "~1.0.0",
+				"@opentelemetry/sdk-trace-node": "~1.0.0"
+			},
+			"dependencies": {
+				"@opentelemetry/context-async-hooks": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.0.1.tgz",
+					"integrity": "sha512-oGCPjDlZ03gXPAdLxw5iqaQJIpL8BZFaiZhAPgF7Vj6XYmrmrA/FXVIsjfNECQTa2D+lt5p8vf0xYIkFufgceQ==",
+					"dev": true,
+					"requires": {}
+				},
+				"@opentelemetry/core": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+					"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
+					"dev": true,
+					"requires": {
+						"@opentelemetry/semantic-conventions": "1.0.1"
+					}
+				},
+				"@opentelemetry/propagator-b3": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.0.1.tgz",
+					"integrity": "sha512-UQQiOpR/WXyoqIRQEkn6RuXtGfpjhBDMq/1HrVxRCRPMVn7f4e+zxZWoQSsCOvSGQTu9S+W8eAutm00sRJN7fg==",
+					"dev": true,
+					"requires": {
+						"@opentelemetry/core": "1.0.1"
+					}
+				},
+				"@opentelemetry/propagator-jaeger": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.0.1.tgz",
+					"integrity": "sha512-bzvXksBn3j0GyiFXQbx87CUSGC1UDyp4hjL+CCOrQfzIEdp6usKCLHv40Ib5WU6739hPMkyr59CPfKwzlviTtA==",
+					"dev": true,
+					"requires": {
+						"@opentelemetry/core": "1.0.1"
+					}
+				},
+				"@opentelemetry/resources": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.0.1.tgz",
+					"integrity": "sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==",
+					"dev": true,
+					"requires": {
+						"@opentelemetry/core": "1.0.1",
+						"@opentelemetry/semantic-conventions": "1.0.1"
+					}
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.0.1.tgz",
+					"integrity": "sha512-JVSAepTpW7dnqfV7XFN0zHj1jXGNd5OcvIGQl76buogqffdgJdgJWQNrOuUJaus56zrOtlzqFH+YtMA9RGEg8w==",
+					"dev": true,
+					"requires": {
+						"@opentelemetry/core": "1.0.1",
+						"@opentelemetry/resources": "1.0.1",
+						"@opentelemetry/semantic-conventions": "1.0.1"
+					}
+				},
+				"@opentelemetry/sdk-trace-node": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.0.1.tgz",
+					"integrity": "sha512-0ifT2pEI5aXy14zDDUQkl3ODzY6jjaC1plbxyAuz5BdPxGJzav9vzIJ2BhEwfXDn1LKqpQ5D1Yy+XnNRQpOo3w==",
+					"dev": true,
+					"requires": {
+						"@opentelemetry/context-async-hooks": "1.0.1",
+						"@opentelemetry/core": "1.0.1",
+						"@opentelemetry/propagator-b3": "1.0.1",
+						"@opentelemetry/propagator-jaeger": "1.0.1",
+						"@opentelemetry/sdk-trace-base": "1.0.1",
+						"semver": "^7.3.5"
+					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz",
+					"integrity": "sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==",
 					"dev": true
 				}
 			}
 		},
 		"@opentelemetry/sdk-trace-base": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-0.25.0.tgz",
-			"integrity": "sha512-TInkLSF/ThM3GNVM+9tgnCVjyNLnRxvAkG585Fhu0HNwaEtCTUwI0r7AvMRIREOreeRWttBG6kvT0LOKdo8yjw==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-0.26.0.tgz",
+			"integrity": "sha512-SqV5pccxJTekOXdE1jp5VWxZ7GYw8rrHy7g0LcxLzn+D8YJ9ZBhE481VrP9EsjyLlJRhicv+z2g1XFxpMkQdmA==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "0.25.0",
-				"@opentelemetry/resources": "0.25.0",
-				"@opentelemetry/semantic-conventions": "0.25.0",
+				"@opentelemetry/core": "0.26.0",
+				"@opentelemetry/resources": "0.26.0",
+				"@opentelemetry/semantic-conventions": "0.26.0",
 				"lodash.merge": "^4.6.2"
 			}
 		},
 		"@opentelemetry/sdk-trace-node": {
-			"version": "0.24.1-alpha.4",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-0.24.1-alpha.4.tgz",
-			"integrity": "sha512-Lbd/OMHgCy5qqbV9MCIB0oIRy8fO+jPBXjPwEYwL/x4wzRPhV8JYPXSockwnGFSr1DigYdwV+SD7pRjdgxqG0g==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-0.26.0.tgz",
+			"integrity": "sha512-TD0i8GWP3EpuF9F5ZBaoicaj0H18gVKivYi/yzYGKFVZnLScHi49ljux8hYIoru3eAIjP789XyFHuVacWb+V1g==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/context-async-hooks": "^0.24.0",
-				"@opentelemetry/core": "^0.24.1-alpha.4+a8d39317",
-				"@opentelemetry/propagator-b3": "^0.24.1-alpha.4+a8d39317",
-				"@opentelemetry/propagator-jaeger": "^0.24.1-alpha.4+a8d39317",
-				"@opentelemetry/sdk-trace-base": "^0.24.1-alpha.4+a8d39317",
-				"semver": "^7.1.3"
+				"@opentelemetry/context-async-hooks": "0.26.0",
+				"@opentelemetry/core": "0.26.0",
+				"@opentelemetry/propagator-b3": "0.26.0",
+				"@opentelemetry/propagator-jaeger": "0.26.0",
+				"@opentelemetry/sdk-trace-base": "0.26.0",
+				"semver": "^7.3.5"
 			},
 			"dependencies": {
-				"@opentelemetry/core": {
-					"version": "0.24.1-alpha.31",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.1-alpha.31.tgz",
-					"integrity": "sha512-ssPWP6c+jXRc+zaf3W/7pumBKNP/11EU5rjFKpBE3/5ZKNolZwX6e+UhhXAX8FhdpuFEvtwumUmqryiTKuYK6A==",
+				"@opentelemetry/context-async-hooks": {
+					"version": "0.26.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.26.0.tgz",
+					"integrity": "sha512-r879ngcadv1SeZ53zS+IOmrnebW0MCpC/XGye6/QrAZJmnldq7ga2hy4cqwKvH+lsR4Ds4gHEpb07rdwCEULIg==",
 					"dev": true,
-					"requires": {
-						"@opentelemetry/semantic-conventions": "^0.24.1-alpha.31+fd2410cc",
-						"semver": "^7.1.3"
-					}
+					"requires": {}
 				},
 				"@opentelemetry/propagator-b3": {
-					"version": "0.24.1-alpha.31",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-0.24.1-alpha.31.tgz",
-					"integrity": "sha512-6DbKyqJAIMguYWFlUCNnTlCnJDJdXW6avLAKJQK20dSttzCOuHI4MtzbZcNLz5CWee6zRTkMPXgJUbtzI/GWJw==",
+					"version": "0.26.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-0.26.0.tgz",
+					"integrity": "sha512-x+fLyqCTjTmpBaWe8/cTpnVnBLAEkcC0K9P2ULNEu99++QPnpE4gM9jri/TdIAOJGzEqCSB6vGfOASNhZHA00Q==",
 					"dev": true,
 					"requires": {
-						"@opentelemetry/core": "^0.24.1-alpha.31+fd2410cc"
+						"@opentelemetry/core": "0.26.0"
 					}
 				},
 				"@opentelemetry/propagator-jaeger": {
-					"version": "0.24.1-alpha.31",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.24.1-alpha.31.tgz",
-					"integrity": "sha512-slWXgCfgcW5vk//kapT+Ne2xPPh0HCw3umVu6ZK/6ov38ejrx0kN2ZeX6E8QQdr8u/v/0gxdfGFiHMw3gbLb9g==",
+					"version": "0.26.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.26.0.tgz",
+					"integrity": "sha512-UM+pHLmkRQOJFUyOY7yBk7NStOMeNvpUswnlWBRM0W2V/kOavyckikkMpNsUi2WlCijETW20feGt/m+Ukus9Rw==",
 					"dev": true,
 					"requires": {
-						"@opentelemetry/core": "^0.24.1-alpha.31+fd2410cc"
+						"@opentelemetry/core": "0.26.0"
 					}
-				},
-				"@opentelemetry/resources": {
-					"version": "0.24.1-alpha.31",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.1-alpha.31.tgz",
-					"integrity": "sha512-QtgoLy0xYXe/O9D8xcZajcrMI47L8tOC7+hbPAjtt7kSGYm0RJU+mupbLvOtxCDKDzsv+VcacxVg/bAbrOF2uA==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/core": "^0.24.1-alpha.31+fd2410cc",
-						"@opentelemetry/semantic-conventions": "^0.24.1-alpha.31+fd2410cc"
-					}
-				},
-				"@opentelemetry/sdk-trace-base": {
-					"version": "0.24.1-alpha.4",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-0.24.1-alpha.4.tgz",
-					"integrity": "sha512-dRMAseFliUOYuKoHha+3/qdNsU0JyY8085xzrRyJP7TvXo6KQKzotRCtMTMvXgv3UOufeZTMHyO13J3cuB+eSg==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/core": "^0.24.1-alpha.4+a8d39317",
-						"@opentelemetry/resources": "^0.24.1-alpha.4+a8d39317",
-						"@opentelemetry/semantic-conventions": "^0.24.0",
-						"lodash.merge": "^4.6.2"
-					},
-					"dependencies": {
-						"@opentelemetry/semantic-conventions": {
-							"version": "0.24.0",
-							"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-							"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
-							"dev": true
-						}
-					}
-				},
-				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.1-alpha.31",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.1-alpha.31.tgz",
-					"integrity": "sha512-kVdxTt4M+Fe5MwZ3QjAFDoHpiJ0MDh0IbvxQkHODb9EUiZxYICgDXKVUM25z/DDctaiXzlfTtVYOLDpPHGStPA==",
-					"dev": true
 				}
 			}
 		},
 		"@opentelemetry/semantic-conventions": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
-			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg=="
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.26.0.tgz",
+			"integrity": "sha512-iO26zEr7GCAG9/yernhSj/LcB4EudVcN8fiI/8B4lVnoqLZQ/qHaOVdyemdeXZ8IkIvoCifoJYPqIARJpqg42w=="
 		},
 		"@opentelemetry/tracing": {
 			"version": "0.24.0",
@@ -2319,9 +2436,9 @@
 			}
 		},
 		"@types/body-parser": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
-			"integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+			"version": "1.19.2",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+			"integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
 			"dev": true,
 			"requires": {
 				"@types/connect": "*",
@@ -2329,12 +2446,12 @@
 			}
 		},
 		"@types/bson": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
-			"integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.0.tgz",
+			"integrity": "sha512-ELCPqAdroMdcuxqwMgUpifQyRoTpyYCNr1V9xKyF40VsBobsj+BbWNRvwGchMgBPGqkw655ypkjj2MEF5ywVwg==",
 			"dev": true,
 			"requires": {
-				"@types/node": "*"
+				"bson": "*"
 			}
 		},
 		"@types/connect": {
@@ -2377,9 +2494,9 @@
 			}
 		},
 		"@types/express-serve-static-core": {
-			"version": "4.17.24",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
-			"integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+			"version": "4.17.26",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.26.tgz",
+			"integrity": "sha512-zeu3tpouA043RHxW0gzRxwCHchMgftE8GArRsvYT0ByDMbn19olQHx5jLue0LxWY6iYtXb7rXmuVtSkhy9YZvQ==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -2483,9 +2600,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "16.7.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
-			"integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==",
+			"version": "16.11.12",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+			"integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
 			"dev": true
 		},
 		"@types/pg": {
@@ -2557,11 +2674,36 @@
 				"debug": "4"
 			}
 		},
+		"base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true
+		},
 		"bignumber.js": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
 			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
 			"dev": true
+		},
+		"bson": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-4.6.0.tgz",
+			"integrity": "sha512-8jw1NU1hglS+Da1jDOUYuNcBJ4cNHCFIqzlwoFNnsTOg2R/ox0aTYcTiBN4dzRa9q7Cvy6XErh3L8ReTEb9AQQ==",
+			"dev": true,
+			"requires": {
+				"buffer": "^5.6.0"
+			}
+		},
+		"buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"requires": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
 		},
 		"chai-spies": {
 			"version": "1.0.0",
@@ -2598,22 +2740,22 @@
 			"dev": true
 		},
 		"gaxios": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.0.tgz",
-			"integrity": "sha512-pHplNbslpwCLMyII/lHPWFQbJWOX0B3R1hwBEOvzYi1GmdKZruuEHK4N9V6f7tf1EaPYyF80mui1+344p6SmLg==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.2.tgz",
+			"integrity": "sha512-T+ap6GM6UZ0c4E6yb1y/hy2UB6hTrqhglp3XfmU9qbLCGRYhLVV5aRPpC4EmoG8N8zOnkYCgoBz+ScvGAARY6Q==",
 			"dev": true,
 			"requires": {
 				"abort-controller": "^3.0.0",
 				"extend": "^3.0.2",
 				"https-proxy-agent": "^5.0.0",
 				"is-stream": "^2.0.0",
-				"node-fetch": "^2.3.0"
+				"node-fetch": "^2.6.1"
 			}
 		},
 		"gcp-metadata": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.0.tgz",
-			"integrity": "sha512-L9XQUpvKJCM76YRSmcxrR4mFPzPGsgZUH+GgHMxAET8qc6+BhRJq63RLhWakgEO2KKVgeSDVfyiNjkGSADwNTA==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+			"integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
 			"dev": true,
 			"requires": {
 				"gaxios": "^4.0.0",
@@ -2621,9 +2763,9 @@
 			}
 		},
 		"graphql": {
-			"version": "15.5.2",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.2.tgz",
-			"integrity": "sha512-dZjLPWNQqYv0dqV2RNbiFed0LtSp6yd4jchsDGnuhDKa9OQHJYCfovaOEvY91w9gqbYO7Se9LKDTl3xxYva/3w==",
+			"version": "16.1.0",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.1.0.tgz",
+			"integrity": "sha512-+PIjmhqGHMIxtnlEirRXDHIzs0cAHAozKG5M2w2N4TnS8VzCxO3bbv1AW9UTeycBfl2QsPduxcVrBvANFKQhiw==",
 			"dev": true
 		},
 		"has": {
@@ -2644,6 +2786,12 @@
 				"agent-base": "6",
 				"debug": "4"
 			}
+		},
+		"ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true
 		},
 		"is-core-module": {
 			"version": "2.6.0",
@@ -2702,10 +2850,13 @@
 			"dev": true
 		},
 		"node-fetch": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-			"dev": true
+			"version": "2.6.6",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+			"integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+			"dev": true,
+			"requires": {
+				"whatwg-url": "^5.0.0"
+			}
 		},
 		"path-parse": {
 			"version": "1.0.7",
@@ -2799,6 +2950,28 @@
 			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
 			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
 			"dev": true
+		},
+		"tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
+		},
+		"webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+			"dev": true
+		},
+		"whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"dev": true,
+			"requires": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/packages/opentelemetry-exporter/package.json
+++ b/packages/opentelemetry-exporter/package.json
@@ -2,7 +2,12 @@
   "name": "@instana/opentelemetry-exporter",
   "version": "1.137.2",
   "description": "OpenTelemetry Instana Exporter",
-  "keywords": ["opentelemetry", "exporter", "nodejs", "tracing"],
+  "keywords": [
+    "opentelemetry",
+    "exporter",
+    "nodejs",
+    "tracing"
+  ],
   "author": "Willian Carvalho <willian.carvalho@instana.com>",
   "homepage": "https://github.com/instana/nodejs/blob/main/packages/opentelemetry-exporter/README.md",
   "license": "MIT",
@@ -11,7 +16,9 @@
     "lib": "src",
     "test": "test"
   },
-  "files": ["src"],
+  "files": [
+    "src"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/instana/nodejs.git"
@@ -47,19 +54,19 @@
   "dependencies": {
     "@instana/serverless": "1.137.2",
     "@opentelemetry/api": "1.0.3",
-    "@opentelemetry/core": "0.25.0"
+    "@opentelemetry/core": "0.26.0"
   },
   "devDependencies": {
     "@instana/core": "1.137.2",
-    "@opentelemetry/auto-instrumentations-node": "0.24.0",
-    "@opentelemetry/instrumentation": "0.24.0",
-    "@opentelemetry/instrumentation-http": "0.24.0",
+    "@opentelemetry/auto-instrumentations-node": "0.27.0",
+    "@opentelemetry/instrumentation": "0.27.0",
+    "@opentelemetry/instrumentation-http": "0.27.0",
     "@opentelemetry/node": "0.24.0",
-    "@opentelemetry/resources": "0.25.0",
-    "@opentelemetry/sdk-node": "0.24.0",
-    "@opentelemetry/sdk-trace-base": "0.25.0",
-    "@opentelemetry/sdk-trace-node": "0.24.1-alpha.4",
-    "@opentelemetry/semantic-conventions": "0.25.0",
+    "@opentelemetry/resources": "0.26.0",
+    "@opentelemetry/sdk-node": "0.27.0",
+    "@opentelemetry/sdk-trace-base": "0.26.0",
+    "@opentelemetry/sdk-trace-node": "0.26.0",
+    "@opentelemetry/semantic-conventions": "0.26.0",
     "chai-spies": "1.0.0",
     "no-code2": "2.0.0"
   }


### PR DESCRIPTION
refs 75234

OTel has released 1.x versions. See https://github.com/open-telemetry/opentelemetry-js/blob/main/CHANGELOG.md#101--experimental-0270

IMO I would not update to it now, but maybe add a ticket to ensure our otel exporter still works with 1.x?