### PR TITLE
fix(kafkajs, rdkafka): use long trace IDs with new Kafka message headers

### DIFF
--- a/packages/collector/test/tracing/messaging/kafkajs/consumer.js
+++ b/packages/collector/test/tracing/messaging/kafkajs/consumer.js
@@ -64,11 +64,16 @@ let receivedMessages = [];
           throw new Error('Boom!');
         }
 
+        const headers = {};
+        Object.keys(message.headers).forEach(headerName => {
+          headers[headerName] = String(message.headers[headerName]);
+        });
+
         receivedMessages.push({
           topic,
           key: message.key.toString(),
           value: message.value.toString(),
-          headerNames: Object.keys(message.headers)
+          headers
         });
 
         // simulating asynchronous follow up steps

--- a/packages/collector/test/tracing/messaging/kafkajs/consumer.js
+++ b/packages/collector/test/tracing/messaging/kafkajs/consumer.js
@@ -124,11 +124,16 @@ let receivedMessages = [];
             throw new Error('Boom!');
           }
 
+          const headers = {};
+          Object.keys(message.headers).forEach(headerName => {
+            headers[headerName] = String(message.headers[headerName]);
+          });
+
           receivedMessages.push({
             topic: batch.topic,
             key: message.key.toString(),
             value: message.value.toString(),
-            headerNames: Object.keys(message.headers)
+            headers
           });
 
           resolveOffset(message.offset);

--- a/packages/collector/test/tracing/messaging/kafkajs/test.js
+++ b/packages/collector/test/tracing/messaging/kafkajs/test.js
@@ -463,49 +463,60 @@ mochaSuiteFn('tracing/kafkajs', function () {
   }
 
   function verifyExpectedHeadersHaveBeenUsed(message, { headerFormat, suppressed }) {
+    const headerNames = message.headers ? Object.keys(message.headers) : [];
+
     switch (headerFormat) {
       case 'binary':
         if (!suppressed) {
-          expect(message.headerNames.length).to.equal(2);
-          expect(message.headerNames).to.include('X_INSTANA_C');
-          expect(message.headerNames).to.include('X_INSTANA_L');
+          expect(headerNames.length).to.equal(2);
+          expect(headerNames).to.include('X_INSTANA_C');
+          expect(headerNames).to.include('X_INSTANA_L');
+          expect(message.headers['X_INSTANA_L']).to.have.length(1);
         } else {
-          expect(message.headerNames.length).to.equal(1);
-          expect(message.headerNames).to.include('X_INSTANA_L');
+          expect(headerNames.length).to.equal(1);
+          expect(headerNames).to.include('X_INSTANA_L');
+          expect(message.headers['X_INSTANA_L']).to.have.length(1);
         }
         break;
       case 'string':
         if (!suppressed) {
-          expect(message.headerNames.length).to.equal(2);
-          expect(message.headerNames).to.include('X_INSTANA_T');
-          expect(message.headerNames).to.include('X_INSTANA_S');
+          expect(headerNames.length).to.equal(2);
+          expect(headerNames).to.include('X_INSTANA_T');
+          expect(message.headers['X_INSTANA_T']).to.have.length(32);
+          expect(headerNames).to.include('X_INSTANA_S');
+          expect(message.headers['X_INSTANA_S']).to.have.length(16);
         } else {
-          expect(message.headerNames.length).to.equal(1);
-          expect(message.headerNames).to.include('X_INSTANA_L_S');
+          expect(headerNames.length).to.equal(1);
+          expect(headerNames).to.include('X_INSTANA_L_S');
         }
         break;
       case 'both':
         if (!suppressed) {
-          expect(message.headerNames.length).to.equal(4);
-          expect(message.headerNames).to.include('X_INSTANA_C');
-          expect(message.headerNames).to.include('X_INSTANA_L');
-          expect(message.headerNames).to.include('X_INSTANA_T');
-          expect(message.headerNames).to.include('X_INSTANA_S');
+          expect(headerNames.length).to.equal(4);
+          expect(headerNames).to.include('X_INSTANA_C');
+          expect(headerNames).to.include('X_INSTANA_L');
+          expect(message.headers['X_INSTANA_L']).to.have.length(1);
+          expect(headerNames).to.include('X_INSTANA_T');
+          expect(message.headers['X_INSTANA_T']).to.have.length(32);
+          expect(headerNames).to.include('X_INSTANA_S');
+          expect(message.headers['X_INSTANA_S']).to.have.length(16);
         } else {
-          expect(message.headerNames.length).to.equal(2);
-          expect(message.headerNames).to.include('X_INSTANA_L');
-          expect(message.headerNames).to.include('X_INSTANA_L_S');
+          expect(headerNames.length).to.equal(2);
+          expect(headerNames).to.include('X_INSTANA_L');
+          expect(message.headers['X_INSTANA_L']).to.have.length(1);
+          expect(headerNames).to.include('X_INSTANA_L_S');
+          expect(message.headers['X_INSTANA_L_S']).to.have.length(1);
         }
         break;
       case 'tracing-disabled':
         // Not an actual header format, just a way for the test to specify that tracing is disabled and no headers
         // should be expected.
-        expect(message.headerNames).to.be.empty;
+        expect(headerNames).to.be.empty;
         break;
       case 'correlation-disabled':
         // Not an actual header format, just a way for the test to specify that trace correlation headers are disabled
         // and no headers should be expected.
-        expect(message.headerNames).to.be.empty;
+        expect(headerNames).to.be.empty;
         break;
 
       default:

--- a/packages/collector/test/tracing/messaging/kafkajs/test.js
+++ b/packages/collector/test/tracing/messaging/kafkajs/test.js
@@ -22,14 +22,6 @@ const ProcessControls = require('../../../test_util/ProcessControls');
 const globalAgent = require('../../../globalAgent');
 const { AgentStubControls } = require('../../../apps/agentStubControls');
 
-const allInstanaHeaders = [
-  constants.kafkaTraceIdHeaderName,
-  constants.kafkaSpanIdHeaderName,
-  constants.kafkaTraceLevelHeaderName,
-  constants.kafkaLegacyTraceContextHeaderName,
-  constants.kafkaLegacyTraceLevelHeaderName
-];
-
 const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 
 mochaSuiteFn('tracing/kafkajs', function () {
@@ -461,7 +453,7 @@ mochaSuiteFn('tracing/kafkajs', function () {
       expect(message.key).to.equal('someKey');
       expect(message.value).to.equal('someMessage');
       const headerNames = message.headers ? Object.keys(message.headers) : [];
-      allInstanaHeaders.forEach(headerName => expect(headerNames).to.not.contain(headerName));
+      constants.allInstanaKafkaHeaders.forEach(headerName => expect(headerNames).to.not.contain(headerName));
     }
 
     expect(msgsPerTopic).to.deep.equal({

--- a/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
@@ -46,11 +46,18 @@ function getConsumer() {
     });
 
     if (process.env.RDKAFKA_CONSUMER_ERROR && process.env.RDKAFKA_CONSUMER_ERROR === 'streamErrorReceiver') {
-      _consumer.consumer.consume(1, err => {
-        if (err.message === 'KafkaConsumer is not connected') {
+      _consumer.consumer.consume(1, (err, msg) => {
+        if (err && err.message === 'KafkaConsumer is not connected') {
           setTimeout(() => {
             _consumer.emit('error', err);
           }, 500);
+        } else {
+          const unexpected = `Unexpected consume result, expected an error. Received message: ${JSON.stringify(
+            msg
+          )}, error: ${err}.`;
+          // eslint-disable-next-line no-console
+          console.log(unexpected);
+          _consumer.emit('error', new Error(unexpected));
         }
       });
     }

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -53,11 +53,11 @@ const retryTime = config.getTestTimeout() * 2;
 const topic = 'rdkafka-topic';
 
 const allInstanaHeaders = [
-  constants.kafkaTraceIdHeaderNameString,
-  constants.kafkaSpanIdHeaderNameString,
-  constants.kafkaTraceLevelHeaderNameString,
-  constants.kafkaTraceContextHeaderNameBinary,
-  constants.kafkaTraceLevelHeaderNameBinary
+  constants.kafkaTraceIdHeaderName,
+  constants.kafkaSpanIdHeaderName,
+  constants.kafkaTraceLevelHeaderName,
+  constants.kafkaLegacyTraceContextHeaderName,
+  constants.kafkaLegacyTraceLevelHeaderName
 ];
 
 let mochaSuiteFn;

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -52,14 +52,6 @@ const SINGLE_TEST_PROPS = {
 const retryTime = config.getTestTimeout() * 2;
 const topic = 'rdkafka-topic';
 
-const allInstanaHeaders = [
-  constants.kafkaTraceIdHeaderName,
-  constants.kafkaSpanIdHeaderName,
-  constants.kafkaTraceLevelHeaderName,
-  constants.kafkaLegacyTraceContextHeaderName,
-  constants.kafkaLegacyTraceLevelHeaderName
-];
-
 let mochaSuiteFn;
 if (!supportedVersion(process.versions.node)) {
   mochaSuiteFn = describe.skip;
@@ -579,7 +571,7 @@ function verifyResponseAndMessage(response, consumerControls, withError, objectM
     const key = Object.keys(keyValuePair)[0];
     headerNames.push(key);
   });
-  allInstanaHeaders.forEach(headerName => expect(headerNames).to.not.contain(headerName));
+  constants.allInstanaKafkaHeaders.forEach(headerName => expect(headerNames).to.not.contain(headerName));
 
   expect(message.topic).to.equal(topic);
   return message;

--- a/packages/core/src/tracing/constants.js
+++ b/packages/core/src/tracing/constants.js
@@ -33,6 +33,14 @@ exports.kafkaTraceCorrelationDefault = true;
 // with phase 2 it will no longer be configurable and will always use 'string'.
 exports.kafkaHeaderFormatDefault = 'binary';
 
+exports.allInstanaKafkaHeaders = [
+  exports.kafkaTraceIdHeaderName,
+  exports.kafkaSpanIdHeaderName,
+  exports.kafkaTraceLevelHeaderName,
+  exports.kafkaLegacyTraceContextHeaderName,
+  exports.kafkaLegacyTraceLevelHeaderName
+];
+
 exports.w3cTraceParent = 'traceparent';
 exports.w3cTraceState = 'tracestate';
 exports.w3cInstana = 'in';

--- a/packages/core/src/tracing/constants.js
+++ b/packages/core/src/tracing/constants.js
@@ -18,15 +18,15 @@ exports.syntheticHeaderName = 'X-INSTANA-SYNTHETIC';
 exports.syntheticHeaderNameLowerCase = exports.syntheticHeaderName.toLowerCase();
 
 // legacy kafka trace correlation (binary values)
-exports.kafkaTraceContextHeaderNameBinary = 'X_INSTANA_C';
-exports.kafkaTraceLevelHeaderNameBinary = 'X_INSTANA_L';
-exports.kafkaTraceLevelBinaryValueSuppressed = Buffer.from([0]);
-exports.kafkaTraceLevelBinaryValueInherit = Buffer.from([1]);
+exports.kafkaLegacyTraceContextHeaderName = 'X_INSTANA_C';
+exports.kafkaLegacyTraceLevelHeaderName = 'X_INSTANA_L';
+exports.kafkaLegacyTraceLevelValueSuppressed = Buffer.from([0]);
+exports.kafkaLegacyTraceLevelValueInherit = Buffer.from([1]);
 
 // new kafka trace correlation (string values) starting approximately 2021-11
-exports.kafkaTraceIdHeaderNameString = 'X_INSTANA_T';
-exports.kafkaSpanIdHeaderNameString = 'X_INSTANA_S';
-exports.kafkaTraceLevelHeaderNameString = 'X_INSTANA_L_S';
+exports.kafkaTraceIdHeaderName = 'X_INSTANA_T';
+exports.kafkaSpanIdHeaderName = 'X_INSTANA_S';
+exports.kafkaTraceLevelHeaderName = 'X_INSTANA_L_S';
 
 exports.kafkaTraceCorrelationDefault = true;
 // Before we start phase 1 of the migration, 'binary' will be the default value. With phase 1, we will move to 'both',

--- a/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
@@ -22,14 +22,6 @@ let headerFormat = constants.kafkaHeaderFormatDefault;
 
 let isActive = false;
 
-const allInstanaHeaders = [
-  constants.kafkaTraceLevelHeaderName,
-  constants.kafkaLegacyTraceLevelHeaderName,
-  constants.kafkaTraceIdHeaderName,
-  constants.kafkaSpanIdHeaderName,
-  constants.kafkaLegacyTraceContextHeaderName
-];
-
 exports.init = function init(config) {
   requireHook.onFileLoad(/\/kafkajs\/src\/producer\/messageProducer\.js/, instrumentProducer);
   requireHook.onFileLoad(/\/kafkajs\/src\/consumer\/runner\.js/, instrumentConsumer);
@@ -534,12 +526,10 @@ function addTraceLevelSuppressionToAllMessagesString(messages) {
 }
 
 function removeInstanaHeadersFromMessage(message) {
-  const headerNames = message.headers && Object.keys(message.headers);
-  if (headerNames && headerNames.length > 0) {
-    headerNames.forEach(name => {
-      if (allInstanaHeaders.includes(name)) {
-        delete message.headers[name];
-      }
+  if (message.headers && typeof message.headers === 'object') {
+    constants.allInstanaKafkaHeaders.forEach(name => {
+      // If the header is not present, deleting it is a no-op.
+      delete message.headers[name];
     });
   }
 }

--- a/packages/core/src/tracing/leftPad.js
+++ b/packages/core/src/tracing/leftPad.js
@@ -55,14 +55,15 @@ const cache = [
  * @returns {string}
  */
 function leftPad(str, len) {
-  // use '0' as the padding char, always
-  let ch = '0';
   // `len` is the `pad`'s length now
   len -= str.length;
   // doesn't need to pad
   if (len <= 0) return str;
   // use cached/precreated padding strings for common use cases (up to length 32)
   if (len < 33) return cache[len] + str;
+
+  // use '0' as the padding char, always
+  let ch = '0';
   // `pad` starts with an empty string
   let pad = '';
   // eslint-disable-next-line no-constant-condition

--- a/packages/core/src/tracing/tracingHeaders.js
+++ b/packages/core/src/tracing/tracingHeaders.js
@@ -132,11 +132,11 @@ exports.fromHeaders = function fromHeaders(headers) {
       synthetic,
       w3cTraceContext
     };
-    return limitTraceId(result);
+    return exports.limitTraceId(result);
   } else if (xInstanaT && xInstanaS) {
     // X-INSTANA- headers are present but W3C trace context headers are not. Use the received IDs and also create a W3C
     // trace context based on those IDs.
-    return limitTraceId({
+    return exports.limitTraceId({
       traceId: /** @type {string} */ (xInstanaT),
       parentId: /** @type {string} */ (xInstanaS),
       usedTraceParent: false,
@@ -164,7 +164,7 @@ exports.fromHeaders = function fromHeaders(headers) {
         p: w3cTraceContext.instanaParentId
       };
     }
-    return limitTraceId({
+    return exports.limitTraceId({
       traceId: !isSuppressed(level) ? w3cTraceContext.traceParentTraceId : null,
       parentId: !isSuppressed(level) ? w3cTraceContext.traceParentParentId : null,
       usedTraceParent: !isSuppressed(level),
@@ -192,7 +192,7 @@ exports.fromHeaders = function fromHeaders(headers) {
       traceId = generateRandomTraceId();
       parentId = null;
     }
-    return limitTraceId({
+    return exports.limitTraceId({
       traceId,
       parentId,
       usedTraceParent: false,
@@ -210,7 +210,7 @@ exports.fromHeaders = function fromHeaders(headers) {
       // pass them down in the traceparent header); this trace and parent IDs ares not actually associated with any
       // existing span (Instana or foreign). This can't be helped, the spec mandates to always set the traceparent
       // header on outgoing requests, even if we didn't sample and it has to have a parent ID field.
-      return limitTraceId({
+      return exports.limitTraceId({
         usedTraceParent: false,
         level,
         synthetic,
@@ -225,7 +225,7 @@ exports.fromHeaders = function fromHeaders(headers) {
       // cls.startSpan, we will update it so it gets the parent ID of the entry span we create there. The bogus
       // parent ID "000..." will never be transmitted to any other service.
       w3cTraceContext = w3c.create(xInstanaT, '0000000000000000', true);
-      return limitTraceId({
+      return exports.limitTraceId({
         traceId: xInstanaT,
         parentId: null,
         usedTraceParent: false,
@@ -361,13 +361,13 @@ function readW3cTraceContext(headers) {
  * @param {TracingHeaders} result
  * @returns {TracingHeaders}
  */
-function limitTraceId(result) {
+exports.limitTraceId = function limitTraceId(result) {
   if (result.traceId && result.traceId.length >= 32) {
     result.longTraceId = result.traceId;
     result.traceId = result.traceId.substring(16, 32);
   }
   return result;
-}
+};
 
 /**
  * Takes the result of fromHttpReques/fromHeaders and sets the required attributes on the span.


### PR DESCRIPTION
I made a mistake when initially preparing the migration for Kafka headers (`X_INSTANA_C` to `X_INSTANA_T`/`X_INSTANA_S`). Our spec mandates to always use long trace IDs (128 bit/32 characters) with `X_INSTANA_T`, but I failed to implement that part correctly. This PR fixes that for the kafkajs and rdkafka instrumentations.

The PR also adds a new feature to kafkajs: Removing our own headers before passing the message on to the application. The rdkafka instrumentation already did that.