### PR TITLE
fix(db2): redact password also from the end of the connection string

### DIFF
--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -185,7 +185,7 @@ exports.sanitizeConnectionStr = function sanitizeConnectionStr(connectionStr) {
     return undefined;
   }
 
-  const replaced = connectionStr.replace(/PWD=.*?(?=;)/, 'PWD=<redacted>');
+  const replaced = connectionStr.replace(/PWD\s*=\s*[^;]*/, 'PWD=<redacted>');
   return replaced;
 };
 


### PR DESCRIPTION
Improves the regex to redact the password by not expecting a subsequent semicolon character after the PWD parameter.

fixes #614