### PR TITLE
feat(agent): read span batching option also from tracing section

### DIFF
--- a/packages/collector/test/announceCycle/unannounced_test.js
+++ b/packages/collector/test/announceCycle/unannounced_test.js
@@ -187,7 +187,23 @@ describe('unannounced state', () => {
       });
     });
 
-    it('should apply span batching configuratino', done => {
+    it('should apply span batching configuration', done => {
+      prepareAnnounceResponse({
+        tracing: { 'span-batching-enabled': true }
+      });
+      unannouncedState.enter({
+        transitionTo: () => {
+          expect(agentOptsStub.config).to.deep.equal({
+            tracing: {
+              spanBatchingEnabled: true
+            }
+          });
+          done();
+        }
+      });
+    });
+
+    it('should apply legacy span batching configuration', done => {
       prepareAnnounceResponse({ spanBatchingEnabled: true });
       unannouncedState.enter({
         transitionTo: () => {

--- a/packages/collector/test/apps/agentStub.js
+++ b/packages/collector/test/apps/agentStub.js
@@ -85,15 +85,13 @@ app.put('/com.instana.plugin.nodejs.discovery', (req, res) => {
     }
   };
 
-  if (enableSpanBatching) {
-    response.spanBatchingEnabled = true;
-  }
-
-  if (kafkaTraceCorrelation != null || kafkaHeaderFormat || extraHeaders.length > 0) {
+  if (kafkaTraceCorrelation != null || kafkaHeaderFormat || extraHeaders.length > 0 || enableSpanBatching) {
     response.tracing = {};
+
     if (extraHeaders.length > 0) {
       response.tracing['extra-http-headers'] = extraHeaders;
     }
+
     if (kafkaTraceCorrelation != null || kafkaHeaderFormat) {
       response.tracing.kafka = {};
       if (kafkaTraceCorrelation != null) {
@@ -102,6 +100,10 @@ app.put('/com.instana.plugin.nodejs.discovery', (req, res) => {
       if (kafkaHeaderFormat) {
         response.tracing.kafka['header-format'] = kafkaHeaderFormat;
       }
+    }
+
+    if (enableSpanBatching) {
+      response.tracing['span-batching-enabled'] = true;
     }
   }
 


### PR DESCRIPTION
The Instana agent would previously send the flag for enabling span
batching via a separate attribute `spanBatchingEnabled`. Starting with
discovery version 1.2.18 it sends this flag as
tracing.span-batching-enabled. Hence we read it from that part of the
response. We fall back to the old attribute for backward compatibility.

refs 94670