### PR TITLE
feat(lambda): send preflight request to the AWS Lambda extension

### DIFF
--- a/packages/aws-lambda/layer/Dockerfile
+++ b/packages/aws-lambda/layer/Dockerfile
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. and contributors 2021
 
-FROM public.ecr.aws/lambda/nodejs:14
+FROM public.ecr.aws/lambda/nodejs:16
 
 WORKDIR /opt
 COPY tmp/ .

--- a/packages/aws-lambda/layer/bin/publish-experimental-layer.sh
+++ b/packages/aws-lambda/layer/bin/publish-experimental-layer.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+#######################################
+# (c) Copyright IBM Corp. 2021
+# (c) Copyright Instana Inc. and contributors 2019
+#######################################
+
+set -eo pipefail
+
+if [[ -z $LAYER_NAME ]]; then
+  LAYER_NAME=experimental-instana-nodejs-with-extension
+fi
+if [[ -z $REGIONS ]]; then
+  REGIONS=us-east-2
+fi
+
+cd `dirname $BASH_SOURCE`
+
+BUILD_LAYER_WITH=local \
+  LAYER_NAME=$LAYER_NAME \
+  NO_PROMPT=yes \
+  REBUILD_LAMBDA_EXTENSION=yes \
+  REGIONS=$REGIONS \
+  SKIP_DOCKER_IMAGE=true \
+  ./publish-layer.sh

--- a/packages/aws-lambda/layer/bin/publish-layer.sh
+++ b/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -203,6 +203,13 @@ if [[ $BUILD_LAYER_WITH == local ]]; then
 
   echo "Building local tar.gz for @instana/aws-lambda."
   cd ../aws-lambda
+  if [[ -n $REBUILD_LAMBDA_EXTENSION ]]; then
+    echo "Rebuilding Lambda extension from local sources for @instana/aws-lambda."
+    pushd ../../../lambda-extension > /dev/null
+    make build
+    popd > /dev/null
+    cp ../../../lambda-extension/_build/extensions/instana-lambda-extension layer/include/instana-lambda-extension
+  fi
   npm --loglevel=warn pack
   mv instana-aws-lambda-*.tgz $LAYER_WORKDIR/instana-aws-lambda.tgz
 

--- a/packages/aws-lambda/test/Control.js
+++ b/packages/aws-lambda/test/Control.js
@@ -16,7 +16,7 @@ const AbstractServerlessControl = require('../../serverless/test/util/AbstractSe
 
 function Control(opts) {
   AbstractServerlessControl.call(this, opts);
-  // With `startExtension` you can start the extension on a different port
+  // With `startExtension` you can start the extension stub on a different port.
   // parallel to the backend stub.
   if (this.opts.startExtension) {
     this.extensionPort = 7365;
@@ -29,6 +29,7 @@ function Control(opts) {
   this.useHttps = !this.opts.startExtension;
   const protocol = this.useHttps ? 'https' : 'http';
   this.backendBaseUrl = this.opts.backendBaseUrl || `${protocol}://localhost:${this.backendPort}/serverless`;
+  this.extensionBaseUrl = `http://localhost:${this.extensionPort}`;
   this.downstreamDummyPort = this.opts.downstreamDummyPort || 3456;
   this.downstreamDummyUrl = this.opts.downstreamDummyUrl || `http://localhost:${this.downstreamDummyPort}`;
   this.proxyPort = this.opts.proxyPort || 3128;

--- a/packages/aws-lambda/test/lambdas/async.js
+++ b/packages/aws-lambda/test/lambdas/async.js
@@ -9,6 +9,8 @@
 
 const instana = require('../..');
 
+const delay = require('../../../core/test/test_util/delay');
+
 // In production, the package @instana/aws-lambda is located in
 // /var/task/node_modules/@instana/aws-lambda/src/metrics while the main package.json of the Lambda is in
 // /var/task/package.json. The assumption about the relative location does not hold in the tests, so we need to fix the
@@ -49,6 +51,11 @@ const handler = async event => {
     throw new Error('Boom!');
   }
   await fetch(downstreamDummyUrl, { headers: { 'X-Downstream-Header': 'yes' } });
+  if (process.env.HANDLER_DELAY) {
+    console.log(`Introducing an artificial delay in the handler of ${process.env.HANDLER_DELAY} ms.`);
+    await delay(parseInt(process.env.HANDLER_DELAY, 10));
+  }
+
   if (event.error === 'asynchronous') {
     const error = new Error('Boom!');
     // deliberately setting error.message to a non-string value to test this case

--- a/packages/serverless/test/extension_stub/index.js
+++ b/packages/serverless/test/extension_stub/index.js
@@ -18,7 +18,14 @@ const logger = pino.child({ name: logPrefix, pid: process.pid });
 logger.level = 'info';
 
 const port = process.env.EXTENSION_PORT;
+
 const unresponsive = process.env.EXTENSION_UNRESPONSIVE === 'true';
+const preflightResponsiveButUnresponsiveLater =
+  process.env.EXTENSION_PREFFLIGHT_RESPONSIVE_BUT_UNRESPONSIVE_LATER === 'true';
+const preflightRespondsWithUnexpectedStatusCode =
+  process.env.PREFLIGHT_REQUEST_RESPONDS_WITH_UNEXPECTED_STATUS_CODE === 'true';
+
+let receivedData = resetReceivedData();
 
 const app = express();
 
@@ -32,37 +39,68 @@ app.use(
   })
 );
 
-// This endpoint will be called when the Lambda integration test simulates talking to the Lambda extension instead of
-// serverless-acceptor.
-app.post('/bundle', acceptBundle);
-
-function acceptBundle(req, res) {
-  logger.debug('incoming bundle', req.body);
-
-  const stringifiedBody = JSON.stringify(req.body);
-
+app.all('/preflight', (req, res) => {
   if (unresponsive) {
     // intentionally not responding for tests that verify proper timeout handling
     return;
   }
 
+  if (preflightRespondsWithUnexpectedStatusCode) {
+    return res.sendStatus(500);
+  }
+
+  res.sendStatus(200);
+});
+
+app.get('/received', (req, res) => res.json(receivedData));
+
+app.delete('/received', (req, res) => {
+  receivedData = resetReceivedData();
+  return res.sendStatus(204);
+});
+
+app.get('/received/spans', (req, res) => res.json(receivedData.spans));
+
+app.delete('/received/spans', (req, res) => {
+  receivedData.spans = [];
+  return res.sendStatus('204');
+});
+
+// With the exception of /preflight, the Lambda extension would forward all requests to the
+// back end (serverless-acceptor). This handler mimicks that behavior.
+app.all('*', (req, res) => {
+  const stringifiedBody = JSON.stringify(req.body);
+  logger.debug(`incoming request: ${req.method} ${req.url}: ${stringifiedBody}`);
+
+  // Store spans so we can later verify that the spans were actually sent to the extension instead of having been
+  // sent directly to the back end.
+  if (req.url === '/bundle' && req.body.spans) {
+    storeSpans(req.body.spans);
+  } else if (req.url === '/traces' && Array.isArray(req.body)) {
+    storeSpans(req.body);
+  }
+
+  if (unresponsive || preflightResponsiveButUnresponsiveLater) {
+    // intentionally not responding for tests that verify proper timeout handling
+    return;
+  }
+
+  // Forward data to the back end.
   const transport = process.env.BACKEND_HTTPS === 'true' ? https : http;
   const options = {
     hostname: 'localhost',
     port: process.env.BACKEND_PORT,
-    path: '/serverless/bundle',
-    method: 'POST',
+    path: `/serverless${req.url}`,
+    method: req.method,
     headers: {
-      'Content-Type': 'application/json',
-      'Content-Length': Buffer.byteLength(stringifiedBody),
       ...req.headers
     }
   };
-
-  const beReq = transport.request(options);
+  const beReq = transport.request(options, backEndResponse => {
+    res.sendStatus(backEndResponse.statusCode);
+  });
   beReq.end(stringifiedBody);
-  return res.sendStatus(201);
-}
+});
 
 http.createServer(app).listen(port, error => {
   if (error) {
@@ -73,3 +111,13 @@ http.createServer(app).listen(port, error => {
     sendToParent('extension: started');
   }
 });
+
+function storeSpans(spansFromThisRequest) {
+  receivedData.spans = receivedData.spans.concat(spansFromThisRequest);
+}
+
+function resetReceivedData() {
+  return {
+    spans: []
+  };
+}


### PR DESCRIPTION
Note: This PR currently contains a modified Lambda extension binary from https://github.ibm.com/instana/lambda-extension/pull/5. We need to review&merge the Lambda extension PR first, then update the binary here again, before merging this PR.

----

The Node.js Lambda in-process collector will now send a preflight
request (POST /preflight) directly at the start of the invocation.

This serves two purposes:
1) The Lambda extension can employ a much shorter timeout when HTTP
  communication between the in-process collector and the extension does
  not work. Previously, the extension would have waited until shortly
  before the Lambda timeout, potentially turning a sub-second Lambda
  invocation into a very long invocation (depending on the timeout set
  on the Lambda). Now, it can safely signal "next" to the AWS Lambda
  runtime environment when the preflight request does not come in until
  one second after the start of the invocation.
2) The in-process collector also profits from this new protocol: It can
  establish whether the Lambda extension is up and running directly at
  the start of the invocation. Previously it might have only found out
  about that when sending the bundle at the end of the invocation.