### PR TITLE
ci(coverage): fix test for nyc coverage job

### DIFF
--- a/packages/collector/test/metrics/appWithWorkerThread/app.js
+++ b/packages/collector/test/metrics/appWithWorkerThread/app.js
@@ -4,7 +4,11 @@
 
 'use strict';
 
-if (!process.env.NODE_OPTIONS) {
+if (
+  !process.env.NODE_OPTIONS ||
+  // nyc adds its own NODE_OPTIONS=--require, thus only checking for the existence of NODE_OPTIONS is not good enough.
+  !process.env.NODE_OPTIONS.includes('src/immediate')
+) {
   // Either the test instruments this app via NODE_OTIONS=--require... or it expects the app to be instrumneted via
   // an in-code require.
   require('../../..')();


### PR DESCRIPTION
The app under test checked NODE_OPTIONS as the test added that for some
configurations but not for others. Turns out, nyc always adds
NODE_OPTIONS so this check needs to be a bit more sophisticated.