### PR TITLE
fix(shared-metrics): package.json not being found

### DIFF
--- a/packages/shared-metrics/.eslintignore
+++ b/packages/shared-metrics/.eslintignore
@@ -1,0 +1,1 @@
+test/ejs-require-in-preload

--- a/packages/shared-metrics/src/name.js
+++ b/packages/shared-metrics/src/name.js
@@ -20,24 +20,26 @@ exports.payloadPrefix = 'name';
 // @ts-ignore
 exports.currentPayload = undefined;
 
-const MAX_ATTEMPTS = 60;
-const DELAY = 1000;
+exports.MAX_ATTEMPTS = 10;
+exports.DELAY = 1000;
 let attempts = 0;
 
 exports.activate = function activate() {
   attempts++;
+
   applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule((err, packageJson) => {
     if (err) {
       return logger.warn('Failed to determine main package json. Reason: ', err.message, err.stack);
-    } else if (!packageJson && attempts < MAX_ATTEMPTS) {
+    } else if (!packageJson && attempts < exports.MAX_ATTEMPTS) {
       logger.debug('Main package.json could not be found. Will try again later.');
-      setTimeout(exports.activate, DELAY).unref();
+      setTimeout(exports.activate, exports.DELAY).unref();
       return;
     } else if (!packageJson) {
-      if (process.mainModule) {
+      if (require.main) {
         // @ts-ignore
-        exports.currentPayload = process.mainModule.filename;
+        exports.currentPayload = require.main.filename;
       }
+
       return logger.warn(
         `Main package.json could not be found. This Node.js app will be labeled "${
           exports.currentPayload ? exports.currentPayload : 'Unknown'
@@ -48,4 +50,10 @@ exports.activate = function activate() {
     // @ts-ignore
     exports.currentPayload = packageJson.name;
   });
+};
+
+exports.reset = () => {
+  exports.currentPayload = undefined;
+  exports.MAX_ATTEMPTS = 60;
+  exports.DELAY = 1000;
 };

--- a/packages/shared-metrics/src/name.js
+++ b/packages/shared-metrics/src/name.js
@@ -20,7 +20,7 @@ exports.payloadPrefix = 'name';
 // @ts-ignore
 exports.currentPayload = undefined;
 
-exports.MAX_ATTEMPTS = 10;
+exports.MAX_ATTEMPTS = 60;
 exports.DELAY = 1000;
 let attempts = 0;
 

--- a/packages/shared-metrics/test/cjs-require-in-preload/module/load-instana.js
+++ b/packages/shared-metrics/test/cjs-require-in-preload/module/load-instana.js
@@ -1,0 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+require('../../../../collector/src')();

--- a/packages/shared-metrics/test/cjs-require-in-preload/module/package.json
+++ b/packages/shared-metrics/test/cjs-require-in-preload/module/package.json
@@ -2,6 +2,6 @@
   "name": "cjs-example",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "src/app.js",
   "dependencies": {}
 }

--- a/packages/shared-metrics/test/cjs-require-in-preload/module/package.json
+++ b/packages/shared-metrics/test/cjs-require-in-preload/module/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cjs-example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {}
+}

--- a/packages/shared-metrics/test/cjs-require-in-preload/module/src/app.js
+++ b/packages/shared-metrics/test/cjs-require-in-preload/module/src/app.js
@@ -7,7 +7,7 @@
 const express = require('express');
 const port = process.env.APP_PORT || 44004;
 const app = express();
-const logPrefix = `CJS Preload: (${process.pid}):\t`;
+const logPrefix = `CJS preload collector: (${process.pid}):\t`;
 
 app.get('/', (req, res) => {
   res.send('OK');

--- a/packages/shared-metrics/test/cjs-require-in-preload/module/src/app.js
+++ b/packages/shared-metrics/test/cjs-require-in-preload/module/src/app.js
@@ -1,0 +1,25 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const express = require('express');
+const port = process.env.APP_PORT || 44004;
+const app = express();
+const logPrefix = `CJS Preload: (${process.pid}):\t`;
+
+app.get('/', (req, res) => {
+  res.send('OK');
+});
+
+app.listen(port, () => {
+  log(`Listening on port: ${port}`);
+});
+
+function log() {
+  const args = Array.prototype.slice.call(arguments);
+  args[0] = `${logPrefix} (${process.pid}):\t${args[0]}`;
+  // eslint-disable-next-line no-console
+  console.log.apply(console, args);
+}

--- a/packages/shared-metrics/test/cjs-require-in-preload/test.js
+++ b/packages/shared-metrics/test/cjs-require-in-preload/test.js
@@ -28,11 +28,6 @@ describe('cjs require collector in preload phase', function () {
   ProcessControls.setUpHooks(controls);
 
   it('should be able to find package.json', async () => {
-    await controls.sendRequest({
-      method: 'GET',
-      path: '/metrics'
-    });
-
     await testUtils.retry(() =>
       controls.agentControls.getAllMetrics(controls.getPid()).then(metrics => {
         const name = findMetric(metrics, ['name']);

--- a/packages/shared-metrics/test/cjs-require-in-preload/test.js
+++ b/packages/shared-metrics/test/cjs-require-in-preload/test.js
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const path = require('path');
+const _ = require('lodash');
+const expect = require('chai').expect;
+
+const testUtils = require('@instana/core/test/test_util');
+const config = require('@instana/core/test/config');
+
+const ProcessControls = require('../../../collector/test/test_util/ProcessControls');
+
+describe('cjs require collector in preload phase', function () {
+  this.timeout(config.getTestTimeout());
+
+  const controls = new ProcessControls({
+    useGlobalAgent: true,
+    cwd: path.join(__dirname, 'module'),
+    appPath: path.join(__dirname, 'module', 'src', 'app'),
+    env: {
+      NODE_OPTIONS: '--require ./load-instana.js'
+    }
+  });
+
+  ProcessControls.setUpHooks(controls);
+
+  it('should be able to find package.json', async () => {
+    await controls.sendRequest({
+      method: 'GET',
+      path: '/metrics'
+    });
+
+    await testUtils.retry(() =>
+      controls.agentControls.getAllMetrics(controls.getPid()).then(metrics => {
+        const name = findMetric(metrics, ['name']);
+        expect(name).to.equal('@instana/shared-metrics');
+      })
+    );
+  });
+});
+
+/**
+ * Find a particular metric in all collected metrics.
+ *
+ * @param {Object[]} allMetrics All collected metrics
+ * @param {string[]} _path The path to the metric in question
+ */
+function findMetric(allMetrics, _path) {
+  for (let i = allMetrics.length - 1; i >= 0; i--) {
+    const value = _.get(allMetrics[i], ['data'].concat(_path));
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}

--- a/packages/shared-metrics/test/ejs-require-in-preload/module/load-instana.cjs
+++ b/packages/shared-metrics/test/ejs-require-in-preload/module/load-instana.cjs
@@ -1,0 +1,7 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+require('../../../../collector/src')();

--- a/packages/shared-metrics/test/ejs-require-in-preload/module/package.json
+++ b/packages/shared-metrics/test/ejs-require-in-preload/module/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cjs-example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {}
+}

--- a/packages/shared-metrics/test/ejs-require-in-preload/module/package.json
+++ b/packages/shared-metrics/test/ejs-require-in-preload/module/package.json
@@ -2,7 +2,7 @@
   "name": "cjs-example",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "src/app.js",
   "type": "module",
   "dependencies": {}
 }

--- a/packages/shared-metrics/test/ejs-require-in-preload/module/src/app.js
+++ b/packages/shared-metrics/test/ejs-require-in-preload/module/src/app.js
@@ -8,7 +8,7 @@ import express from 'express';
 
 const port = process.env.APP_PORT || 44004;
 const app = express();
-const logPrefix = `EJS preload: (${process.pid}):\t`;
+const logPrefix = `EJS preload collector: (${process.pid}):\t`;
 
 app.get('/', (req, res) => {
   res.send('OK');

--- a/packages/shared-metrics/test/ejs-require-in-preload/module/src/app.js
+++ b/packages/shared-metrics/test/ejs-require-in-preload/module/src/app.js
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+import express from 'express';
+
+const port = process.env.APP_PORT || 44004;
+const app = express();
+const logPrefix = `EJS preload: (${process.pid}):\t`;
+
+app.get('/', (req, res) => {
+  res.send('OK');
+});
+
+app.listen(port, () => {
+  log(`Listening on port: ${port}`);
+});
+
+function log() {
+  const args = Array.prototype.slice.call(arguments);
+  args[0] = `${logPrefix} (${process.pid}):\t${args[0]}`;
+  // eslint-disable-next-line no-console
+  console.log.apply(console, args);
+}

--- a/packages/shared-metrics/test/ejs-require-in-preload/test.js
+++ b/packages/shared-metrics/test/ejs-require-in-preload/test.js
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const path = require('path');
+const _ = require('lodash');
+const expect = require('chai').expect;
+
+const testUtils = require('@instana/core/test/test_util');
+const config = require('@instana/core/test/config');
+
+const ProcessControls = require('../../../collector/test/test_util/ProcessControls');
+
+describe('ejs require collector in preload', function () {
+  this.timeout(config.getTestTimeout());
+
+  const controls = new ProcessControls({
+    useGlobalAgent: true,
+    cwd: path.join(__dirname, 'module'),
+    appPath: path.join(__dirname, 'module', 'src', 'app'),
+    env: {
+      NODE_OPTIONS: '--require ./load-instana.cjs'
+    }
+  });
+
+  ProcessControls.setUpHooks(controls);
+
+  it('should be able to find package.json', async () => {
+    await controls.sendRequest({
+      method: 'GET',
+      path: '/metrics'
+    });
+
+    await testUtils.retry(() =>
+      controls.agentControls.getAllMetrics(controls.getPid()).then(metrics => {
+        const name = findMetric(metrics, ['name']);
+        expect(name).to.equal('@instana/shared-metrics');
+      })
+    );
+  });
+});
+
+/**
+ * Find a particular metric in all collected metrics.
+ *
+ * @param {Object[]} allMetrics All collected metrics
+ * @param {string[]} _path The path to the metric in question
+ */
+function findMetric(allMetrics, _path) {
+  for (let i = allMetrics.length - 1; i >= 0; i--) {
+    const value = _.get(allMetrics[i], ['data'].concat(_path));
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}

--- a/packages/shared-metrics/test/ejs-require-in-preload/test.js
+++ b/packages/shared-metrics/test/ejs-require-in-preload/test.js
@@ -28,11 +28,6 @@ describe('ejs require collector in preload', function () {
   ProcessControls.setUpHooks(controls);
 
   it('should be able to find package.json', async () => {
-    await controls.sendRequest({
-      method: 'GET',
-      path: '/metrics'
-    });
-
     await testUtils.retry(() =>
       controls.agentControls.getAllMetrics(controls.getPid()).then(metrics => {
         const name = findMetric(metrics, ['name']);

--- a/packages/shared-metrics/test/name_test.js
+++ b/packages/shared-metrics/test/name_test.js
@@ -6,22 +6,51 @@
 'use strict';
 
 const expect = require('chai').expect;
-
+const sinon = require('sinon');
 const testUtils = require('../../core/test/test_util');
 const name = require('../src/name');
+const { applicationUnderMonitoring } = require('@instana/core').util;
 
 describe('metrics.name', () => {
+  afterEach(() => {
+    name.reset();
+  });
+
   it('should export a name payload prefix', () => {
     expect(name.payloadPrefix).to.equal('name');
   });
 
-  it('should provide the main module name', () => {
-    name.activate();
+  describe('when the package.json can be found', function () {
+    it('it should extract the package.json name', async () => {
+      name.activate();
 
-    return testUtils.retry(() => {
-      // Mocha is used to execute the tests via the mocha executable.
-      // As such mocha is the main module.
-      expect(name.currentPayload).to.equal('mocha');
+      return testUtils.retry(() => {
+        // Mocha is used to execute the tests via the mocha executable.
+        // As such mocha is the main module.
+        expect(name.currentPayload).to.equal('mocha');
+      });
+    });
+  });
+
+  describe('when the package.json cannot be found', function () {
+    before(() => {
+      sinon.stub(applicationUnderMonitoring, 'getMainPackageJsonStartingAtMainModule').callsFake(cb => {
+        cb(null, null);
+      });
+    });
+
+    after(() => {
+      sinon.restore();
+    });
+
+    it('it should use the main module name', async () => {
+      name.MAX_ATTEMPTS = 5;
+      name.DELAY = 50;
+      name.activate();
+
+      return testUtils.retry(() => {
+        expect(name.currentPayload).to.contain('node_modules/mocha/bin/mocha');
+      });
     });
   });
 });


### PR DESCRIPTION
refs #581

- replaced deprecated usage of process.mainModule (this is not the main fix, just a replacement)
- https://nodejs.org/api/process.html#processmainmodule
- the main fix is to fallback reading the process.argv for the following case:
  - application uses ES modules and preloads a commonJS file using `--require`
  - in this preload file the Instana collector is required
  - package.json & existing fallback solutions did not work