### PR TITLE
chore(lambda): remove nodejs8.10 from compatible runtimes

### DIFF
--- a/packages/aws-lambda/layer/bin/publish-layer.sh
+++ b/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -233,7 +233,7 @@ if [[ -z $SKIP_AWS_PUBLISH_LAYER ]]; then
         --license-info $LICENSE \
         --zip-file fileb://$ZIP_NAME \
         --output json \
-        --compatible-runtimes nodejs8.10 nodejs10.x nodejs12.x nodejs14.x \
+        --compatible-runtimes nodejs10.x nodejs12.x nodejs14.x \
         | jq '.Version' \
     )
     echo "   + published version $lambda_layer_version to region $region"


### PR DESCRIPTION
Remove the AWS Lambda runtime for Node.js 8 from the list of runtimes
since we dropped support for Node.js 8.

BREAKING CHANGE: The Instana Node.js Lambda layer is no longer compatible with
Node.js 8. For Lambda functions still running on Node.js 8, please use the
latest layer version that has been published for Node.js 8, see
https://www.ibm.com/docs/en/obi/current?topic=kinesis-aws-lambda-native-tracing-nodejs