### PR TITLE
feat(aws-lambda): added support for Node v16

### DIFF
--- a/packages/aws-lambda-auto-wrap/src/index.js
+++ b/packages/aws-lambda-auto-wrap/src/index.js
@@ -27,7 +27,7 @@ let lambdaRuntimeErrors = {
   ImportModuleError
 };
 
-// NOTE: Lambda v16 removed the ability to required `Error.js`
+// NOTE: Lambda v16 removed the ability to require `Error.js`
 if (Number(process.versions.node.split('.')[0]) < 16) {
   lambdaRuntimeErrors = require(`${RUNTIME_PATH}/Errors.js`);
 }

--- a/packages/aws-lambda-auto-wrap/src/index.js
+++ b/packages/aws-lambda-auto-wrap/src/index.js
@@ -15,7 +15,22 @@ const RUNTIME_PATH = '/var/runtime';
 const SPLIT_AT_DOT_REGEX = /^([^.]*)\.(.*)$/;
 const TWO_DOTS = '..';
 
-const lambdaRuntimeErrors = require(`${RUNTIME_PATH}/Errors.js`);
+class HandlerNotFound extends Error {}
+class MalformedHandlerName extends Error {}
+class UserCodeSyntaxError extends Error {}
+class ImportModuleError extends Error {}
+
+let lambdaRuntimeErrors = {
+  HandlerNotFound,
+  MalformedHandlerName,
+  UserCodeSyntaxError,
+  ImportModuleError
+};
+
+// NOTE: Lambda v16 removed the ability to required `Error.js`
+if (Number(process.versions.node.split('.')[0]) < 16) {
+  lambdaRuntimeErrors = require(`${RUNTIME_PATH}/Errors.js`);
+}
 
 let wrappedHandler;
 

--- a/packages/aws-lambda/layer/bin/publish-layer.sh
+++ b/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -261,7 +261,7 @@ if [[ -z $SKIP_AWS_PUBLISH_LAYER ]]; then
         --license-info $LICENSE \
         --zip-file fileb://$ZIP_NAME \
         --output json \
-        --compatible-runtimes nodejs10.x nodejs12.x nodejs14.x \
+        --compatible-runtimes nodejs10.x nodejs12.x nodejs14.x nodejs16.x \
         | jq '.Version' \
     )
     echo "   + published version $lambda_layer_version to region $region"


### PR DESCRIPTION
- see https://aws.amazon.com/de/about-aws/whats-new/2022/05/aws-lambda-adds-support-node-js-16/
- `Error.js` is no longer available in /var/runtime