### PR TITLE
Revert "build(deps-dev): bump @opentelemetry/sdk-trace-node from 1.0.1 to 1.5.0"

### DIFF
--- a/packages/opentelemetry-exporter/package-lock.json
+++ b/packages/opentelemetry-exporter/package-lock.json
@@ -20,7 +20,7 @@
 				"@opentelemetry/resources": "1.0.1",
 				"@opentelemetry/sdk-node": "0.27.0",
 				"@opentelemetry/sdk-trace-base": "1.0.1",
-				"@opentelemetry/sdk-trace-node": "1.5.0",
+				"@opentelemetry/sdk-trace-node": "1.0.1",
 				"@opentelemetry/semantic-conventions": "1.0.1",
 				"chai": "*",
 				"chai-spies": "1.0.0",
@@ -572,18 +572,6 @@
 				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/context-async-hooks": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.0.1.tgz",
-			"integrity": "sha512-oGCPjDlZ03gXPAdLxw5iqaQJIpL8BZFaiZhAPgF7Vj6XYmrmrA/FXVIsjfNECQTa2D+lt5p8vf0xYIkFufgceQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.1.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.1.0"
-			}
-		},
 		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/core": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
@@ -594,56 +582,6 @@
 			},
 			"engines": {
 				"node": ">=8.5.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.1.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/propagator-b3": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.0.1.tgz",
-			"integrity": "sha512-UQQiOpR/WXyoqIRQEkn6RuXtGfpjhBDMq/1HrVxRCRPMVn7f4e+zxZWoQSsCOvSGQTu9S+W8eAutm00sRJN7fg==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/core": "1.0.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.1.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/propagator-jaeger": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.0.1.tgz",
-			"integrity": "sha512-bzvXksBn3j0GyiFXQbx87CUSGC1UDyp4hjL+CCOrQfzIEdp6usKCLHv40Ib5WU6739hPMkyr59CPfKwzlviTtA==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/core": "1.0.1"
-			},
-			"engines": {
-				"node": ">=8.5.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.1.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-node": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.0.1.tgz",
-			"integrity": "sha512-0ifT2pEI5aXy14zDDUQkl3ODzY6jjaC1plbxyAuz5BdPxGJzav9vzIJ2BhEwfXDn1LKqpQ5D1Yy+XnNRQpOo3w==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/context-async-hooks": "1.0.1",
-				"@opentelemetry/core": "1.0.1",
-				"@opentelemetry/propagator-b3": "1.0.1",
-				"@opentelemetry/propagator-jaeger": "1.0.1",
-				"@opentelemetry/sdk-trace-base": "1.0.1",
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.1.0"
@@ -682,122 +620,80 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.5.0.tgz",
-			"integrity": "sha512-MzS+urf2KufpwgaHbGcUgccHr6paxI98lHFMgJAkK6w76AmPYavsxSwjiVPrchy/24d2J9svDirSgui3NNZo8g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.0.1.tgz",
+			"integrity": "sha512-0ifT2pEI5aXy14zDDUQkl3ODzY6jjaC1plbxyAuz5BdPxGJzav9vzIJ2BhEwfXDn1LKqpQ5D1Yy+XnNRQpOo3w==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/context-async-hooks": "1.5.0",
-				"@opentelemetry/core": "1.5.0",
-				"@opentelemetry/propagator-b3": "1.5.0",
-				"@opentelemetry/propagator-jaeger": "1.5.0",
-				"@opentelemetry/sdk-trace-base": "1.5.0",
+				"@opentelemetry/context-async-hooks": "1.0.1",
+				"@opentelemetry/core": "1.0.1",
+				"@opentelemetry/propagator-b3": "1.0.1",
+				"@opentelemetry/propagator-jaeger": "1.0.1",
+				"@opentelemetry/sdk-trace-base": "1.0.1",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/context-async-hooks": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.5.0.tgz",
-			"integrity": "sha512-mhBPP0BU0RaH2HB8U4MDd5OjWA1y7SoLOovCT0iEpJAltaq2z04uxRJVzIs91vkpNnV0utUZowQQD3KElgU+VA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.0.1.tgz",
+			"integrity": "sha512-oGCPjDlZ03gXPAdLxw5iqaQJIpL8BZFaiZhAPgF7Vj6XYmrmrA/FXVIsjfNECQTa2D+lt5p8vf0xYIkFufgceQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=14"
+				"node": ">=8.1.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.5.0.tgz",
-			"integrity": "sha512-B3DIMkQN0DANrr7XrMLS4pR6d2o/jqT09x4nZJz6wSJ9SHr4eQIqeFBNeEUQG1I+AuOcH2UbJtgFm7fKxLqd+w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+			"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.5.0"
+				"@opentelemetry/semantic-conventions": "1.0.1"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/propagator-b3": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.5.0.tgz",
-			"integrity": "sha512-38iGIScgU9OLhoPKAV3p2rEf4RmmQC/Lo4LvpQ6TaSQrRht/oDgnpsPJnmNQLFboklmukKataJO+FhAieOc7mg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.0.1.tgz",
+			"integrity": "sha512-UQQiOpR/WXyoqIRQEkn6RuXtGfpjhBDMq/1HrVxRCRPMVn7f4e+zxZWoQSsCOvSGQTu9S+W8eAutm00sRJN7fg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "1.5.0"
+				"@opentelemetry/core": "1.0.1"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/propagator-jaeger": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.5.0.tgz",
-			"integrity": "sha512-aSUH5RDEZj+lmy4PbXAJ26E+yJcZloyPUBWgqYX+JBS4NnbriIznCF/tXV5s/RUXeVABibi/+yAZndv+2XBg4w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.0.1.tgz",
+			"integrity": "sha512-bzvXksBn3j0GyiFXQbx87CUSGC1UDyp4hjL+CCOrQfzIEdp6usKCLHv40Ib5WU6739hPMkyr59CPfKwzlviTtA==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "1.5.0"
+				"@opentelemetry/core": "1.0.1"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/resources": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.5.0.tgz",
-			"integrity": "sha512-YeEfC6IY54U3xL3P2+UAiom+r50ZF2jM0J47RV5uTFGF19Xjd5zazSwDPgmxtAd6DwLX0/5S5iqrsH4nEXMYoA==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/core": "1.5.0",
-				"@opentelemetry/semantic-conventions": "1.5.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.5.0.tgz",
-			"integrity": "sha512-6lx7YDf67HSQYuWnvq3XgSrWikDJLiGCbrpUP6UWJ5Z47HLcJvwZPRH+cQGJu1DFS3dT2cV3GpAR75/OofPNHQ==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/core": "1.5.0",
-				"@opentelemetry/resources": "1.5.0",
-				"@opentelemetry/semantic-conventions": "1.5.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.5.0.tgz",
-			"integrity": "sha512-wlYG/U6ddW1ilXslnDLLQYJ8nd97W8JJTTfwkGhubx6dzW6SUkd+N4/MzTjjyZlrHQunxHtkHFvVpUKiROvFDw==",
-			"dev": true,
-			"engines": {
-				"node": ">=14"
+				"@opentelemetry/api": ">=1.0.0 <1.1.0"
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
@@ -1999,6 +1895,53 @@
 				"@opentelemetry/sdk-trace-node": "~1.0.0"
 			},
 			"dependencies": {
+				"@opentelemetry/core": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+					"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
+					"dev": true,
+					"requires": {
+						"@opentelemetry/semantic-conventions": "1.0.1"
+					}
+				}
+			}
+		},
+		"@opentelemetry/sdk-trace-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.0.1.tgz",
+			"integrity": "sha512-JVSAepTpW7dnqfV7XFN0zHj1jXGNd5OcvIGQl76buogqffdgJdgJWQNrOuUJaus56zrOtlzqFH+YtMA9RGEg8w==",
+			"dev": true,
+			"requires": {
+				"@opentelemetry/core": "1.0.1",
+				"@opentelemetry/resources": "1.0.1",
+				"@opentelemetry/semantic-conventions": "1.0.1"
+			},
+			"dependencies": {
+				"@opentelemetry/core": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
+					"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
+					"dev": true,
+					"requires": {
+						"@opentelemetry/semantic-conventions": "1.0.1"
+					}
+				}
+			}
+		},
+		"@opentelemetry/sdk-trace-node": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.0.1.tgz",
+			"integrity": "sha512-0ifT2pEI5aXy14zDDUQkl3ODzY6jjaC1plbxyAuz5BdPxGJzav9vzIJ2BhEwfXDn1LKqpQ5D1Yy+XnNRQpOo3w==",
+			"dev": true,
+			"requires": {
+				"@opentelemetry/context-async-hooks": "1.0.1",
+				"@opentelemetry/core": "1.0.1",
+				"@opentelemetry/propagator-b3": "1.0.1",
+				"@opentelemetry/propagator-jaeger": "1.0.1",
+				"@opentelemetry/sdk-trace-base": "1.0.1",
+				"semver": "^7.3.5"
+			},
+			"dependencies": {
 				"@opentelemetry/context-async-hooks": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.0.1.tgz",
@@ -2032,119 +1975,6 @@
 					"requires": {
 						"@opentelemetry/core": "1.0.1"
 					}
-				},
-				"@opentelemetry/sdk-trace-node": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.0.1.tgz",
-					"integrity": "sha512-0ifT2pEI5aXy14zDDUQkl3ODzY6jjaC1plbxyAuz5BdPxGJzav9vzIJ2BhEwfXDn1LKqpQ5D1Yy+XnNRQpOo3w==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/context-async-hooks": "1.0.1",
-						"@opentelemetry/core": "1.0.1",
-						"@opentelemetry/propagator-b3": "1.0.1",
-						"@opentelemetry/propagator-jaeger": "1.0.1",
-						"@opentelemetry/sdk-trace-base": "1.0.1",
-						"semver": "^7.3.5"
-					}
-				}
-			}
-		},
-		"@opentelemetry/sdk-trace-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.0.1.tgz",
-			"integrity": "sha512-JVSAepTpW7dnqfV7XFN0zHj1jXGNd5OcvIGQl76buogqffdgJdgJWQNrOuUJaus56zrOtlzqFH+YtMA9RGEg8w==",
-			"dev": true,
-			"requires": {
-				"@opentelemetry/core": "1.0.1",
-				"@opentelemetry/resources": "1.0.1",
-				"@opentelemetry/semantic-conventions": "1.0.1"
-			},
-			"dependencies": {
-				"@opentelemetry/core": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.0.1.tgz",
-					"integrity": "sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/semantic-conventions": "1.0.1"
-					}
-				}
-			}
-		},
-		"@opentelemetry/sdk-trace-node": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.5.0.tgz",
-			"integrity": "sha512-MzS+urf2KufpwgaHbGcUgccHr6paxI98lHFMgJAkK6w76AmPYavsxSwjiVPrchy/24d2J9svDirSgui3NNZo8g==",
-			"dev": true,
-			"requires": {
-				"@opentelemetry/context-async-hooks": "1.5.0",
-				"@opentelemetry/core": "1.5.0",
-				"@opentelemetry/propagator-b3": "1.5.0",
-				"@opentelemetry/propagator-jaeger": "1.5.0",
-				"@opentelemetry/sdk-trace-base": "1.5.0",
-				"semver": "^7.3.5"
-			},
-			"dependencies": {
-				"@opentelemetry/context-async-hooks": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.5.0.tgz",
-					"integrity": "sha512-mhBPP0BU0RaH2HB8U4MDd5OjWA1y7SoLOovCT0iEpJAltaq2z04uxRJVzIs91vkpNnV0utUZowQQD3KElgU+VA==",
-					"dev": true,
-					"requires": {}
-				},
-				"@opentelemetry/core": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.5.0.tgz",
-					"integrity": "sha512-B3DIMkQN0DANrr7XrMLS4pR6d2o/jqT09x4nZJz6wSJ9SHr4eQIqeFBNeEUQG1I+AuOcH2UbJtgFm7fKxLqd+w==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/semantic-conventions": "1.5.0"
-					}
-				},
-				"@opentelemetry/propagator-b3": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.5.0.tgz",
-					"integrity": "sha512-38iGIScgU9OLhoPKAV3p2rEf4RmmQC/Lo4LvpQ6TaSQrRht/oDgnpsPJnmNQLFboklmukKataJO+FhAieOc7mg==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/core": "1.5.0"
-					}
-				},
-				"@opentelemetry/propagator-jaeger": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.5.0.tgz",
-					"integrity": "sha512-aSUH5RDEZj+lmy4PbXAJ26E+yJcZloyPUBWgqYX+JBS4NnbriIznCF/tXV5s/RUXeVABibi/+yAZndv+2XBg4w==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/core": "1.5.0"
-					}
-				},
-				"@opentelemetry/resources": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.5.0.tgz",
-					"integrity": "sha512-YeEfC6IY54U3xL3P2+UAiom+r50ZF2jM0J47RV5uTFGF19Xjd5zazSwDPgmxtAd6DwLX0/5S5iqrsH4nEXMYoA==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/core": "1.5.0",
-						"@opentelemetry/semantic-conventions": "1.5.0"
-					}
-				},
-				"@opentelemetry/sdk-trace-base": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.5.0.tgz",
-					"integrity": "sha512-6lx7YDf67HSQYuWnvq3XgSrWikDJLiGCbrpUP6UWJ5Z47HLcJvwZPRH+cQGJu1DFS3dT2cV3GpAR75/OofPNHQ==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/core": "1.5.0",
-						"@opentelemetry/resources": "1.5.0",
-						"@opentelemetry/semantic-conventions": "1.5.0"
-					}
-				},
-				"@opentelemetry/semantic-conventions": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.5.0.tgz",
-					"integrity": "sha512-wlYG/U6ddW1ilXslnDLLQYJ8nd97W8JJTTfwkGhubx6dzW6SUkd+N4/MzTjjyZlrHQunxHtkHFvVpUKiROvFDw==",
-					"dev": true
 				}
 			}
 		},

--- a/packages/opentelemetry-exporter/package.json
+++ b/packages/opentelemetry-exporter/package.json
@@ -69,7 +69,7 @@
     "@opentelemetry/resources": "1.0.1",
     "@opentelemetry/sdk-node": "0.27.0",
     "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.5.0",
+    "@opentelemetry/sdk-trace-node": "1.0.1",
     "@opentelemetry/semantic-conventions": "1.0.1",
     "chai": "*",
     "chai-spies": "1.0.0",

--- a/packages/opentelemetry-sampler/package-lock.json
+++ b/packages/opentelemetry-sampler/package-lock.json
@@ -21,7 +21,7 @@
 				"@opentelemetry/resources": "1.4.0",
 				"@opentelemetry/sdk-node": "0.30.0",
 				"@opentelemetry/sdk-trace-base": "1.4.0",
-				"@opentelemetry/sdk-trace-node": "1.5.0",
+				"@opentelemetry/sdk-trace-node": "1.4.0",
 				"@opentelemetry/semantic-conventions": "1.0.1",
 				"chai": "*",
 				"chai-spies": "1.0.0",
@@ -1925,83 +1925,6 @@
 				"@opentelemetry/api": ">=1.0.0 <1.2.0"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/context-async-hooks": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.4.0.tgz",
-			"integrity": "sha512-yXpe1qCK3CevzWN3VmLlEOcipNdSV6al204lWMDoBI4eCy3rWZZEAGlwRvIiEy3uPrHClh6BQ5Z0q1+LEB/y8g==",
-			"dev": true,
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/propagator-b3": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.4.0.tgz",
-			"integrity": "sha512-KKFjvU2qrOEoK2S9FfSkE11u3AVxCniJOH7av6pmbFwkv1YD6uHNqvjvY4Xe6VwFOyKuTYS69VydO9OjJ5gvVA==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/core": "1.4.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/propagator-jaeger": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.4.0.tgz",
-			"integrity": "sha512-LvSzgt9RIGYiMP9E45ifT5WtALsDyY74y/1Ol0DK4xmJt8Sku7YastjCZaxpsvLGA4CGAtth0ozic88AvJrmgw==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/core": "1.4.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-node": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.4.0.tgz",
-			"integrity": "sha512-LET70LwaE8gK3W6jpeG6C7BNbl5m8fnEgNmO0LFXHyl4yofIzficDy06zjgVtPp1urygNuYPtK/4yiactzTvZg==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/context-async-hooks": "1.4.0",
-				"@opentelemetry/core": "1.4.0",
-				"@opentelemetry/propagator-b3": "1.4.0",
-				"@opentelemetry/propagator-jaeger": "1.4.0",
-				"@opentelemetry/sdk-trace-base": "1.4.0",
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-node/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.4.0.tgz",
@@ -2029,16 +1952,16 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.5.0.tgz",
-			"integrity": "sha512-MzS+urf2KufpwgaHbGcUgccHr6paxI98lHFMgJAkK6w76AmPYavsxSwjiVPrchy/24d2J9svDirSgui3NNZo8g==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.4.0.tgz",
+			"integrity": "sha512-LET70LwaE8gK3W6jpeG6C7BNbl5m8fnEgNmO0LFXHyl4yofIzficDy06zjgVtPp1urygNuYPtK/4yiactzTvZg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/context-async-hooks": "1.5.0",
-				"@opentelemetry/core": "1.5.0",
-				"@opentelemetry/propagator-b3": "1.5.0",
-				"@opentelemetry/propagator-jaeger": "1.5.0",
-				"@opentelemetry/sdk-trace-base": "1.5.0",
+				"@opentelemetry/context-async-hooks": "1.4.0",
+				"@opentelemetry/core": "1.4.0",
+				"@opentelemetry/propagator-b3": "1.4.0",
+				"@opentelemetry/propagator-jaeger": "1.4.0",
+				"@opentelemetry/sdk-trace-base": "1.4.0",
 				"semver": "^7.3.5"
 			},
 			"engines": {
@@ -2049,25 +1972,10 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/context-async-hooks": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.5.0.tgz",
-			"integrity": "sha512-mhBPP0BU0RaH2HB8U4MDd5OjWA1y7SoLOovCT0iEpJAltaq2z04uxRJVzIs91vkpNnV0utUZowQQD3KElgU+VA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.4.0.tgz",
+			"integrity": "sha512-yXpe1qCK3CevzWN3VmLlEOcipNdSV6al204lWMDoBI4eCy3rWZZEAGlwRvIiEy3uPrHClh6BQ5Z0q1+LEB/y8g==",
 			"dev": true,
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.5.0.tgz",
-			"integrity": "sha512-B3DIMkQN0DANrr7XrMLS4pR6d2o/jqT09x4nZJz6wSJ9SHr4eQIqeFBNeEUQG1I+AuOcH2UbJtgFm7fKxLqd+w==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.5.0"
-			},
 			"engines": {
 				"node": ">=14"
 			},
@@ -2076,12 +1984,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/propagator-b3": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.5.0.tgz",
-			"integrity": "sha512-38iGIScgU9OLhoPKAV3p2rEf4RmmQC/Lo4LvpQ6TaSQrRht/oDgnpsPJnmNQLFboklmukKataJO+FhAieOc7mg==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.4.0.tgz",
+			"integrity": "sha512-KKFjvU2qrOEoK2S9FfSkE11u3AVxCniJOH7av6pmbFwkv1YD6uHNqvjvY4Xe6VwFOyKuTYS69VydO9OjJ5gvVA==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "1.5.0"
+				"@opentelemetry/core": "1.4.0"
 			},
 			"engines": {
 				"node": ">=14"
@@ -2091,60 +1999,18 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/propagator-jaeger": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.5.0.tgz",
-			"integrity": "sha512-aSUH5RDEZj+lmy4PbXAJ26E+yJcZloyPUBWgqYX+JBS4NnbriIznCF/tXV5s/RUXeVABibi/+yAZndv+2XBg4w==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.4.0.tgz",
+			"integrity": "sha512-LvSzgt9RIGYiMP9E45ifT5WtALsDyY74y/1Ol0DK4xmJt8Sku7YastjCZaxpsvLGA4CGAtth0ozic88AvJrmgw==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "1.5.0"
+				"@opentelemetry/core": "1.4.0"
 			},
 			"engines": {
 				"node": ">=14"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.2.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/resources": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.5.0.tgz",
-			"integrity": "sha512-YeEfC6IY54U3xL3P2+UAiom+r50ZF2jM0J47RV5uTFGF19Xjd5zazSwDPgmxtAd6DwLX0/5S5iqrsH4nEXMYoA==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/core": "1.5.0",
-				"@opentelemetry/semantic-conventions": "1.5.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.5.0.tgz",
-			"integrity": "sha512-6lx7YDf67HSQYuWnvq3XgSrWikDJLiGCbrpUP6UWJ5Z47HLcJvwZPRH+cQGJu1DFS3dT2cV3GpAR75/OofPNHQ==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/core": "1.5.0",
-				"@opentelemetry/resources": "1.5.0",
-				"@opentelemetry/semantic-conventions": "1.5.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.2.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.5.0.tgz",
-			"integrity": "sha512-wlYG/U6ddW1ilXslnDLLQYJ8nd97W8JJTTfwkGhubx6dzW6SUkd+N4/MzTjjyZlrHQunxHtkHFvVpUKiROvFDw==",
-			"dev": true,
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node/node_modules/semver": {
@@ -5088,6 +4954,39 @@
 				"@opentelemetry/sdk-metrics-base": "0.30.0",
 				"@opentelemetry/sdk-trace-base": "1.4.0",
 				"@opentelemetry/sdk-trace-node": "1.4.0"
+			}
+		},
+		"@opentelemetry/sdk-trace-base": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.4.0.tgz",
+			"integrity": "sha512-l7EEjcOgYlKWK0hfxz4Jtkkk2DuGiqBDWmRZf7g2Is9RVneF1IgcrbYZTKGaVfBKA7lPuVtUiQ2qTv3R+dKJrw==",
+			"dev": true,
+			"requires": {
+				"@opentelemetry/core": "1.4.0",
+				"@opentelemetry/resources": "1.4.0",
+				"@opentelemetry/semantic-conventions": "1.4.0"
+			},
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+					"integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
+					"dev": true
+				}
+			}
+		},
+		"@opentelemetry/sdk-trace-node": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.4.0.tgz",
+			"integrity": "sha512-LET70LwaE8gK3W6jpeG6C7BNbl5m8fnEgNmO0LFXHyl4yofIzficDy06zjgVtPp1urygNuYPtK/4yiactzTvZg==",
+			"dev": true,
+			"requires": {
+				"@opentelemetry/context-async-hooks": "1.4.0",
+				"@opentelemetry/core": "1.4.0",
+				"@opentelemetry/propagator-b3": "1.4.0",
+				"@opentelemetry/propagator-jaeger": "1.4.0",
+				"@opentelemetry/sdk-trace-base": "1.4.0",
+				"semver": "^7.3.5"
 			},
 			"dependencies": {
 				"@opentelemetry/context-async-hooks": {
@@ -5114,125 +5013,6 @@
 					"requires": {
 						"@opentelemetry/core": "1.4.0"
 					}
-				},
-				"@opentelemetry/sdk-trace-node": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.4.0.tgz",
-					"integrity": "sha512-LET70LwaE8gK3W6jpeG6C7BNbl5m8fnEgNmO0LFXHyl4yofIzficDy06zjgVtPp1urygNuYPtK/4yiactzTvZg==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/context-async-hooks": "1.4.0",
-						"@opentelemetry/core": "1.4.0",
-						"@opentelemetry/propagator-b3": "1.4.0",
-						"@opentelemetry/propagator-jaeger": "1.4.0",
-						"@opentelemetry/sdk-trace-base": "1.4.0",
-						"semver": "^7.3.5"
-					}
-				},
-				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
-			}
-		},
-		"@opentelemetry/sdk-trace-base": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.4.0.tgz",
-			"integrity": "sha512-l7EEjcOgYlKWK0hfxz4Jtkkk2DuGiqBDWmRZf7g2Is9RVneF1IgcrbYZTKGaVfBKA7lPuVtUiQ2qTv3R+dKJrw==",
-			"dev": true,
-			"requires": {
-				"@opentelemetry/core": "1.4.0",
-				"@opentelemetry/resources": "1.4.0",
-				"@opentelemetry/semantic-conventions": "1.4.0"
-			},
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
-					"integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
-					"dev": true
-				}
-			}
-		},
-		"@opentelemetry/sdk-trace-node": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.5.0.tgz",
-			"integrity": "sha512-MzS+urf2KufpwgaHbGcUgccHr6paxI98lHFMgJAkK6w76AmPYavsxSwjiVPrchy/24d2J9svDirSgui3NNZo8g==",
-			"dev": true,
-			"requires": {
-				"@opentelemetry/context-async-hooks": "1.5.0",
-				"@opentelemetry/core": "1.5.0",
-				"@opentelemetry/propagator-b3": "1.5.0",
-				"@opentelemetry/propagator-jaeger": "1.5.0",
-				"@opentelemetry/sdk-trace-base": "1.5.0",
-				"semver": "^7.3.5"
-			},
-			"dependencies": {
-				"@opentelemetry/context-async-hooks": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.5.0.tgz",
-					"integrity": "sha512-mhBPP0BU0RaH2HB8U4MDd5OjWA1y7SoLOovCT0iEpJAltaq2z04uxRJVzIs91vkpNnV0utUZowQQD3KElgU+VA==",
-					"dev": true,
-					"requires": {}
-				},
-				"@opentelemetry/core": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.5.0.tgz",
-					"integrity": "sha512-B3DIMkQN0DANrr7XrMLS4pR6d2o/jqT09x4nZJz6wSJ9SHr4eQIqeFBNeEUQG1I+AuOcH2UbJtgFm7fKxLqd+w==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/semantic-conventions": "1.5.0"
-					}
-				},
-				"@opentelemetry/propagator-b3": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.5.0.tgz",
-					"integrity": "sha512-38iGIScgU9OLhoPKAV3p2rEf4RmmQC/Lo4LvpQ6TaSQrRht/oDgnpsPJnmNQLFboklmukKataJO+FhAieOc7mg==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/core": "1.5.0"
-					}
-				},
-				"@opentelemetry/propagator-jaeger": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.5.0.tgz",
-					"integrity": "sha512-aSUH5RDEZj+lmy4PbXAJ26E+yJcZloyPUBWgqYX+JBS4NnbriIznCF/tXV5s/RUXeVABibi/+yAZndv+2XBg4w==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/core": "1.5.0"
-					}
-				},
-				"@opentelemetry/resources": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.5.0.tgz",
-					"integrity": "sha512-YeEfC6IY54U3xL3P2+UAiom+r50ZF2jM0J47RV5uTFGF19Xjd5zazSwDPgmxtAd6DwLX0/5S5iqrsH4nEXMYoA==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/core": "1.5.0",
-						"@opentelemetry/semantic-conventions": "1.5.0"
-					}
-				},
-				"@opentelemetry/sdk-trace-base": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.5.0.tgz",
-					"integrity": "sha512-6lx7YDf67HSQYuWnvq3XgSrWikDJLiGCbrpUP6UWJ5Z47HLcJvwZPRH+cQGJu1DFS3dT2cV3GpAR75/OofPNHQ==",
-					"dev": true,
-					"requires": {
-						"@opentelemetry/core": "1.5.0",
-						"@opentelemetry/resources": "1.5.0",
-						"@opentelemetry/semantic-conventions": "1.5.0"
-					}
-				},
-				"@opentelemetry/semantic-conventions": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.5.0.tgz",
-					"integrity": "sha512-wlYG/U6ddW1ilXslnDLLQYJ8nd97W8JJTTfwkGhubx6dzW6SUkd+N4/MzTjjyZlrHQunxHtkHFvVpUKiROvFDw==",
-					"dev": true
 				},
 				"semver": {
 					"version": "7.3.7",

--- a/packages/opentelemetry-sampler/package.json
+++ b/packages/opentelemetry-sampler/package.json
@@ -65,7 +65,7 @@
     "@opentelemetry/resources": "1.4.0",
     "@opentelemetry/sdk-node": "0.30.0",
     "@opentelemetry/sdk-trace-base": "1.4.0",
-    "@opentelemetry/sdk-trace-node": "1.5.0",
+    "@opentelemetry/sdk-trace-node": "1.4.0",
     "@opentelemetry/semantic-conventions": "1.0.1",
     "chai": "*",
     "chai-spies": "1.0.0",


### PR DESCRIPTION
Reverts instana/nodejs#584

Not sure what is going on.
The exporter test failed 3 times on main with Node 18
It failed locally for me, but now it is working again.