### PR TITLE
refactor(test): remove duplicate method, add eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,6 +51,7 @@ module.exports = {
     'no-console': 'error',
     'no-const-assign': 'error',
     'no-continue': 'off',
+    'no-dupe-class-members': 'error',
     'no-else-return': 'off',
     'no-labels': 'off',
     'no-mixed-operators': 'off',


### PR DESCRIPTION
Commit [a3b3fbf57](https://github.com/instana/nodejs/commit/a3b3fbf57941368ba5b53c3dbf1ddd87dd8971e8) accidentally duplicated the method
`AgentStubControls#waitUntilAppIsCompletelyInitialized`. The first
definition became dead code at that point, because the second definition
would override the first. Later commits then changed the second definition
of the method.

This removes the first definition and moves the effective definition of
the method up.

This also adds a new eslint rule to prevent the same mistake in the
future.