### PR TITLE
Instrumentation of node-rdfafka/kafka-avro

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ shared: &shared
     - MONGODB=127.0.0.1:27017
     - ZOOKEEPER=127.0.0.1:2181
     - KAFKA=127.0.0.1:9092
+    - KAFKA2=127.0.0.1:29092
+    - SCHEMA_REGISTRY=127.0.0.1:8081
     - REDIS=127.0.0.1:6379
     - MYSQL_HOST=127.0.0.1
     - MYSQL_PORT=3306
@@ -227,9 +229,20 @@ elasticsearch: &elasticsearch
 kafka: &kafka
   - image: wurstmeister/kafka:2.12-2.2.1
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
-      KAFKA_CREATE_TOPICS: "test:1:1,test-topic-1:1:1,test-topic-2:1:1,test-batch-topic-1:1:1,test-batch-topic-2:1:1"
+      KAFKA_LISTENERS: EXTERNAL://:9092,PLAINTEXT://:29092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:29092,EXTERNAL://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CREATE_TOPICS: "test:1:1,test-topic-1:1:1,test-topic-2:1:1,test-batch-topic-1:1:1,test-batch-topic-2:1:1,rdkafka-topic:1:1,kafka-avro-topic:1:1"
       KAFKA_ZOOKEEPER_CONNECT: 127.0.0.1:2181
+
+schema-registry: &schema-registry
+  - image: confluentinc/cp-schema-registry:4.1.0
+    environment:
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: "127.0.0.1:2181"
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "PLAINTEXT://127.0.0.1:29092"
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
 
 mongo: &mongo
   - image: circleci/mongo:4.1.13
@@ -284,6 +297,7 @@ jobs:
       - <<: *mongo
       - <<: *redis
       - <<: *kafka
+      - <<: *schema-registry
       - <<: *mysql
       - <<: *postgres
       - <<: *mssql
@@ -302,6 +316,7 @@ jobs:
       - <<: *mongo
       - <<: *redis
       - <<: *kafka
+      - <<: *schema-registry
       - <<: *mysql
       - <<: *postgres
       - <<: *mssql
@@ -320,6 +335,7 @@ jobs:
       - <<: *mongo
       - <<: *redis
       - <<: *kafka
+      - <<: *schema-registry
       - <<: *mysql
       - <<: *postgres
       - <<: *mssql
@@ -338,6 +354,7 @@ jobs:
       - <<: *mongo
       - <<: *redis
       - <<: *kafka
+      - <<: *schema-registry
       - <<: *mysql
       - <<: *postgres
       - <<: *mssql
@@ -356,6 +373,7 @@ jobs:
       - <<: *mongo
       - <<: *redis
       - <<: *kafka
+      - <<: *schema-registry
       - <<: *mysql
       - <<: *postgres
       - <<: *mssql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,17 +55,38 @@ services:
     image: wurstmeister/kafka:2.12-2.2.1
     ports:
       - 9092:9092
+      - 29092:29092
     depends_on:
       - "zookeeper"
+    hostname: kafka0
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
-      KAFKA_ADVERTISED_PORT: 9092
-      KAFKA_CREATE_TOPICS: "test:1:1,test-topic-1:1:1,test-topic-2:1:1,test-batch-topic-1:1:1,test-batch-topic-2:1:1"
+
+      KAFKA_LISTENERS: EXTERNAL://:9092,PLAINTEXT://:29092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka0:29092,EXTERNAL://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      # Leave the internal listener mapped as PLAINTEXT to avoid issues in schema-registry:
+      # https://github.com/confluentinc/schema-registry/issues/648#issuecomment-398032429
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+
+      KAFKA_CREATE_TOPICS: "test:1:1,test-topic-1:1:1,test-topic-2:1:1,test-batch-topic-1:1:1,test-batch-topic-2:1:1,rdkafka-topic:1:1,kafka-avro-topic:1:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./bin:/nodejs-collector-bin
     command: ["/nodejs-collector-bin/wait-for-it.sh", "-s", "-t", "120", "zookeeper:2181", "--", "start-kafka.sh"]
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:4.1.0
+    hostname: schema-registry
+    depends_on:
+      - "kafka"
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: "zookeeper:2181"
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "PLAINTEXT://kafka0:29092"
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
 
   mysql:
     image: mysql:8.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,9 +129,6 @@
         "uuid": "^8.3.2",
         "winston": "^3.3.3",
         "ws": "^7.5.6"
-      },
-      "optionalDependencies": {
-        "kafka-avro": "^3.1.1"
       }
     },
     "misc/eslint-plugin": {
@@ -14910,18 +14907,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
-      "optional": true
-    },
-    "node_modules/ansistyles": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
-      "optional": true
-    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -16014,15 +15999,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/avsc": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.3.tgz",
-      "integrity": "sha512-uUbetCWczQHbsKyX1C99XpQHBM8SWfovvaZhPIj23/1uV7SQf0WeRZbiLpw0JZm+LHTChfNgrLfDJOVoU2kU+A==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.11"
-      }
-    },
     "node_modules/avvio": {
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/avvio/-/avvio-5.9.0.tgz",
@@ -16133,7 +16109,7 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
@@ -16211,7 +16187,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/base": {
       "version": "0.11.2",
@@ -16379,7 +16355,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -16442,7 +16418,7 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/body-parser": {
       "version": "1.19.0",
@@ -16590,7 +16566,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -16823,53 +16799,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/bunyan": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
-      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
-      "engines": [
-        "node >=0.10.0"
-      ],
-      "optional": true,
-      "bin": {
-        "bunyan": "bin/bunyan"
-      },
-      "optionalDependencies": {
-        "dtrace-provider": "~0.8",
-        "moment": "^2.19.3",
-        "mv": "~2",
-        "safe-json-stringify": "~1"
-      }
-    },
-    "node_modules/bunyan-format": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/bunyan-format/-/bunyan-format-0.2.1.tgz",
-      "integrity": "sha1-pLOw2ABwqGUnlBcmnj8A/wL7y0c=",
-      "optional": true,
-      "dependencies": {
-        "ansicolors": "~0.2.1",
-        "ansistyles": "~0.1.1",
-        "xtend": "~2.1.1"
-      }
-    },
-    "node_modules/bunyan-format/node_modules/object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-      "optional": true
-    },
-    "node_modules/bunyan-format/node_modules/xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-      "optional": true,
-      "dependencies": {
-        "object-keys": "~0.4.0"
-      },
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/busboy": {
@@ -17336,12 +17265,6 @@
       "resolved": "https://registry.npmjs.org/cint/-/cint-8.2.1.tgz",
       "integrity": "sha1-cDhrG0jidz0NYxZqVa/5TvRFahI=",
       "dev": true
-    },
-    "node_modules/cip": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cip/-/cip-1.0.1.tgz",
-      "integrity": "sha1-FzAzSiIvhWXgl/YMM5BxiUsPva8=",
-      "optional": true
     },
     "node_modules/class-utils": {
       "version": "0.3.6",
@@ -18103,7 +18026,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -19639,19 +19562,6 @@
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg==",
       "dev": true
-    },
-    "node_modules/dtrace-provider": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
-      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "nan": "^2.14.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -21890,7 +21800,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/fill-keys": {
       "version": "1.0.2",
@@ -22130,7 +22040,7 @@
       "version": "1.14.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
       "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -25166,7 +25076,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -25176,7 +25086,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -26469,38 +26379,6 @@
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/kafka-avro": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/kafka-avro/-/kafka-avro-3.1.1.tgz",
-      "integrity": "sha512-GVIXVC4I7+KkI77btc4SeSNmOsHHNV9TRdQTnYYMK+ClU7EAyb/xD/I84z3MOqIaZehhH+FsXUPzLJqvKMxeCA==",
-      "optional": true,
-      "dependencies": {
-        "avsc": "^5.2.3",
-        "axios": "^0.21.1",
-        "bluebird": "^3.4.6",
-        "bunyan": "^1.8.5",
-        "bunyan-format": "^0.2.1",
-        "cip": "^1.0.0",
-        "node-rdkafka": "~2.9.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/kafka-avro/node_modules/node-rdkafka": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.9.1.tgz",
-      "integrity": "sha512-C5EVDZlDG+5D8KXiz2zKwEiLWIGW5Z1mkVFRzp13T4mrbXz+ESyjrDSLIj7aoUIi5+T10H9p1wwLZJBh9ivjLg==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.3.1",
-        "nan": "^2.14.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/kafka-node": {
@@ -28026,7 +27904,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -28720,7 +28598,7 @@
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -29255,66 +29133,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "node_modules/mv": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
-      "optional": true,
-      "dependencies": {
-        "mkdirp": "~0.5.1",
-        "ncp": "~2.0.0",
-        "rimraf": "~2.4.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/mv/node_modules/glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-      "optional": true,
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mv/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "optional": true
-    },
-    "node_modules/mv/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "optional": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mv/node_modules/rimraf": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-      "optional": true,
-      "dependencies": {
-        "glob": "^6.0.1"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/mysql": {
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
@@ -29461,7 +29279,7 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -29522,15 +29340,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node_modules/ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
-      "optional": true,
-      "bin": {
-        "ncp": "bin/ncp"
-      }
     },
     "node_modules/negotiator": {
       "version": "0.6.2",
@@ -30643,7 +30452,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -31208,7 +31017,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -33301,12 +33110,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
-    },
-    "node_modules/safe-json-stringify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
-      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
-      "optional": true
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
@@ -36834,7 +36637,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -50172,18 +49975,6 @@
         }
       }
     },
-    "ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
-      "optional": true
-    },
-    "ansistyles": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
-      "optional": true
-    },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -51048,12 +50839,6 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
-    "avsc": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.3.tgz",
-      "integrity": "sha512-uUbetCWczQHbsKyX1C99XpQHBM8SWfovvaZhPIj23/1uV7SQf0WeRZbiLpw0JZm+LHTChfNgrLfDJOVoU2kU+A==",
-      "optional": true
-    },
     "avvio": {
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/avvio/-/avvio-5.9.0.tgz",
@@ -51156,7 +50941,7 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "follow-redirects": "^1.14.0"
       }
@@ -51227,7 +51012,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "devOptional": true
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -51353,7 +51138,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -51415,7 +51200,7 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "devOptional": true
+      "dev": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -51525,7 +51310,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -51722,46 +51507,6 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
-    "bunyan": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
-      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
-      "optional": true,
-      "requires": {
-        "dtrace-provider": "~0.8",
-        "moment": "^2.19.3",
-        "mv": "~2",
-        "safe-json-stringify": "~1"
-      }
-    },
-    "bunyan-format": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/bunyan-format/-/bunyan-format-0.2.1.tgz",
-      "integrity": "sha1-pLOw2ABwqGUnlBcmnj8A/wL7y0c=",
-      "optional": true,
-      "requires": {
-        "ansicolors": "~0.2.1",
-        "ansistyles": "~0.1.1",
-        "xtend": "~2.1.1"
-      },
-      "dependencies": {
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-          "optional": true
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "optional": true,
-          "requires": {
-            "object-keys": "~0.4.0"
           }
         }
       }
@@ -52121,12 +51866,6 @@
       "resolved": "https://registry.npmjs.org/cint/-/cint-8.2.1.tgz",
       "integrity": "sha1-cDhrG0jidz0NYxZqVa/5TvRFahI=",
       "dev": true
-    },
-    "cip": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cip/-/cip-1.0.1.tgz",
-      "integrity": "sha1-FzAzSiIvhWXgl/YMM5BxiUsPva8=",
-      "optional": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -52767,7 +52506,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "devOptional": true
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -54011,15 +53750,6 @@
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg==",
       "dev": true
-    },
-    "dtrace-provider": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
-      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
-      "optional": true,
-      "requires": {
-        "nan": "^2.14.0"
-      }
     },
     "duplexer": {
       "version": "0.1.2",
@@ -55849,7 +55579,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "devOptional": true
+      "dev": true
     },
     "fill-keys": {
       "version": "1.0.2",
@@ -56048,7 +55778,7 @@
       "version": "1.14.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
       "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
-      "devOptional": true
+      "dev": true
     },
     "for-each": {
       "version": "0.3.3",
@@ -58391,7 +58121,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -58401,7 +58131,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "devOptional": true
+      "dev": true
     },
     "ini": {
       "version": "1.3.8",
@@ -59403,33 +59133,6 @@
       "requires": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "kafka-avro": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/kafka-avro/-/kafka-avro-3.1.1.tgz",
-      "integrity": "sha512-GVIXVC4I7+KkI77btc4SeSNmOsHHNV9TRdQTnYYMK+ClU7EAyb/xD/I84z3MOqIaZehhH+FsXUPzLJqvKMxeCA==",
-      "optional": true,
-      "requires": {
-        "avsc": "^5.2.3",
-        "axios": "^0.21.1",
-        "bluebird": "^3.4.6",
-        "bunyan": "^1.8.5",
-        "bunyan-format": "^0.2.1",
-        "cip": "^1.0.0",
-        "node-rdkafka": "~2.9.0"
-      },
-      "dependencies": {
-        "node-rdkafka": {
-          "version": "2.9.1",
-          "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.9.1.tgz",
-          "integrity": "sha512-C5EVDZlDG+5D8KXiz2zKwEiLWIGW5Z1mkVFRzp13T4mrbXz+ESyjrDSLIj7aoUIi5+T10H9p1wwLZJBh9ivjLg==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.3.1",
-            "nan": "^2.14.0"
-          }
-        }
       }
     },
     "kafka-node": {
@@ -60700,7 +60403,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -61272,7 +60975,7 @@
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "devOptional": true
+      "dev": true
     },
     "moment-timezone": {
       "version": "0.5.33",
@@ -61662,56 +61365,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "mv": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
-      "optional": true,
-      "requires": {
-        "mkdirp": "~0.5.1",
-        "ncp": "~2.0.0",
-        "rimraf": "~2.4.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "optional": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "optional": true
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "optional": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "rimraf": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-          "optional": true,
-          "requires": {
-            "glob": "^6.0.1"
-          }
-        }
-      }
-    },
     "mysql": {
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
@@ -61843,7 +61496,7 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "devOptional": true
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -61892,12 +61545,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
-      "optional": true
     },
     "negotiator": {
       "version": "0.6.2",
@@ -62779,7 +62426,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -63233,7 +62880,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "devOptional": true
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",
@@ -64886,12 +64533,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
-    },
-    "safe-json-stringify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
-      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
-      "optional": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -67738,7 +67379,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "devOptional": true
+      "dev": true
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,6 +104,7 @@
         "nats": "^1.4.12",
         "node-fetch": "^2.6.1",
         "node-nats-streaming": "^0.3.2",
+        "node-rdkafka": "^2.12.0",
         "npm-check-updates": "^11.5.13",
         "pg": "^8.7.1",
         "pg-native": "^3.0.0",
@@ -29611,6 +29612,20 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/node-rdkafka": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.12.0.tgz",
+      "integrity": "sha512-Wda7AQP+Bo8AhJDSAWTxSD8CsaJnirM+2whlKKP0mOO/I3iz9yoq/JQ2k1DGQ3BSEwXmg8adK064+ThjvCuOpw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.3.1",
+        "nan": "^2.14.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -61769,6 +61784,16 @@
         "google-protobuf": "^3.11.2",
         "nats": "^1.4.9",
         "nuid": "^1.1.4"
+      }
+    },
+    "node-rdkafka": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.12.0.tgz",
+      "integrity": "sha512-Wda7AQP+Bo8AhJDSAWTxSD8CsaJnirM+2whlKKP0mOO/I3iz9yoq/JQ2k1DGQ3BSEwXmg8adK064+ThjvCuOpw==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.3.1",
+        "nan": "^2.14.0"
       }
     },
     "node-releases": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,6 +129,9 @@
         "uuid": "^8.3.2",
         "winston": "^3.3.3",
         "ws": "^7.5.6"
+      },
+      "optionalDependencies": {
+        "kafka-avro": "^3.1.1"
       }
     },
     "misc/eslint-plugin": {
@@ -14907,6 +14910,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/ansicolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
+      "optional": true
+    },
+    "node_modules/ansistyles": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
+      "optional": true
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -15999,6 +16014,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/avsc": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.3.tgz",
+      "integrity": "sha512-uUbetCWczQHbsKyX1C99XpQHBM8SWfovvaZhPIj23/1uV7SQf0WeRZbiLpw0JZm+LHTChfNgrLfDJOVoU2kU+A==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.11"
+      }
+    },
     "node_modules/avvio": {
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/avvio/-/avvio-5.9.0.tgz",
@@ -16109,7 +16133,7 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
@@ -16187,7 +16211,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/base": {
       "version": "0.11.2",
@@ -16355,7 +16379,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -16418,7 +16442,7 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/body-parser": {
       "version": "1.19.0",
@@ -16566,7 +16590,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -16799,6 +16823,53 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/bunyan": {
+      "version": "1.8.15",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
+      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
+      "engines": [
+        "node >=0.10.0"
+      ],
+      "optional": true,
+      "bin": {
+        "bunyan": "bin/bunyan"
+      },
+      "optionalDependencies": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.19.3",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
+    },
+    "node_modules/bunyan-format": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/bunyan-format/-/bunyan-format-0.2.1.tgz",
+      "integrity": "sha1-pLOw2ABwqGUnlBcmnj8A/wL7y0c=",
+      "optional": true,
+      "dependencies": {
+        "ansicolors": "~0.2.1",
+        "ansistyles": "~0.1.1",
+        "xtend": "~2.1.1"
+      }
+    },
+    "node_modules/bunyan-format/node_modules/object-keys": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+      "optional": true
+    },
+    "node_modules/bunyan-format/node_modules/xtend": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+      "optional": true,
+      "dependencies": {
+        "object-keys": "~0.4.0"
+      },
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/busboy": {
@@ -17265,6 +17336,12 @@
       "resolved": "https://registry.npmjs.org/cint/-/cint-8.2.1.tgz",
       "integrity": "sha1-cDhrG0jidz0NYxZqVa/5TvRFahI=",
       "dev": true
+    },
+    "node_modules/cip": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cip/-/cip-1.0.1.tgz",
+      "integrity": "sha1-FzAzSiIvhWXgl/YMM5BxiUsPva8=",
+      "optional": true
     },
     "node_modules/class-utils": {
       "version": "0.3.6",
@@ -18026,7 +18103,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -19562,6 +19639,19 @@
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg==",
       "dev": true
+    },
+    "node_modules/dtrace-provider": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.14.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -21800,7 +21890,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/fill-keys": {
       "version": "1.0.2",
@@ -22040,7 +22130,7 @@
       "version": "1.14.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
       "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -25076,7 +25166,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -25086,7 +25176,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -26379,6 +26469,38 @@
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kafka-avro": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/kafka-avro/-/kafka-avro-3.1.1.tgz",
+      "integrity": "sha512-GVIXVC4I7+KkI77btc4SeSNmOsHHNV9TRdQTnYYMK+ClU7EAyb/xD/I84z3MOqIaZehhH+FsXUPzLJqvKMxeCA==",
+      "optional": true,
+      "dependencies": {
+        "avsc": "^5.2.3",
+        "axios": "^0.21.1",
+        "bluebird": "^3.4.6",
+        "bunyan": "^1.8.5",
+        "bunyan-format": "^0.2.1",
+        "cip": "^1.0.0",
+        "node-rdkafka": "~2.9.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/kafka-avro/node_modules/node-rdkafka": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.9.1.tgz",
+      "integrity": "sha512-C5EVDZlDG+5D8KXiz2zKwEiLWIGW5Z1mkVFRzp13T4mrbXz+ESyjrDSLIj7aoUIi5+T10H9p1wwLZJBh9ivjLg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.3.1",
+        "nan": "^2.14.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/kafka-node": {
@@ -27904,7 +28026,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -28598,7 +28720,7 @@
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": "*"
       }
@@ -29133,6 +29255,66 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "node_modules/mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/mv/node_modules/glob": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "optional": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mv/node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "optional": true
+    },
+    "node_modules/mv/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "optional": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mv/node_modules/rimraf": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+      "optional": true,
+      "dependencies": {
+        "glob": "^6.0.1"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/mysql": {
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
@@ -29279,7 +29461,7 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -29340,6 +29522,15 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "optional": true,
+      "bin": {
+        "ncp": "bin/ncp"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.2",
@@ -30452,7 +30643,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -31017,7 +31208,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -33110,6 +33301,12 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "node_modules/safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "optional": true
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
@@ -36637,7 +36834,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -49975,6 +50172,18 @@
         }
       }
     },
+    "ansicolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
+      "optional": true
+    },
+    "ansistyles": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
+      "optional": true
+    },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -50839,6 +51048,12 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
+    "avsc": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.3.tgz",
+      "integrity": "sha512-uUbetCWczQHbsKyX1C99XpQHBM8SWfovvaZhPIj23/1uV7SQf0WeRZbiLpw0JZm+LHTChfNgrLfDJOVoU2kU+A==",
+      "optional": true
+    },
     "avvio": {
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/avvio/-/avvio-5.9.0.tgz",
@@ -50941,7 +51156,7 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "follow-redirects": "^1.14.0"
       }
@@ -51012,7 +51227,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "devOptional": true
     },
     "base": {
       "version": "0.11.2",
@@ -51138,7 +51353,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -51200,7 +51415,7 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
+      "devOptional": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -51310,7 +51525,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -51507,6 +51722,46 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "bunyan": {
+      "version": "1.8.15",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
+      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
+      "optional": true,
+      "requires": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.19.3",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
+    },
+    "bunyan-format": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/bunyan-format/-/bunyan-format-0.2.1.tgz",
+      "integrity": "sha1-pLOw2ABwqGUnlBcmnj8A/wL7y0c=",
+      "optional": true,
+      "requires": {
+        "ansicolors": "~0.2.1",
+        "ansistyles": "~0.1.1",
+        "xtend": "~2.1.1"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+          "optional": true
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "optional": true,
+          "requires": {
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -51866,6 +52121,12 @@
       "resolved": "https://registry.npmjs.org/cint/-/cint-8.2.1.tgz",
       "integrity": "sha1-cDhrG0jidz0NYxZqVa/5TvRFahI=",
       "dev": true
+    },
+    "cip": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cip/-/cip-1.0.1.tgz",
+      "integrity": "sha1-FzAzSiIvhWXgl/YMM5BxiUsPva8=",
+      "optional": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -52506,7 +52767,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "devOptional": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -53750,6 +54011,15 @@
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg==",
       "dev": true
+    },
+    "dtrace-provider": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.0"
+      }
     },
     "duplexer": {
       "version": "0.1.2",
@@ -55579,7 +55849,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true
+      "devOptional": true
     },
     "fill-keys": {
       "version": "1.0.2",
@@ -55778,7 +56048,7 @@
       "version": "1.14.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
       "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
-      "dev": true
+      "devOptional": true
     },
     "for-each": {
       "version": "0.3.3",
@@ -58121,7 +58391,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -58131,7 +58401,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "devOptional": true
     },
     "ini": {
       "version": "1.3.8",
@@ -59133,6 +59403,33 @@
       "requires": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "kafka-avro": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/kafka-avro/-/kafka-avro-3.1.1.tgz",
+      "integrity": "sha512-GVIXVC4I7+KkI77btc4SeSNmOsHHNV9TRdQTnYYMK+ClU7EAyb/xD/I84z3MOqIaZehhH+FsXUPzLJqvKMxeCA==",
+      "optional": true,
+      "requires": {
+        "avsc": "^5.2.3",
+        "axios": "^0.21.1",
+        "bluebird": "^3.4.6",
+        "bunyan": "^1.8.5",
+        "bunyan-format": "^0.2.1",
+        "cip": "^1.0.0",
+        "node-rdkafka": "~2.9.0"
+      },
+      "dependencies": {
+        "node-rdkafka": {
+          "version": "2.9.1",
+          "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.9.1.tgz",
+          "integrity": "sha512-C5EVDZlDG+5D8KXiz2zKwEiLWIGW5Z1mkVFRzp13T4mrbXz+ESyjrDSLIj7aoUIi5+T10H9p1wwLZJBh9ivjLg==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.3.1",
+            "nan": "^2.14.0"
+          }
+        }
       }
     },
     "kafka-node": {
@@ -60403,7 +60700,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -60975,7 +61272,7 @@
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "dev": true
+      "devOptional": true
     },
     "moment-timezone": {
       "version": "0.5.33",
@@ -61365,6 +61662,56 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "optional": true,
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "optional": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "optional": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "optional": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "rimraf": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "optional": true,
+          "requires": {
+            "glob": "^6.0.1"
+          }
+        }
+      }
+    },
     "mysql": {
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
@@ -61496,7 +61843,7 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true
+      "devOptional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -61545,6 +61892,12 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "optional": true
     },
     "negotiator": {
       "version": "0.6.2",
@@ -62426,7 +62779,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "wrappy": "1"
       }
@@ -62880,7 +63233,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "devOptional": true
     },
     "path-key": {
       "version": "2.0.1",
@@ -64533,6 +64886,12 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "optional": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -67379,7 +67738,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "devOptional": true
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "nats": "^1.4.12",
     "node-fetch": "^2.6.1",
     "node-nats-streaming": "^0.3.2",
+    "node-rdkafka": "^2.12.0",
     "npm-check-updates": "^11.5.13",
     "pg": "^8.7.1",
     "pg-native": "^3.0.0",
@@ -169,6 +170,9 @@
     "uuid": "^8.3.2",
     "winston": "^3.3.3",
     "ws": "^7.5.6"
+  },
+  "optionalDependencies": {
+    "kafka-avro": "^3.1.1"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -171,9 +171,6 @@
     "winston": "^3.3.3",
     "ws": "^7.5.6"
   },
-  "optionalDependencies": {
-    "kafka-avro": "^3.1.1"
-  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"

--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -285,7 +285,6 @@ class ProcessControls {
       return Promise.resolve();
     }
     return new Promise(resolve => {
-      this.process.once('exit', resolve);
       this.process.once('exit', () => {
         this.process.pid = null;
         resolve();

--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -246,6 +246,7 @@ class ProcessControls {
     const requestOptions = Object.assign({}, opts);
     const baseUrl = this.getBaseUrl(opts);
     requestOptions.baseUrl = baseUrl;
+
     if (this.http2) {
       return http2Promise.request(requestOptions);
     } else {

--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -225,7 +225,7 @@ class ProcessControls {
 
   getPid() {
     if (!this.process) {
-      return 'no process, no PID';
+      return false;
     }
     return this.process.pid;
   }
@@ -286,6 +286,11 @@ class ProcessControls {
     }
     return new Promise(resolve => {
       this.process.once('exit', resolve);
+      this.process.once('exit', () => {
+        this.process.pid = null;
+        resolve();
+      });
+
       this.process.kill();
     });
   }

--- a/packages/collector/test/tracing/messaging/kafka-avro/consumer.js
+++ b/packages/collector/test/tracing/messaging/kafka-avro/consumer.js
@@ -1,0 +1,82 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const instana = require('../../../../')();
+const KafkaAvro = require('kafka-avro');
+
+const fetch = require('node-fetch');
+const delay = require('../../../../../core/test/test_util/delay');
+const agentPort = process.env.INSTANA_AGENT_PORT || 42699;
+const { sendToParent } = require('@instana/core/test/test_util');
+const logPrefix = `Kafka Avro Consumer (${process.pid}):\t`;
+const log = require('@instana/core/test/test_util/log').getLogger(logPrefix);
+const express = require('express');
+const port = process.env.APP_PORT || 3215;
+
+const kafkaAvro = new KafkaAvro({
+  kafkaBroker: 'localhost:9092',
+  schemaRegistry: 'http://localhost:8081'
+});
+
+let isReady = false;
+
+const topicName = 'kafka-avro-topic';
+
+(async () => {
+  await kafkaAvro.init();
+
+  isReady = true;
+
+  const consumer = await kafkaAvro.getConsumer({
+    // Keep this value low (default is 5000ms) to be sure that messages won't survive between tests.
+    'auto.commit.interval.ms': 500,
+    'group.id': 'librd-test',
+    'socket.keepalive.enable': true,
+    'enable.auto.commit': true
+  });
+
+  await new Promise((resolve, reject) => {
+    consumer.on('ready', () => {
+      resolve(consumer);
+    });
+
+    consumer.connect({}, err => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(consumer); // depend on Promises' single resolve contract.
+    });
+  });
+
+  // Subscribe and consume.
+  consumer.subscribe([topicName]);
+
+  consumer.on('data', async rawData => {
+    const span = instana.currentSpan();
+    span.disableAutoEnd();
+    sendToParent(rawData.value);
+    log('Got message');
+
+    await delay(200);
+    await fetch(`http://127.0.0.1:${agentPort}`);
+    span.end();
+  });
+
+  consumer.consume();
+})();
+
+const app = express();
+
+app.get('/', (_req, res) => {
+  if (isReady) {
+    res.send('ok');
+  } else {
+    res.status(500).send('Kafka Avro Consumer is not ready yet.');
+  }
+});
+
+app.listen(port, () => log(`Kafka Avro Consumer app listening on port ${port}`));

--- a/packages/collector/test/tracing/messaging/kafka-avro/consumer.js
+++ b/packages/collector/test/tracing/messaging/kafka-avro/consumer.js
@@ -28,8 +28,6 @@ const topicName = 'kafka-avro-topic';
 (async () => {
   await kafkaAvro.init();
 
-  isReady = true;
-
   const consumer = await kafkaAvro.getConsumer({
     // Keep this value low (default is 5000ms) to be sure that messages won't survive between tests.
     'auto.commit.interval.ms': 500,
@@ -40,6 +38,7 @@ const topicName = 'kafka-avro-topic';
 
   await new Promise((resolve, reject) => {
     consumer.on('ready', () => {
+      isReady = true;
       resolve(consumer);
     });
 

--- a/packages/collector/test/tracing/messaging/kafka-avro/producer.js
+++ b/packages/collector/test/tracing/messaging/kafka-avro/producer.js
@@ -1,0 +1,80 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+require('../../../../')({
+  tracing: {
+    kafka: {
+      headerFormat: 'string'
+    }
+  }
+});
+
+const KafkaAvro = require('kafka-avro');
+
+const fetch = require('node-fetch');
+const agentPort = process.env.INSTANA_AGENT_PORT || 42699;
+const logPrefix = `Kafka Avro Producer (${process.pid}):\t`;
+const log = require('@instana/core/test/test_util/log').getLogger(logPrefix);
+const express = require('express');
+const port = process.env.APP_PORT || 3216;
+
+const app = express();
+
+const kafkaAvro = new KafkaAvro({
+  kafkaBroker: 'localhost:9092',
+  schemaRegistry: 'http://localhost:8081'
+});
+
+let isReady = false;
+// Query the Schema Registry for all topic-schema's
+// fetch them and evaluate them.
+kafkaAvro.init().then(() => {
+  isReady = true;
+  log('Ready to use');
+});
+
+let messageCounter = 0;
+const topicName = 'kafka-avro-topic';
+
+app.get('/produce', async (req, res) => {
+  ++messageCounter;
+  const producer = await kafkaAvro.getProducer({});
+
+  producer.on('disconnected', arg => {
+    log('producer disconnected. ' + JSON.stringify(arg));
+  });
+
+  const value = { name: 'John', messageCounter };
+  const key = 'key';
+
+  // if partition is set to -1, librdkafka will use the default partitioner
+  const partition = -1;
+  producer.produce(topicName, partition, value, key);
+  log('Sent message');
+
+  setTimeout(async () => {
+    await fetch(`http://127.0.0.1:${agentPort}`);
+
+    res.send({
+      topicName,
+      partition,
+      key,
+      value
+    });
+  }, 100);
+});
+
+app.get('/', (_req, res) => {
+  if (isReady) {
+    res.send('ok');
+  } else {
+    res.status(500).send('Kafka Avro Producer is not ready yet.');
+  }
+});
+
+app.listen(port, () => {
+  log(`Kafka Avro Producer app listening on port ${port}`);
+});

--- a/packages/collector/test/tracing/messaging/kafka-avro/producer.js
+++ b/packages/collector/test/tracing/messaging/kafka-avro/producer.js
@@ -4,13 +4,7 @@
 
 'use strict';
 
-require('../../../../')({
-  tracing: {
-    kafka: {
-      headerFormat: 'string'
-    }
-  }
-});
+require('../../../../')({});
 
 const KafkaAvro = require('kafka-avro');
 

--- a/packages/collector/test/tracing/messaging/kafka-avro/test.js
+++ b/packages/collector/test/tracing/messaging/kafka-avro/test.js
@@ -1,0 +1,244 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+/**
+ * Important notes
+ * ---------------
+ *
+ * * Kafka Avro is instrumented through node-rdkafka, which is the API underneath Kafka Avro
+ * * Kafka Avro currently works only in Node 14 and below, as it depends on an older version of node-rdkafka where
+ * native modules.
+ * * The Producer as a stream can only have span correlation if the Writtable option objectMode is set to true.
+ * Otherwise, there is no way to append the Instana headers to it.
+ * * The Producer, as stream or standard API cannot propagate span correlation when headerFormat is set to 'binary'.
+ * More info here: https://github.com/Blizzard/node-rdkafka/pull/935.
+ * * If the option dr_cb is not set to true, we cannot guarantee that a message was sent, but a span with a successful
+ * sent message will be created.
+ */
+
+const path = require('path');
+const { expect } = require('chai');
+const { fail } = expect;
+const {
+  tracing: { constants }
+} = require('@instana/core');
+
+const {
+  tracing: { supportedVersion }
+} = require('@instana/core');
+
+const { satisfies } = require('semver');
+const config = require('../../../../../core/test/config');
+const { expectExactlyOneMatching, retry, delay, stringifyItems } = require('../../../../../core/test/test_util');
+const ProcessControls = require('../../../test_util/ProcessControls');
+const globalAgent = require('../../../globalAgent');
+const { verifyHttpRootEntry, verifyHttpExit } = require('@instana/core/test/test_util/common_verifications');
+
+let mochaSuiteFn;
+
+/**
+ * Although kafka-avro is compatible with Node v8.x.x we are limiting tests to v10 as minimum as there is an unknown
+ * issue with Circle CI where kafka-avro seems to be installed properly in version 8, but the module is not found in
+ * node_modules.
+ */
+const kafkaAvroAllowedVersions = satisfies(process.versions.node, '10 - 14.17');
+
+if (!supportedVersion(process.versions.node) || !kafkaAvroAllowedVersions) {
+  mochaSuiteFn = describe.skip;
+} else {
+  mochaSuiteFn = describe;
+}
+const retryTime = config.getTestTimeout() * 2;
+const topic = 'kafka-avro-topic';
+
+mochaSuiteFn('tracing/messaging/kafka-avro', function () {
+  this.timeout(config.getTestTimeout() * 4);
+
+  globalAgent.setUpCleanUpHooks();
+  const agentControls = globalAgent.instance;
+
+  describe('tracing enabled, no suppression', function () {
+    const producerControls = new ProcessControls({
+      appPath: path.join(__dirname, 'producer'),
+      port: 3216,
+      useGlobalAgent: true
+    });
+
+    ProcessControls.setUpHooksWithRetryTime(retryTime, producerControls);
+
+    describe('consuming message', () => {
+      const consumerControls = new ProcessControls({
+        appPath: path.join(__dirname, 'consumer'),
+        port: 3215,
+        useGlobalAgent: true
+      });
+
+      ProcessControls.setUpHooksWithRetryTime(retryTime, consumerControls);
+
+      const apiPath = '/produce';
+
+      it('produces and consumes a message', async () => {
+        const response = await producerControls.sendRequest({
+          method: 'GET',
+          path: apiPath
+        });
+
+        return verify(consumerControls, producerControls, response, apiPath);
+      });
+    });
+  });
+
+  function verify(_producerControls, _consumerControls, response, apiPath) {
+    return retry(() => {
+      verifyResponseAndMessage(response, _producerControls);
+
+      return agentControls.getSpans().then(spans => verifySpans(_producerControls, _consumerControls, spans, apiPath));
+    }, retryTime);
+  }
+
+  function verifySpans(receiverControls, _senderControls, spans, apiPath) {
+    const httpEntry = verifyHttpRootEntry({ spans, apiPath, pid: String(_senderControls.getPid()) });
+    const kafkaExit = verifyKafkaAvroExit(_senderControls, spans, httpEntry);
+    verifyHttpExit({ spans, parent: httpEntry, pid: String(_senderControls.getPid()) });
+    const kafkaEntry = verifyKafkaAvroEntry(receiverControls, spans, kafkaExit);
+    verifyHttpExit({ spans, parent: kafkaEntry, pid: String(receiverControls.getPid()) });
+  }
+
+  function verifyKafkaAvroEntry(receiverControls, spans, parent) {
+    const operation = expectExactlyOneMatching;
+
+    return operation(spans, [
+      span => expect(span.n).to.equal('kafka'),
+      span => expect(span.k).to.equal(constants.ENTRY),
+      span => expect(span.t).to.equal(parent.t),
+      span => expect(span.p).to.equal(parent.s),
+      span => expect(span.f.e).to.equal(String(receiverControls.getPid())),
+      span => expect(span.f.h).to.equal('agent-stub-uuid'),
+      span => expect(span.data.kafka.error).to.not.exist,
+      span => expect(span.ec).to.equal(0),
+      span => expect(span.async).to.not.exist,
+      span => expect(span.data).to.exist,
+      span => expect(span.data.kafka).to.be.an('object'),
+      span => expect(span.data.kafka.service).to.equal(topic),
+      span => expect(span.data.kafka.access).to.equal('consume')
+    ]);
+  }
+
+  function verifyKafkaAvroExit(_senderControls, spans, parent) {
+    return expectExactlyOneMatching(spans, [
+      span => expect(span.n).to.equal('kafka'),
+      span => expect(span.k).to.equal(constants.EXIT),
+      span => expect(span.t).to.equal(parent.t),
+      span => expect(span.p).to.equal(parent.s),
+      span => expect(span.f.e).to.equal(String(_senderControls.getPid())),
+      span => expect(span.f.h).to.equal('agent-stub-uuid'),
+      span => expect(span.error).to.not.exist,
+      span => expect(span.ec).to.equal(0),
+      span => expect(span.async).to.not.exist,
+      span => expect(span.data).to.exist,
+      span => expect(span.data.kafka).to.be.an('object'),
+      span => expect(span.data.kafka.service).to.equal(topic),
+      span => expect(span.data.kafka.access).to.equal('send')
+    ]);
+  }
+
+  describe('tracing disabled', () => {
+    this.timeout(config.getTestTimeout() * 2);
+
+    const producerControls = new ProcessControls({
+      appPath: path.join(__dirname, 'producer'),
+      port: 3216,
+      useGlobalAgent: true,
+      tracingEnabled: false
+    });
+
+    ProcessControls.setUpHooksWithRetryTime(retryTime, producerControls);
+
+    describe('producing and consuming', () => {
+      const consumerControls = new ProcessControls({
+        appPath: path.join(__dirname, 'consumer'),
+        port: 3215,
+        useGlobalAgent: true,
+        tracingEnabled: false
+      });
+
+      ProcessControls.setUpHooksWithRetryTime(retryTime, consumerControls);
+
+      it('should not trace for producing / consuming messages', async () => {
+        const response = await producerControls.sendRequest({
+          method: 'GET',
+          path: '/produce'
+        });
+
+        return retry(() => verifyResponseAndMessage(response, consumerControls), retryTime)
+          .then(() => delay(config.getTestTimeout() / 4))
+          .then(() => agentControls.getSpans())
+          .then(spans => {
+            if (spans.length > 0) {
+              fail(`Unexpected spans (kafka-avro suppressed: ${stringifyItems(spans)}`);
+            }
+          });
+      });
+    });
+  });
+
+  describe('tracing enabled but suppressed', () => {
+    const producerControls = new ProcessControls({
+      appPath: path.join(__dirname, 'producer'),
+      port: 3216,
+      useGlobalAgent: true
+    });
+
+    ProcessControls.setUpHooksWithRetryTime(retryTime, producerControls);
+
+    describe('tracing suppressed', () => {
+      const receiverControls = new ProcessControls({
+        appPath: path.join(__dirname, 'consumer'),
+        port: 3215,
+        useGlobalAgent: true
+      });
+
+      ProcessControls.setUpHooksWithRetryTime(retryTime, receiverControls);
+
+      it("doesn't trace when producing / consuming messages", async () => {
+        const response = await producerControls.sendRequest({
+          method: 'GET',
+          path: '/produce',
+          suppressTracing: true
+        });
+
+        return retry(() => {
+          verifyResponseAndMessage(response, receiverControls);
+        }, retryTime)
+          .then(() => delay(config.getTestTimeout() / 4))
+          .then(() => agentControls.getSpans())
+          .then(spans => {
+            if (spans.length > 0) {
+              fail(`Unexpected spans (kafka avro suppressed: ${stringifyItems(spans)}`);
+            }
+          });
+      });
+    });
+  });
+});
+
+function verifyResponseAndMessage(response, consumerControls) {
+  expect(response).to.be.an('object');
+  const receivedMessages = consumerControls.getIpcMessages();
+  expect(receivedMessages).to.be.an('array');
+  expect(receivedMessages).to.have.lengthOf.at.least(1);
+
+  /**
+   * Each message is an object in the following format: {type: 'Buffer', data: number[]}
+   */
+  const message = receivedMessages
+    .map(({ data }) => JSON.parse(Buffer.from(data).toString()))
+    .filter(data => data.messageCounter === response.value.messageCounter)[0];
+
+  expect(message).to.exist;
+  expect(message.name).to.equal('John');
+  return message;
+}

--- a/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
@@ -45,6 +45,8 @@ function getConsumer() {
     });
 
     _consumer.on('data', async data => {
+      log('Got stream message');
+
       const span = instana.currentSpan();
       span.disableAutoEnd();
       // "headers" may or may not be present in data.
@@ -57,8 +59,6 @@ function getConsumer() {
       } else {
         sendToParent(data);
       }
-
-      log('Got message');
 
       await delay(200);
       await fetch(`http://127.0.0.1:${agentPort}`);
@@ -87,6 +87,8 @@ function getConsumer() {
         // }, 100);
       })
       .on('data', async data => {
+        log('Got standard message');
+
         const span = instana.currentSpan();
         span.disableAutoEnd();
         // "headers" may or may not be present in data.
@@ -94,7 +96,6 @@ function getConsumer() {
         // the producer can set a value either as string or Buffer, but the response received by the consumer is always
         // a Uint8Array
         sendToParent(data);
-        log('Got message');
         await delay(200);
         await fetch(`http://127.0.0.1:${agentPort}`);
         span.end();

--- a/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
@@ -1,0 +1,123 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const instana = require('../../../../')();
+const fetch = require('node-fetch');
+const delay = require('../../../../../core/test/test_util/delay');
+const agentPort = process.env.INSTANA_AGENT_PORT || 42699;
+const { sendToParent } = require('@instana/core/test/test_util');
+const Kafka = require('node-rdkafka');
+const { v4: uuid } = require('uuid');
+const logPrefix = `Node rdkafka Consumer (${process.pid}):\t`;
+const log = require('@instana/core/test/test_util/log').getLogger(logPrefix);
+const express = require('express');
+const port = process.env.APP_PORT || 3215;
+const isStream = process.env.RDKAFKA_CONSUMER_AS_STREAM === 'true';
+
+const app = express();
+
+const topic = 'rdkafka-topic';
+
+function getConsumer() {
+  /** @type {Kafka.KafkaConsumer | Kafka.ConsumerStream} */
+  let _consumer;
+
+  const consumerOptions = {
+    'metadata.broker.list': '127.0.0.1:9092',
+    'group.id': uuid()
+  };
+
+  if (isStream) {
+    _consumer = Kafka.KafkaConsumer.createReadStream(
+      consumerOptions,
+      {},
+      {
+        topics: [topic],
+        streamAsBatch: true
+      }
+    );
+
+    _consumer.on('error', err => {
+      log('Consumer as stream reader error:', err);
+    });
+
+    _consumer.on('data', async data => {
+      const span = instana.currentSpan();
+      span.disableAutoEnd();
+      // "headers" may or may not be present in data.
+      // It is an array of objects {key: value}.
+      // The producer can set a value either as string or Buffer, but the response received by the consumer is always
+      // a Uint8Array
+
+      if (Array.isArray(data)) {
+        data.forEach(sendToParent);
+      } else {
+        sendToParent(data);
+      }
+
+      log('Got message');
+
+      await delay(200);
+      await fetch(`http://127.0.0.1:${agentPort}`);
+      span.end();
+    });
+  } else {
+    _consumer = new Kafka.KafkaConsumer(consumerOptions);
+
+    _consumer.connect();
+
+    _consumer
+      .on('ready', () => {
+        log('Ready.');
+        _consumer.subscribe([topic]);
+
+        // Consume from the rdkafka-topic. This is what determines
+        // the mode we are running in. By not specifying a callback (or specifying
+        // only a callback) we get messages as soon as they are available.
+        _consumer.consume();
+
+        // Even if we use this, messages are received one by one.
+        // This basically means: wait until we have 5 messages and consume them
+        // So we can assure that the consumer as standard api (not as stream) will always spit 1 message at a time.
+        // setInterval(function () {
+        //   _consumer.consume(5);
+        // }, 100);
+      })
+      .on('data', async data => {
+        const span = instana.currentSpan();
+        span.disableAutoEnd();
+        // "headers" may or may not be present in data.
+        // it is an array of objects {key: value}.
+        // the producer can set a value either as string or Buffer, but the response received by the consumer is always
+        // a Uint8Array
+        sendToParent(data);
+        log('Got message');
+        await delay(200);
+        await fetch(`http://127.0.0.1:${agentPort}`);
+        span.end();
+      });
+
+    _consumer.on('event.error', err => {
+      log('Consumer as standard api error:', err);
+    });
+  }
+
+  return _consumer;
+}
+
+const consumer = getConsumer();
+
+app.get('/', (_req, res) => {
+  if (consumer.read || (consumer.isConnected && consumer.isConnected())) {
+    res.send('ok');
+  } else {
+    res.status(500).send('rdkafka Consumer is not ready yet.');
+  }
+});
+
+app.listen(port, () =>
+  log(`rdkafka Consumer (as ${isStream ? 'Stream' : 'Standard API'}) app listening on port ${port}`)
+);

--- a/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
@@ -111,15 +111,22 @@ function doProduce(_producer, isStream, bufferErrorSender = false, msg = 'Node r
 
       log('Sending message as stream');
 
+      let wasSent = false;
       /**
        * Producer as stream can only send an object (which we need in order to set the header) if the option objectMode
        * is provided: https://github.com/Blizzard/node-rdkafka/blob/master/lib/producer-stream.js#L59
        */
-      const wasSent = _producer.write({
-        topic: topic,
-        headers: [{ message_counter: ++messageCounter }],
-        value: theMessage
-      });
+      try {
+        wasSent = _producer.write({
+          topic: topic,
+          headers: [{ message_counter: ++messageCounter }],
+          value: theMessage
+        });
+      } catch (e) {
+        // [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer or
+        // Uint8Array. Received an instance of Object
+        // NOTE: Somehow this error is not thrown for Node < 14
+      }
 
       setTimeout(async () => {
         await fetch(`http://127.0.0.1:${agentPort}`);

--- a/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
@@ -4,13 +4,8 @@
 
 'use strict';
 
-require('../../../../')({
-  tracing: {
-    kafka: {
-      headerFormat: 'string'
-    }
-  }
-});
+require('../../../../')({});
+
 const Kafka = require('node-rdkafka');
 const fetch = require('node-fetch');
 const agentPort = process.env.INSTANA_AGENT_PORT || 42699;

--- a/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
@@ -1,0 +1,200 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+require('../../../../')({
+  tracing: {
+    kafka: {
+      headerFormat: 'string'
+    }
+  }
+});
+const Kafka = require('node-rdkafka');
+const fetch = require('node-fetch');
+const agentPort = process.env.INSTANA_AGENT_PORT || 42699;
+const logPrefix = `rdkafka Producer (${process.pid}):\t`;
+const log = require('@instana/core/test/test_util/log').getLogger(logPrefix);
+const express = require('express');
+const port = process.env.APP_PORT || 3216;
+const enableDeliveryCb = process.env.RDKAFKA_PRODUCER_DELIVERY_CB === 'true';
+
+const app = express();
+
+const topic = 'rdkafka-topic';
+
+function getProducer(isStream = false) {
+  /** @type {Kafka.Producer | Kafka.ProducerStream} */
+  let _producer;
+  const producerOptions = {
+    'client.id': 'rdkafka-producer',
+    'metadata.broker.list': '127.0.0.1:9092',
+    // Enable to receive message payload in "delivery reports" event. This is the only way to know when a message
+    // was successfully sent. But we cannot rely on it, nor set this option without the customer's knowledge.
+    dr_cb: enableDeliveryCb
+  };
+
+  if (isStream) {
+    _producer = Kafka.Producer.createWriteStream(
+      producerOptions,
+      {},
+      {
+        topic: topic,
+        // This option is needed in order to use headers as Producer stream.
+        // This information needs to be very clear in the documentation.
+        // In the instrumentation we can check Buffer.isBuffer, like it's done here:
+        // https://github.com/Blizzard/node-rdkafka/blob/master/lib/producer-stream.js#L232
+        // Without this option, the stream expects only the message as a Buffer.
+        objectMode: true
+      }
+    );
+  } else {
+    _producer = new Kafka.Producer(producerOptions, {});
+
+    _producer.connect();
+
+    // Any errors we encounter, including connection errors
+    _producer.on('event.error', err => {
+      log('Error from producer', err);
+    });
+
+    // This requires dr_cb option in order to work. When enabled, it gives us a confirmation that the message was
+    // delivered successfully or not. This is handled by the instrumentation, if it's enabled.
+    // Be aware that this only works for standard API - not for stream cases.
+    // _producer.on('delivery-report', (err, data) => {
+    // log('Delivery report:', err, data);
+    // });
+
+    // We must either call .poll() manually after sending messages or set the producer to poll on an interval.
+    // Without this, we do not get delivery events and the queue will eventually fill up.
+    _producer.setPollInterval(100);
+  }
+
+  return _producer;
+}
+
+let messageCounter = 0;
+
+/**
+ * @param {Kafka.Producer | Kafka.ProducerStream} _producer
+ * @param {string} msg
+ * @returns {{ wasSent: boolean, topic: string, msg: string, timestamp: number }}
+ */
+function doProduce(_producer, isStream, withError = false, msg = 'Node rdkafka is great!') {
+  let theMessage = Buffer.from(msg);
+
+  log(`Sending message as ${isStream ? 'stream' : 'standard API'}`);
+  if (isStream) {
+    if (withError) {
+      // Message must be a buffer or null, so a number causes an error
+      theMessage = 123;
+    }
+
+    return new Promise((resolve, reject) => {
+      _producer.once('error', err => {
+        _producer.close();
+        reject(err);
+      });
+
+      /**
+       * Producer as stream can only send an object (which we need in order to set the header) if the option objectMode
+       * is provided: https://github.com/Blizzard/node-rdkafka/blob/master/lib/producer-stream.js#L59
+       */
+      const wasSent = _producer.write({
+        topic: topic,
+        headers: [{ message_counter: ++messageCounter }],
+        value: theMessage
+      });
+
+      setTimeout(async () => {
+        await fetch(`http://127.0.0.1:${agentPort}`);
+
+        resolve({
+          timestamp: Date.now(),
+          wasSent,
+          topic,
+          msg: theMessage,
+          messageCounter
+        });
+      }, 100);
+    });
+  } else {
+    if (withError) {
+      theMessage = 'invalid message as string';
+    }
+
+    return new Promise((resolve, reject) => {
+      _producer.on('error', reject);
+
+      const wasSent = _producer.produce(topic, null, theMessage, null, null, null, [
+        { message_counter: ++messageCounter }
+      ]);
+
+      setTimeout(async () => {
+        await fetch(`http://127.0.0.1:${agentPort}`);
+
+        resolve({
+          timestamp: Date.now(),
+          wasSent,
+          topic,
+          msg: theMessage,
+          messageCounter
+        });
+      }, 100);
+    });
+  }
+}
+
+const standardProducer = getProducer(false);
+let streamProducer = getProducer(true);
+
+// method is either standard or stream
+app.get('/produce/:method', async (req, res) => {
+  const method = req.params.method || 'standard';
+  const withError = req.query.withError === 'true';
+
+  try {
+    const response = await doProduce(
+      method === 'stream' ? streamProducer : standardProducer,
+      method === 'stream',
+      withError
+    );
+    res.status(200).send(response);
+  } catch (err) {
+    /**
+     * According to the Node.js spec, if a writtable stream receives the 'error' event, the only valid event by then is
+     * 'close'. So we create a new stream after an error occurs.
+     *
+     * From the Node.js docs (https://nodejs.org/dist/latest-v16.x/docs/api/stream.html#event-error):
+     *
+     * The 'error' event is emitted if an error occurred while writing or piping data. The listener callback is passed a
+     * single Error argument when called.
+     *
+     * The stream is closed when the 'error' event is emitted unless the autoDestroy option was set to false when
+     * creating the stream.
+     *
+     * After 'error', no further events other than 'close' should be emitted (including 'error' events).
+     */
+    if (method === 'stream') {
+      streamProducer = getProducer(true);
+    }
+    res.status(500).send({
+      error: err.message
+    });
+  }
+});
+
+app.get('/', (_req, res) => {
+  // If producer is a stream, it doesn't have a "isConnected" method, so we check if the method "writer" is available
+  // otherwise. If the producer as stream fails to start, it throws an error before we even reach this piece of code.
+  if (streamProducer.write && standardProducer.isConnected()) {
+    res.send('ok');
+  } else {
+    res.status(500).send('rdkafka Producer is not ready yet.');
+  }
+});
+
+app.listen(port, () => {
+  log(`rdkafka Producer app listening on port ${port}`);
+});

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -44,7 +44,7 @@ const withErrorMethods = [false, 'bufferErrorSender', 'deliveryErrorSender', 'st
 if (!supportedVersion(process.versions.node)) {
   mochaSuiteFn = describe.skip;
 } else {
-  mochaSuiteFn = describe;
+  mochaSuiteFn = describe.only;
 }
 
 const RUN_SINGLE_TEST = false;
@@ -209,6 +209,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
     //       no producer exit span because we use headers and objectMode false does not support it
     if (objectMode === 'false' && producerMethod === 'stream' && !withError) {
       verifyHttpRootEntry({ spans, apiPath, pid: String(_senderControls.getPid()) });
+      console.log('!DEBUG!');
+      console.log(spans);
       expect(spans.length).to.equal(1);
       return;
     }

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -1,0 +1,290 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+/**
+ * Important notes
+ * ---------------
+ *
+ * * The Producer as a stream can only have span correlation if the Writtable option objectMode is set to true.
+ * Otherwise, there is no way to append the Instana headers to it.
+ * * The Producer, as stream or standard API cannot propagate span correlation when headerFormat is set to 'binary'.
+ * More info here: https://github.com/Blizzard/node-rdkafka/pull/935.
+ * * If the option dr_cb is not set to true, we cannot guarantee that a message was sent, but a span with a successful
+ * sent message will be created.
+ */
+
+const path = require('path');
+const { expect } = require('chai');
+const { fail } = expect;
+const {
+  tracing: { constants }
+} = require('@instana/core');
+
+const {
+  tracing: { supportedVersion }
+} = require('@instana/core');
+
+const config = require('../../../../../core/test/config');
+const { expectExactlyOneMatching, retry, delay, stringifyItems } = require('../../../../../core/test/test_util');
+const ProcessControls = require('../../../test_util/ProcessControls');
+const globalAgent = require('../../../globalAgent');
+const { verifyHttpRootEntry, verifyHttpExit } = require('@instana/core/test/test_util/common_verifications');
+
+let mochaSuiteFn;
+
+const producerEnableDeliveryCbOptions = ['true', 'false'];
+const producerApiMethods = ['standard', 'stream'];
+const consumerApiMethods = ['standard', 'stream'];
+
+const { getCircularList } = require('@instana/core/test/test_util/circular_list');
+const getNextProducerMethod = getCircularList(producerApiMethods);
+const getNextConsumerMethod = getCircularList(consumerApiMethods);
+const getNextDeliveryCb = getCircularList(producerEnableDeliveryCbOptions);
+
+if (!supportedVersion(process.versions.node)) {
+  mochaSuiteFn = describe.skip;
+} else {
+  mochaSuiteFn = describe;
+}
+const retryTime = config.getTestTimeout() * 2;
+
+const topic = 'rdkafka-topic';
+
+mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
+  this.timeout(config.getTestTimeout() * 4);
+
+  globalAgent.setUpCleanUpHooks();
+  const agentControls = globalAgent.instance;
+
+  describe('tracing enabled, no suppression', function () {
+    const producerControls = new ProcessControls({
+      appPath: path.join(__dirname, 'producer'),
+      port: 3216,
+      useGlobalAgent: true,
+      env: {
+        RDKAFKA_PRODUCER_DELIVERY_CB: getNextDeliveryCb()
+      }
+    });
+
+    ProcessControls.setUpHooksWithRetryTime(retryTime, producerControls);
+
+    consumerApiMethods.forEach(consumerMethod => {
+      describe(`consuming via ${consumerMethod} API`, () => {
+        const consumerControls = new ProcessControls({
+          appPath: path.join(__dirname, 'consumer'),
+          port: 3215,
+          useGlobalAgent: true,
+          env: {
+            RDKAFKA_CONSUMER_AS_STREAM: consumerMethod === 'stream' ? 'true' : 'false'
+          }
+        });
+
+        ProcessControls.setUpHooksWithRetryTime(retryTime, consumerControls);
+
+        producerApiMethods.forEach(producerMethod => {
+          [false, 'sender'].forEach(withError => {
+            const apiPath = `/produce/${producerMethod}`;
+            const urlWithParams = withError ? apiPath + '?withError=true' : apiPath;
+
+            it(`produces as ${producerMethod}; consumes as ${consumerMethod}; error: ${!!withError}`, async () => {
+              const response = await producerControls.sendRequest({
+                method: 'GET',
+                path: urlWithParams,
+                simple: withError !== 'sender'
+              });
+
+              return verify(consumerControls, producerControls, response, apiPath, withError);
+            });
+          });
+        });
+      });
+    });
+  });
+
+  function verify(_producerControls, _consumerControls, response, apiPath, withError) {
+    if (withError === 'sender') {
+      expect(response.error).to.equal('Message must be a buffer or null');
+    } else {
+      return retry(() => {
+        verifyResponseAndMessage(response, _producerControls);
+
+        return agentControls
+          .getSpans()
+          .then(spans => verifySpans(_producerControls, _consumerControls, spans, apiPath, null, withError));
+      }, retryTime);
+    }
+  }
+
+  function verifySpans(receiverControls, _senderControls, spans, apiPath, messageId, withError) {
+    const httpEntry = verifyHttpRootEntry({ spans, apiPath, pid: String(_senderControls.getPid()) });
+    const kafkaExit = verifyRdKafkaExit(_senderControls, spans, httpEntry, messageId, withError);
+    verifyHttpExit({ spans, parent: httpEntry, pid: String(_senderControls.getPid()) });
+
+    if (withError !== 'publisher') {
+      const kafkaEntry = verifyRdKafkaEntry(receiverControls, spans, kafkaExit, messageId, withError);
+      verifyHttpExit({ spans, parent: kafkaEntry, pid: String(receiverControls.getPid()) });
+    }
+  }
+
+  function verifyRdKafkaEntry(receiverControls, spans, parent, messageId, withError) {
+    const operation = expectExactlyOneMatching;
+
+    return operation(spans, [
+      span => expect(span.n).to.equal('kafka'),
+      span => expect(span.k).to.equal(constants.ENTRY),
+      span => expect(span.t).to.equal(parent.t),
+      span => expect(span.p).to.equal(parent.s),
+      span => expect(span.f.e).to.equal(String(receiverControls.getPid())),
+      span => expect(span.f.h).to.equal('agent-stub-uuid'),
+      span => {
+        if (withError === 'receiver') {
+          expect(span.data.kafka.error).to.match(/Forced error/);
+        } else {
+          expect(span.data.kafka.error).to.not.exist;
+        }
+      },
+      span => expect(span.ec).to.equal(withError === 'receiver' ? 1 : 0),
+      span => expect(span.async).to.not.exist,
+      span => expect(span.data).to.exist,
+      span => expect(span.data.kafka).to.be.an('object'),
+      span => expect(span.data.kafka.service).to.equal(topic),
+      span => expect(span.data.kafka.access).to.equal('consume')
+    ]);
+  }
+
+  function verifyRdKafkaExit(_senderControls, spans, parent, messageId, withError) {
+    return expectExactlyOneMatching(spans, [
+      span => expect(span.n).to.equal('kafka'),
+      span => expect(span.k).to.equal(constants.EXIT),
+      span => expect(span.t).to.equal(parent.t),
+      span => expect(span.p).to.equal(parent.s),
+      span => expect(span.f.e).to.equal(String(_senderControls.getPid())),
+      span => expect(span.f.h).to.equal('agent-stub-uuid'),
+      span => expect(span.error).to.not.exist,
+      span => expect(span.ec).to.equal(withError === 'sender' ? 1 : 0),
+      span => expect(span.async).to.not.exist,
+      span => expect(span.data).to.exist,
+      span => expect(span.data.kafka).to.be.an('object'),
+      span => expect(span.data.kafka.service).to.equal(topic),
+      span => expect(span.data.kafka.access).to.equal('send')
+    ]);
+  }
+
+  describe('tracing disabled', () => {
+    this.timeout(config.getTestTimeout() * 2);
+
+    const producerControls = new ProcessControls({
+      appPath: path.join(__dirname, 'producer'),
+      port: 3216,
+      useGlobalAgent: true,
+      tracingEnabled: false,
+      env: {
+        RDKAFKA_PRODUCER_DELIVERY_CB: getNextDeliveryCb()
+      }
+    });
+
+    ProcessControls.setUpHooksWithRetryTime(retryTime, producerControls);
+
+    const receivingMethod = getNextConsumerMethod();
+    describe('producing and consuming', () => {
+      const consumerControls = new ProcessControls({
+        appPath: path.join(__dirname, 'consumer'),
+        port: 3215,
+        useGlobalAgent: true,
+        tracingEnabled: false,
+        env: {
+          RDKAFKA_CONSUMER_AS_STREAM: 'false'
+        }
+      });
+
+      ProcessControls.setUpHooksWithRetryTime(retryTime, consumerControls);
+
+      const producerMethod = getNextProducerMethod();
+      it(`should not trace for producing as ${producerMethod} / consuming as ${receivingMethod}`, async () => {
+        const response = await producerControls.sendRequest({
+          method: 'GET',
+          path: `/produce/${producerMethod}`
+        });
+
+        return retry(() => verifyResponseAndMessage(response, consumerControls), retryTime)
+          .then(() => delay(config.getTestTimeout() / 4))
+          .then(() => agentControls.getSpans())
+          .then(spans => {
+            if (spans.length > 0) {
+              fail(`Unexpected spans (rdkafka suppressed: ${stringifyItems(spans)}`);
+            }
+          });
+      });
+    });
+  });
+
+  describe('tracing enabled but suppressed', () => {
+    const producerControls = new ProcessControls({
+      appPath: path.join(__dirname, 'producer'),
+      port: 3216,
+      useGlobalAgent: true,
+      env: {
+        RDKAFKA_PRODUCER_DELIVERY_CB: getNextDeliveryCb()
+      }
+    });
+
+    ProcessControls.setUpHooksWithRetryTime(retryTime, producerControls);
+
+    const consumerMethod = getNextConsumerMethod();
+    describe('tracing suppressed', () => {
+      const receiverControls = new ProcessControls({
+        appPath: path.join(__dirname, 'consumer'),
+        port: 3215,
+        useGlobalAgent: true,
+        env: {
+          RDKAFKA_CONSUMER_AS_STREAM: 'false'
+        }
+      });
+
+      ProcessControls.setUpHooksWithRetryTime(retryTime, receiverControls);
+
+      const producerMethod = getNextProducerMethod();
+      it(`doesn't trace when producing as ${producerMethod} / consuming as ${consumerMethod}`, async () => {
+        const response = await producerControls.sendRequest({
+          method: 'GET',
+          path: `/produce/${producerMethod}`,
+          suppressTracing: true
+        });
+
+        return retry(() => {
+          verifyResponseAndMessage(response, receiverControls);
+        }, retryTime)
+          .then(() => delay(config.getTestTimeout() / 4))
+          .then(() => agentControls.getSpans())
+          .then(spans => {
+            if (spans.length > 0) {
+              fail(`Unexpected spans (rdkafka suppressed: ${stringifyItems(spans)}`);
+            }
+          });
+      });
+    });
+  });
+});
+
+function verifyResponseAndMessage(response, consumerControls) {
+  expect(response).to.be.an('object');
+  const receivedMessages = consumerControls.getIpcMessages();
+  expect(receivedMessages).to.be.an('array');
+  expect(receivedMessages).to.have.lengthOf.at.least(1);
+  const message = receivedMessages.filter(({ headers }) => {
+    const header = headers.filter(_header => {
+      return _header.message_counter != null;
+    })[0];
+
+    const messageCounter = Buffer.from(header.message_counter.data).toString();
+    return parseInt(messageCounter, 10) === response.messageCounter;
+  })[0];
+
+  expect(message).to.exist;
+  expect(Buffer.from(message.value.data, 'utf8').toString()).to.equal('Node rdkafka is great!');
+  expect(message.topic).to.equal(topic);
+  return message;
+}

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -209,7 +209,9 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
     //       no producer exit span because we use headers and objectMode false does not support it
     if (objectMode === 'false' && producerMethod === 'stream' && !withError) {
       verifyHttpRootEntry({ spans, apiPath, pid: String(_senderControls.getPid()) });
+      // eslint-disable-next-line no-console
       console.log('!DEBUG!');
+      // eslint-disable-next-line no-console
       console.log(spans);
       expect(spans.length).to.equal(1);
       return;

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -71,6 +71,7 @@ const instrumentations = [
   './instrumentation/messaging/amqp',
   './instrumentation/messaging/kafkaJs',
   './instrumentation/messaging/kafkaNode',
+  './instrumentation/messaging/rdkafka',
   './instrumentation/messaging/nats',
   './instrumentation/messaging/natsStreaming',
   './instrumentation/messaging/bull',

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -39,7 +39,7 @@ function instrumentConsumer(module) {
   const className = 'KafkaConsumer';
   const originalKafkaConsumer = module[className];
 
-  module[className] = function () {
+  module[className] = function InstrumentedKafkaConsumer() {
     const that = new originalKafkaConsumer(...arguments);
     shimmer.wrap(that, 'emit', shimConsumerStreamEmit);
     return that;
@@ -216,6 +216,7 @@ function instrumentedEmit(ctx, originalEmit, originalArgs) {
         if (cls.tracingSuppressed()) {
           const headers = addTraceLevelSuppression(messageData.headers);
           messageData.headers = headers;
+          return originalEmit.apply(ctx, originalArgs);
         } else {
           let traceId;
           let parentSpanId;
@@ -292,8 +293,12 @@ function instrumentedEmit(ctx, originalEmit, originalArgs) {
             return originalEmit.apply(ctx, originalArgs);
           }
         }
+      } else {
+        return originalEmit.apply(ctx, originalArgs);
       }
     });
+  } else {
+    return originalEmit.apply(ctx, originalArgs);
   }
 }
 

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -96,7 +96,7 @@ function shimConsumerStreamEmit(originalEmit) {
       return originalEmit.apply(this, originalArgs);
     }
 
-    return instrumentedEmit(this, originalEmit, originalArgs);
+    return instrumentedConsumerEmit(this, originalEmit, originalArgs);
   };
 }
 
@@ -200,7 +200,7 @@ function removeInstanaHeadersFromMessage(messageData) {
   }
 }
 
-function instrumentedEmit(ctx, originalEmit, originalArgs) {
+function instrumentedConsumerEmit(ctx, originalEmit, originalArgs) {
   let [event, eventData] = originalArgs;
 
   /**
@@ -279,7 +279,7 @@ function instrumentedEmit(ctx, originalEmit, originalArgs) {
             return originalEmit.apply(ctx, originalArgs);
           }
           const span = cls.startSpan('kafka', constants.ENTRY, traceId, parentSpanId);
-          span.stack = tracingUtil.getStackTrace(instrumentedEmit, 1);
+          span.stack = tracingUtil.getStackTrace(instrumentedConsumerEmit, 1);
           span.data.kafka = {
             access: 'consume',
             service: messageData.topic

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -263,8 +263,8 @@ function instrumentedConsumerEmit(ctx, originalEmit, originalArgs) {
       }
 
       cls.ns.runAndReturn(function () {
-        if (level !== '1') {
-          cls.setTracingLevel(level || '0');
+        if (level && level === '0') {
+          cls.setTracingLevel('0');
           return originalEmit.apply(ctx, originalArgs);
         }
 

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -1,0 +1,412 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const requireHook = require('../../../util/requireHook');
+const tracingUtil = require('../../tracingUtil');
+const constants = require('../../constants');
+const cls = require('../../cls');
+const shimmer = require('shimmer');
+const { getFunctionArguments } = require('../../../util/function_arguments');
+
+let logger;
+logger = require('../../../logger').getLogger('tracing/rdkafka', newLogger => {
+  logger = newLogger;
+});
+
+let traceCorrelationEnabled = true;
+// Before we start phase 1 of the migration, 'binary' will be the default value. With phase 1, we will move to 'both',
+// with phase 2 it will no longer be configurable and will always use 'string'.
+let headerFormat = 'binary';
+
+let isActive = false;
+
+exports.init = function init(config) {
+  requireHook.onFileLoad(/\/node-rdkafka\/lib\/producer\.js/, instrumentProducer);
+  requireHook.onFileLoad(/\/node-rdkafka\/lib\/kafka-consumer-stream\.js/, instrumentConsumerAsStream);
+  requireHook.onModuleLoad('node-rdkafka', instrumentConsumer);
+  traceCorrelationEnabled = config.tracing.kafka.traceCorrelation;
+  headerFormat = config.tracing.kafka.headerFormat;
+};
+
+function instrumentProducer(ProducerClass) {
+  shimmer.wrap(ProducerClass.prototype, 'produce', shimProduce);
+}
+
+function instrumentConsumer(module) {
+  const className = 'KafkaConsumer';
+  const originalKafkaConsumer = module[className];
+
+  module[className] = function () {
+    const that = new originalKafkaConsumer(...arguments);
+    shimmer.wrap(that, 'emit', shimConsumerStreamEmit);
+    return that;
+  };
+
+  // We need to recover all static methods and attributes
+  // Currently, there is only one function: createReadStream
+  const keys = Object.keys(originalKafkaConsumer);
+
+  keys.forEach(key => {
+    module[className][key] = originalKafkaConsumer[key];
+  });
+}
+
+function instrumentConsumerAsStream(KafkaConsumerStream) {
+  shimmer.wrap(KafkaConsumerStream.prototype, 'emit', shimConsumerStreamEmit);
+}
+
+function shimProduce(originalProduce) {
+  return function () {
+    /**
+     * Arguments (ordered by their indexes):
+     * - topic: string,
+     * - partition: number,
+     * - message: Buffer,
+     * - key?: Kafka.MessageKey,
+     * - timestamp?: number,
+     * - opaque?: any,
+     * - headers?: Kafka.MessageHeader[]
+     */
+    const originalArgs = getFunctionArguments(arguments);
+    const message = originalArgs[2];
+
+    if (!isActive || !message) {
+      logger.debug('Will not instrument');
+      return originalProduce.apply(this, originalArgs);
+    }
+
+    return instrumentedProduce(this, originalProduce, originalArgs);
+  };
+}
+
+function shimConsumerStreamEmit(originalEmit) {
+  return function () {
+    /**
+     * Arguments (ordered by their indexes):
+     * - event name: string,
+     * - chunk: Object | any,
+     */
+    const originalArgs = getFunctionArguments(arguments);
+
+    if (!isActive) {
+      logger.debug('Will not instrument');
+      return originalEmit.apply(this, originalArgs);
+    }
+
+    return instrumentedEmit(this, originalEmit, originalArgs);
+  };
+}
+
+function instrumentedProduce(ctx, originalProduce, originalArgs) {
+  if (cls.tracingSuppressed()) {
+    const headers = addTraceLevelSuppression(originalArgs[6]);
+    originalArgs[6] = headers;
+    return originalProduce.apply(ctx, originalArgs);
+  }
+
+  const parentSpan = cls.getCurrentSpan();
+  if (!parentSpan || constants.isExitSpan(parentSpan)) {
+    return originalProduce.apply(ctx, originalArgs);
+  }
+
+  /**
+   * When `dr_cb` is set to true in the producer options during the creation step, we have the chance to get a message
+   * delivery callback, which makes our instrumentation more accurate in terms of message delivery success or failure.
+   * If this option is not set to true, the 'delivery-report' is not triggered.
+   * When this event is triggered, we get either an error or some pieces of the message back, which would indicate that
+   * the message was delivered successfully.
+   */
+  const deliveryCb =
+    ctx._cb_configs &&
+    ctx._cb_configs.event &&
+    ctx._cb_configs.event.delivery_cb &&
+    typeof ctx._cb_configs.event.delivery_cb === 'function';
+
+  return cls.ns.runAndReturn(() => {
+    const span = cls.startSpan('kafka', constants.EXIT);
+    const topic = originalArgs[0];
+
+    span.stack = tracingUtil.getStackTrace(instrumentedProduce, 1);
+    span.data.kafka = {
+      service: topic,
+      access: 'send'
+    };
+
+    const headers = addTraceContextHeader(originalArgs[6], span);
+    originalArgs[6] = headers;
+
+    if (deliveryCb) {
+      ctx.once('delivery-report', err => {
+        span.d = Date.now() - span.ts;
+        if (err) {
+          span.ec = 1;
+          span.data.kafka.error = err.message;
+        }
+        span.transmit();
+      });
+    }
+
+    try {
+      const result = originalProduce.apply(ctx, originalArgs);
+
+      if (!deliveryCb) {
+        span.d = Date.now() - span.ts;
+        span.transmit();
+      }
+
+      return result;
+    } catch (error) {
+      // This error is properly captured for both Stream and standard API
+      span.ec = 1;
+      span.data.kafka.error = error.message;
+
+      if (!deliveryCb) {
+        span.d = Date.now() - span.ts;
+        span.transmit();
+      }
+
+      throw error;
+    }
+  });
+}
+
+function removeInstanaHeadersFromMessage(messageData) {
+  if (messageData.headers && messageData.headers.length) {
+    const instanaHeaders = [
+      constants.kafkaTraceLevelHeaderNameString,
+      constants.kafkaTraceLevelHeaderNameBinary,
+      constants.kafkaTraceIdHeaderNameString,
+      constants.kafkaSpanIdHeaderNameString,
+      constants.kafkaTraceContextHeaderNameBinary
+    ].map(header => header.toLowerCase());
+
+    for (let i = messageData.headers.length - 1; i >= 0; i--) {
+      const headerObject = messageData.headers[i];
+      // There should be only one. That's how the API works. This can be tested, for instance, by sending a message
+      // via kafkajs to be recieved by rdkafka consumer. Each header will be a single object as an item in the
+      // messageData.headers array
+      const headerKey = Object.keys(headerObject)[0];
+
+      if (instanaHeaders.indexOf(headerKey.toLocaleLowerCase()) > -1) {
+        messageData.headers.splice(i, 1);
+      }
+    }
+  }
+}
+
+function instrumentedEmit(ctx, originalEmit, originalArgs) {
+  let [event, eventData] = originalArgs;
+
+  /**
+   * If the stream batch is enabled, eventData will be an array. So in order to guarantee that array and non array cases
+   * are covered, we make sure that the data is always an array, and loop through them at all times.
+   */
+  if (!Array.isArray(eventData)) {
+    eventData = [eventData];
+  }
+
+  if (isActive) {
+    eventData.forEach(messageData => {
+      const parentSpan = cls.getCurrentSpan();
+
+      if (!parentSpan) {
+        if (cls.tracingSuppressed()) {
+          const headers = addTraceLevelSuppression(messageData.headers);
+          messageData.headers = headers;
+        } else {
+          let traceId;
+          let parentSpanId;
+          let level;
+
+          const instanaHeaders = (messageData.headers || []).filter(headerObject => {
+            const headerKey = Object.keys(headerObject)[0].toLowerCase();
+            return headerKey.indexOf('x_instana') > -1;
+          });
+
+          // flatten array to object
+          const instanaHeadersAsObject = {};
+
+          instanaHeaders.forEach(instanaHeader => {
+            const key = Object.keys(instanaHeader)[0];
+            instanaHeadersAsObject[key] = instanaHeader[key];
+          });
+
+          if (instanaHeaders.length) {
+            // Look for the the newer string header format first.
+            if (instanaHeadersAsObject[constants.kafkaTraceIdHeaderNameString]) {
+              traceId = String(instanaHeadersAsObject[constants.kafkaTraceIdHeaderNameString]);
+            }
+            if (instanaHeadersAsObject[constants.kafkaSpanIdHeaderNameString]) {
+              parentSpanId = String(instanaHeadersAsObject[constants.kafkaSpanIdHeaderNameString]);
+            }
+            if (instanaHeadersAsObject[constants.kafkaTraceLevelHeaderNameString]) {
+              level = String(instanaHeadersAsObject[constants.kafkaTraceLevelHeaderNameString]);
+            }
+
+            // Only fall back to legacy binary trace correlation headers if no new header is present.
+            if (traceId == null && parentSpanId == null && level == null) {
+              // The newer string header format has not been found, fall back to legacy binary headers.
+              if (instanaHeadersAsObject[constants.kafkaTraceContextHeaderNameBinary]) {
+                const traceContextBuffer = instanaHeadersAsObject[constants.kafkaTraceContextHeaderNameBinary];
+                if (Buffer.isBuffer(traceContextBuffer) && traceContextBuffer.length === 24) {
+                  const traceContext = tracingUtil.readTraceContextFromBuffer(traceContextBuffer);
+                  traceId = traceContext.t;
+                  parentSpanId = traceContext.s;
+                }
+              }
+              level = readTraceLevelBinary(instanaHeadersAsObject);
+            }
+            removeInstanaHeadersFromMessage(messageData);
+          }
+
+          if (event === 'data' || event === 'error') {
+            cls.ns.runAndReturn(function () {
+              if (level !== '1') {
+                cls.setTracingLevel(level || '0');
+                return originalEmit.apply(ctx, originalArgs);
+              }
+              const span = cls.startSpan('kafka', constants.ENTRY, traceId, parentSpanId);
+              span.stack = tracingUtil.getStackTrace(instrumentedEmit, 1);
+              span.data.kafka = {
+                access: 'consume',
+                service: messageData.topic
+              };
+
+              if (event === 'error') {
+                delete messageData.headers;
+                span.ec = 1;
+                span.data.kafka.error = messageData.message;
+              }
+
+              setImmediate(() => {
+                span.d = Date.now() - span.ts;
+                span.transmit();
+              });
+
+              return originalEmit.apply(ctx, originalArgs);
+            });
+          } else {
+            return originalEmit.apply(ctx, originalArgs);
+          }
+        }
+      }
+    });
+  }
+}
+
+function readTraceLevelBinary(instanaHeadersAsObject) {
+  if (instanaHeadersAsObject[constants.kafkaTraceLevelHeaderNameBinary]) {
+    const traceLevelBuffer = instanaHeadersAsObject[constants.kafkaTraceLevelHeaderNameBinary];
+    if (Buffer.isBuffer(traceLevelBuffer) && traceLevelBuffer.length >= 1) {
+      return String(traceLevelBuffer.readInt8());
+    }
+  }
+  return '1';
+}
+
+function addTraceContextHeader(headers, span) {
+  if (!traceCorrelationEnabled) {
+    return headers;
+  }
+  switch (headerFormat) {
+    case 'binary':
+      return addTraceContextHeaderBinary(headers, span);
+    case 'string':
+      return addTraceContextHeaderString(headers, span);
+    case 'both':
+    // fall through (both is the default)
+    default:
+      return addTraceContextHeaderBinary(addTraceContextHeaderString(headers, span), span);
+  }
+}
+
+/**
+ * At the time of this instrumentation, the node-rdkafka had an issue with handling binary content, where any zeros
+ * found in the beginning of the data are trimmed out, and any number higher than 127 is replaced by "unknown".
+ * More details in the PR that fixes the issue: https://github.com/Blizzard/node-rdkafka/pull/935.
+ *
+ * This means that customers using node-rdkafka or any libs that depend on it will not have proper span correlation
+ * when headers are sent as binary. The exit and entry spans will still be created though.
+ * It's important to know that customers using node-rdkafka only as consumers, where the producer was another runtime
+ * instrumented by Instana, the correlation should work as intended. The problem lies only in the node-rdkafka producer.
+ */
+function addTraceContextHeaderBinary(headers, span) {
+  if (headers == null) {
+    headers = [
+      { [constants.kafkaTraceContextHeaderNameBinary]: tracingUtil.renderTraceContextToBuffer(span) },
+      { [constants.kafkaTraceLevelHeaderNameBinary]: constants.kafkaTraceLevelBinaryValueInherit }
+    ];
+  } else if (headers && Array.isArray(headers)) {
+    headers.push({ [constants.kafkaTraceContextHeaderNameBinary]: tracingUtil.renderTraceContextToBuffer(span) });
+    headers.push({ [constants.kafkaTraceLevelHeaderNameBinary]: constants.kafkaTraceLevelBinaryValueInherit });
+  }
+  return headers;
+}
+
+function addTraceContextHeaderString(headers, span) {
+  if (headers == null) {
+    headers = [
+      { [constants.kafkaTraceIdHeaderNameString]: span.t },
+      { [constants.kafkaSpanIdHeaderNameString]: span.s },
+      { [constants.kafkaTraceLevelHeaderNameString]: '1' }
+    ];
+  } else if (headers && Array.isArray(headers)) {
+    headers.push({ [constants.kafkaTraceIdHeaderNameString]: span.t });
+    headers.push({ [constants.kafkaSpanIdHeaderNameString]: span.s });
+    headers.push({ [constants.kafkaTraceLevelHeaderNameString]: '1' });
+  }
+  return headers;
+}
+
+function addTraceLevelSuppression(headers) {
+  if (!traceCorrelationEnabled) {
+    return headers;
+  }
+  switch (headerFormat) {
+    case 'binary':
+      return addTraceLevelSuppressionBinary(headers);
+    case 'string':
+      return addTraceLevelSuppressionString(headers);
+    case 'both':
+    // fall through (both is the default)
+    default:
+      return addTraceLevelSuppressionString(addTraceLevelSuppressionBinary(headers));
+  }
+}
+
+function addTraceLevelSuppressionBinary(headers) {
+  if (headers == null) {
+    headers = [
+      {
+        [constants.kafkaTraceLevelHeaderNameBinary]: constants.kafkaTraceLevelBinaryValueSuppressed
+      }
+    ];
+  } else if (headers && typeof Array.isArray(headers)) {
+    headers.push({ [constants.kafkaTraceLevelHeaderNameBinary]: constants.kafkaTraceLevelBinaryValueSuppressed });
+  }
+  return headers;
+}
+
+function addTraceLevelSuppressionString(headers) {
+  if (headers == null) {
+    headers = [
+      {
+        [constants.kafkaTraceLevelHeaderNameString]: '0'
+      }
+    ];
+  } else if (headers && Array.isArray(headers)) {
+    headers.push({ [constants.kafkaTraceLevelHeaderNameString]: '0' });
+  }
+  return headers;
+}
+
+exports.activate = function activate() {
+  isActive = true;
+};
+
+exports.deactivate = function deactivate() {
+  isActive = false;
+};

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -139,12 +139,14 @@ function instrumentedProduce(ctx, originalProduce, originalArgs) {
     originalArgs[6] = headers;
 
     if (deliveryCb) {
-      ctx.once('delivery-report', err => {
+      ctx.once('delivery-report', function instanaDeliveryReportListener(err) {
         span.d = Date.now() - span.ts;
+
         if (err) {
           span.ec = 1;
           span.data.kafka.error = err.message;
         }
+
         span.transmit();
       });
     }
@@ -159,7 +161,8 @@ function instrumentedProduce(ctx, originalProduce, originalArgs) {
 
       return result;
     } catch (error) {
-      // This error is properly captured for both Stream and standard API
+      // e.g. cannot send message because format is byte
+      //      "Message must be a buffer or null"
       span.ec = 1;
       span.data.kafka.error = error.message;
 

--- a/packages/core/test/test_util/common_verifications.js
+++ b/packages/core/test/test_util/common_verifications.js
@@ -143,10 +143,10 @@ exports.verifyHttpExit = function verifyHttpExit({
 }) {
   const tests = [
     (/** @type {InstanaBaseSpan} */ span) => {
-      expect(span.t).to.equal(parent.t);
+      parent ? expect(span.t).to.equal(parent.t) : '';
     },
     (/** @type {InstanaBaseSpan} */ span) => {
-      expect(span.p).to.equal(parent.s);
+      parent ? expect(span.p).to.equal(parent.s) : '';
     },
     (/** @type {InstanaBaseSpan} */ span) => {
       expect(span.k).to.equal(constants.EXIT);

--- a/test-suite-ports.md
+++ b/test-suite-ports.md
@@ -9,7 +9,7 @@ For this reason, we maintain an overview of the ports used by the integration te
 | -------------------- | ---------- |
 | aws-fargate          | app under test: 4215, mock back end: 9443, downstream dummy: 4567, metadata endpoint mock: 1604, proxy 4128 |
 | aws-lambda           | mock back end: 8443, mock Lambda extension: 7365, downstream dummy: 3456, proxy: 3128 |
-| collector            | apps under test: 3000, 3213-3217, 3222, 4200-4203; individual mock agent: 3210, global mock agent: 3211, PostgreSQL: 5432, MongoDB: 27017, MSSQL: 1433, Elasticsearch: 9200, Redis: 6379, NATS: 4222, 4223, Kafka: 9092, RabbitMQ: 5672, GRPC:  50051 |
+| collector            | apps under test: 3000, 3213-3217, 3222, 4200-4203; individual mock agent: 3210, global mock agent: 3211, PostgreSQL: 5432, MongoDB: 27017, MSSQL: 1433, Elasticsearch: 9200, Redis: 6379, NATS: 4222, 4223, Kafka: 9092 and 29092, Schema Registry: 8081, RabbitMQ: 5672, GRPC:  50051 |
 | core                 | N.A. (no integration tests, only unit tests) |
 | google-cloud-run     | app under test: 4216, mock back end: 9444, downstream dummy: 4568, metadata endpoint mock: 1605, proxy: N.A. (no proxy tests) |
 | legacy-sensor        | apps under test: 5215, 5216; individual mock agent: 5210, global mock agent: 5211 (unused) |


### PR DESCRIPTION
### Node-RdKafka Limitations

These limitations impact how the tracer performs and must be explicit to customers in the documentation:

 * The **Producer as a stream** can only have span correlation if the Writable option **objectMode is set to true**, otherwise, there is no way to append the Instana headers to it.
 * The Producer, as stream or standard API **cannot** propagate span correlation when headerFormat is set to `binary`. More info here: https://github.com/Blizzard/node-rdkafka/pull/935.
 * If the option `dr_cb` is not set to true, we assume that the message was sent, but without any guarantee.

### Relevant Notes

* Kafka-Avro currently works up until Node.js v14.17 due to a dependency to an old version of Node-RdKafka.
* Because of the above, we install kafka-avro as an optional dependency. However, even in Node.js v16 and above, npm will attempt to install it, but the installation won't fail if an error occurs. This means two things:
   * The CI time will increase also for Node v16 > as there will be actually an installation attempt.
   * There may be some garbage in node_modules after the installation attempt. Some packages installed during the installation that fails seem to not being cleaned up.
 * In order to test kafka-avro, we had to add Schema Registry to docker-compose.yml and config.yml, also increasing the time of the CI build.
 * Kafka configuration was changed in order to support and communicate properly with the Schema Registry server
 
 Tasks

 - [x] increase code coverage for error cases @kirrg001 
 - [x] optimise readability in instrumention @kirrg001 
 - [x] add avro installation to the test for v14 @kirrg001 
 - [x] fix level !== 1 @kirrg001 
 - [x] objectMode @kirrg001 
 - [x] fix https://github.com/instana/nodejs/pull/486#discussion_r818908700 @kirrg001 
 - [x] fix https://github.com/instana/nodejs/pull/486#discussion_r818827112