### PR TITLE
build(deps): bump event-loop-stats from 1.3.0 to 1.4.1

### DIFF
--- a/packages/shared-metrics/package-lock.json
+++ b/packages/shared-metrics/package-lock.json
@@ -9,10 +9,8 @@
 			"version": "1.137.5",
 			"license": "MIT",
 			"dependencies": {
-				"@instana/core": "1.137.5",
 				"detect-libc": "^1.0.3",
 				"event-loop-lag": "^1.4.0",
-				"event-loop-stats": "1.4.1",
 				"recursive-copy": "^2.0.13",
 				"semver": "7.3.3",
 				"tar": "^6.1.11"
@@ -24,21 +22,6 @@
 			"optionalDependencies": {
 				"event-loop-stats": "1.4.1",
 				"gcstats.js": "1.0.0"
-			}
-		},
-		"node_modules/@instana/core": {
-			"version": "1.137.5",
-			"resolved": "https://registry.npmjs.org/@instana/core/-/core-1.137.5.tgz",
-			"integrity": "sha512-1g9pBNNn0g9uIIXuljkSggHllYbcr48Dhse3+Ln73MqEZ5rl+ospF8W/S05QceD4MeqmJSCAzPnlvACOzB/VoA==",
-			"dependencies": {
-				"async-hook-jl": "^1.7.6",
-				"cls-bluebird": "^2.1.0",
-				"lru-cache": "6.0.0",
-				"methods": "^1.1.2",
-				"opentracing": "^0.14.5",
-				"redis-commands": "^1.7.0",
-				"semver": "7.3.3",
-				"shimmer": "1.2.1"
 			}
 		},
 		"node_modules/@types/minipass": {
@@ -106,17 +89,6 @@
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
-		"node_modules/async-hook-jl": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-			"integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-			"dependencies": {
-				"stack-chain": "^1.3.7"
-			},
-			"engines": {
-				"node": "^4.7 || >=6.9 || >=7.3"
-			}
-		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -137,15 +109,6 @@
 			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/cls-bluebird": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
-			"integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
-			"dependencies": {
-				"is-bluebird": "^1.0.2",
-				"shimmer": "^1.1.0"
 			}
 		},
 		"node_modules/concat-map": {
@@ -312,14 +275,6 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
-		"node_modules/is-bluebird": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-			"integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI=",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -358,17 +313,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/maximatch": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
@@ -381,14 +325,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/minimatch": {
@@ -472,14 +408,6 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dependencies": {
 				"wrappy": "1"
-			}
-		},
-		"node_modules/opentracing": {
-			"version": "0.14.7",
-			"resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
-			"integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
-			"engines": {
-				"node": ">=0.10"
 			}
 		},
 		"node_modules/path-is-absolute": {
@@ -567,11 +495,6 @@
 				"mkdirp": "bin/cmd.js"
 			}
 		},
-		"node_modules/redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
-		},
 		"node_modules/semver": {
 			"version": "7.3.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
@@ -600,11 +523,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
-		"node_modules/shimmer": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-		},
 		"node_modules/slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -612,11 +530,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/stack-chain": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-			"integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
 		},
 		"node_modules/tar": {
 			"version": "6.1.11",
@@ -646,21 +559,6 @@
 		}
 	},
 	"dependencies": {
-		"@instana/core": {
-			"version": "1.137.5",
-			"resolved": "https://registry.npmjs.org/@instana/core/-/core-1.137.5.tgz",
-			"integrity": "sha512-1g9pBNNn0g9uIIXuljkSggHllYbcr48Dhse3+Ln73MqEZ5rl+ospF8W/S05QceD4MeqmJSCAzPnlvACOzB/VoA==",
-			"requires": {
-				"async-hook-jl": "^1.7.6",
-				"cls-bluebird": "^2.1.0",
-				"lru-cache": "6.0.0",
-				"methods": "^1.1.2",
-				"opentracing": "^0.14.5",
-				"redis-commands": "^1.7.0",
-				"semver": "7.3.3",
-				"shimmer": "1.2.1"
-			}
-		},
 		"@types/minipass": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@types/minipass/-/minipass-3.1.0.tgz",
@@ -714,14 +612,6 @@
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
-		"async-hook-jl": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-			"integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-			"requires": {
-				"stack-chain": "^1.3.7"
-			}
-		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -740,15 +630,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
 			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
-		},
-		"cls-bluebird": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
-			"integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
-			"requires": {
-				"is-bluebird": "^1.0.2",
-				"shimmer": "^1.1.0"
-			}
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -884,11 +765,6 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
-		"is-bluebird": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-			"integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI="
-		},
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -915,14 +791,6 @@
 			"resolved": "https://registry.npmjs.org/junk/-/junk-1.0.3.tgz",
 			"integrity": "sha1-h75jSIZJy9ym9Tqzm+yczSNH9ZI="
 		},
-		"lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"requires": {
-				"yallist": "^4.0.0"
-			}
-		},
 		"maximatch": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
@@ -933,11 +801,6 @@
 				"arrify": "^1.0.0",
 				"minimatch": "^3.0.0"
 			}
-		},
-		"methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -1003,11 +866,6 @@
 			"requires": {
 				"wrappy": "1"
 			}
-		},
-		"opentracing": {
-			"version": "0.14.7",
-			"resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
-			"integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q=="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -1081,11 +939,6 @@
 				}
 			}
 		},
-		"redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
-		},
 		"semver": {
 			"version": "7.3.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
@@ -1110,20 +963,10 @@
 				}
 			}
 		},
-		"shimmer": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
-		},
-		"stack-chain": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-			"integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
 		},
 		"tar": {
 			"version": "6.1.11",

--- a/packages/shared-metrics/package-lock.json
+++ b/packages/shared-metrics/package-lock.json
@@ -9,8 +9,10 @@
 			"version": "1.137.5",
 			"license": "MIT",
 			"dependencies": {
+				"@instana/core": "1.137.5",
 				"detect-libc": "^1.0.3",
 				"event-loop-lag": "^1.4.0",
+				"event-loop-stats": "1.4.1",
 				"recursive-copy": "^2.0.13",
 				"semver": "7.3.3",
 				"tar": "^6.1.11"
@@ -20,8 +22,23 @@
 				"no-code2": "2.0.0"
 			},
 			"optionalDependencies": {
-				"event-loop-stats": "1.3.0",
+				"event-loop-stats": "1.4.1",
 				"gcstats.js": "1.0.0"
+			}
+		},
+		"node_modules/@instana/core": {
+			"version": "1.137.5",
+			"resolved": "https://registry.npmjs.org/@instana/core/-/core-1.137.5.tgz",
+			"integrity": "sha512-1g9pBNNn0g9uIIXuljkSggHllYbcr48Dhse3+Ln73MqEZ5rl+ospF8W/S05QceD4MeqmJSCAzPnlvACOzB/VoA==",
+			"dependencies": {
+				"async-hook-jl": "^1.7.6",
+				"cls-bluebird": "^2.1.0",
+				"lru-cache": "6.0.0",
+				"methods": "^1.1.2",
+				"opentracing": "^0.14.5",
+				"redis-commands": "^1.7.0",
+				"semver": "7.3.3",
+				"shimmer": "1.2.1"
 			}
 		},
 		"node_modules/@types/minipass": {
@@ -89,6 +106,17 @@
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
+		"node_modules/async-hook-jl": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+			"integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+			"dependencies": {
+				"stack-chain": "^1.3.7"
+			},
+			"engines": {
+				"node": "^4.7 || >=6.9 || >=7.3"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -109,6 +137,15 @@
 			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/cls-bluebird": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
+			"integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
+			"dependencies": {
+				"is-bluebird": "^1.0.2",
+				"shimmer": "^1.1.0"
 			}
 		},
 		"node_modules/concat-map": {
@@ -183,9 +220,9 @@
 			}
 		},
 		"node_modules/event-loop-stats": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/event-loop-stats/-/event-loop-stats-1.3.0.tgz",
-			"integrity": "sha512-CRto3Zyg3YE3AaBM/hPc7mJrbSOhy32P1wqIsZpp4rPHrj5qQavLUJKf+8fFq13ahC24T+RcX3f3fK13ElYZNw==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/event-loop-stats/-/event-loop-stats-1.4.1.tgz",
+			"integrity": "sha512-Wzohoz1JrQOBjt/shh5Z3/8Ti6SVoGl5nyX952Vcp5N56QVOtjPuJsQa+dEhsDJHu4QAFz45ePXRFq01skb9xA==",
 			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {
@@ -275,6 +312,14 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
+		"node_modules/is-bluebird": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
+			"integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI=",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -313,6 +358,17 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/maximatch": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
@@ -325,6 +381,14 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/minimatch": {
@@ -408,6 +472,14 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/opentracing": {
+			"version": "0.14.7",
+			"resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
+			"integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/path-is-absolute": {
@@ -495,6 +567,11 @@
 				"mkdirp": "bin/cmd.js"
 			}
 		},
+		"node_modules/redis-commands": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+		},
 		"node_modules/semver": {
 			"version": "7.3.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
@@ -523,6 +600,11 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
+		"node_modules/shimmer": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+		},
 		"node_modules/slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -530,6 +612,11 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/stack-chain": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+			"integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
 		},
 		"node_modules/tar": {
 			"version": "6.1.11",
@@ -559,6 +646,21 @@
 		}
 	},
 	"dependencies": {
+		"@instana/core": {
+			"version": "1.137.5",
+			"resolved": "https://registry.npmjs.org/@instana/core/-/core-1.137.5.tgz",
+			"integrity": "sha512-1g9pBNNn0g9uIIXuljkSggHllYbcr48Dhse3+Ln73MqEZ5rl+ospF8W/S05QceD4MeqmJSCAzPnlvACOzB/VoA==",
+			"requires": {
+				"async-hook-jl": "^1.7.6",
+				"cls-bluebird": "^2.1.0",
+				"lru-cache": "6.0.0",
+				"methods": "^1.1.2",
+				"opentracing": "^0.14.5",
+				"redis-commands": "^1.7.0",
+				"semver": "7.3.3",
+				"shimmer": "1.2.1"
+			}
+		},
 		"@types/minipass": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@types/minipass/-/minipass-3.1.0.tgz",
@@ -612,6 +714,14 @@
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
+		"async-hook-jl": {
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+			"integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+			"requires": {
+				"stack-chain": "^1.3.7"
+			}
+		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -630,6 +740,15 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
 			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+		},
+		"cls-bluebird": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
+			"integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
+			"requires": {
+				"is-bluebird": "^1.0.2",
+				"shimmer": "^1.1.0"
+			}
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -690,9 +809,9 @@
 			}
 		},
 		"event-loop-stats": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/event-loop-stats/-/event-loop-stats-1.3.0.tgz",
-			"integrity": "sha512-CRto3Zyg3YE3AaBM/hPc7mJrbSOhy32P1wqIsZpp4rPHrj5qQavLUJKf+8fFq13ahC24T+RcX3f3fK13ElYZNw==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/event-loop-stats/-/event-loop-stats-1.4.1.tgz",
+			"integrity": "sha512-Wzohoz1JrQOBjt/shh5Z3/8Ti6SVoGl5nyX952Vcp5N56QVOtjPuJsQa+dEhsDJHu4QAFz45ePXRFq01skb9xA==",
 			"optional": true,
 			"requires": {
 				"nan": "^2.14.0"
@@ -765,6 +884,11 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
+		"is-bluebird": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
+			"integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI="
+		},
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -791,6 +915,14 @@
 			"resolved": "https://registry.npmjs.org/junk/-/junk-1.0.3.tgz",
 			"integrity": "sha1-h75jSIZJy9ym9Tqzm+yczSNH9ZI="
 		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
 		"maximatch": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
@@ -801,6 +933,11 @@
 				"arrify": "^1.0.0",
 				"minimatch": "^3.0.0"
 			}
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -866,6 +1003,11 @@
 			"requires": {
 				"wrappy": "1"
 			}
+		},
+		"opentracing": {
+			"version": "0.14.7",
+			"resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
+			"integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q=="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -939,6 +1081,11 @@
 				}
 			}
 		},
+		"redis-commands": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+		},
 		"semver": {
 			"version": "7.3.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
@@ -963,10 +1110,20 @@
 				}
 			}
 		},
+		"shimmer": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+		},
+		"stack-chain": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+			"integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
 		},
 		"tar": {
 			"version": "6.1.11",

--- a/packages/shared-metrics/package.json
+++ b/packages/shared-metrics/package.json
@@ -80,7 +80,7 @@
     "no-code2": "2.0.0"
   },
   "optionalDependencies": {
-    "event-loop-stats": "1.3.0",
+    "event-loop-stats": "1.4.1",
     "gcstats.js": "1.0.0"
   }
 }


### PR DESCRIPTION
Reopened to clean up the package-lock file.