### PR TITLE
fix(collector): fix export returned from init

### DIFF
--- a/packages/collector/test/agentCommunication_test.js
+++ b/packages/collector/test/agentCommunication_test.js
@@ -5,14 +5,12 @@
 
 'use strict';
 
-const path = require('path');
 const expect = require('chai').expect;
 
 const config = require('@instana/core/test/config');
-const { delay, retry } = require('@instana/core/test/test_util');
+const { retry } = require('@instana/core/test/test_util');
 const globalAgent = require('./globalAgent');
 const { isNodeVersionEOL } = require('../src/util/eol');
-const ProcessControls = require('./test_util/ProcessControls');
 
 const isEOL = isNodeVersionEOL();
 
@@ -134,34 +132,4 @@ describe('announce retry', function () {
         retryTime
       ));
   }
-});
-
-describe('prevent initializing @instana/collector multiple times', function () {
-  this.timeout(config.getTestTimeout());
-
-  globalAgent.setUpCleanUpHooks();
-  const agentControls = globalAgent.instance;
-
-  const controls = new ProcessControls({
-    appPath: path.join(__dirname, 'apps', 'express'),
-    execArgv: ['--require', path.join(__dirname, '..', 'src', 'immediate')],
-    useGlobalAgent: true
-  }).registerTestHooks();
-
-  it('must only announce to agent once', async () => {
-    await delay(100); // give potential multiple announce attempts time to be triggered
-    await retry(() =>
-      agentControls.getDiscoveries().then(discoveries => {
-        const announceAttemptsForPid = discoveries[String(controls.getPid())];
-        expect(
-          announceAttemptsForPid,
-          `Expected only one announce attempt, but two have been recorded: ${JSON.stringify(
-            announceAttemptsForPid,
-            null,
-            2
-          )}`
-        ).to.have.lengthOf(1);
-      })
-    );
-  });
 });

--- a/packages/collector/test/apps/express.js
+++ b/packages/collector/test/apps/express.js
@@ -83,6 +83,14 @@ app.post('/set-logger', (req, res) => {
   res.send('OK');
 });
 
+app.get('/trace-id-and-span-id', (req, res) => {
+  const span = instana.currentSpan();
+  res.json({
+    t: span.getTraceId(),
+    s: span.getSpanId()
+  });
+});
+
 function appendToDummyLogFile(level, logFilePath) {
   return message => {
     const content = typeof messsage === 'string' ? message : JSON.stringify(message);

--- a/packages/collector/test/prevent_instrumenting_multiple_times/test.js
+++ b/packages/collector/test/prevent_instrumenting_multiple_times/test.js
@@ -1,0 +1,74 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const expect = require('chai').expect;
+const { mkdtempSync } = require('fs');
+const os = require('os');
+const path = require('path');
+const rimraf = require('rimraf');
+
+const config = require('@instana/core/test/config');
+const { delay, retry, runCommandSync } = require('@instana/core/test/test_util');
+const globalAgent = require('../globalAgent');
+const ProcessControls = require('../test_util/ProcessControls');
+
+describe('prevent initializing @instana/collector multiple times', function () {
+  // The tests in this suite include running npm install and on CI we have observed that this can take roughly
+  // two minutes (!) sometimes, so we go with a large timeout. Base timeout on CI is 30 seconds, with
+  // factor 6 this allows for test durations up to three minutes.
+  this.timeout(config.getTestTimeout() * 6);
+
+  globalAgent.setUpCleanUpHooks();
+  const agentControls = globalAgent.instance;
+
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), '@instana-collector-test-prevent-multiple-init'));
+  const pathToSeparateInstanaCollector = path.join(tmpDir, 'node_modules', '@instana', 'collector', 'src', 'immediate');
+
+  before(() => {
+    runCommandSync('npm install --production --no-optional --no-audit @instana/collector', tmpDir);
+  });
+
+  after(done => {
+    rimraf(tmpDir, done);
+  });
+
+  const controls = new ProcessControls({
+    appPath: path.join(__dirname, '..', 'apps', 'express'),
+    execArgv: ['--require', pathToSeparateInstanaCollector],
+    useGlobalAgent: true,
+    env: {
+      INSTANA_COPY_PRECOMPILED_NATIVE_ADDONS: 'false',
+      INSTANA_LOG_LEVEL: 'error'
+    }
+  }).registerTestHooks();
+
+  it('must only announce to agent once', async () => {
+    await delay(100); // give potential multiple announce attempts time to be triggered
+    await retry(() =>
+      agentControls.getDiscoveries().then(discoveries => {
+        const announceAttemptsForPid = discoveries[String(controls.getPid())];
+        expect(
+          announceAttemptsForPid,
+          `Expected only one announce attempt, but two have been recorded: ${JSON.stringify(
+            announceAttemptsForPid,
+            null,
+            2
+          )}`
+        ).to.have.lengthOf(1);
+      })
+    );
+  });
+
+  it('must still export the active Instana handle', async () => {
+    const response = await controls.sendRequest({
+      path: '/trace-id-and-span-id'
+    });
+    expect(response.t).to.be.a('string');
+    expect(response.t).to.have.lengthOf.at.least(16);
+    expect(response.s).to.be.a('string');
+    expect(response.s).to.have.lengthOf(16);
+  });
+});

--- a/packages/core/test/test_util/index.js
+++ b/packages/core/test/test_util/index.js
@@ -18,6 +18,7 @@ module.exports = {
   getSpansByName: require('./getSpansByName'),
   retry: require('./retry'),
   retryUntilSpansMatch: require('./retryUntilSpansMatch'),
+  runCommandSync: require('./runCommand').runCommandSync,
   sendToParent: require('./sendToParent'),
   stringifyItems: require('./stringifyItems'),
   ...commonVerifications

--- a/packages/core/test/test_util/runCommand.js
+++ b/packages/core/test/test_util/runCommand.js
@@ -1,0 +1,21 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const { execSync } = require('child_process');
+
+/**
+ * Run a shell command synchronously in a given directory.
+ *
+ * @param {string} cmd The command to run
+ * @param {string} cwd The working directory for running the program
+ */
+exports.runCommandSync = function runCommandSync(cmd, cwd) {
+  // eslint-disable-next-line no-console
+  console.log(`Running ${cmd} in ${cwd}.`);
+  const cmdOutput = execSync(cmd, { cwd });
+  // eslint-disable-next-line no-console
+  console.log(`Done with running ${cmd} in ${cwd}:\n${cmdOutput}`);
+};


### PR DESCRIPTION
The fix to prevent initializing @instana/collector multiple times
(commit [b3261b7a653b406cbe2eeaaf9050134bbeedfac9](https://github.com/instana/nodejs/commit/b3261b7a653b406cbe2eeaaf9050134bbeedfac9)) broke the export returned
from the init function. Instead of returning a reference to the init function,
to which all exports are attached, the function returned undefined for the case
when @instana/collector had already been initialized previously. This breaks the
contract of the init function and in particular it breaks users that want to use
the export to access the API of @instana/collector.