### PR TITLE
test(google cloud storage): 1 day retention, overwrite rules

### DIFF
--- a/packages/collector/test/tracing/cloud/gcp/storage/app.js
+++ b/packages/collector/test/tracing/cloud/gcp/storage/app.js
@@ -202,8 +202,11 @@ const bucketRoutes = [
           {
             action: 'delete',
             condition: {
-              age: 365
+              age: 1
             }
+          },
+          {
+            append: false
           }
         ]
       }


### PR DESCRIPTION
By setting the retention period to 1 day in the lifecycle rule we avoid
accumulating more and more objects in the test bucket. By adding the
`append: false` parameter to the lifecycle rule test we avoid
accumulating more and more identical rules.