### PR TITLE
chore(sqs, sns): remove fallback to legacy headers

### DIFF
--- a/packages/aws-lambda/src/triggers.js
+++ b/packages/aws-lambda/src/triggers.js
@@ -337,29 +337,14 @@ function readTraceCorrelationFromSqs(event) {
 
 function readTraceCorrelationFromSqsAttributes(attributes) {
   const traceCorrelationData = {};
-  traceCorrelationData.traceId = readSqsMessageAttributeWithFallback(
-    attributes,
-    tracingConstants.sqsAttributeNames.TRACE_ID,
-    tracingConstants.sqsAttributeNames.LEGACY_TRACE_ID
-  );
-  traceCorrelationData.parentId = readSqsMessageAttributeWithFallback(
-    attributes,
-    tracingConstants.sqsAttributeNames.SPAN_ID,
-    tracingConstants.sqsAttributeNames.LEGACY_SPAN_ID
-  );
-  traceCorrelationData.level = readSqsMessageAttributeWithFallback(
-    attributes,
-    tracingConstants.sqsAttributeNames.LEVEL,
-    tracingConstants.sqsAttributeNames.LEGACY_LEVEL
-  );
+  traceCorrelationData.traceId = readSqsMessageAttribute(attributes, tracingConstants.sqsAttributeNames.TRACE_ID);
+  traceCorrelationData.parentId = readSqsMessageAttribute(attributes, tracingConstants.sqsAttributeNames.SPAN_ID);
+  traceCorrelationData.level = readSqsMessageAttribute(attributes, tracingConstants.sqsAttributeNames.LEVEL);
   return traceCorrelationData;
 }
 
-function readSqsMessageAttributeWithFallback(messageAttributes, key, keyFallback) {
-  return (
-    readSqsStringMessageAttribute(messageAttributes, key) ||
-    readSqsStringMessageAttribute(messageAttributes, keyFallback)
-  );
+function readSqsMessageAttribute(messageAttributes, key) {
+  return readSqsStringMessageAttribute(messageAttributes, key);
 }
 
 function readSqsStringMessageAttribute(messageAttributes, key) {

--- a/packages/aws-lambda/test/runtime_mock/index.js
+++ b/packages/aws-lambda/test/runtime_mock/index.js
@@ -611,15 +611,6 @@ function addSqsTracingHeaders(event, trigger) {
     if (process.env.INSTANA_HEADER_L) {
       addSqsMessageAttribute(event, 'x_InStaNa_l', 'INSTANA_HEADER_L');
     }
-    if (process.env.INSTANA_SQS_LEGACY_HEADER_T) {
-      addSqsMessageAttribute(event, 'x_InStaNa_st', 'INSTANA_SQS_LEGACY_HEADER_T');
-    }
-    if (process.env.INSTANA_SQS_LEGACY_HEADER_S) {
-      addSqsMessageAttribute(event, 'x_InStaNa_sS', 'INSTANA_SQS_LEGACY_HEADER_S');
-    }
-    if (process.env.INSTANA_SQS_LEGACY_HEADER_L) {
-      addSqsMessageAttribute(event, 'x_InStaNa_Sl', 'INSTANA_SQS_LEGACY_HEADER_L');
-    }
   } else if (trigger === 'sns-to-sqs') {
     event.Records[0].body = JSON.stringify({
       Type: 'Notification',
@@ -637,15 +628,6 @@ function addSqsTracingHeaders(event, trigger) {
     }
     if (process.env.INSTANA_HEADER_L) {
       addSnsPropertyToSqsMessageBody(event, 'x_InStaNa_l', 'INSTANA_HEADER_L');
-    }
-    if (process.env.INSTANA_SQS_LEGACY_HEADER_T) {
-      addSnsPropertyToSqsMessageBody(event, 'x_InStaNa_st', 'INSTANA_SQS_LEGACY_HEADER_T');
-    }
-    if (process.env.INSTANA_SQS_LEGACY_HEADER_S) {
-      addSnsPropertyToSqsMessageBody(event, 'x_InStaNa_sS', 'INSTANA_SQS_LEGACY_HEADER_S');
-    }
-    if (process.env.INSTANA_SQS_LEGACY_HEADER_L) {
-      addSnsPropertyToSqsMessageBody(event, 'x_InStaNa_Sl', 'INSTANA_SQS_LEGACY_HEADER_L');
     }
   } else {
     throw new Error(`Unknown trigger type: ${trigger}.`);

--- a/packages/collector/test/tracing/cloud/aws-sdk/v2/sqs/sendNonInstrumented.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v2/sqs/sendNonInstrumented.js
@@ -8,54 +8,12 @@
 const { sqs } = require('./sqsUtil');
 
 /*
- * Sends out a message directly to the SQS queue with a given trace ID and parent ID.
- */
-exports.sendMessageWithLegacyHeaders = function sendMessageWithLegacyHeaders(queueURL, traceId, parentId) {
-  return new Promise((resolve, reject) => {
-    const sendParams = {
-      MessageBody: 'message sent via callback function',
-      QueueUrl: queueURL,
-      MessageAttributes: {
-        X_InSTaNa_St: {
-          DataType: 'String',
-          StringValue: traceId
-        },
-        x_insTAnA_sS: {
-          DataType: 'String',
-          StringValue: parentId
-        },
-        X_INSTaNa_SL: {
-          DataType: 'String',
-          StringValue: '1'
-        }
-      }
-    };
-
-    sqs.sendMessage(sendParams, (err, data) => {
-      if (err) {
-        return reject(err);
-      } else {
-        return resolve({
-          status: 'OK-CALLBACK-NOT-INSTRUMENTED',
-          data
-        });
-      }
-    });
-  });
-};
-
-/*
  * Sends a message to the queue that simulates a SNS notification routed into SQS via a SNS/SQS subscription.
  */
-exports.sendSnsNotificationToSqsQueue = function sendSnsNotificationToSqsQueue(
-  queueURL,
-  traceId,
-  parentId,
-  legacyAttributeNames
-) {
-  const traceIdKey = legacyAttributeNames ? 'X_InSTaNa_St' : 'X_InSTaNa_t';
-  const parentIdKey = legacyAttributeNames ? 'x_insTAnA_sS' : 'x_insTAnA_S';
-  const levelKey = legacyAttributeNames ? 'X_INSTaNa_SL' : 'X_INSTaNa_L';
+exports.sendSnsNotificationToSqsQueue = function sendSnsNotificationToSqsQueue(queueURL, traceId, parentId) {
+  const traceIdKey = 'X_InSTaNa_t';
+  const parentIdKey = 'x_insTAnA_S';
+  const levelKey = 'X_INSTaNa_L';
   return new Promise((resolve, reject) => {
     const sendParams = {
       MessageBody: JSON.stringify({

--- a/packages/collector/test/tracing/cloud/aws-sdk/v2/sqs/test.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v2/sqs/test.js
@@ -23,7 +23,7 @@ const {
 } = require('../../../../../../../core/test/test_util');
 const ProcessControls = require('../../../../../test_util/ProcessControls');
 const globalAgent = require('../../../../../globalAgent');
-const { sendMessageWithLegacyHeaders, sendSnsNotificationToSqsQueue } = require('./sendNonInstrumented');
+const { sendSnsNotificationToSqsQueue } = require('./sendNonInstrumented');
 const { verifyHttpRootEntry, verifyHttpExit } = require('@instana/core/test/test_util/common_verifications');
 const defaultPrefix = 'https://sqs.us-east-2.amazonaws.com/410797082306/';
 const queueUrlPrefix = process.env.SQS_QUEUE_URL_PREFIX || defaultPrefix;
@@ -127,14 +127,6 @@ mochaSuiteFn('tracing/cloud/aws-sdk/v2/sqs', function () {
           });
         });
 
-        it('falls back to legacy "S" headers if needed. eg: X_INSTANA_ST instead of X_INSTANA_T', async () => {
-          const traceId = '1234';
-          const spanId = '5678';
-          await sendMessageWithLegacyHeaders(queueURL, traceId, spanId);
-          await verifySingleSqsEntrySpanWithParent(traceId, spanId);
-          await verifyNoUnclosedSpansHaveBeenDetected(receiverControls);
-        });
-
         it('continues trace from a SNS notification routed to an SQS queue via SNS-to-SQS subscription', async () => {
           const traceId = 'abcdef9876543210';
           const spanId = '9876543210abcdef';
@@ -142,18 +134,6 @@ mochaSuiteFn('tracing/cloud/aws-sdk/v2/sqs', function () {
           await verifySingleSqsEntrySpanWithParent(traceId, spanId);
           await verifyNoUnclosedSpansHaveBeenDetected(receiverControls);
         });
-
-        it(
-          'continues trace from a SNS notification routed to an SQS queue via SNS-to-SQS subscription ' +
-            '(legacy headers)',
-          async () => {
-            const traceId = 'abcdef9876543210';
-            const spanId = '9876543210abcdef';
-            await sendSnsNotificationToSqsQueue(queueURL, traceId, spanId, true);
-            await verifySingleSqsEntrySpanWithParent(traceId, spanId);
-            await verifyNoUnclosedSpansHaveBeenDetected(receiverControls);
-          }
-        );
       });
 
       describe(`polling via ${sqsReceiveMethod} when no messages are available`, () => {

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sendNonInstrumented.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sendNonInstrumented.js
@@ -9,54 +9,12 @@ const aws = require('@aws-sdk/client-sqs');
 const sqs = new aws.SQS({ region: 'us-east-2' });
 
 /*
- * Sends out a message directly to the SQS queue with a given trace ID and parent ID.
- */
-exports.sendMessageWithLegacyHeaders = function sendMessageWithLegacyHeaders(queueURL, traceId, parentId) {
-  return new Promise((resolve, reject) => {
-    const sendParams = {
-      MessageBody: 'message sent via callback function',
-      QueueUrl: queueURL,
-      MessageAttributes: {
-        X_InSTaNa_St: {
-          DataType: 'String',
-          StringValue: traceId
-        },
-        x_insTAnA_sS: {
-          DataType: 'String',
-          StringValue: parentId
-        },
-        X_INSTaNa_SL: {
-          DataType: 'String',
-          StringValue: '1'
-        }
-      }
-    };
-
-    sqs.sendMessage(sendParams, (err, data) => {
-      if (err) {
-        return reject(err);
-      } else {
-        return resolve({
-          status: 'OK-CALLBACK-NOT-INSTRUMENTED',
-          data
-        });
-      }
-    });
-  });
-};
-
-/*
  * Sends a message to the queue that simulates a SNS notification routed into SQS via a SNS/SQS subscription.
  */
-exports.sendSnsNotificationToSqsQueue = function sendSnsNotificationToSqsQueue(
-  queueURL,
-  traceId,
-  parentId,
-  legacyAttributeNames
-) {
-  const traceIdKey = legacyAttributeNames ? 'X_InSTaNa_St' : 'X_InSTaNa_t';
-  const parentIdKey = legacyAttributeNames ? 'x_insTAnA_sS' : 'x_insTAnA_S';
-  const levelKey = legacyAttributeNames ? 'X_INSTaNa_SL' : 'X_INSTaNa_L';
+exports.sendSnsNotificationToSqsQueue = function sendSnsNotificationToSqsQueue(queueURL, traceId, parentId) {
+  const traceIdKey = 'X_InSTaNa_t';
+  const parentIdKey = 'x_insTAnA_S';
+  const levelKey = 'X_INSTaNa_L';
   return new Promise((resolve, reject) => {
     const sendParams = {
       MessageBody: JSON.stringify({

--- a/packages/core/src/tracing/constants.js
+++ b/packages/core/src/tracing/constants.js
@@ -68,11 +68,8 @@ exports.SDK = {
 
 exports.sqsAttributeNames = {
   TRACE_ID: 'X_INSTANA_T',
-  LEGACY_TRACE_ID: 'X_INSTANA_ST',
   SPAN_ID: 'X_INSTANA_S',
-  LEGACY_SPAN_ID: 'X_INSTANA_SS',
-  LEVEL: 'X_INSTANA_L',
-  LEGACY_LEVEL: 'X_INSTANA_SL'
+  LEVEL: 'X_INSTANA_L'
 };
 
 exports.snsSqsInstanaHeaderPrefixRegex = /"X_INSTANA_/i;

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/aws_utils.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/aws_utils.js
@@ -20,21 +20,9 @@ function readTracingAttributes(sqsAttributes) {
     return tracingAttributes;
   }
 
-  tracingAttributes.traceId = readMessageAttributeWithFallback(
-    sqsAttributes,
-    sqsAttributeNames.TRACE_ID,
-    sqsAttributeNames.LEGACY_TRACE_ID
-  );
-  tracingAttributes.parentId = readMessageAttributeWithFallback(
-    sqsAttributes,
-    sqsAttributeNames.SPAN_ID,
-    sqsAttributeNames.LEGACY_SPAN_ID
-  );
-  tracingAttributes.level = readMessageAttributeWithFallback(
-    sqsAttributes,
-    sqsAttributeNames.LEVEL,
-    sqsAttributeNames.LEGACY_LEVEL
-  );
+  tracingAttributes.traceId = readMessageAttribute(sqsAttributes, sqsAttributeNames.TRACE_ID);
+  tracingAttributes.parentId = readMessageAttribute(sqsAttributes, sqsAttributeNames.SPAN_ID);
+  tracingAttributes.level = readMessageAttribute(sqsAttributes, sqsAttributeNames.LEVEL);
 
   return tracingAttributes;
 }
@@ -52,21 +40,9 @@ function readTracingAttributesFromSns(messageBody) {
     try {
       const parsedBody = JSON.parse(messageBody);
       if (parsedBody && parsedBody.MessageAttributes) {
-        tracingAttributes.traceId = readMessageAttributeWithFallback(
-          parsedBody.MessageAttributes,
-          sqsAttributeNames.TRACE_ID,
-          sqsAttributeNames.LEGACY_TRACE_ID
-        );
-        tracingAttributes.parentId = readMessageAttributeWithFallback(
-          parsedBody.MessageAttributes,
-          sqsAttributeNames.SPAN_ID,
-          sqsAttributeNames.LEGACY_SPAN_ID
-        );
-        tracingAttributes.level = readMessageAttributeWithFallback(
-          parsedBody.MessageAttributes,
-          sqsAttributeNames.LEVEL,
-          sqsAttributeNames.LEGACY_LEVEL
-        );
+        tracingAttributes.traceId = readMessageAttribute(parsedBody.MessageAttributes, sqsAttributeNames.TRACE_ID);
+        tracingAttributes.parentId = readMessageAttribute(parsedBody.MessageAttributes, sqsAttributeNames.SPAN_ID);
+        tracingAttributes.level = readMessageAttribute(parsedBody.MessageAttributes, sqsAttributeNames.LEVEL);
       }
     } catch (e) {
       // The attempt to parse the message body as JSON failed, so this is not an SQS message resulting from an SNS
@@ -77,9 +53,8 @@ function readTracingAttributesFromSns(messageBody) {
   return tracingAttributes;
 }
 
-function readMessageAttributeWithFallback(attributes, key1, key2) {
-  const attribute =
-    tracingUtil.readAttribCaseInsensitive(attributes, key1) || tracingUtil.readAttribCaseInsensitive(attributes, key2);
+function readMessageAttribute(attributes, key) {
+  const attribute = tracingUtil.readAttribCaseInsensitive(attributes, key);
   if (attribute) {
     // attribute.stringValue is used by SQS message attributes, attribute.Value is used by SNS-to-SQS.
     return attribute.StringValue || attribute.Value;


### PR DESCRIPTION
This is the last step of a multi-year header migration from using X_INSTANA_T/X_INSTANA_S with signed long values over using X_INSTANA_ST/X_INSTANA_SS with string values back to X_INSTANA_T/X_INSTANA_S with string values.

In this final step, we remove the fallback to the legacy header names X_INSTANA_ST/X_INSTANA_SS on the consumer side. Tracers have been sending X_INSTANA_T and X_INSTANA_S with string values since approximately January 2020, so the grace period for updating has been a generous 22 months.