### PR TITLE
feat: self-disable if detected Node.js runtime version is too old

### DIFF
--- a/packages/aws-fargate/src/index.js
+++ b/packages/aws-fargate/src/index.js
@@ -5,6 +5,17 @@
 
 'use strict';
 
+const { isNodeJsTooOld, minimumNodeJsVersion } = require('@instana/core/src/util/nodeJsVersionCheck');
+
+if (isNodeJsTooOld()) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `The package @instana/aws-fargate requires at least Node.js ${minimumNodeJsVersion} but this process is ` +
+      `running on Node.js ${process.version}. This Fargate container will not be monitored by Instana.`
+  );
+  return;
+}
+
 const { util: coreUtil } = require('@instana/core');
 const { environment: environmentUtil } = require('@instana/serverless');
 

--- a/packages/aws-lambda/src/index.js
+++ b/packages/aws-lambda/src/index.js
@@ -5,6 +5,17 @@
 
 'use strict';
 
+const { isNodeJsTooOld, minimumNodeJsVersion } = require('@instana/core/src/util/nodeJsVersionCheck');
+
+if (isNodeJsTooOld()) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `The package @instana/aws-lambda requires at least Node.js ${minimumNodeJsVersion} but this Lambda function is ` +
+      `running on Node.js ${process.version}. This Lambda will not be monitored by Instana.`
+  );
+  return;
+}
+
 const { environment: environmentUtil } = require('@instana/serverless');
 
 environmentUtil.validate();

--- a/packages/collector/src/immediate.js
+++ b/packages/collector/src/immediate.js
@@ -5,6 +5,18 @@
 
 'use strict';
 
+const { isNodeJsTooOld, minimumNodeJsVersion } = require('@instana/core/src/util/nodeJsVersionCheck');
+
+if (isNodeJsTooOld()) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `The package @instana/collector requires at least Node.js ${minimumNodeJsVersion} but this process is ` +
+      `running Node.js ${process.version}. This process will not be monitored by Instana.`
+  );
+  // @ts-ignore TS1108 (return can only be used within a function body)
+  return;
+}
+
 const { util: coreUtil } = require('@instana/core');
 const agentOpts = require('./agent/opts');
 

--- a/packages/collector/src/index.js
+++ b/packages/collector/src/index.js
@@ -5,6 +5,19 @@
 
 'use strict';
 
+const { isNodeJsTooOld, minimumNodeJsVersion } = require('@instana/core/src/util/nodeJsVersionCheck');
+
+if (isNodeJsTooOld()) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `The package @instana/collector requires at least Node.js ${minimumNodeJsVersion} but this process is ` +
+      `running on Node.js ${process.version}. This process will not be monitored by Instana.`
+  );
+  module.exports = function noOp() {};
+  // @ts-ignore TS1108 (return can only be used within a function body)
+  return;
+}
+
 const path = require('path');
 const instanaNodeJsCore = require('@instana/core');
 const instanaSharedMetrics = require('@instana/shared-metrics');

--- a/packages/core/src/util/nodeJsVersionCheck.js
+++ b/packages/core/src/util/nodeJsVersionCheck.js
@@ -1,0 +1,29 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+/**
+ * This is the minimum required Node.js version for all @instana packages.
+ */
+exports.minimumNodeJsVersion = 10;
+
+/**
+ * Checks if the value of process.version denotes a Node.js version that is not supported, that is, older than the given
+ * minimum version.
+ *
+ * @param {number} minimumNodeJsVersion
+ * @returns {boolean} true, if and only if process.version can be parsed and is older than minimumNodeJsVersion
+ */
+exports.isNodeJsTooOld = function isNodeJsTooOld(minimumNodeJsVersion = exports.minimumNodeJsVersion) {
+  const currentVersion = process.version;
+  if (typeof currentVersion === 'string') {
+    const majorVersionStr = process.version.split('.')[0];
+    if (majorVersionStr.length > 1 && majorVersionStr.charAt(0) === 'v') {
+      const majorVersion = parseInt(majorVersionStr.substring(1), 10);
+      return !isNaN(majorVersion) && majorVersion < minimumNodeJsVersion;
+    }
+  }
+  return false;
+};

--- a/packages/core/test/util/nodeJsTooOld_test.js
+++ b/packages/core/test/util/nodeJsTooOld_test.js
@@ -1,0 +1,105 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const expect = require('chai').expect;
+
+const { isNodeJsTooOld } = require('../../src/util/nodeJsVersionCheck');
+
+describe('util.nodeJsTooOld', () => {
+  const originalProcessVersion = process.version;
+
+  afterEach(() => {
+    // Simply executing process.version = ... would result in
+    // Cannot assign to read only property 'version' of object '#<process>'
+    Object.defineProperty(process, 'version', { value: originalProcessVersion, writable: false });
+  });
+
+  it('should reject Node.js 0.10', () => {
+    setProcessVersion('v0.10.48');
+    expect(isNodeJsTooOld(10)).to.be.true;
+  });
+
+  it('should reject Node.js 4', () => {
+    setProcessVersion('v4.9.1');
+    expect(isNodeJsTooOld(10)).to.be.true;
+  });
+
+  it('should reject Node.js 6', () => {
+    setProcessVersion('v6.17.1');
+    expect(isNodeJsTooOld(10)).to.be.true;
+  });
+
+  it('should reject Node.js 8', () => {
+    setProcessVersion('v8.17.0');
+    expect(isNodeJsTooOld(10)).to.be.true;
+  });
+
+  it('should reject Node.js 8 when 10 is the default', () => {
+    setProcessVersion('v8.17.0');
+    expect(isNodeJsTooOld()).to.be.true;
+  });
+
+  it('should reject Node.js 9', () => {
+    setProcessVersion('v9.11.2');
+    expect(isNodeJsTooOld(10)).to.be.true;
+  });
+
+  it('should accept Node.js 10', () => {
+    setProcessVersion('v10.0.0');
+    expect(isNodeJsTooOld(10)).to.be.false;
+  });
+
+  it('should accept Node.js 11', () => {
+    setProcessVersion('v11.0.0');
+    expect(isNodeJsTooOld(10)).to.be.false;
+  });
+
+  it('should accept Node.js 12', () => {
+    setProcessVersion('v12.22.8');
+    expect(isNodeJsTooOld(10)).to.be.false;
+  });
+
+  it('should accept Node.js 14', () => {
+    setProcessVersion('v14.18.2');
+    expect(isNodeJsTooOld(10)).to.be.false;
+  });
+
+  it('should accept Node.js 16', () => {
+    setProcessVersion('v16.13.1');
+    expect(isNodeJsTooOld(10)).to.be.false;
+  });
+
+  it('should accept Node.js 17', () => {
+    setProcessVersion('v17.3.0');
+    expect(isNodeJsTooOld(10)).to.be.false;
+  });
+
+  it('should accept if process.version is not set', () => {
+    setProcessVersion(undefined);
+    expect(isNodeJsTooOld(10)).to.be.false;
+  });
+
+  it('should accept if process.version is not a string', () => {
+    setProcessVersion(1234);
+    expect(isNodeJsTooOld(10)).to.be.false;
+  });
+
+  it('should accept if process.version is in an unexpected format (not major.minor.patch)', () => {
+    setProcessVersion('v123');
+    expect(isNodeJsTooOld(10)).to.be.false;
+  });
+
+  it('should accept if process.version is in an unexpected format (no v prefix)', () => {
+    setProcessVersion('11.22.33');
+    expect(isNodeJsTooOld(10)).to.be.false;
+  });
+});
+
+function setProcessVersion(version) {
+  // Simply executing process.version = ... would result in
+  // Cannot assign to read only property 'version' of object '#<process>'
+  Object.defineProperty(process, 'version', { value: version, writable: true });
+}

--- a/packages/google-cloud-run/src/index.js
+++ b/packages/google-cloud-run/src/index.js
@@ -5,6 +5,17 @@
 
 'use strict';
 
+const { isNodeJsTooOld, minimumNodeJsVersion } = require('@instana/core/src/util/nodeJsVersionCheck');
+
+if (isNodeJsTooOld()) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `The package @instana/google-cloud-run requires at least Node.js ${minimumNodeJsVersion} but this process is ` +
+      `running on Node.js ${process.version}. This Google Cloud Run service will not be monitored by Instana.`
+  );
+  return;
+}
+
 const { util: coreUtil } = require('@instana/core');
 const { environment: environmentUtil } = require('@instana/serverless');
 


### PR DESCRIPTION
This change prevents @instana packages from loading in (and thereby crashing)
Node.js processes that run on an unsupported, outdated Node.js version.

refs 80206