### PR TITLE
fix(tracing): fix version constraint for http2 instrumentation

### DIFF
--- a/packages/collector/test/tracing/protocols/http2/test.js
+++ b/packages/collector/test/tracing/protocols/http2/test.js
@@ -21,8 +21,8 @@ const serverPort = 3217;
 
 const mochaSuiteFn =
   supportedVersion(process.versions.node) &&
-  // HTTP2 support was added in Node.js 8.4.0
-  // semver.gte(process.versions.node, '8.4.0') &&
+  // HTTP2 support was added in Node.js 8.4.0 behind the flag --expose-http2 and exposed in 8.8.0 without a flag.
+  // semver.gte(process.versions.node, '8.8.0') &&
   // The http2 module seems to trigger spurious segfaults on Node.js 8, so we skip these tests in Node.js 8.
   // alltogether.
   semver.gte(process.versions.node, '10.0.0')

--- a/packages/core/src/tracing/instrumentation/protocols/http2Client.js
+++ b/packages/core/src/tracing/instrumentation/protocols/http2Client.js
@@ -24,7 +24,7 @@ let HTTP2_HEADER_PATH;
 let HTTP2_HEADER_STATUS;
 
 exports.init = function init(config) {
-  if (semver.gte(process.versions.node, '8.4.0')) {
+  if (semver.gte(process.versions.node, '8.8.0')) {
     const http2 = require('http2');
     HTTP2_HEADER_METHOD = http2.constants.HTTP2_HEADER_METHOD;
     HTTP2_HEADER_PATH = http2.constants.HTTP2_HEADER_PATH;

--- a/packages/core/src/tracing/instrumentation/protocols/http2Server.js
+++ b/packages/core/src/tracing/instrumentation/protocols/http2Server.js
@@ -27,7 +27,7 @@ let HTTP2_HEADER_PATH;
 let HTTP2_HEADER_STATUS;
 
 exports.init = function init(config) {
-  if (semver.gte(process.versions.node, '8.4.0')) {
+  if (semver.gte(process.versions.node, '8.8.0')) {
     const http2 = require('http2');
     HTTP2_HEADER_AUTHORITY = http2.constants.HTTP2_HEADER_AUTHORITY;
     HTTP2_HEADER_METHOD = http2.constants.HTTP2_HEADER_METHOD;


### PR DESCRIPTION
Until Node.js v8.7.0, the http2 module was behind a flag (--expose-http2).
Unconditionally requiring it on Node.js 8.4.0 - 8.7.0 will crash the Node.js
process when that flag has not been provided. Starting with Node.js v8.8.0,
the http2 module became available without that flag.

See also:
* https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.4.0
* https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.8.0