### PR TITLE
test(google cloud storage): use random object names

### DIFF
--- a/packages/collector/test/tracing/cloud/gcp/storage/app.js
+++ b/packages/collector/test/tracing/cloud/gcp/storage/app.js
@@ -16,8 +16,6 @@ const path = require('path');
 const { Storage } = require('@google-cloud/storage');
 const { v4: uuid } = require('uuid');
 
-const asyncRoute = require('../../../../test_util/asyncExpressRoute');
-
 const logPrefix = `Google Cloud Storage Client (${process.pid}):\t`;
 
 const options = { projectId: process.env.GCP_PROJECT };
@@ -52,19 +50,16 @@ app.get('/', (req, res) => {
   return res.sendStatus(200);
 });
 
-app.post(
-  '/storage-createBucket-bucket-delete-promise',
-  asyncRoute(async (req, res) => {
-    try {
-      const [bucket] = await storage.createBucket(randomBucketName());
-      await bucket.delete();
-      res.sendStatus(200);
-    } catch (e) {
-      log(e);
-      res.sendStatus(e.code || 500);
-    }
-  })
-);
+app.post('/storage-createBucket-bucket-delete-promise', async (req, res) => {
+  try {
+    const [bucket] = await storage.createBucket(randomBucketName());
+    await bucket.delete();
+    res.sendStatus(200);
+  } catch (e) {
+    log(e);
+    res.sendStatus(e.code || 500);
+  }
+});
 
 app.post('/storage-createBucket-bucket-delete-callback', (req, res) => {
   storage.createBucket(randomBucketName(), (errCreate, bucket) => {
@@ -82,20 +77,17 @@ app.post('/storage-createBucket-bucket-delete-callback', (req, res) => {
   });
 });
 
-app.post(
-  '/bucket-create-bucket-delete-promise',
-  asyncRoute(async (req, res) => {
-    try {
-      const bucket = storage.bucket(randomBucketName());
-      await bucket.create();
-      await bucket.delete();
-      res.sendStatus(200);
-    } catch (e) {
-      log(e);
-      res.sendStatus(e.code || 500);
-    }
-  })
-);
+app.post('/bucket-create-bucket-delete-promise', async (req, res) => {
+  try {
+    const bucket = storage.bucket(randomBucketName());
+    await bucket.create();
+    await bucket.delete();
+    res.sendStatus(200);
+  } catch (e) {
+    log(e);
+    res.sendStatus(e.code || 500);
+  }
+});
 
 app.post('/bucket-create-bucket-delete-callback', (req, res) => {
   storage.createBucket(randomBucketName(), (errCreate, bucket) => {
@@ -113,18 +105,15 @@ app.post('/bucket-create-bucket-delete-callback', (req, res) => {
   });
 });
 
-app.post(
-  '/storage-get-buckets-promise',
-  asyncRoute(async (req, res) => {
-    try {
-      await storage.getBuckets();
-      res.sendStatus(200);
-    } catch (e) {
-      log(e);
-      res.sendStatus(e.code || 500);
-    }
-  })
-);
+app.post('/storage-get-buckets-promise', async (req, res) => {
+  try {
+    await storage.getBuckets();
+    res.sendStatus(200);
+  } catch (e) {
+    log(e);
+    res.sendStatus(e.code || 500);
+  }
+});
 
 app.post('/storage-get-buckets-callback', (req, res) => {
   storage.getBuckets(err => {
@@ -136,18 +125,15 @@ app.post('/storage-get-buckets-callback', (req, res) => {
   });
 });
 
-app.post(
-  '/storage-get-service-account-promise',
-  asyncRoute(async (req, res) => {
-    try {
-      await storage.getServiceAccount();
-      res.sendStatus(200);
-    } catch (e) {
-      log(e);
-      res.sendStatus(e.code || 500);
-    }
-  })
-);
+app.post('/storage-get-service-account-promise', async (req, res) => {
+  try {
+    await storage.getServiceAccount();
+    res.sendStatus(200);
+  } catch (e) {
+    log(e);
+    res.sendStatus(e.code || 500);
+  }
+});
 
 app.post('/storage-get-service-account-callback', (req, res) => {
   storage.getServiceAccount(err => {
@@ -360,23 +346,20 @@ const bucketRoutes = [
 ];
 
 bucketRoutes.forEach(({ pathPrefix, actions }) => {
-  app.post(
-    `/bucket-${pathPrefix}-promise`,
-    asyncRoute(async (req, res) => {
-      try {
-        const bucket = storage.bucket(bucketName);
-        for (let i = 0; i < actions.length; i++) {
-          const { method, args } = actions[i];
-          // eslint-disable-next-line no-await-in-loop
-          await bucket[method].apply(bucket, args);
-        }
-        res.sendStatus(200);
-      } catch (e) {
-        log(e);
-        res.sendStatus(e.code || 500);
+  app.post(`/bucket-${pathPrefix}-promise`, async (req, res) => {
+    try {
+      const bucket = storage.bucket(bucketName);
+      for (let i = 0; i < actions.length; i++) {
+        const { method, args } = actions[i];
+        // eslint-disable-next-line no-await-in-loop
+        await bucket[method].apply(bucket, args);
       }
-    })
-  );
+      res.sendStatus(200);
+    } catch (e) {
+      log(e);
+      res.sendStatus(e.code || 500);
+    }
+  });
 
   app.post(`/bucket-${pathPrefix}-callback`, (req, res) => {
     const bucket = storage.bucket(bucketName);
@@ -396,19 +379,16 @@ bucketRoutes.forEach(({ pathPrefix, actions }) => {
   });
 });
 
-app.post(
-  '/bucket-combine-error-promise',
-  asyncRoute(async (req, res) => {
-    try {
-      const bucket = storage.bucket(bucketName);
-      await bucket.combine(['does-not-exist-1.txt', 'does-not-exist-2.txt'], 'combine-error.gz');
-      log('Operation bucket.combine succeeded although it should not have succeeded.');
-      res.sendStatus(500);
-    } catch (e) {
-      res.sendStatus(200);
-    }
-  })
-);
+app.post('/bucket-combine-error-promise', async (req, res) => {
+  try {
+    const bucket = storage.bucket(bucketName);
+    await bucket.combine(['does-not-exist-1.txt', 'does-not-exist-2.txt'], 'combine-error.gz');
+    log('Operation bucket.combine succeeded although it should not have succeeded.');
+    res.sendStatus(500);
+  } catch (e) {
+    res.sendStatus(200);
+  }
+});
 
 app.post('/bucket-combine-error-callback', (req, res) => {
   const bucket = storage.bucket(bucketName);
@@ -529,24 +509,21 @@ const fileRoutes = [
 ];
 
 fileRoutes.forEach(({ pathPrefix, uploadName, actions }) => {
-  app.post(
-    `/file-${pathPrefix}-promise`,
-    asyncRoute(async (req, res) => {
-      try {
-        const bucket = storage.bucket(bucketName);
-        const [file] = await bucket.upload(localFileName, { destination: uploadName, gzip: true });
-        for (let i = 0; i < actions.length; i++) {
-          const { method, args } = actions[i];
-          // eslint-disable-next-line no-await-in-loop
-          await file[method].apply(file, args);
-        }
-        res.sendStatus(200);
-      } catch (e) {
-        log(e);
-        res.sendStatus(e.code || 500);
+  app.post(`/file-${pathPrefix}-promise`, async (req, res) => {
+    try {
+      const bucket = storage.bucket(bucketName);
+      const [file] = await bucket.upload(localFileName, { destination: uploadName, gzip: true });
+      for (let i = 0; i < actions.length; i++) {
+        const { method, args } = actions[i];
+        // eslint-disable-next-line no-await-in-loop
+        await file[method].apply(file, args);
       }
-    })
-  );
+      res.sendStatus(200);
+    } catch (e) {
+      log(e);
+      res.sendStatus(e.code || 500);
+    }
+  });
 
   app.post(`/file-${pathPrefix}-callback`, (req, res) => {
     const bucket = storage.bucket(bucketName);
@@ -573,28 +550,25 @@ fileRoutes.forEach(({ pathPrefix, uploadName, actions }) => {
   });
 });
 
-app.post(
-  '/file-read-stream',
-  asyncRoute(async (req, res) => {
-    try {
-      const bucket = storage.bucket(bucketName);
-      const [remoteSource] = await bucket.upload(localFileName, { destination: randomObjectName('file'), gzip: true });
-      const localTarget = path.join(__dirname, 'read-stream-target.txt');
+app.post('/file-read-stream', async (req, res) => {
+  try {
+    const bucket = storage.bucket(bucketName);
+    const [remoteSource] = await bucket.upload(localFileName, { destination: randomObjectName('file'), gzip: true });
+    const localTarget = path.join(__dirname, 'read-stream-target.txt');
 
-      remoteSource
-        .createReadStream()
-        .on('error', err => {
-          log(err);
-          res.sendStatus(err.code || 500);
-        })
-        .on('end', () => res.sendStatus(200))
-        .pipe(fs.createWriteStream(localTarget));
-    } catch (err) {
-      log(err);
-      res.sendStatus(err.code || 500);
-    }
-  })
-);
+    remoteSource
+      .createReadStream()
+      .on('error', err => {
+        log(err);
+        res.sendStatus(err.code || 500);
+      })
+      .on('end', () => res.sendStatus(200))
+      .pipe(fs.createWriteStream(localTarget));
+  } catch (err) {
+    log(err);
+    res.sendStatus(err.code || 500);
+  }
+});
 
 app.post('/file-write-stream', async (req, res) => {
   const bucket = storage.bucket(bucketName);
@@ -610,24 +584,21 @@ app.post('/file-write-stream', async (req, res) => {
     });
 });
 
-app.post(
-  '/hmac-keys-promise',
-  asyncRoute(async (req, res) => {
-    try {
-      const [hmacKey] = await storage.createHmacKey(serviceAccountEmail);
-      await hmacKey.setMetadata({
-        state: 'INACTIVE'
-      });
-      await hmacKey.getMetadata();
-      await hmacKey.get('ACCESS_KEY');
-      await hmacKey.delete();
-      res.sendStatus(200);
-    } catch (e) {
-      log(e);
-      res.sendStatus(e.code || 500);
-    }
-  })
-);
+app.post('/hmac-keys-promise', async (req, res) => {
+  try {
+    const [hmacKey] = await storage.createHmacKey(serviceAccountEmail);
+    await hmacKey.setMetadata({
+      state: 'INACTIVE'
+    });
+    await hmacKey.getMetadata();
+    await hmacKey.get('ACCESS_KEY');
+    await hmacKey.delete();
+    res.sendStatus(200);
+  } catch (e) {
+    log(e);
+    res.sendStatus(e.code || 500);
+  }
+});
 
 app.post('/hmac-keys-callback', (req, res) => {
   storage.createHmacKey(serviceAccountEmail, (errCreate, hmacKey) => {

--- a/packages/collector/test/tracing/cloud/gcp/storage/test.js
+++ b/packages/collector/test/tracing/cloud/gcp/storage/test.js
@@ -24,6 +24,7 @@ const delay = require('../../../../../../core/test/test_util/delay');
 const globalAgent = require('../../../../globalAgent');
 
 const bucketName = 'nodejs-tracer-test-bucket';
+const bucketPrefixRegex = new RegExp(`^${bucketName}-.*$`);
 
 /**
  * This suite is skipped if no GCP project ID has been provided via GPC_PROJECT. It also requires to either have GCP
@@ -109,13 +110,13 @@ if (
             {
               operation: 'buckets.insert',
               attributes: {
-                bucket: /^nodejs-tracer-test-bucket-.*$/
+                bucket: bucketPrefixRegex
               }
             },
             {
               operation: 'buckets.delete',
               attributes: {
-                bucket: /^nodejs-tracer-test-bucket-.*$/
+                bucket: bucketPrefixRegex
               }
             }
           ]
@@ -126,13 +127,13 @@ if (
             {
               operation: 'buckets.insert',
               attributes: {
-                bucket: /^nodejs-tracer-test-bucket-.*$/
+                bucket: bucketPrefixRegex
               }
             },
             {
               operation: 'buckets.delete',
               attributes: {
-                bucket: /^nodejs-tracer-test-bucket-.*$/
+                bucket: bucketPrefixRegex
               }
             }
           ]
@@ -171,21 +172,21 @@ if (
               operation: 'objects.insert',
               attributes: {
                 bucket: bucketName,
-                object: 'combine-source-1.txt'
+                object: /^combine-source-1-.*$/
               }
             },
             {
               operation: 'objects.insert',
               attributes: {
                 bucket: bucketName,
-                object: 'combine-source-2.txt'
+                object: /^combine-source-2-.*$/
               }
             },
             {
               operation: 'objects.compose',
               attributes: {
                 destinationBucket: bucketName,
-                destinationObject: 'combine-destination.gz'
+                destinationObject: /^combine-destination-.*$/
               }
             }
           ]
@@ -211,7 +212,7 @@ if (
               operation: 'objects.insert',
               attributes: {
                 bucket: bucketName,
-                object: 'delete-me'
+                object: /^delete-me-.*/
               }
             },
             {
@@ -303,17 +304,29 @@ if (
           pathPrefix: 'bucket-set-and-remove-retention-period',
           expectedGcsSpans: [
             {
-              operation: 'buckets.patch',
-              unique: false,
+              operation: 'buckets.insert',
               attributes: {
-                bucket: bucketName
+                bucket: bucketPrefixRegex
               }
             },
             {
               operation: 'buckets.patch',
               unique: false,
               attributes: {
-                bucket: bucketName
+                bucket: bucketPrefixRegex
+              }
+            },
+            {
+              operation: 'buckets.patch',
+              unique: false,
+              attributes: {
+                bucket: bucketPrefixRegex
+              }
+            },
+            {
+              operation: 'buckets.delete',
+              attributes: {
+                bucket: bucketPrefixRegex
               }
             }
           ]
@@ -381,16 +394,16 @@ if (
               operation: 'objects.insert',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^source-.*$/
               }
             },
             {
               operation: 'objects.rewrite',
               attributes: {
                 sourceBucket: bucketName,
-                sourceObject: 'file.txt',
+                sourceObject: /^source-.*$/,
                 destinationBucket: bucketName,
-                destinationObject: 'destination.txt'
+                destinationObject: /^destination-.*$/
               }
             }
           ]
@@ -402,14 +415,14 @@ if (
               operation: 'objects.insert',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             },
             {
               operation: 'objects.delete',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             }
           ]
@@ -421,14 +434,14 @@ if (
               operation: 'objects.insert',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             },
             {
               operation: 'objects.get',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             }
           ]
@@ -440,14 +453,14 @@ if (
               operation: 'objects.insert',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             },
             {
               operation: 'objects.get',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             }
           ]
@@ -459,14 +472,14 @@ if (
               operation: 'objects.insert',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             },
             {
               operation: 'objects.get',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             }
           ]
@@ -478,14 +491,14 @@ if (
               operation: 'objects.insert',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             },
             {
               operation: 'objects.get',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             }
           ]
@@ -497,14 +510,14 @@ if (
               operation: 'objects.insert',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             },
             {
               operation: 'objects.get',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             }
           ]
@@ -516,16 +529,16 @@ if (
               operation: 'objects.insert',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             },
             {
               operation: 'objects.rewrite',
               attributes: {
                 sourceBucket: bucketName,
-                sourceObject: 'file.txt',
+                sourceObject: /^file-.*$/,
                 destinationBucket: bucketName,
-                destinationObject: 'destination.txt'
+                destinationObject: /^destination-.*$/
               }
             }
           ]
@@ -538,7 +551,7 @@ if (
               unique: false,
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             },
             {
@@ -546,7 +559,7 @@ if (
               unique: false,
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             }
           ]
@@ -558,14 +571,14 @@ if (
               operation: 'objects.insert',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             },
             {
               operation: 'objects.patch',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             }
           ]
@@ -577,16 +590,16 @@ if (
               operation: 'objects.insert',
               attributes: {
                 bucket: bucketName,
-                object: 'file.txt'
+                object: /^file-.*$/
               }
             },
             {
               operation: 'objects.rewrite',
               attributes: {
                 sourceBucket: bucketName,
-                sourceObject: 'file.txt',
+                sourceObject: /^file-.*$/,
                 destinationBucket: bucketName,
-                destinationObject: 'file.txt'
+                destinationObject: /^file-.*$/
               }
             }
           ]
@@ -630,14 +643,14 @@ if (
                 operation: 'objects.insert',
                 attributes: {
                   bucket: bucketName,
-                  object: 'file.txt'
+                  object: /^file-.*$/
                 }
               },
               {
                 operation: 'objects.get',
                 attributes: {
                   bucket: bucketName,
-                  object: 'file.txt'
+                  object: /^file-.*$/
                 }
               }
             ])
@@ -657,7 +670,7 @@ if (
                 operation: 'objects.insert',
                 attributes: {
                   bucket: bucketName,
-                  object: 'target.txt'
+                  object: /^target-.*$/
                 }
               }
             ])
@@ -675,7 +688,7 @@ if (
           httpEntry,
           operation,
           error,
-          verifyGcsAttributes.bind(null, attributes),
+          verifyGcsAttributes(attributes),
           unique,
           gcsExits
         );
@@ -705,22 +718,26 @@ if (
       expect(getSpansByName(spans, 'node.http.client')).to.be.empty;
     }
 
-    function verifyGcsAttributes(attributes, gcsExit) {
+    function verifyGcsAttributes(attributes) {
+      const expectations = [];
       if (attributes) {
         Object.keys(attributes).forEach(key => {
           if (attributes[key] instanceof RegExp) {
-            expect(gcsExit.data.gcs[key]).to.match(attributes[key]);
+            expectations.push(span => expect(span.data.gcs[key]).to.match(attributes[key]));
           } else {
-            expect(gcsExit.data.gcs[key]).to.equal(attributes[key]);
+            expectations.push(span => expect(span.data.gcs[key]).to.equal(attributes[key]));
           }
         });
-        expect(Object.keys(gcsExit.data.gcs)).to.have.lengthOf(
-          // + 1 because span.data.gcs.op is always present
-          Object.keys(attributes).length + 1
+        expectations.push(span =>
+          expect(Object.keys(span.data.gcs)).to.have.lengthOf(
+            // + 1 because span.data.gcs.op is always present
+            Object.keys(attributes).length + 1
+          )
         );
       } else {
-        expect(Object.keys(gcsExit.data.gcs)).to.have.lengthOf(1);
+        expectations.push(span => expect(Object.keys(span.data.gcs)).to.have.lengthOf(1));
       }
+      return expectations;
     }
 
     function verifyHttpEntry(spans, url) {
@@ -743,30 +760,32 @@ if (
       unique = true,
       otherSpans
     ) {
-      return (unique === false ? expectAtLeastOneMatching : expectExactlyOneMatching)(spans, span => {
-        expect(span.n).to.equal('gcs');
-        expect(span.k).to.equal(constants.EXIT);
-        expect(span.t).to.equal(parent.t);
-        expect(span.p).to.equal(parent.s);
-        if (otherSpans) {
-          otherSpans.forEach(other => expect(span.s).to.not.equal(other.s));
-        }
-        expect(span.f.e).to.equal(String(controls.getPid()));
-        expect(span.f.h).to.equal('agent-stub-uuid');
-        expect(span.error).to.not.exist;
-        if (error) {
-          expect(span.ec).to.equal(1);
-        } else {
-          expect(span.ec).to.equal(0);
-        }
-        expect(span.async).to.not.exist;
-        expect(span.data).to.exist;
-        expect(span.data.gcs).to.be.an('object');
-        expect(span.data.gcs.op).to.equal(operation);
-        if (additionalExpectations) {
-          additionalExpectations(span);
-        }
-      });
+      let expectations = [
+        span => expect(span.n).to.equal('gcs'),
+        span => expect(span.k).to.equal(constants.EXIT),
+        span => expect(span.t).to.equal(parent.t),
+        span => expect(span.p).to.equal(parent.s),
+        span => expect(span.f.e).to.equal(String(controls.getPid())),
+        span => expect(span.f.h).to.equal('agent-stub-uuid'),
+        span => expect(span.error).to.not.exist,
+        span => expect(span.async).to.not.exist,
+        span => expect(span.data).to.exist,
+        span => expect(span.data.gcs).to.be.an('object'),
+        span => expect(span.data.gcs.op).to.equal(operation),
+        span => (error ? expect(span.ec).to.equal(1) : expect(span.ec).to.equal(0))
+      ];
+      if (otherSpans) {
+        otherSpans.forEach(other => {
+          expectations.push(span => {
+            expect(span.s).to.not.equal(other.s);
+          });
+        });
+      }
+      if (additionalExpectations) {
+        expectations = expectations.concat(additionalExpectations);
+      }
+      const matchingFunction = unique === false ? expectAtLeastOneMatching : expectExactlyOneMatching;
+      return matchingFunction(spans, expectations);
     }
   });
 }


### PR DESCRIPTION
Context: 

```
@instana/collector: Retrying test after failure: tracing/cloud/gcp/storage::must trace google cloud storage file-save (promise API) (retry 1/1)
@instana/collector: Google Cloud Storage Client (6327):	 { Error: Object 'nodejs-tracer-test-bucket/file.txt' is subject to bucket's retention policy and cannot be deleted, overwritten or archived until 2022-05-23T22:11:17.715679-07:00
@instana/collector:     at Gaxios._request (/home/circleci/repo/node_modules/gaxios/build/src/gaxios.js:127:23)
```

https://app.circleci.com/pipelines/github/instana/nodejs/3524/workflows/58b9131b-4830-4422-95fc-0da439a5e7be/jobs/15124/parallel-runs/16?invite=true#step-137-883

----


This is another attempt at making the Google Cloud Storage integration
tests more stable: Tests that performed bucket operations were already
using random bucket names, but tests for object operations were
previously all operating on the same bucket and on fixed object names.
Thus, concurrently running tests (for example the test suite for a
different Node.js version) would all operate on the same file in the
same bucket. This might lead to conflicts.

Additionally, tests sometimes failed when trying to delete an object
from the bucket, due to a retention policy. Therefore the test that sets
(and removes) a retention policy now operates on its own unique bucket.