### PR TITLE
feat(kafka): use kafka header format 'both' by default

### DIFF
--- a/packages/aws-fargate/test/using_api/test.js
+++ b/packages/aws-fargate/test/using_api/test.js
@@ -63,17 +63,20 @@ describe('Using the API', function () {
   function verify(control, response) {
     expect(response).to.be.an('object');
     expect(response.message).to.equal('Hello Fargate!');
-    expect(response.logs).to.deep.equal({
-      debug: ['Sending data to Instana (/metrics).', 'Sent data to Instana (/metrics).'],
-      info: [],
-      warn: [
-        'INSTANA_DISABLE_CA_CHECK is set, which means that the server certificate will not be verified against the ' +
-          'list of known CAs. This makes your lambda vulnerable to MITM attacks when connecting to Instana. This ' +
-          'setting should never be used in production, unless you use our on-premises product and are unable to ' +
-          'operate the Instana back end with a certificate with a known root CA.'
-      ],
-      error: []
-    });
+
+    // During phase 1 of the Kafka header migration (October 2022 - October 2023) there will be a debug log about
+    // ignoring the option 'both' for rdkafka. We do not care about that log message in this test.
+    const debug = response.logs.debug.filter(msg => !msg.includes('Ignoring configuration or default value'));
+    expect(debug).to.deep.equal(['Sending data to Instana (/metrics).', 'Sent data to Instana (/metrics).']);
+    expect(response.logs.info).to.be.empty;
+    expect(response.logs.warn).to.deep.equal([
+      'INSTANA_DISABLE_CA_CHECK is set, which means that the server certificate will not be verified against the ' +
+        'list of known CAs. This makes your service vulnerable to MITM attacks when connecting to Instana. This ' +
+        'setting should never be used in production, unless you use our on-premises product and are unable to ' +
+        'operate the Instana back end with a certificate with a known root CA.'
+    ]);
+    expect(response.logs.error).to.be.empty;
+
     expect(response.currentSpan.span.n).to.equal('node.http.server');
     expect(response.currentSpan.span.f.hl).to.be.true;
     expect(response.currentSpan.span.f.e).to.equal(instrumentedContainerId);

--- a/packages/aws-lambda/test/using_api/test.js
+++ b/packages/aws-lambda/test/using_api/test.js
@@ -201,7 +201,7 @@ describe('Using the API', () => {
         expect(body.logs.info).to.be.empty;
         expect(body.logs.warn).to.deep.equal([
           'INSTANA_DISABLE_CA_CHECK is set, which means that the server certificate will not be verified against the ' +
-            'list of known CAs. This makes your lambda vulnerable to MITM attacks when connecting to Instana. ' +
+            'list of known CAs. This makes your service vulnerable to MITM attacks when connecting to Instana. ' +
             'This setting should never be used in production, unless you use our on-premises product and are unable ' +
             'to operate the Instana back end with a certificate with a known root CA.'
         ]);

--- a/packages/collector/test/tracing/messaging/kafka-avro/test.js
+++ b/packages/collector/test/tracing/messaging/kafka-avro/test.js
@@ -8,15 +8,15 @@
  * Important notes
  * ---------------
  *
- * * Kafka Avro is instrumented through node-rdkafka, which is the API underneath Kafka Avro
- * * Kafka Avro currently works only in Node 14 and below, as it depends on an older version of node-rdkafka where
- * native modules.
- * * The Producer as a stream can only have span correlation if the Writtable option objectMode is set to true.
- * Otherwise, there is no way to append the Instana headers to it.
- * * The Producer, as stream or standard API cannot propagate span correlation when headerFormat is set to 'binary'.
- * More info here: https://github.com/Blizzard/node-rdkafka/pull/935.
- * * If the option dr_cb is not set to true, we cannot guarantee that a message was sent, but a span with a successful
- * sent message will be created.
+ * - Kafka Avro is instrumented through node-rdkafka, which is the API underneath Kafka Avro
+ * - Kafka Avro currently works only in Node 14 and below, as it depends on an older version of node-rdkafka with
+ *   native modules.
+ * - The Producer as a stream can only have trace correlation if the objectMode option is set to true on the
+ *   writable stream. Otherwise, there is no way to append the Instana headers to it.
+ * - The Producer, as stream or standard API cannot propagate trace correlation headers in format 'binary' and will
+ *   always use 'string'. More info here: https://github.com/Blizzard/node-rdkafka/pull/968.
+ * - If the option dr_cb is not set to true, we cannot guarantee that a message was sent, but a span with a successful
+ *   sent message will be created.
  */
 
 const path = require('path');

--- a/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
@@ -183,7 +183,7 @@ app.get('/produce/:method', async (req, res) => {
     res.status(200).send(response);
   } catch (err) {
     /**
-     * According to the Node.js spec, if a writtable stream receives the 'error' event, the only valid event by then is
+     * According to the Node.js spec, if a writable stream receives the 'error' event, the only valid event by then is
      * 'close'. So we create a new stream after an error occurs.
      *
      * From the Node.js docs (https://nodejs.org/dist/latest-v16.x/docs/api/stream.html#event-error):

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -8,12 +8,12 @@
  * Important notes
  * ---------------
  *
- * * The Producer as a stream can only have span correlation if the Writtable option objectMode is set to true.
- * Otherwise, there is no way to append the Instana headers to it.
- * * The Producer, as stream or standard API cannot propagate span correlation when headerFormat is set to 'binary'.
- * More info here: https://github.com/Blizzard/node-rdkafka/pull/935.
- * * If the option dr_cb is not set to true, we cannot guarantee that a message was sent, but a span with a successful
- * sent message will be created.
+ * - The Producer as a stream can only have span correlation if the objectMode option is set to true on the
+ *   writable stream. Otherwise, there is no way to append the Instana headers to it.
+ * - The Producer, as stream or standard API cannot propagate trace correlation headers in format 'binary' and will
+ *   always use 'string'. More info here: https://github.com/Blizzard/node-rdkafka/pull/968.
+ * - If the option dr_cb is not set to true, we cannot guarantee that a message was sent, but a span with a successful
+ *   sent message will be created.
  */
 
 const path = require('path');

--- a/packages/core/src/tracing/constants.js
+++ b/packages/core/src/tracing/constants.js
@@ -23,15 +23,22 @@ exports.kafkaLegacyTraceLevelHeaderName = 'X_INSTANA_L';
 exports.kafkaLegacyTraceLevelValueSuppressed = Buffer.from([0]);
 exports.kafkaLegacyTraceLevelValueInherit = Buffer.from([1]);
 
-// new kafka trace correlation (string values) starting approximately 2021-11
+// New kafka trace correlation (string values). Available as opt-in since 2021-10, and send out together with the legacy
+// binary headers by default starting in 2022-10. We will switch over to these headers completely (omitting the legacy
+// headers approximately in 2023-10.
 exports.kafkaTraceIdHeaderName = 'X_INSTANA_T';
 exports.kafkaSpanIdHeaderName = 'X_INSTANA_S';
 exports.kafkaTraceLevelHeaderName = 'X_INSTANA_L_S';
 
+/**
+ * @typedef {'binary' | 'string' | 'both'} KafkaTraceCorrelationFormat
+ */
+
+// With the current phase 1 of the Kafka header format migration, 'both', is the default.
+// With phase 2 (starting approximately October 2023) it will no longer be configurable and will always use 'string'.
+/** @type {KafkaTraceCorrelationFormat} */
+exports.kafkaHeaderFormatDefault = 'both';
 exports.kafkaTraceCorrelationDefault = true;
-// Before we start phase 1 of the migration, 'binary' will be the default value. With phase 1, we will move to 'both',
-// with phase 2 it will no longer be configurable and will always use 'string'.
-exports.kafkaHeaderFormatDefault = 'binary';
 
 exports.allInstanaKafkaHeaders = [
   exports.kafkaTraceIdHeaderName,

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -9,6 +9,8 @@
 
 const supportedTracingVersion = require('../tracing/supportedVersion');
 
+const constants = require('../tracing/constants');
+
 /**
  * @typedef {Object} InstanaTracingOption
  * @property {boolean} [enabled]
@@ -33,11 +35,7 @@ const supportedTracingVersion = require('../tracing/supportedVersion');
 /**
  * @typedef {Object} KafkaTracingOptions
  * @property {boolean} [traceCorrelation]
- * @property {KafkaTraceCorrelationFormat} [headerFormat]
- */
-
-/**
- * @typedef {'binary' | 'string' | 'both'} KafkaTraceCorrelationFormat
+ * @property {import('../tracing/constants').KafkaTraceCorrelationFormat} [headerFormat]
  */
 
 /**
@@ -114,9 +112,7 @@ const defaults = {
     disableW3cTraceCorrelation: false,
     kafka: {
       traceCorrelation: true,
-      // Before we start phase 3 of the migration, 'binary' will be the default value. With phase 1, we will move to
-      // 'both',  with phase 2 it will no longer be configurable and will always use 'string'.
-      headerFormat: 'binary'
+      headerFormat: constants.kafkaHeaderFormatDefault
     }
   },
   secrets: {

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -353,14 +353,16 @@ describe('util.normalizeConfig', () => {
 
   it('should ignore non-string Kafka header format', () => {
     const config = normalizeConfig({ tracing: { kafka: { headerFormat: 13 } } });
-    // before we start phase 1 of the migration, 'binary' will be the default value
-    expect(config.tracing.kafka.headerFormat).to.equal('binary');
+    // During phase 1 of the migration, 'both' will be the default value. In phase 2, the ability to configure the
+    // format will be removed and we will only use the 'string' format.
+    expect(config.tracing.kafka.headerFormat).to.equal('both');
   });
 
   it('should ignore invalid Kafka header format', () => {
     const config = normalizeConfig({ tracing: { kafka: { headerFormat: 'whatever' } } });
-    // before we start phase 1 of the migration, 'binary' will be the default value
-    expect(config.tracing.kafka.headerFormat).to.equal('binary');
+    // During phase 1 of the migration, 'both' will be the default value. In phase 2, the ability to configure the
+    // format will be removed and we will only use the 'string' format.
+    expect(config.tracing.kafka.headerFormat).to.equal('both');
   });
 
   it('should set Kafka header format to binary via INSTANA_KAFKA_HEADER_FORMAT', () => {
@@ -384,8 +386,9 @@ describe('util.normalizeConfig', () => {
   it('should ignore invalid Kafka header format in INSTANA_KAFKA_HEADER_FORMAT', () => {
     process.env.INSTANA_KAFKA_HEADER_FORMAT = 'whatever';
     const config = normalizeConfig();
-    // before we start phase 1 of the migration, 'binary' will be the default value
-    expect(config.tracing.kafka.headerFormat).to.equal('binary');
+    // During phase 1 of the migration, 'both' will be the default value. In phase 2, the ability to configure the
+    // format will be removed and we will only use the 'string' format.
+    expect(config.tracing.kafka.headerFormat).to.equal('both');
   });
 
   it('should accept custom secrets config', () => {
@@ -478,7 +481,7 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.spanBatchingEnabled).to.be.false;
     expect(config.tracing.disableW3cTraceCorrelation).to.be.false;
     expect(config.tracing.kafka.traceCorrelation).to.be.true;
-    expect(config.tracing.kafka.headerFormat).to.equal('binary');
+    expect(config.tracing.kafka.headerFormat).to.equal('both');
     expect(config.secrets).to.be.an('object');
     expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
     expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);

--- a/packages/serverless/src/backend_connector.js
+++ b/packages/serverless/src/backend_connector.js
@@ -231,7 +231,7 @@ function send(resourcePath, payload, finalLambdaRequest, callback) {
     if (disableCaCheck) {
       logger.warn(
         `${disableCaCheckEnvVar} is set, which means that the server certificate will not be verified against ` +
-          'the list of known CAs. This makes your lambda vulnerable to MITM attacks when connecting to Instana. ' +
+          'the list of known CAs. This makes your service vulnerable to MITM attacks when connecting to Instana. ' +
           'This setting should never be used in production, unless you use our on-premises product and are unable to ' +
           'operate the Instana back end with a certificate with a known root CA.'
       );


### PR DESCRIPTION
~~DO NOT MERGE THIS YET!~~

This is the switch to phase 1 of the [Kafka header migration](https://www.ibm.com/docs/en/instana-observability/current?topic=references-kafka-header-migration). The plan is to release this in early October. 

See
https://www.ibm.com/docs/en/instana-observability/current?topic=references-kafka-header-migration
for more information.