### PR TITLE
chore: added experimental dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    target-branch: main
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
refs 75234

- update dependencies more often, but ensure it's not noisy or annoying

"Once a week it will look for patch+minor dependency updates (dev+prod), but it won't create more than 2 pull requests"

Need to see it in action.