### PR TITLE
chore: pinned mongodb version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - 6379:6379
 
   mongo:
-    image: mongo
+    image: mongo:4.1.13
     ports:
       - 27017:27017
 


### PR DESCRIPTION
- otherwise the mongodb test fails locally
- circleci is already using this version
- possible reason: count is deprecated