### PR TITLE
feat(core): added ability to complete specific intermediate spans

### DIFF
--- a/packages/collector/test/tracing/sdk/app.js
+++ b/packages/collector/test/tracing/sdk/app.js
@@ -166,7 +166,7 @@ app.post('/promise/create-intermediate', function createIntermediatePromise(req,
     });
 });
 
-app.post('/callback/create-intermediates', async function createIntermediatesCallback(req, res) {
+app.post('/callback/create-overlapping-intermediates', async function createOverlappingIntermediatesCallback(req, res) {
   instana.sdk.callback.startIntermediateSpan('intermediate1', async span1 => {
     await delay(200);
 
@@ -184,7 +184,7 @@ app.post('/callback/create-intermediates', async function createIntermediatesCal
   res.status(200).send();
 });
 
-app.post('/promise/create-intermediates', async function createIntermediatesPromise(req, res) {
+app.post('/promise/create-overlapping-intermediates', async function createOverlappingIntermediatesPromise(req, res) {
   (async () => {
     const span1 = await instana.sdk.async.startIntermediateSpan('intermediate1');
     await delay(200);

--- a/packages/collector/test/tracing/sdk/app.js
+++ b/packages/collector/test/tracing/sdk/app.js
@@ -184,7 +184,7 @@ app.post('/callback/create-intermediates', async function createIntermediatesCal
   res.status(200).send();
 });
 
-app.post('/promise/create-intermediates', async function createIntermediatesCallback(req, res) {
+app.post('/promise/create-intermediates', async function createIntermediatesPromise(req, res) {
   (async () => {
     const span1 = await instana.sdk.async.startIntermediateSpan('intermediate1');
     await delay(200);

--- a/packages/collector/test/tracing/sdk/test.js
+++ b/packages/collector/test/tracing/sdk/test.js
@@ -231,6 +231,41 @@ mochaSuiteFn('tracing/sdk', function () {
               );
             }));
 
+        it('must create parallel intermediate spans', () =>
+          controls
+            .sendRequest({
+              method: 'POST',
+              path: `/${apiType}/create-intermediates`
+            })
+            .then(response => {
+              expect(response).does.not.exist;
+
+              return retry(() =>
+                agentControls.getSpans().then(spans => {
+                  const httpEntry = expectHttpEntry({
+                    spans,
+                    path: `/${apiType}/create-intermediates`
+                  });
+
+                  const intermediateSpan1 = expectCustomFsIntermediate({
+                    spans,
+                    parentEntry: httpEntry,
+                    pid: controls.getPid(),
+                    sdkName: 'intermediate1',
+                    duration: 400
+                  });
+
+                  expectCustomFsIntermediate({
+                    spans,
+                    parentEntry: intermediateSpan1,
+                    pid: controls.getPid(),
+                    sdkName: 'intermediate2',
+                    duration: 400
+                  });
+                })
+              );
+            }));
+
         it('must create an exit span', () =>
           controls
             .sendRequest({
@@ -616,15 +651,17 @@ mochaSuiteFn('tracing/sdk', function () {
     ]);
   }
 
-  function expectCustomFsIntermediate({ spans, parentEntry, pid, path, error }) {
+  function expectCustomFsIntermediate({ spans, parentEntry, pid, path, error, sdkName, functionName, duration }) {
     return expectCustomFsSpan({
       spans,
       kind: 'INTERMEDIATE',
-      functionName: /^createIntermediate/,
+      functionName,
       parentEntry,
       pid,
       path,
-      error
+      error,
+      sdkName,
+      duration
     });
   }
 
@@ -632,7 +669,7 @@ mochaSuiteFn('tracing/sdk', function () {
     return expectCustomFsSpan({ spans, kind: 'EXIT', functionName: /^createExit/, parentEntry, pid, path, error });
   }
 
-  function expectCustomFsSpan({ spans, kind, functionName, parentEntry, pid, path, error }) {
+  function expectCustomFsSpan({ spans, kind, functionName, parentEntry, pid, path, error, sdkName, duration }) {
     return expectExactlyOneMatching(spans, span => {
       expect(span.t).to.equal(parentEntry.t);
       expect(span.p).to.equal(parentEntry.s);
@@ -640,25 +677,46 @@ mochaSuiteFn('tracing/sdk', function () {
       expect(span.k).to.equal(constants[kind]);
       expect(span.f.e).to.equal(String(pid));
       expect(span.f.h).to.equal('agent-stub-uuid');
+
       expect(span.async).to.not.exist;
       // eslint-disable-next-line no-unneeded-ternary
       expect(span.error).to.not.exist;
       expect(span.ec).to.equal(error ? 1 : 0);
       expect(span.data.sdk).to.exist;
-      expect(span.data.sdk.name).to.equal(kind === 'INTERMEDIATE' ? 'intermediate-file-access' : 'file-access');
+
+      if (sdkName) {
+        expect(span.data.sdk.name).to.equal(sdkName);
+      } else {
+        expect(span.data.sdk.name).to.equal(kind === 'INTERMEDIATE' ? 'intermediate-file-access' : 'file-access');
+      }
+
       expect(span.data.sdk.type).to.equal(constants.SDK[kind]);
-      expect(span.stack[0].c).to.match(/test\/tracing\/sdk\/app.js$/);
-      expect(span.stack[0].m).to.match(functionName);
+
+      if (functionName) {
+        expect(span.stack[0].c).to.match(/test\/tracing\/sdk\/app.js$/);
+        expect(span.stack[0].m).to.match(functionName);
+      }
+
       expect(span.data.sdk.custom).to.exist;
       expect(span.data.sdk.custom.tags).to.exist;
-      expect(span.data.sdk.custom.tags.path).to.match(path);
-      expect(span.data.sdk.custom.tags.encoding).to.equal('UTF-8');
+
+      if (path) {
+        expect(span.data.sdk.custom.tags.path).to.match(path);
+        expect(span.data.sdk.custom.tags.encoding).to.equal('UTF-8');
+      }
+
       expect(span.crid).to.not.exist;
       expect(span.crtp).to.not.exist;
+
       if (error) {
         expect(span.data.sdk.custom.tags.error.indexOf('ENOENT: no such file or directory')).to.equal(0);
       } else {
         expect(span.data.sdk.custom.tags.success).to.be.true;
+      }
+
+      if (duration) {
+        expect(span.d).to.be.greaterThan(duration - 5);
+        expect(span.d).to.be.lessThan(duration + 20);
       }
     });
   }

--- a/packages/collector/test/tracing/sdk/test.js
+++ b/packages/collector/test/tracing/sdk/test.js
@@ -231,11 +231,11 @@ mochaSuiteFn('tracing/sdk', function () {
               );
             }));
 
-        it('must create parallel intermediate spans', () =>
+        it('must create overlapping parent and child spans', () =>
           controls
             .sendRequest({
               method: 'POST',
-              path: `/${apiType}/create-intermediates`
+              path: `/${apiType}/create-overlapping-intermediates`
             })
             .then(response => {
               expect(response).does.not.exist;
@@ -244,7 +244,7 @@ mochaSuiteFn('tracing/sdk', function () {
                 agentControls.getSpans().then(spans => {
                   const httpEntry = expectHttpEntry({
                     spans,
-                    path: `/${apiType}/create-intermediates`
+                    path: `/${apiType}/create-overlapping-intermediates`
                   });
 
                   const intermediateSpan1 = expectCustomFsIntermediate({
@@ -715,8 +715,7 @@ mochaSuiteFn('tracing/sdk', function () {
       }
 
       if (duration) {
-        expect(span.d).to.be.greaterThan(duration - 5);
-        expect(span.d).to.be.lessThan(duration + 20);
+        expect(span.d).to.be.closeTo(duration, 20);
       }
     });
   }

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -71,6 +71,9 @@ function init(config, _processIdentityProvider) {
  * @property {string} [crtp] correlation type
  * @property {string} [crid] correlation ID
  * @property {boolean} [sy] synthetic marker
+ * @property {boolean} [pathTplFrozen] pathTplFrozen
+ * @property {boolean} [transmitted] transmitted
+ * @property {boolean} [manualEndMode] manualEndMode
  * @property {*} [stack] stack trace
  * @property {Object.<string, *>} [data]
  * @property {{s?: number, d?: number}} [b] batching information
@@ -80,6 +83,8 @@ function init(config, _processIdentityProvider) {
  * @property {Function} [disableAutoEnd]
  * @property {Function} [transmitManual]
  * @property {Function} [cancel]
+ * @property {Function} [addCleanup]
+ * @property {Function} [cleanup]
  */
 
 class InstanaSpan {
@@ -351,7 +356,7 @@ function setCurrentSpan(span) {
 /**
  * Get the currently active span.
  * @param {boolean} [fallbackToSharedContext=false]
- * @returns {InstanaSpan}
+ * @returns {InstanaBaseSpan}
  */
 function getCurrentSpan(fallbackToSharedContext = false) {
   return ns.get(currentSpanKey, fallbackToSharedContext);

--- a/packages/core/src/tracing/sdk/sdk.js
+++ b/packages/core/src/tracing/sdk/sdk.js
@@ -152,18 +152,14 @@ module.exports = function (isCallbackApi) {
   /**
    * @param {Error} error
    * @param {Object.<string, *>} tags
-   * @param {InstanaBaseSpan} currentSpan
+   * @param {InstanaBaseSpan} spanToBeCompleted
    */
-  function completeIntermediateSpan(error, tags, currentSpan) {
+  function completeIntermediateSpan(error, tags, spanToBeCompleted) {
     if (!isActive) {
       return;
     }
 
-    let span = cls.getCurrentSpan();
-
-    if (currentSpan) {
-      span = currentSpan;
-    }
+    const span = spanToBeCompleted || cls.getCurrentSpan();
 
     if (!span) {
       logger.warn(

--- a/packages/core/src/tracing/sdk/sdk.js
+++ b/packages/core/src/tracing/sdk/sdk.js
@@ -9,6 +9,8 @@ const deepMerge = require('../../util/deepMerge');
 const tracingUtil = require('../tracingUtil');
 const constants = require('../constants');
 
+/** @typedef {import('../cls').InstanaBaseSpan} InstanaBaseSpan */
+
 /** @type {import('../../logger').GenericLogger} */
 let logger;
 logger = require('../../logger').getLogger('tracing/sdk', newLogger => {
@@ -150,13 +152,18 @@ module.exports = function (isCallbackApi) {
   /**
    * @param {Error} error
    * @param {Object.<string, *>} tags
+   * @param {InstanaBaseSpan} currentSpan
    */
-  function completeIntermediateSpan(error, tags) {
+  function completeIntermediateSpan(error, tags, currentSpan) {
     if (!isActive) {
       return;
     }
 
-    const span = cls.getCurrentSpan();
+    let span = cls.getCurrentSpan();
+
+    if (currentSpan) {
+      span = currentSpan;
+    }
 
     if (!span) {
       logger.warn(
@@ -340,7 +347,8 @@ module.exports = function (isCallbackApi) {
    * @returns {Function | Promise<*>}
    */
   function callNext(callback) {
-    return isCallbackApi ? callback() : Promise.resolve();
+    const span = cls ? cls.getCurrentSpan() : null;
+    return isCallbackApi ? callback(span) : Promise.resolve(span);
   }
 
   /**


### PR DESCRIPTION
refs #561

- parallel intermediate spans can create incorrect span durations
  because the SDK relied on the fact that `getCurrentSpan` is the correct span to transmit/close