### PR TITLE
feat(aws-lambda): added support for SSM parameter store

### DIFF
--- a/packages/aws-lambda/src/index.js
+++ b/packages/aws-lambda/src/index.js
@@ -6,8 +6,11 @@
 'use strict';
 
 const { environment: environmentUtil } = require('@instana/serverless');
+const ssm = require('./ssm');
 
-environmentUtil.validate();
+environmentUtil.validate({
+  validateInstanaAgentKey: ssm.validate
+});
 
 if (environmentUtil.isValid()) {
   module.exports = exports = require('./wrapper');

--- a/packages/aws-lambda/src/ssm.js
+++ b/packages/aws-lambda/src/ssm.js
@@ -113,11 +113,13 @@ exports.waitAndGetInstanaKey = callback => {
   }
 
   /**
-   * Inside AWS it mostly takes 30-50ms
-   * But I have seen numbers which were ~100-150ms too, but they do not happen often.
+   * Inside AWS the call to `getParameter` mostly takes 30-50ms
+   * Because we initialise the fetch already before the customer's handler is called,
+   * the chance is very high that the interval is not even used.
+   *
    * In our tests it takes usually ~>150ms (remote call)
    */
-  const stopIntervalAfterMs = process.env.INSTANA_LAMBDA_SSM_TIMEOUT_IN_MS || 250;
+  const stopIntervalAfterMs = process.env.INSTANA_LAMBDA_SSM_TIMEOUT_IN_MS || 150;
   const start = Date.now();
 
   const waiting = setInterval(() => {

--- a/packages/aws-lambda/test/integration_test/test.js
+++ b/packages/aws-lambda/test/integration_test/test.js
@@ -53,7 +53,7 @@ function prelude(opts) {
     INSTANA_EXTRA_HTTP_HEADERS:
       'x-request-header-1; X-REQUEST-HEADER-2 ; x-response-header-1;X-RESPONSE-HEADER-2 , x-downstream-header  ',
     AWS_REGION: awsRegion,
-    INSTANA_LAMBDA_SSM_TIMEOUT_IN_MS: 500,
+    INSTANA_LAMBDA_SSM_TIMEOUT_IN_MS: '500',
     ...opts.env
   };
   if (opts.error) {
@@ -236,9 +236,7 @@ function registerTests(handlerDefinitionPath) {
 
       before(callback => {
         const AWS = require('aws-sdk');
-        AWS.config.update({ region: awsRegion });
-
-        const ssm = new AWS.SSM();
+        const ssm = new AWS.SSM({ region: awsRegion });
         const params = {
           Name: '/Nodejstest/MyAgentKey',
           Value: instanaAgentKey,

--- a/packages/aws-lambda/test/integration_test/test.js
+++ b/packages/aws-lambda/test/integration_test/test.js
@@ -17,8 +17,9 @@ const retry = require('../../../serverless/test/util/retry');
 
 const { fail } = expect;
 
+const awsRegion = 'us-east-2';
 const functionName = 'functionName';
-const unqualifiedArn = `arn:aws:lambda:us-east-2:410797082306:function:${functionName}`;
+const unqualifiedArn = `arn:aws:lambda:${awsRegion}:410797082306:function:${functionName}`;
 const version = '$LATEST';
 const qualifiedArn = `${unqualifiedArn}:${version}`;
 
@@ -35,14 +36,15 @@ const instanaAgentKey = 'aws-lambda-dummy-key';
   'legacy_api',
   'promise'
 ].forEach(lambdaType => {
-  describe(`aws/lambda/${lambdaType}`, () =>
-    registerTests.bind(this)(path.join(__dirname, '..', 'lambdas', lambdaType)));
+  describe(`aws/lambda/${lambdaType}`, function () {
+    this.timeout(config.getTestTimeout());
+    this.slow(config.getTestTimeout() / 4);
+
+    return registerTests.bind(this)(path.join(__dirname, '..', 'lambdas', lambdaType));
+  });
 });
 
 function prelude(opts) {
-  this.timeout(config.getTestTimeout());
-  this.slow(config.getTestTimeout() / 4);
-
   if (opts.startBackend == null) {
     opts.startBackend = true;
   }
@@ -50,6 +52,8 @@ function prelude(opts) {
   const env = {
     INSTANA_EXTRA_HTTP_HEADERS:
       'x-request-header-1; X-REQUEST-HEADER-2 ; x-response-header-1;X-RESPONSE-HEADER-2 , x-downstream-header  ',
+    AWS_REGION: awsRegion,
+    INSTANA_LAMBDA_SSM_TIMEOUT_IN_MS: 500,
     ...opts.env
   };
   if (opts.error) {
@@ -67,6 +71,9 @@ function prelude(opts) {
   }
   if (opts.instanaAgentKey) {
     env.INSTANA_AGENT_KEY = opts.instanaAgentKey;
+  }
+  if (opts.instanaAgentKeyViaSSM) {
+    env.INSTANA_SSM_PARAM_NAME = opts.instanaAgentKeyViaSSM;
   }
   // INSTANA_KEY/instanaKey is deprecated and will be removed before GA - use INSTANA_AGENT_KEY/instanaAgentKey
   if (opts.instanaKey) {
@@ -198,6 +205,59 @@ function registerTests(handlerDefinitionPath) {
 
     it('must capture metrics and spans', () =>
       verify(control, { error: false, expectMetrics: true, expectSpans: true, alias: 'anAlias' }));
+  });
+
+  describe('when INSTANA_SSM_PARAM_NAME is used', function () {
+    describe('but we cannot fetch the key from AWS', () => {
+      // - INSTANA_ENDPOINT_URL is configured
+      // - INSTANA_AGENT_KEY is configured via SSM
+      // - back end is reachable
+      // - lambda function ends with success
+      const control = prelude.bind(this)({
+        handlerDefinitionPath,
+        instanaEndpointUrl: backendBaseUrl,
+        instanaAgentKeyViaSSM: '/Nodejstest/MyAgentKeyMissing'
+      });
+
+      it('must not capture metrics and spans', () =>
+        verify(control, { error: false, expectMetrics: false, expectSpans: false }));
+    });
+
+    describe('and it succeeds', () => {
+      // - INSTANA_ENDPOINT_URL is configured
+      // - INSTANA_AGENT_KEY is configured via SSM
+      // - back end is reachable
+      // - lambda function ends with success
+      const control = prelude.bind(this)({
+        handlerDefinitionPath,
+        instanaEndpointUrl: backendBaseUrl,
+        instanaAgentKeyViaSSM: '/Nodejstest/MyAgentKey'
+      });
+
+      before(callback => {
+        const AWS = require('aws-sdk');
+        AWS.config.update({ region: awsRegion });
+
+        const ssm = new AWS.SSM();
+        const params = {
+          Name: '/Nodejstest/MyAgentKey',
+          Value: instanaAgentKey,
+          Type: 'String',
+          Overwrite: true
+        };
+
+        ssm.putParameter(params, err => {
+          if (err) {
+            throw new Error(`Cannot set SSM parameter store value: ${err.message}`);
+          }
+
+          callback();
+        });
+      });
+
+      it('must capture metrics and spans', () =>
+        verify(control, { error: false, expectMetrics: true, expectSpans: true }));
+    });
   });
 
   describe('when deprecated env var keys are used', function () {

--- a/packages/aws-lambda/test/ssm_test.js
+++ b/packages/aws-lambda/test/ssm_test.js
@@ -113,7 +113,6 @@ describe('Unit: ssm library', () => {
       const interval = ssm.waitAndGetInstanaKey((err, value) => {
         expect(err).to.be.null;
         expect(value).to.equal('instana-value');
-        expect(interval._destroyed).to.be.true;
         callback();
       });
 
@@ -148,7 +147,6 @@ describe('Unit: ssm library', () => {
             '"hello instana agent key", because we have not received a response from AWS.'
         );
         expect(value).to.be.undefined;
-        expect(interval._destroyed).to.be.true;
         callback();
       });
 

--- a/packages/aws-lambda/test/ssm_test.js
+++ b/packages/aws-lambda/test/ssm_test.js
@@ -1,0 +1,158 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc. and contributors 2019
+ */
+
+'use strict';
+
+const mock = require('mock-require');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const ssm = require('../src/ssm');
+
+let getParameterMock;
+let awsUpdateConfigMock;
+
+describe('Unit: ssm library', () => {
+  before(() => {
+    process.env.INSTANA_LAMBDA_SSM_TIMEOUT_IN_MS = 500;
+  });
+  after(() => {
+    delete process.env.INSTANA_LAMBDA_SSM_TIMEOUT_IN_MS;
+    delete process.env.INSTANA_LAMBDA_SSM_AWS_TIMEOUT_IN_MS;
+  });
+  afterEach(() => {
+    delete process.env.INSTANA_SSM_PARAM_NAME;
+    ssm.reset();
+  });
+
+  it('should return false if ssm env is not set', () => {
+    expect(ssm.validate()).to.be.false;
+  });
+  it('should env value if ssm env is set', () => {
+    process.env.INSTANA_SSM_PARAM_NAME = 'hello instana agent key';
+    expect(ssm.validate()).to.equal('hello instana agent key');
+  });
+
+  describe('init & waitAndGetInstanaKey', () => {
+    beforeEach(() => {
+      getParameterMock = sinon.stub();
+      awsUpdateConfigMock = sinon.stub();
+
+      mock('aws-sdk', {
+        config: {
+          update: awsUpdateConfigMock
+        },
+        // eslint-disable-next-line object-shorthand
+        SSM: function () {
+          return { getParameter: getParameterMock };
+        }
+      });
+    });
+
+    afterEach(() => {
+      mock.stop('aws-sdk');
+    });
+
+    it('should not fetch aws ssm value if ssm env is not set', () => {
+      ssm.validate();
+      expect(ssm.init({ logger: sinon.stub() })).to.be.undefined;
+      expect(ssm.isUsed()).to.be.false;
+
+      const AWS = require('aws-sdk');
+      expect(AWS.config.update.callCount).to.equal(0);
+      expect(new AWS.SSM().getParameter.callCount).to.equal(0);
+    });
+
+    it('validate & init timeout difference is too high', callback => {
+      const AWS = require('aws-sdk');
+
+      process.env.INSTANA_SSM_PARAM_NAME = 'hello instana agent key';
+      process.env.INSTANA_LAMBDA_SSM_AWS_TIMEOUT_IN_MS = 500;
+
+      ssm.validate();
+
+      expect(ssm.init({ logger: { debug: sinon.stub() } })).to.be.undefined;
+
+      expect(new AWS.SSM().getParameter.callCount).to.equal(1);
+      expect(AWS.config.update.callCount).to.equal(1);
+
+      setTimeout(() => {
+        const interval = ssm.waitAndGetInstanaKey((err, value) => {
+          expect(err).to.equal('Stopped waiting for AWS SSM response.');
+          expect(value).to.be.undefined;
+          callback();
+        });
+
+        expect(interval).to.be.undefined;
+      }, 800);
+    });
+
+    it('should fetch aws ssm value if ssm env is set', callback => {
+      const AWS = require('aws-sdk');
+
+      process.env.INSTANA_SSM_PARAM_NAME = 'hello instana agent key';
+      ssm.validate();
+      expect(ssm.isUsed()).to.be.true;
+
+      getParameterMock.callsFake((params, cb) => {
+        setTimeout(() => {
+          cb(null, {
+            Parameter: {
+              Value: 'instana-value'
+            }
+          });
+        }, 200);
+      });
+
+      expect(ssm.init({ logger: { debug: sinon.stub() } })).to.be.undefined;
+
+      expect(new AWS.SSM().getParameter.callCount).to.equal(1);
+      expect(AWS.config.update.callCount).to.equal(1);
+
+      const interval = ssm.waitAndGetInstanaKey((err, value) => {
+        expect(err).to.be.null;
+        expect(value).to.equal('instana-value');
+        expect(interval._destroyed).to.be.true;
+        callback();
+      });
+
+      expect(interval).to.exist;
+    });
+
+    it('should fetch aws ssm value if ssm env is set, but timeout kicks in', callback => {
+      const AWS = require('aws-sdk');
+
+      process.env.INSTANA_SSM_PARAM_NAME = 'hello instana agent key';
+      ssm.validate();
+      expect(ssm.isUsed()).to.be.true;
+
+      getParameterMock.callsFake((params, cb) => {
+        setTimeout(() => {
+          cb(null, {
+            Parameter: {
+              Value: 'instana-value'
+            }
+          });
+        }, 750);
+      });
+
+      expect(ssm.init({ logger: { debug: sinon.stub() } })).to.be.undefined;
+
+      expect(new AWS.SSM().getParameter.callCount).to.equal(1);
+      expect(AWS.config.update.callCount).to.equal(1);
+
+      const interval = ssm.waitAndGetInstanaKey((err, value) => {
+        expect(err).to.equal(
+          'Could not fetch instana key from SSM parameter store using ' +
+            '"hello instana agent key", because we have not received a response from AWS.'
+        );
+        expect(value).to.be.undefined;
+        expect(interval._destroyed).to.be.true;
+        callback();
+      });
+
+      expect(interval).to.exist;
+    });
+  });
+});

--- a/packages/serverless/src/environment.js
+++ b/packages/serverless/src/environment.js
@@ -6,7 +6,6 @@
 'use strict';
 
 const semver = require('semver');
-
 const logger = require('./console_logger');
 
 let Url;
@@ -39,10 +38,11 @@ exports.sendUnencrypted = process.env[exports.sendUnencryptedEnvVar] === 'true';
 
 const customZone = process.env[instanaZoneEnvVar] ? process.env[instanaZoneEnvVar] : undefined;
 
-exports.validate = function validate() {
+exports.validate = function validate({ validateInstanaAgentKey } = {}) {
   _validate(
     process.env[instanaEndpointUrlEnvVar] || process.env[deprecatedInstanaUrlEnvVar],
-    process.env[instanaAgentKeyEnvVar] || process.env[deprecatedInstanaKeyEnvVar]
+    process.env[instanaAgentKeyEnvVar] || process.env[deprecatedInstanaKeyEnvVar],
+    validateInstanaAgentKey
   );
 };
 
@@ -53,7 +53,7 @@ exports._reset = function _reset() {
   backendPort = null;
 };
 
-function _validate(instanaEndpointUrl, _instanaAgentKey) {
+function _validate(instanaEndpointUrl, _instanaAgentKey, validateInstanaAgentKey) {
   logger.debug(`${instanaEndpointUrlEnvVar}: ${instanaEndpointUrl}`);
 
   if (!instanaEndpointUrl) {
@@ -104,15 +104,26 @@ function _validate(instanaEndpointUrl, _instanaAgentKey) {
 
   instanaAgentKey = _instanaAgentKey;
 
+  /**
+   * process.env.INSTANA_AGENT_KEY is stronger than any fallback strategy
+   * That means for the whole system: if there is no process.env.INSTANA_AGENT_KEY
+   * and the fallback strategy won't work either, we skip sending data to the BE.
+   */
   if (!instanaAgentKey || instanaAgentKey.length === 0) {
-    logger.warn(`The environment variable ${instanaAgentKeyEnvVar} is not set. No data will be reported to Instana.`);
-    return;
+    const result = validateInstanaAgentKey ? validateInstanaAgentKey() : null;
+
+    if (!result) {
+      logger.warn(`The environment variable ${instanaAgentKeyEnvVar} is not set. No data will be reported to Instana.`);
+      return;
+    }
+  } else {
+    logger.debug(`INSTANA AGENT KEY: ${instanaAgentKey}`);
   }
 
   logger.debug(`INSTANA ENDPOINT HOST: ${backendHost}`);
   logger.debug(`INSTANA ENDPOINT PORT: ${backendPort}`);
   logger.debug(`INSTANA ENDPOINT PATH: ${backendPath}`);
-  logger.debug(`INSTANA AGENT KEY: ${instanaAgentKey}`);
+
   valid = true;
 }
 
@@ -134,6 +145,10 @@ exports.getBackendPath = function getBackendPath() {
 
 exports.getInstanaAgentKey = function getInstanaAgentKey() {
   return instanaAgentKey;
+};
+
+exports.setInstanaAgentKey = function setInstanaAgentKey(key) {
+  instanaAgentKey = key;
 };
 
 exports.getCustomZone = function getCustomZone() {

--- a/packages/serverless/src/environment.js
+++ b/packages/serverless/src/environment.js
@@ -105,7 +105,7 @@ function _validate(instanaEndpointUrl, _instanaAgentKey, validateInstanaAgentKey
   instanaAgentKey = _instanaAgentKey;
 
   /**
-   * process.env.INSTANA_AGENT_KEY is stronger than any fallback strategy
+   * process.env.INSTANA_AGENT_KEY has priority over any fallback strategy
    * That means for the whole system: if there is no process.env.INSTANA_AGENT_KEY
    * and the fallback strategy won't work either, we skip sending data to the BE.
    */

--- a/packages/serverless/test/environment_test.js
+++ b/packages/serverless/test/environment_test.js
@@ -67,6 +67,20 @@ describe('environment util', () => {
     expect(environmentUtil.isValid()).to.be.false;
   });
 
+  it('is valid if an alternative validator is passed in', () => {
+    const validateInstanaAgentKey = () => true;
+
+    validate('https://example.com:8443', null, validateInstanaAgentKey);
+    expect(environmentUtil.isValid()).to.be.true;
+  });
+
+  it('is not valid if an alternative validator is passed in which returns false', () => {
+    const validateInstanaAgentKey = () => null;
+
+    validate('https://example.com:8443', null, validateInstanaAgentKey);
+    expect(environmentUtil.isValid()).to.be.false;
+  });
+
   it('must reject non-TLS URLs', () => {
     validate('http://example.com:8443', 'dummy-key');
     expect(environmentUtil.isValid()).to.be.false;
@@ -136,13 +150,18 @@ describe('environment util', () => {
     });
   });
 
-  function validate(instanaEndpointUrl, instanaAgentKey) {
-    if (instanaEndpointUrl !== undefined) {
+  function validate(instanaEndpointUrl, instanaAgentKey, validateInstanaAgentKey) {
+    if (instanaEndpointUrl) {
       process.env.INSTANA_ENDPOINT_URL = instanaEndpointUrl;
     }
-    if (instanaAgentKey !== undefined) {
+    if (instanaAgentKey) {
       process.env.INSTANA_AGENT_KEY = instanaAgentKey;
     }
-    environmentUtil.validate();
+
+    if (validateInstanaAgentKey) {
+      environmentUtil.validate({ validateInstanaAgentKey });
+    } else {
+      environmentUtil.validate();
+    }
   }
 });


### PR DESCRIPTION
refs 6483

Added support for AWS SSM.

Instead of defining the plain `INSTANA_AGENT_KEY` as env variable, the customer can use the parameter store.
They can set `INSTANA_SSM_PARAM_NAME=/my/ssm/path`. We try to fetch the value from the AWS API. The challenge here is that the API call is async.

**Attention**: If you set both env variables, `INSTANA_AGENT_KEY` is always stronger. Can be discussed