### PR TITLE
fix(agent): reduce log level for sending data from debug to trace

### DIFF
--- a/packages/collector/src/agentConnection.js
+++ b/packages/collector/src/agentConnection.js
@@ -365,7 +365,11 @@ function sendData(path, data, cb, ignore404 = false) {
   cb = atMostOnce(`callback for sendData: ${path}`, cb);
 
   const payloadAsString = JSON.stringify(data, circularReferenceRemover());
-  logger.debug('Sending data to %s', path);
+  if (typeof logger.trace === 'function') {
+    logger.trace('Sending data to %s', path);
+  } else {
+    logger.debug('Sending data to %s', path);
+  }
 
   // Convert payload to a buffer to correctly identify content-length ahead of time.
   const payload = Buffer.from(payloadAsString, 'utf8');

--- a/packages/core/src/logger.js
+++ b/packages/core/src/logger.js
@@ -12,6 +12,7 @@ const registry = {};
 
 /**
  * @typedef {Object} GenericLogger
+ * @property {(...args: *) => void} [trace]
  * @property {(...args: *) => void} debug
  * @property {(...args: *) => void} info
  * @property {(...args: *) => void} warn


### PR DESCRIPTION
When enabling debug logging, we write one log line each time something is
sent to the agent, which happens at least twice per second. These log messages
have been reduced to level trace now, so it is easier to see read debug logs
due to reduced noise. The previous behavior can still be activated
with INSTNANA_LOG_LEVEL=trace.