### PR TITLE
fix(sqs, sns): do not add message attributes if that would violate limit

### DIFF
--- a/packages/collector/test/tracing/cloud/aws-sdk/v2/sqs/sendMessage.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v2/sqs/sendMessage.js
@@ -23,7 +23,7 @@ app.get('/', (_req, res) => {
   res.send('Ok');
 });
 
-function buildMessageParams(withError, isBatch) {
+function buildMessageParams(withError, isBatch, addHeaders) {
   const sendParams = {
     QueueUrl: queueURL
   };
@@ -51,13 +51,24 @@ function buildMessageParams(withError, isBatch) {
     ];
   }
 
+  if (addHeaders) {
+    sendParams.MessageAttributes = {};
+    for (let i = 0; i < addHeaders; i++) {
+      sendParams.MessageAttributes[`dummy-attribute-${i}`] = {
+        DataType: 'String',
+        StringValue: `dummy value ${i}`
+      };
+    }
+  }
+
   return sendParams;
 }
 
 app.post('/send-callback', (req, res) => {
   const withError = req.query.withError !== undefined;
   const isBatch = req.query.isBatch !== undefined;
-  const sendParams = buildMessageParams(withError, isBatch);
+  const addHeaders = req.query.addHeaders ? parseInt(req.query.addHeaders, 10) : 0;
+  const sendParams = buildMessageParams(withError, isBatch, addHeaders);
 
   const method = isBatch ? 'sendMessageBatch' : 'sendMessage';
 
@@ -81,7 +92,8 @@ app.post('/send-callback', (req, res) => {
 app.post('/send-promise', async (req, res) => {
   const withError = req.query.withError !== undefined;
   const isBatch = req.query.isBatch !== undefined;
-  const sendParams = buildMessageParams(withError, isBatch);
+  const addHeaders = req.query.addHeaders ? parseInt(req.query.addHeaders, 10) : 0;
+  const sendParams = buildMessageParams(withError, isBatch, addHeaders);
   const method = isBatch ? 'sendMessageBatch' : 'sendMessage';
 
   try {

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
@@ -9,6 +9,7 @@ const cls = require('../../../../cls');
 const {
   configureEntrySpan,
   hasTracingAttributes,
+  logTooManyAttributesWarningOnce,
   readTracingAttributesFromSns,
   readTracingAttributes
 } = require('../aws_utils');
@@ -289,6 +290,12 @@ class InstanaAWSSQS extends InstanaAWSProduct {
       return;
     }
 
+    // SQS has a limit of 10 message attributes, we would need to add one attribute.
+    if (Object.keys(attributes).length >= 10) {
+      logTooManyAttributesWarningOnce(logger, attributes, 1);
+      return;
+    }
+
     attributes[sqsAttributeNames.LEVEL] = {
       DataType: 'String',
       StringValue: '0'
@@ -300,6 +307,12 @@ class InstanaAWSSQS extends InstanaAWSProduct {
       return;
     }
 
+    // SQS has a limit of 10 message attributes, we need to add two attributes.
+    if (Object.keys(attributes).length >= 9) {
+      logTooManyAttributesWarningOnce(logger, attributes, 2);
+      return;
+    }
+
     attributes[sqsAttributeNames.TRACE_ID] = {
       DataType: 'String',
       StringValue: span.t
@@ -308,11 +321,6 @@ class InstanaAWSSQS extends InstanaAWSProduct {
     attributes[sqsAttributeNames.SPAN_ID] = {
       DataType: 'String',
       StringValue: span.s
-    };
-
-    attributes[sqsAttributeNames.LEVEL] = {
-      DataType: 'String',
-      StringValue: '1'
     };
   }
 }


### PR DESCRIPTION
It turns out that SQS and SNS enforce a limit of max 10 message
attributes. If the message already has some attributes, the ones that we
add for trace correlation could lead to a violation of that limit. In
that case we now refrain from adding message attributes and log a
warning instead.

refs 103388