### PR TITLE
chore: removed legacy support for config.timeBetweenHealthcheckCalls

### DIFF
--- a/packages/collector/test/apps/express.js
+++ b/packages/collector/test/apps/express.js
@@ -12,7 +12,9 @@
 const instana = require('../../')({
   agentPort: process.env.AGENT_PORT,
   tracing: {
-    timeBetweenHealthcheckCalls: 1000,
+    metrics: {
+      timeBetweenHealthcheckCalls: 1000
+    },
     enabled: process.env.TRACING_ENABLED !== 'false',
     forceTransmissionStartingAt: 1,
     stackTraceLength: process.env.STACK_TRACE_LENGTH != null ? parseInt(process.env.STACK_TRACE_LENGTH, 10) : 10

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -156,13 +156,8 @@ function normalizeMetricsConfig(config) {
     'INSTANA_METRICS_TRANSMISSION_DELAY'
   );
 
-  // The correct location for this is config.metrics.timeBetweenHealthcheckCalls but previous versions accepted
-  // config.timeBetweenHealthcheckCalls. We still accept that to not break applications relying on that.
   config.metrics.timeBetweenHealthcheckCalls =
-    config.metrics.timeBetweenHealthcheckCalls ||
-    config.timeBetweenHealthcheckCalls ||
-    defaults.metrics.timeBetweenHealthcheckCalls;
-  delete config.timeBetweenHealthcheckCalls;
+    config.metrics.timeBetweenHealthcheckCalls || defaults.metrics.timeBetweenHealthcheckCalls;
 }
 
 /**

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -83,13 +83,6 @@ describe('util.normalizeConfig', () => {
       }
     });
     expect(config.metrics.timeBetweenHealthcheckCalls).to.equal(9876);
-    expect(config.timeBetweenHealthcheckCalls).to.not.exist;
-  });
-
-  it('should use legacy config.timeBetweenHealthcheckCalls', () => {
-    const config = normalizeConfig({ timeBetweenHealthcheckCalls: 1234 });
-    expect(config.metrics.timeBetweenHealthcheckCalls).to.equal(1234);
-    expect(config.timeBetweenHealthcheckCalls).to.not.exist;
   });
 
   it('should disable tracing', () => {


### PR DESCRIPTION
refs 80206

BREAKING CHANGE