### PR TITLE
ci: run bin/clean-aws.js script with every build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,17 @@ shared: &shared
     # error.
     - run: npm run lint
 
+      # Clean up old left over AWS resources from earlier test runs (created more more than 24 hours ago):
+    - run: |
+        ([[ ! $(node -v) =~ ^v16.*$ ]] || \
+          ( \
+            bin/clean-aws.js s3 dry=false && \
+             bin/clean-aws.js dynamodb dry=false && \
+             bin/clean-aws.js sqs dry=false && \
+             bin/clean-aws.js kinesis dry=false \
+          ) \
+        )
+
     # Run the test suites.
     # (Use ulimit to remove the file size limit on core dump files before running tests.)
     # The ci_glob_setup.sh script designates which files should be tested in each CircleCI process.


### PR DESCRIPTION
By default AWS S3 has a limit of 100 buckets per account. Other AWS services
also usually have some kind of limit for certain objects in place.
Although all integration tests usually clean up after themselves (and
delete things they have created), left-over objects (S3 buckets, SQS queues,
Kinesis streams, DynamoDB tables) might accrue over time; for example
when test runs are terminated while a test is in progress.

This change adds the cleanup script to the CI pipeline so that it is run
regularly. Only objects that match a certain name pattern and that are older
than 24 hours are deleted.