### PR TITLE
fix(metrics): do not report metrics from worker threads

### DIFF
--- a/packages/collector/src/logger.js
+++ b/packages/collector/src/logger.js
@@ -7,6 +7,15 @@
 
 'use strict';
 
+/** @type number */
+let threadId = 0;
+try {
+  threadId = require('worker_threads').threadId;
+} catch (ignored) {
+  // We are apparently running in a Node.js version that does not have worker threads yet, thus we are on the main
+  // thread (0).
+}
+
 const bunyan = require('bunyan');
 const { logger } = require('@instana/core');
 
@@ -37,6 +46,7 @@ exports.init = function init(config, isReInit) {
     // we create later on.
     parentLogger = bunyan.createLogger({
       name: '@instana/collector',
+      thread: threadId,
       __in: 1
     });
   }

--- a/packages/collector/test/metrics/appWithWorkerThread/app.js
+++ b/packages/collector/test/metrics/appWithWorkerThread/app.js
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+if (!process.env.NODE_OPTIONS) {
+  // Either the test instruments this app via NODE_OTIONS=--require... or it expects the app to be instrumneted via
+  // an in-code require.
+  require('../../..')();
+}
+
+const express = require('express');
+const morgan = require('morgan');
+
+const { getLogger } = require('../../../../core/test/test_util');
+
+const app = express();
+const logPrefix = `Worker Thread App (${process.pid}):\t`;
+const log = getLogger(logPrefix);
+
+// starts the worker thread
+require('module-that-creates-a-worker-thread')();
+
+if (process.env.WITH_STDOUT) {
+  app.use(morgan(`${logPrefix}:method :url :status`));
+}
+
+app.get('/', (req, res) => {
+  res.sendStatus(200);
+});
+
+app.listen(process.env.APP_PORT, () => {
+  log(`Listening on port: ${process.env.APP_PORT}`);
+});

--- a/packages/collector/test/metrics/appWithWorkerThread/node_modules/module-that-creates-a-worker-thread/index.js
+++ b/packages/collector/test/metrics/appWithWorkerThread/node_modules/module-that-creates-a-worker-thread/index.js
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+if (process.env.REQUIRE_INSTANA_IN_WORKER_THREAD) {
+  require('../../../../..')();
+}
+
+const { Worker, isMainThread, parentPort, workerData } = require('worker_threads');
+const http = require('http');
+const fetch = require('node-fetch');
+
+const { delay } = require('../../../../../../core/test/test_util');
+
+const appPort = process.env.WORKER_THREAD_APP_PORT || 3216;
+
+if (isMainThread) {
+  runInMainThread();
+} else {
+  runInWorkerThread();
+}
+
+function runInMainThread() {
+  module.exports = function createNewWorkerThread() {
+    return new Promise((resolve, reject) => {
+      const worker = new Worker(__filename);
+      worker.on('message', resolve);
+      worker.on('error', reject);
+      worker.on('exit', (code) => {
+        if (code !== 0)
+          reject(new Error(`Worker stopped with exit code ${code}`));
+      });
+    });
+  };
+}
+
+async function runInWorkerThread() {
+  const requestListener = function (req, res) {
+    res.writeHead(201)
+    res.end();
+  }
+
+  // Creating a server makes sure the worker thread is running long enough so that it could theoretically announce.
+  const server = http.createServer(requestListener);
+  server.listen(appPort);
+
+  // We continually trigger HTTP requests to ourself in a loop to create HTTP entry spans. It does not really matter for
+  // how many iterations we keep the loop going here. The test determines how long the application under test is kept
+  // alive and killing the application under test (or rather, its main thread) will also terminate the worker thread,
+  // which then also terminates this loop. That's why we arbitrarily use 100 iterations.
+  for (let i = 0; i < 100; i++) {
+    const res = await fetch(`http://localhost:${appPort}`);
+    await delay(300);
+  }
+
+  parentPort.postMessage('Worker thread done, kthxbai!');
+}

--- a/packages/collector/test/metrics/appWithWorkerThread/node_modules/module-that-creates-a-worker-thread/node_modules/README.md
+++ b/packages/collector/test/metrics/appWithWorkerThread/node_modules/module-that-creates-a-worker-thread/node_modules/README.md
@@ -1,0 +1,2 @@
+The test relies on ../package.json being identified as the main package.json and that relies on a node_modules folder being present.
+

--- a/packages/collector/test/metrics/appWithWorkerThread/node_modules/module-that-creates-a-worker-thread/package.json
+++ b/packages/collector/test/metrics/appWithWorkerThread/node_modules/module-that-creates-a-worker-thread/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "worker-thread-helper-module",
+  "private": true,
+  "version": "1.0.0",
+  "description": "This is a separate module that creates a worker thread and has its own package.json.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/instana/nodejs.git"
+  },
+  "main": "index.js",
+  "author": {
+    "name": "Bastian Krol",
+    "email": "bastian.krol@ibm.com"
+  },
+  "license": "MIT"
+}

--- a/packages/collector/test/metrics/appWithWorkerThread/package.json
+++ b/packages/collector/test/metrics/appWithWorkerThread/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "worker-thread-test-app",
+  "private": true,
+  "version": "1.0.0",
+  "description": "This is a test application to test snapshot and metrics data.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/instana/nodejs.git"
+  },
+  "main": "app.js",
+  "author": {
+    "name": "Bastian Krol",
+    "email": "bastian.krol@ibm.com"
+  },
+  "license": "MIT"
+}

--- a/packages/collector/test/metrics/appWithWorkerThread/test.js
+++ b/packages/collector/test/metrics/appWithWorkerThread/test.js
@@ -1,0 +1,123 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const expect = require('chai').expect;
+const path = require('path');
+const semver = require('semver');
+
+const config = require('../../../../core/test/config');
+const { delay, retry } = require('../../../../core/test/test_util');
+const ProcessControls = require('../../test_util/ProcessControls');
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const globalAgent = require('../../globalAgent');
+
+// See https://instana.kanbanize.com/ctrl_board/56/cards/48699/details/ for more details on worker threads.
+
+const mochaSuiteFn =
+  supportedVersion(process.versions.node) &&
+  // worker threads became stable in Node.js 12.
+  semver.gte(process.versions.node, '12.0.0')
+    ? describe
+    : describe.skip;
+
+mochaSuiteFn('worker threads', function () {
+  this.timeout(config.getTestTimeout());
+
+  globalAgent.setUpCleanUpHooks();
+  const agentControls = globalAgent.instance;
+
+  describe('with in-app require main thread but not in worker thread', () => {
+    const controls = createProcess();
+
+    it('will neither report metrics nor spans from a worker thread', async () => {
+      await verify({
+        controls,
+        expectSpans: false
+      });
+    });
+  });
+
+  describe('with in-app require in main thread and in worker thread', () => {
+    const controls = createProcess({
+      REQUIRE_INSTANA_IN_WORKER_THREAD: true
+    });
+
+    it('must not report metrics from a worker thread', async () => {
+      await verify({
+        controls,
+        expectSpans: true
+      });
+    });
+  });
+
+  describe('with NODE_OPTIONS/pre-require', () => {
+    const controls = createProcess({
+      NODE_OPTIONS: '--require ../../../src/immediate'
+    });
+
+    it('must not report metrics from a worker thread', async () => {
+      await verify({
+        controls,
+        expectSpans: true
+      });
+    });
+  });
+
+  function createProcess(env = {}) {
+    env.WORKER_THREAD_APP_PORT = 3216;
+    return new ProcessControls({
+      appPath: path.join(__dirname, 'app'),
+      cwd: __dirname,
+      useGlobalAgent: true,
+      env
+    }).registerTestHooks();
+  }
+
+  async function verify({ controls, expectSpans }) {
+    let allMetrics;
+    let allNames;
+
+    // First, make sure that the announce from the main thread has happened by retrying until we find
+    //   (a) a metric object that has a "name" attribute, and
+    //   (b) where the value for "name" is the expected application name (from the main thread).
+    await retry(async () => {
+      allMetrics = await agentControls.getAllMetrics(controls.getPid());
+      allNames = [];
+      allMetrics.forEach(metrics => {
+        if (metrics.data.name) {
+          allNames.push(metrics.data.name);
+        }
+      });
+      expect(allNames).to.contain('worker-thread-test-app');
+    });
+
+    // We have made sure that the main thread has announced itself. Now we give the worker thread a chance to announce
+    // itself and send metrics. Actually, we do _not_ want the worker thread to send metrics on its own, but to verify
+    // that this does not happen, we need to wait a bit so that the test actually would fail if the worker thread sent
+    // metrics.
+    await delay(800);
+
+    // Check whether we capture spans from the worker thread. At the moment, we only get spans from worker spans under
+    // certain circumstances, these expectations will need to change when we capture spans from all worker threads
+    // independent of how the main thread is instrumented.
+    if (expectSpans) {
+      await retry(async () => {
+        const spans = await agentControls.getSpans(controls.getPid());
+        expect(spans).is.not.empty;
+        expect(spans[0].n).equals('node.http.server');
+      });
+    } else {
+      const spans = await agentControls.getSpans(controls.getPid());
+      expect(spans).to.be.empty;
+    }
+
+    // Verify that the worker thread did not report metrics/snapshot data.
+    allMetrics = await agentControls.getAllMetrics(controls.getPid());
+    allMetrics.forEach(metrics => {
+      expect(metrics.data.name).to.not.equal('worker-thread-helper-module');
+    });
+  }
+});

--- a/packages/core/test/test_util/index.js
+++ b/packages/core/test/test_util/index.js
@@ -16,6 +16,7 @@ module.exports = {
   expectExactlyNMatching: require('./expectExactlyNMatching'),
   expectExactlyOneMatching: require('./expectExactlyOneMatching'),
   getSpansByName: require('./getSpansByName'),
+  getLogger: require('./log').getLogger,
   retry: require('./retry'),
   retryUntilSpansMatch: require('./retryUntilSpansMatch'),
   runCommandSync: require('./runCommand').runCommandSync,

--- a/packages/shared-metrics/src/util/nativeModuleRetry.js
+++ b/packages/shared-metrics/src/util/nativeModuleRetry.js
@@ -61,7 +61,8 @@ function loadNativeAddOnInternal(opts, loaderEmitter) {
   try {
     const { isMainThread } = require('worker_threads');
     if (!isMainThread) {
-      logger.warn(opts.message + ' (Native addons are currently not loaded in worker threads)');
+      // Fail silently, we currently do not want to send any metrics from a worker thread.
+      // (But see https://instana.kanbanize.com/ctrl_board/56/cards/48699/details/)
       loaderEmitter.emit('failed');
       return;
     }


### PR DESCRIPTION
When instrumented via NODE_OPTIONS="--require ..." (which is inherited by
worker threads), each worker thread will announce independently and act like
the main thread. This can cause issues, in particular if the worker thread is
started from a dependency in node_ module and it identifies a different
package.json as its main package.json, hence reporting a different application
name etc.

To prevent this, we disable sending metrics and snapshot data from
worker threads for now.

fixes #500

refs 88823