### PR TITLE
test(lambda): troubleshoot lambda tests on CI

### DIFF
--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -28,7 +28,7 @@
     "audit": "bin/prepare-audit.sh && npm audit --production; AUDIT_RESULT=$?; git checkout package-lock.json; exit $AUDIT_RESULT",
     "test": "mocha --config=test/.mocharc.js --sort $(find test -iname '*test.js' -not -path '*node_modules*')",
     "test:debug": "WITH_STDOUT=true npm run test",
-    "test:ci": "(echo \"******* Files to be tested:\n $CI_AWS_LAMBDA_TEST_FILES\" && if [ -z \"${CI_AWS_LAMBDA_TEST_FILES}\" ]; then echo \"No Files to test in this node\"; else mocha --config=test/.mocharc.js --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json --sort ${CI_AWS_LAMBDA_TEST_FILES}; fi)",
+    "test:ci": "(echo \"******* Files to be tested:\n $CI_AWS_LAMBDA_TEST_FILES\" && if [ -z \"${CI_AWS_LAMBDA_TEST_FILES}\" ]; then echo \"No Files to test in this node\"; else WITH_STDOUT=true mocha --config=test/.mocharc.js --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json --sort ${CI_AWS_LAMBDA_TEST_FILES}; fi)",
     "lint": "eslint src test lambdas",
     "verify": "npm run lint && npm test",
     "prettier": "prettier --write 'src/**/*.js' 'test/**/*.js' 'lambdas/**/*.js'"

--- a/packages/aws-lambda/test/Control.js
+++ b/packages/aws-lambda/test/Control.js
@@ -68,6 +68,7 @@ Control.prototype.startMonitoredProcess = function startMonitoredProcess() {
       {
         HANDLER_DEFINITION_PATH: this.opts.handlerDefinitionPath,
         DOWNSTREAM_DUMMY_URL: this.downstreamDummyUrl,
+        INSTANA_LOG_LEVEL: 'debug',
         INSTANA_DISABLE_CA_CHECK: this.useHttps,
         INSTANA_DEV_SEND_UNENCRYPTED: !this.useHttps,
         WAIT_FOR_MESSAGE: true

--- a/packages/serverless/test/backend_stub/index.js
+++ b/packages/serverless/test/backend_stub/index.js
@@ -21,7 +21,7 @@ const deepMerge = require('../../../core/src/util/deepMerge');
 
 const logPrefix = 'backend-stub';
 const logger = pino.child({ name: logPrefix, pid: process.pid });
-logger.level = 'info';
+logger.level = process.env.INSTANA_DEBUG ? 'debug' : process.env.INSTANA_LOG_LEVEL || 'info';
 const useHttps = process.env.USE_HTTPS !== 'false';
 
 const options = {
@@ -52,7 +52,7 @@ app.use(
 app.post('/serverless/bundle', acceptBundle);
 
 function acceptBundle(req, res) {
-  logger.debug('incoming bundle', req.body);
+  logger.debug({ msg: 'incoming bundle', body: req.body });
   receivedData.rawBundles.push(req.body);
   if (unresponsive) {
     // intentionally not responding for tests that verify proper timeout handling
@@ -88,7 +88,7 @@ app.post('/serverless/metrics', acceptMetrics);
 app.post('/metrics', acceptMetrics);
 
 function acceptMetrics(req, res) {
-  logger.debug('incoming metrics', req.body);
+  logger.debug({ msg: 'incoming metrics', body: req.body });
   receivedData.rawMetrics.push(req.body);
   if (unresponsive) {
     // intentionally not responding for tests that verify proper timeout handling
@@ -116,7 +116,7 @@ app.post('/serverless/traces', acceptTraces);
 app.post('/traces', acceptTraces);
 
 function acceptTraces(req, res) {
-  logger.debug('incoming spans', req.body);
+  logger.debug({ msg: 'incoming spans', body: req.body });
   receivedData.rawSpanArrays.push(req.body);
   if (unresponsive) {
     // intentionally not responding for tests that verify proper timeout handling

--- a/packages/serverless/test/util/AbstractServerlessControl.js
+++ b/packages/serverless/test/util/AbstractServerlessControl.js
@@ -131,6 +131,7 @@ AbstractServerlessControl.prototype.startBackendAndWaitForIt = function startBac
       {
         USE_HTTPS: this.useHttps == null || this.useHttps,
         BACKEND_PORT: this.backendPort,
+        INSTANA_LOG_LEVEL: 'debug',
         BACKEND_UNRESPONSIVE: this.opts.startBackend === 'unresponsive'
       },
       process.env,
@@ -151,6 +152,7 @@ AbstractServerlessControl.prototype.startExtensionAndWaitForIt = function startE
       {
         BACKEND_HTTPS: this.useHttps == null || this.useHttps,
         BACKEND_PORT: this.backendPort,
+        INSTANA_LOG_LEVEL: 'debug',
         EXTENSION_PORT: this.extensionPort,
         EXTENSION_UNRESPONSIVE: this.opts.startExtension === 'unresponsive',
         EXTENSION_PREFFLIGHT_RESPONSIVE_BUT_UNRESPONSIVE_LATER: this.opts.startExtension === 'unresponsive-later',


### PR DESCRIPTION
The new integration tests for AWS Lambda [failed](https://app.circleci.com/pipelines/github/instana/nodejs/4015/workflows/dc786cb0-07c9-4678-9acb-a334e59f8040) for legacy Node.js versions yesterday and I do not really understand why. I'd like to add a bit more output to diagnose these failures.