### PR TITLE
chore: fixed tests for @elasic/elasticsearch 7.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@aws-sdk/client-sqs2": "npm:@aws-sdk/client-sqs@3.24.0",
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
-        "@elastic/elasticsearch": "^7.15.0",
+        "@elastic/elasticsearch": "^7.16.0",
         "@google-cloud/pubsub": "2.12.0",
         "@google-cloud/storage": "^5.16.1",
         "@grpc/proto-loader": "0.5.6",
@@ -7519,9 +7519,9 @@
       }
     },
     "node_modules/@elastic/elasticsearch": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.15.0.tgz",
-      "integrity": "sha512-FUKvjV2IKtIiWsvBy7D+wLbSEONsmNR15RRN7P/Sb30g4ObZRHH2qGOP5PPnzxdntEkzZ8HzY7nKKXFS+3Du1g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.16.0.tgz",
+      "integrity": "sha512-lMY2MFZZFG3om7QNHninxZZOXYx3NdIUwEISZxqaI9dXPoL3DNhU31keqjvx1gN6T74lGXAzrRNP4ag8CJ/VXw==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.1",
@@ -42149,9 +42149,9 @@
       }
     },
     "@elastic/elasticsearch": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.15.0.tgz",
-      "integrity": "sha512-FUKvjV2IKtIiWsvBy7D+wLbSEONsmNR15RRN7P/Sb30g4ObZRHH2qGOP5PPnzxdntEkzZ8HzY7nKKXFS+3Du1g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.16.0.tgz",
+      "integrity": "sha512-lMY2MFZZFG3om7QNHninxZZOXYx3NdIUwEISZxqaI9dXPoL3DNhU31keqjvx1gN6T74lGXAzrRNP4ag8CJ/VXw==",
       "dev": true,
       "requires": {
         "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/client-sqs2": "npm:@aws-sdk/client-sqs@3.24.0",
     "@commitlint/cli": "^14.1.0",
     "@commitlint/config-conventional": "^14.1.0",
-    "@elastic/elasticsearch": "^7.15.0",
+    "@elastic/elasticsearch": "^7.16.0",
     "@google-cloud/pubsub": "2.12.0",
     "@google-cloud/storage": "^5.16.1",
     "@grpc/proto-loader": "0.5.6",

--- a/packages/collector/test/tracing/database/elasticsearch_modern/app.js
+++ b/packages/collector/test/tracing/database/elasticsearch_modern/app.js
@@ -13,6 +13,8 @@ require('../../../../')();
 
 const bodyParser = require('body-parser');
 const express = require('express');
+const path = require('path');
+const fs = require('fs');
 const morgan = require('morgan');
 const request = require('request-promise-native');
 const { Client } = require('@elastic/elasticsearch');
@@ -32,16 +34,14 @@ const client = new Client({
   node: `http://${process.env.ELASTICSEARCH}`
 });
 
-/*
-TODO: fix me
+const originalEsVersion = JSON.parse(
+  fs.readFileSync(`${path.dirname(require.resolve('@elastic/elasticsearch'))}/package.json`)
+).version;
+
 log(
-  // eslint-disable-next-line max-len
-  `Using Elasticsearch API version ${ES_API_VERSION},
-  please make sure the installed client library @elastic/elasticsearch@${
-    require('@elastic/elasticsearch/package.json').version
-  } the Elasticsearch Docker container match that API version.`
+  `Using Elasticsearch API version ${ES_API_VERSION}, please make sure the installed client library 
+  @elastic/elasticsearch@${originalEsVersion} the Elasticsearch Docker container match that API version.`
 );
-*/
 
 app.get('/', (req, res) => {
   res.sendStatus(200);

--- a/packages/collector/test/tracing/database/elasticsearch_modern/app.js
+++ b/packages/collector/test/tracing/database/elasticsearch_modern/app.js
@@ -32,12 +32,16 @@ const client = new Client({
   node: `http://${process.env.ELASTICSEARCH}`
 });
 
+/*
+TODO: fix me
 log(
   // eslint-disable-next-line max-len
-  `Using Elasticsearch API version ${ES_API_VERSION}, please make sure the installed client library @elastic/elasticsearch@${
+  `Using Elasticsearch API version ${ES_API_VERSION},
+  please make sure the installed client library @elastic/elasticsearch@${
     require('@elastic/elasticsearch/package.json').version
   } the Elasticsearch Docker container match that API version.`
 );
+*/
 
 app.get('/', (req, res) => {
   res.sendStatus(200);

--- a/packages/collector/test/tracing/database/elasticsearch_modern/test.js
+++ b/packages/collector/test/tracing/database/elasticsearch_modern/test.js
@@ -31,7 +31,8 @@ mochaSuiteFn('tracing/elasticsearch (modern client)', function () {
   this.timeout(Math.max(config.getTestTimeout() * 4, 30000));
 
   before(() => {
-    originalEsVersion = require('@elastic/elasticsearch/package.json').version;
+    // TODO: fix me
+    originalEsVersion = '7.16.0';
     // eslint-disable-next-line no-console
     console.log(`original version: @elastic/elasticsearch@${originalEsVersion}`);
   });
@@ -39,7 +40,7 @@ mochaSuiteFn('tracing/elasticsearch (modern client)', function () {
   after(done => installLibraryVersion(originalEsVersion, done));
 
   [
-    //
+    // TODO: Add newer versions, currently we only test against 7.9
     {
       versionRange: '^7.9.1',
       apiVersion: '7.9',

--- a/packages/collector/test/tracing/database/elasticsearch_modern/test.js
+++ b/packages/collector/test/tracing/database/elasticsearch_modern/test.js
@@ -8,6 +8,7 @@
 const expect = require('chai').expect;
 const path = require('path');
 const semver = require('semver');
+const fs = require('fs');
 const { exec } = require('child_process');
 
 const constants = require('@instana/core').tracing.constants;
@@ -31,8 +32,12 @@ mochaSuiteFn('tracing/elasticsearch (modern client)', function () {
   this.timeout(Math.max(config.getTestTimeout() * 4, 30000));
 
   before(() => {
-    // TODO: fix me
-    originalEsVersion = '7.16.0';
+    // NOTE: We cannot use `require(@elastic/elasticsearch/package.json), because of
+    //       https://github.com/elastic/elasticsearch-js/blob/v7.16.0/package.json#L11
+    originalEsVersion = JSON.parse(
+      fs.readFileSync(`${path.dirname(require.resolve('@elastic/elasticsearch'))}/package.json`)
+    ).version;
+
     // eslint-disable-next-line no-console
     console.log(`original version: @elastic/elasticsearch@${originalEsVersion}`);
   });


### PR DESCRIPTION
This no longer works because of https://github.com/elastic/elasticsearch-js/compare/v7.15.0...v7.16.0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11

They only allow to require js files


---

PR contains cleanup commits and commits for better readability.