### PR TITLE
feat(aws-lambda): added ES module support

### DIFF
--- a/bin/run-aws-lambda-auto-wrap.sh
+++ b/bin/run-aws-lambda-auto-wrap.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+#######################################
+# (c) Copyright IBM Corp. 2022
+#######################################
+
+set -eo pipefail
+
+lerna exec "npm run test:debug" --scope=instana-aws-lambda-auto-wrap
+

--- a/packages/aws-lambda-auto-wrap/README.md
+++ b/packages/aws-lambda-auto-wrap/README.md
@@ -3,3 +3,5 @@ Instana Auto-Wrapper for Native Tracing of AWS Lambdas
 
 This mainly exists because AWS Lambda handlers cannot be scoped packages.
 
+NOTE: This is an internal package. We have deprecated the NPM package as of Nov 2022.
+      We will remove it from NPM in the next major release.

--- a/packages/aws-lambda-auto-wrap/esm/.eslintrc.js
+++ b/packages/aws-lambda-auto-wrap/esm/.eslintrc.js
@@ -1,0 +1,13 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+module.exports = {
+  extends: '../../../.eslintrc.js',
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'script'
+  }
+};

--- a/packages/aws-lambda-auto-wrap/esm/README.md
+++ b/packages/aws-lambda-auto-wrap/esm/README.md
@@ -1,0 +1,15 @@
+# ES Module support for AWS Lambda
+
+The support for ES modules was added in Node v14.
+See https://aws.amazon.com/about-aws/whats-new/2022/01/aws-lambda-es-modules-top-level-await-node-js-14/
+
+But AWS forgot to add support for layers. There are currently two known bugs:
+
+1. You cannot import an ES module, which is located in a layer. See https://github.com/vibe/aws-esm-modules-layer-support
+2. You cannot define an ES module as handler, which is located in a layer. See AWS support case ID 11226031451.
+
+We are affected by the second bug. When AWS fixes the underlying problem in their AWS runtime, we are able to transform the new esm handler into a real ES module.
+
+For now: We ship the ES handler as commonjs module with the help of dynamic imports.
+
+In 3.x: We remove the aws-lambda-auto-wrap npm package and manually copy over the files in the publish layer script.

--- a/packages/aws-lambda-auto-wrap/esm/index.js
+++ b/packages/aws-lambda-auto-wrap/esm/index.js
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const instana = require('@instana/aws-lambda');
+const localUtils = require('./utils');
+
+const majorNodeVersion = Number(process.versions.node.split('.')[0]);
+
+// CASE: ES support was added in Node v14, throw error if the handler is used in < 14
+// NOTE: The esm handler can be used for Lambdas with commonjs or es module.
+//       See https://github.com/nodejs/node/pull/35249
+// NOTE: Theoretically you can use this handler with Node > 10, because in Node v12
+//       dynamic imports were added. But as soon as we switch to a real ES module
+//       we will no longer use dynamic imports. We might use top level imports.
+if (majorNodeVersion < 14) {
+  throw new localUtils.errors.lambda.ImportModuleError(
+    `ES Module support was added in Node v14. Your Lambda function is using ${majorNodeVersion}.` +
+      "Please use the 'instana-aws-lambda-auto-wrap.handler' as runtime handler."
+  );
+}
+
+exports.handler = async function instanaAutowrapHandler(event, context, callback) {
+  const targetHandler = await loadTargetHandlerFunction();
+  const wrappedHandler = instana.wrap(targetHandler);
+  return wrappedHandler(event, context, callback);
+};
+
+async function loadTargetHandlerFunction() {
+  const {
+    targetHandlerModuleFolder, //
+    targetHandlerModuleName,
+    targetHandlerFunctionName
+  } = localUtils.parseHandlerEnvVar();
+
+  // eslint-disable-next-line no-return-await
+  const targetHandlerModule = await loadTargetHandlerModule(
+    process.env.LAMBDA_TASK_ROOT,
+    targetHandlerModuleFolder,
+    targetHandlerModuleName
+  );
+
+  return localUtils.findHandlerFunctionOnModule(targetHandlerModule, targetHandlerFunctionName);
+}
+
+async function loadTargetHandlerModule(lambdaTaskRoot, targetHandlerModuleFolder, targetHandlerModuleName) {
+  const importPath = localUtils.getImportPath(lambdaTaskRoot, targetHandlerModuleFolder, targetHandlerModuleName);
+
+  try {
+    // NOTE: We use dynamic import for now, because ES modules do not work on layers. See README.md
+    return await import(importPath);
+  } catch (importErr) {
+    if ('MODULE_NOT_FOUND' === importErr.code) {
+      throw new localUtils.errors.lambda.ImportModuleError(importErr);
+    } else if (importErr instanceof SyntaxError) {
+      throw new localUtils.errors.lambda.UserCodeSyntaxError(importErr);
+    } else {
+      throw importErr;
+    }
+  }
+}

--- a/packages/aws-lambda-auto-wrap/esm/utils.js
+++ b/packages/aws-lambda-auto-wrap/esm/utils.js
@@ -1,0 +1,1 @@
+../src/utils.js

--- a/packages/aws-lambda-auto-wrap/package.json
+++ b/packages/aws-lambda-auto-wrap/package.json
@@ -25,9 +25,9 @@
   },
   "scripts": {
     "audit": "bin/prepare-audit.sh && npm audit --production; AUDIT_RESULT=$?; git checkout package-lock.json; exit $AUDIT_RESULT",
-    "test": "true",
-    "test:ci": "true",
-    "test:debug": "true",
+    "test": "NODE_ENV=debug mocha --config=test/.mocharc.js --sort $(find test -iname '*test.js' -not -path '*node_modules*')",
+    "test:debug": "WITH_STDOUT=true npm run test",
+    "test:ci": "echo \"******* Files to be tested:\n $CI_AWS_LAMBDA_AUTO_WRAP_TEST_FILES\" && if [ -z \"${CI_AWS_LAMBDA_AUTO_WRAP_TEST_FILES}\" ]; then echo \"No Files to test in this node\"; else mocha --config=test/.mocharc.js --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json --sort ${CI_LAMBDA_AUTO_WRAP_TEST_FILES}; fi",
     "lint": "eslint src",
     "verify": "npm run lint",
     "prettier": "prettier --write 'src/**/*.js'"

--- a/packages/aws-lambda-auto-wrap/reporter-config.json
+++ b/packages/aws-lambda-auto-wrap/reporter-config.json
@@ -1,0 +1,6 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter, ../core/test/test_util/retryReporter.js",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "../../test-results/aws-lambda-auto-wrap/results.xml"
+  }
+}

--- a/packages/aws-lambda-auto-wrap/src/index.js
+++ b/packages/aws-lambda-auto-wrap/src/index.js
@@ -6,31 +6,7 @@
 'use strict';
 
 const instana = require('@instana/aws-lambda');
-
-const fs = require('fs');
-const path = require('path');
-
-const DEFAULT_HANDLER = 'index.handler';
-const RUNTIME_PATH = '/var/runtime';
-const SPLIT_AT_DOT_REGEX = /^([^.]*)\.(.*)$/;
-const TWO_DOTS = '..';
-
-class HandlerNotFound extends Error {}
-class MalformedHandlerName extends Error {}
-class UserCodeSyntaxError extends Error {}
-class ImportModuleError extends Error {}
-
-let lambdaRuntimeErrors = {
-  HandlerNotFound,
-  MalformedHandlerName,
-  UserCodeSyntaxError,
-  ImportModuleError
-};
-
-// NOTE: Lambda v16 removed the ability to require `Error.js`
-if (Number(process.versions.node.split('.')[0]) < 16) {
-  lambdaRuntimeErrors = require(`${RUNTIME_PATH}/Errors.js`);
-}
+const localUtils = require('./utils');
 
 let wrappedHandler;
 
@@ -44,83 +20,38 @@ exports.handler = function instanaAutowrapHandler(event, context, callback) {
 };
 
 function loadTargetHandlerFunction() {
-  let targetHandlerEnvVar = process.env.LAMBDA_HANDLER;
-  if (!targetHandlerEnvVar || targetHandlerEnvVar.length === 0) {
-    targetHandlerEnvVar = DEFAULT_HANDLER;
-  }
-
   const {
     targetHandlerModuleFolder, //
     targetHandlerModuleName,
     targetHandlerFunctionName
-  } = parseHandlerEnvVar(targetHandlerEnvVar);
+  } = localUtils.parseHandlerEnvVar();
+
   const targetHandlerModule = requireTargetHandlerModule(
     process.env.LAMBDA_TASK_ROOT,
     targetHandlerModuleFolder,
     targetHandlerModuleName
   );
-  const targetHandlerFunction = findHandlerFunctionOnModule(targetHandlerModule, targetHandlerFunctionName);
 
-  if (!targetHandlerFunction) {
-    throw new lambdaRuntimeErrors.HandlerNotFound(`${targetHandlerEnvVar} is undefined or not exported`);
-  }
-  if (typeof targetHandlerFunction !== 'function') {
-    throw new lambdaRuntimeErrors.HandlerNotFound(`${targetHandlerEnvVar} is not a function`);
-  }
-  return targetHandlerFunction;
-}
-
-function parseHandlerEnvVar(targetHandlerEnvVar) {
-  if (targetHandlerEnvVar.indexOf(TWO_DOTS) >= 0) {
-    throw new lambdaRuntimeErrors.MalformedHandlerName(
-      `'${targetHandlerEnvVar}' is not a valid handler name. Use absolute paths when specifying root directories in ` +
-        'handler names.'
-    );
-  }
-  const handlerModuleAndFunction = path.basename(targetHandlerEnvVar);
-  const startIndex = targetHandlerEnvVar.indexOf(handlerModuleAndFunction);
-  const targetHandlerModuleFolder = targetHandlerEnvVar.substring(0, startIndex);
-  const moduleAndFunctionMatch = handlerModuleAndFunction.match(SPLIT_AT_DOT_REGEX);
-  if (!moduleAndFunctionMatch || moduleAndFunctionMatch.length !== 3) {
-    throw new lambdaRuntimeErrors.MalformedHandlerName('Bad handler');
-  }
-  return {
-    targetHandlerModuleFolder, //
-    targetHandlerModuleName: moduleAndFunctionMatch[1],
-    targetHandlerFunctionName: moduleAndFunctionMatch[2]
-  };
+  return localUtils.findHandlerFunctionOnModule(targetHandlerModule, targetHandlerFunctionName);
 }
 
 function requireTargetHandlerModule(lambdaTaskRoot, targetHandlerModuleFolder, targetHandlerModuleName) {
+  const requirePath = localUtils.getImportPath(lambdaTaskRoot, targetHandlerModuleFolder, targetHandlerModuleName);
+
   try {
-    return attemptRequire(lambdaTaskRoot, targetHandlerModuleFolder, targetHandlerModuleName);
+    return require(requirePath);
   } catch (e) {
     if ('MODULE_NOT_FOUND' === e.code) {
-      throw new lambdaRuntimeErrors.ImportModuleError(e);
+      throw new localUtils.errors.lambda.ImportModuleError(e);
+    } else if ('ERR_REQUIRE_ESM' === e.code) {
+      throw new localUtils.errors.lambda.ImportModuleError(
+        'Your Lambda function is using an ES module. ' +
+          "Please use the 'instana-aws-lambda-auto-wrap-esm.handler' as runtime handler."
+      );
     } else if (e instanceof SyntaxError) {
-      throw new lambdaRuntimeErrors.UserCodeSyntaxError(e);
+      throw new localUtils.errors.lambda.UserCodeSyntaxError(e);
     } else {
       throw e;
     }
   }
-}
-
-function attemptRequire(lambdaTaskRoot, targetHandlerModuleFolder, targetHandlerModuleName) {
-  const directPath = path.resolve(lambdaTaskRoot, targetHandlerModuleFolder, targetHandlerModuleName);
-  if (moduleFileExists(directPath)) {
-    return require(directPath);
-  } else {
-    const lookupRoots = { paths: [lambdaTaskRoot, targetHandlerModuleFolder] };
-    const pathWithAlternativeLookupRootFolders = require.resolve(targetHandlerModuleName, lookupRoots);
-    return require(pathWithAlternativeLookupRootFolders);
-  }
-}
-
-function moduleFileExists(m) {
-  return fs.existsSync(`${m}.js`) || fs.existsSync(m);
-}
-
-function findHandlerFunctionOnModule(targetHandlerModuleObject, targetHandlerFunctionName) {
-  const pathToFunction = targetHandlerFunctionName.split('.');
-  return pathToFunction.reduce((obj, pathFragment) => obj && obj[pathFragment], targetHandlerModuleObject);
 }

--- a/packages/aws-lambda-auto-wrap/src/utils.js
+++ b/packages/aws-lambda-auto-wrap/src/utils.js
@@ -1,0 +1,146 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc. and contributors 2019
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const SPLIT_AT_DOT_REGEX = /^([^.]*)\.(.*)$/;
+const TWO_DOTS = '..';
+const DEFAULT_HANDLER = 'index.handler';
+const RUNTIME_PATH = '/var/runtime';
+
+class HandlerNotFound extends Error {}
+class MalformedHandlerName extends Error {}
+class UserCodeSyntaxError extends Error {}
+class ImportModuleError extends Error {}
+
+const lambdaRuntimeErrorsFallback = {
+  HandlerNotFound,
+  MalformedHandlerName,
+  UserCodeSyntaxError,
+  ImportModuleError
+};
+
+let lambdaRuntimeErrors;
+
+const errors = {
+  get lambda() {
+    return getLambdaRuntimeErrors();
+  }
+};
+
+function getLambdaRuntimeErrors() {
+  if (lambdaRuntimeErrors) {
+    return lambdaRuntimeErrors;
+  }
+
+  // NOTE: Lambda v16 removed the ability to require `Error.js`
+  if (Number(process.versions.node.split('.')[0]) < 16) {
+    return require(`${RUNTIME_PATH}/Errors.js`);
+  }
+
+  return lambdaRuntimeErrorsFallback;
+}
+
+function parseHandlerEnvVar() {
+  const targetHandlerEnvVar = getLambdaHandlerEnvVar();
+
+  if (targetHandlerEnvVar.indexOf(TWO_DOTS) >= 0) {
+    throw new errors.lambda.MalformedHandlerName(
+      `'${targetHandlerEnvVar}' is not a valid handler name. Use absolute paths when specifying root directories in ` +
+        'handler names.'
+    );
+  }
+  const handlerModuleAndFunction = path.basename(targetHandlerEnvVar);
+  const startIndex = targetHandlerEnvVar.indexOf(handlerModuleAndFunction);
+  const targetHandlerModuleFolder = targetHandlerEnvVar.substring(0, startIndex);
+  const moduleAndFunctionMatch = handlerModuleAndFunction.match(SPLIT_AT_DOT_REGEX);
+
+  if (!moduleAndFunctionMatch || moduleAndFunctionMatch.length !== 3) {
+    throw new errors.lambda.MalformedHandlerName('Bad handler');
+  }
+
+  return {
+    targetHandlerModuleFolder, //
+    targetHandlerModuleName: moduleAndFunctionMatch[1],
+    targetHandlerFunctionName: moduleAndFunctionMatch[2]
+  };
+}
+
+function getFullModulePath(m) {
+  if (fs.existsSync(`${m}.js`)) {
+    return `${m}.js`;
+  }
+  if (fs.existsSync(`${m}.cjs`)) {
+    return `${m}.cjs`;
+  }
+  // NOTE: We only use the mjs file ending here to be able to throw a good error
+  if (fs.existsSync(`${m}.mjs`)) {
+    return `${m}.mjs`;
+  }
+  if (fs.existsSync(m)) {
+    return m;
+  }
+
+  return false;
+}
+
+function findHandlerFunctionOnModule(targetHandlerModuleObject, targetHandlerFunctionName) {
+  const pathToFunction = targetHandlerFunctionName.split('.');
+  const targetHandlerFunction = pathToFunction.reduce(
+    (obj, pathFragment) => obj && obj[pathFragment],
+    targetHandlerModuleObject
+  );
+
+  if (!targetHandlerFunction) {
+    throw new errors.lambda.HandlerNotFound(`${targetHandlerFunctionName} is undefined or not exported`);
+  }
+
+  if (typeof targetHandlerFunction !== 'function') {
+    throw new errors.lambda.HandlerNotFound(`${targetHandlerFunctionName} is not a function`);
+  }
+
+  return targetHandlerFunction;
+}
+
+function getLambdaHandlerEnvVar() {
+  let targetHandlerEnvVar = process.env.LAMBDA_HANDLER;
+  if (!targetHandlerEnvVar || targetHandlerEnvVar.length === 0) {
+    targetHandlerEnvVar = DEFAULT_HANDLER;
+  }
+
+  return targetHandlerEnvVar;
+}
+
+function getImportPath(lambdaTaskRoot, targetHandlerModuleFolder, targetHandlerModuleName) {
+  const directPath = path.resolve(lambdaTaskRoot, targetHandlerModuleFolder, targetHandlerModuleName);
+  let importPath = getFullModulePath(directPath);
+
+  if (!importPath) {
+    const lookupRoots = { paths: [lambdaTaskRoot, targetHandlerModuleFolder] };
+
+    try {
+      importPath = require.resolve(targetHandlerModuleName, lookupRoots);
+    } catch (resolveErr) {
+      if ('MODULE_NOT_FOUND' === resolveErr.code) {
+        throw new errors.lambda.ImportModuleError(resolveErr);
+      } else {
+        throw resolveErr;
+      }
+    }
+  }
+
+  return importPath;
+}
+
+module.exports = {
+  getLambdaHandlerEnvVar,
+  errors,
+  getImportPath,
+  getFullModulePath,
+  findHandlerFunctionOnModule,
+  parseHandlerEnvVar
+};

--- a/packages/aws-lambda-auto-wrap/test/.eslintrc.js
+++ b/packages/aws-lambda-auto-wrap/test/.eslintrc.js
@@ -1,0 +1,11 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+module.exports = {
+  extends: '../../../.eslintrc.tests.js',
+  // see https://github.com/eslint/eslint/issues/13385#issuecomment-641252879
+  root: true
+};

--- a/packages/aws-lambda-auto-wrap/test/.mocharc.js
+++ b/packages/aws-lambda-auto-wrap/test/.mocharc.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const mochaOptions = {};
+
+if (process.env.CI) {
+  // Retry failed tests once on CI.
+  mochaOptions.retries = 1;
+}
+
+module.exports = mochaOptions;

--- a/packages/aws-lambda-auto-wrap/test/cjs_test.js
+++ b/packages/aws-lambda-auto-wrap/test/cjs_test.js
@@ -1,0 +1,192 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const instana = require('@instana/aws-lambda');
+
+describe('cjs wrapper', function () {
+  before(() => {
+    const Module = require('module');
+    const originalRequire = Module.prototype.require;
+
+    Module.prototype.require = function fakeRequire(path) {
+      if (path === '/var/runtime/Errors.js') {
+        class HandlerNotFound extends Error {}
+        class MalformedHandlerName extends Error {}
+        class UserCodeSyntaxError extends Error {}
+        class ImportModuleError extends Error {}
+
+        const lambdaRuntimeErrors = {
+          HandlerNotFound,
+          MalformedHandlerName,
+          UserCodeSyntaxError,
+          ImportModuleError
+        };
+
+        return lambdaRuntimeErrors;
+      }
+
+      return originalRequire.apply(this, arguments);
+    };
+  });
+
+  beforeEach(() => {
+    sinon.stub(instana, 'wrap').callsFake(function fake(originalHandler) {
+      return function fakeWrapper() {
+        return originalHandler.apply(this, arguments);
+      };
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    delete process.env.LAMBDA_TASK_ROOT;
+    delete process.env.LAMBDA_HANDLER;
+    delete process.env.LAMBDA_HANDLER;
+
+    delete require.cache[require.resolve('../src/index')];
+  });
+
+  it('should not successfully import a module which does not exist', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/doesnotexist';
+
+    try {
+      const wrapper = require('../src/index');
+      await wrapper.handler();
+    } catch (e) {
+      expect(e.message).to.contain("Error: Cannot find module 'index'");
+    }
+
+    expect(instana.wrap.called).to.be.false;
+  });
+
+  it('should not successfully import a malformed handler', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/cjs-1';
+    process.env.LAMBDA_HANDLER = '../hello';
+
+    try {
+      const wrapper = require('../src/index');
+      await wrapper.handler();
+    } catch (e) {
+      expect(e.message).to.contain('is not a valid handler');
+    }
+
+    expect(instana.wrap.called).to.be.false;
+  });
+
+  it('should not successfully import a bad handler', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/cjs-1';
+    process.env.LAMBDA_HANDLER = 'hello';
+
+    try {
+      const wrapper = require('../src/index');
+      await wrapper.handler();
+    } catch (e) {
+      expect(e.message).to.contain('Bad handler');
+    }
+
+    expect(instana.wrap.called).to.be.false;
+  });
+
+  it('should successfully import a CJS module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/cjs-1';
+
+    const wrapper = require('../src/index');
+    const result = await wrapper.handler();
+    expect(result).to.eql(200);
+    expect(instana.wrap.called).to.be.true;
+  });
+
+  it('should successfully import a CJS module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/cjs-2';
+
+    const wrapper = require('../src/index');
+    const result = await wrapper.handler();
+    expect(result).to.eql(200);
+    expect(instana.wrap.called).to.be.true;
+  });
+
+  it('should successfully import a CJS module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/cjs-3';
+    process.env.LAMBDA_HANDLER = 'server.handler';
+
+    const wrapper = require('../src/index');
+    const result = await wrapper.handler();
+    expect(result).to.eql(200);
+    expect(instana.wrap.called).to.be.true;
+  });
+
+  it('should successfully import a CJS module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/cjs-4';
+    process.env.LAMBDA_HANDLER = 'server.handler';
+
+    const wrapper = require('../src/index');
+    const result = await wrapper.handler();
+    expect(result).to.eql(200);
+    expect(instana.wrap.called).to.be.true;
+  });
+
+  it('should not successfully import a CJS module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/cjs-5';
+    process.env.LAMBDA_HANDLER = 'server.handler';
+
+    try {
+      const wrapper = require('../src/index');
+      await wrapper.handler();
+    } catch (e) {
+      expect(e.message).to.eql('handler is undefined or not exported');
+    }
+
+    expect(instana.wrap.called).to.be.false;
+  });
+
+  it('should not successfully import an ES module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/esm-1';
+    process.env.LAMBDA_HANDLER = 'server.handler';
+
+    try {
+      const wrapper = require('../src/index');
+      await wrapper.handler();
+    } catch (e) {
+      expect(e.message).to.eql('SyntaxError: Cannot use import statement outside a module');
+    }
+
+    expect(instana.wrap.called).to.be.false;
+  });
+
+  it('should not successfully import an ES module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/esm-2';
+
+    try {
+      const wrapper = require('../src/index');
+      await wrapper.handler();
+    } catch (e) {
+      expect(e.message).to.eql(
+        'Your Lambda function is using an ES module. ' +
+          "Please use the 'instana-aws-lambda-auto-wrap-esm.handler' as runtime handler."
+      );
+    }
+
+    expect(instana.wrap.called).to.be.false;
+  });
+
+  it('should not successfully import an ES module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/esm-3';
+
+    try {
+      const wrapper = require('../src/index');
+      await wrapper.handler();
+    } catch (e) {
+      expect(e.message).to.eql(
+        'Your Lambda function is using an ES module. ' +
+          "Please use the 'instana-aws-lambda-auto-wrap-esm.handler' as runtime handler."
+      );
+    }
+
+    expect(instana.wrap.called).to.be.false;
+  });
+});

--- a/packages/aws-lambda-auto-wrap/test/esm_test.js
+++ b/packages/aws-lambda-auto-wrap/test/esm_test.js
@@ -1,0 +1,157 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const sinon = require('sinon');
+const semver = require('semver');
+const expect = require('chai').expect;
+const instana = require('@instana/aws-lambda');
+
+describe('esm wrapper', function () {
+  if (semver.lt(process.versions.node, '14.0.0')) {
+    const majorNodeVersion = semver.major(process.versions.node);
+
+    it(`should throw error for Node v${majorNodeVersion}`, () => {
+      try {
+        require('../esm/index');
+      } catch (e) {
+        expect(e.message).to.eql(
+          `ES Module support was added in Node v14. Your Lambda function is using ${majorNodeVersion}.` +
+            "Please use the 'instana-aws-lambda-auto-wrap.handler' as runtime handler."
+        );
+      }
+    });
+
+    return;
+  }
+
+  before(() => {
+    const Module = require('module');
+    const originalRequire = Module.prototype.require;
+
+    Module.prototype.require = function fakeRequire(path) {
+      if (path === '/var/runtime/Errors.js') {
+        class HandlerNotFound extends Error {}
+        class MalformedHandlerName extends Error {}
+        class UserCodeSyntaxError extends Error {}
+        class ImportModuleError extends Error {}
+
+        const lambdaRuntimeErrors = {
+          HandlerNotFound,
+          MalformedHandlerName,
+          UserCodeSyntaxError,
+          ImportModuleError
+        };
+
+        return lambdaRuntimeErrors;
+      }
+
+      return originalRequire.apply(this, arguments);
+    };
+  });
+
+  beforeEach(() => {
+    sinon.stub(instana, 'wrap').callsFake(function fake(originalHandler) {
+      return function fakeWrapper() {
+        return originalHandler.apply(this, arguments);
+      };
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    delete process.env.LAMBDA_TASK_ROOT;
+    delete process.env.LAMBDA_HANDLER;
+    delete process.env.LAMBDA_HANDLER;
+
+    delete require.cache[require.resolve('../esm/index')];
+  });
+
+  it('should not successfully import a module which does not exist', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/doesnotexist';
+
+    try {
+      const wrapper = require('../esm/index');
+      await wrapper.handler();
+    } catch (e) {
+      expect(e.message).to.contain("Cannot find module 'index'");
+    }
+
+    expect(instana.wrap.called).to.be.false;
+  });
+
+  it('should not successfully import an ES module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/esm-1';
+    process.env.LAMBDA_HANDLER = 'server.handler';
+
+    try {
+      const wrapper = require('../esm/index');
+      await wrapper.handler();
+    } catch (e) {
+      expect(e.message).to.eql('SyntaxError: Cannot use import statement outside a module');
+    }
+
+    expect(instana.wrap.called).to.be.false;
+  });
+
+  it('should successfully import an ES module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/esm-2';
+
+    const wrapper = require('../esm/index');
+    const result = await wrapper.handler();
+    expect(result).to.eql(200);
+    expect(instana.wrap.called).to.be.true;
+  });
+
+  it('should successfully import an ES module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/esm-3';
+
+    const wrapper = require('../esm/index');
+    const result = await wrapper.handler();
+    expect(result).to.eql(200);
+    expect(instana.wrap.called).to.be.true;
+  });
+
+  it('should not successfully import an ES module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/esm-4';
+
+    try {
+      const wrapper = require('../esm/index');
+      await wrapper.handler();
+    } catch (e) {
+      expect(e.message).to.contain('handler is undefined or not exported');
+    }
+
+    expect(instana.wrap.called).to.be.false;
+  });
+
+  it('should successfully import a CJS module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/cjs-1';
+
+    const wrapper = require('../esm/index');
+    const result = await wrapper.handler();
+    expect(result).to.eql(200);
+    expect(instana.wrap.called).to.be.true;
+  });
+
+  it('should successfully import a CJS module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/cjs-2';
+
+    const wrapper = require('../esm/index');
+    const result = await wrapper.handler();
+    expect(result).to.eql(200);
+    expect(instana.wrap.called).to.be.true;
+  });
+
+  it('should successfully import a CJS module', async () => {
+    process.env.LAMBDA_TASK_ROOT = 'test/functions/cjs-3';
+    process.env.LAMBDA_HANDLER = 'server.handler';
+
+    const wrapper = require('../esm/index');
+    const result = await wrapper.handler();
+    expect(result).to.eql(200);
+    expect(instana.wrap.called).to.be.true;
+  });
+});

--- a/packages/aws-lambda-auto-wrap/test/functions/cjs-1/index.js
+++ b/packages/aws-lambda-auto-wrap/test/functions/cjs-1/index.js
@@ -1,0 +1,9 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+exports.handler = async () => {
+  return 200;
+};

--- a/packages/aws-lambda-auto-wrap/test/functions/cjs-1/package.json
+++ b/packages/aws-lambda-auto-wrap/test/functions/cjs-1/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/aws-lambda-auto-wrap/test/functions/cjs-2/index.cjs
+++ b/packages/aws-lambda-auto-wrap/test/functions/cjs-2/index.cjs
@@ -1,0 +1,9 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+exports.handler = async () => {
+  return 200;
+};

--- a/packages/aws-lambda-auto-wrap/test/functions/cjs-3/server.cjs
+++ b/packages/aws-lambda-auto-wrap/test/functions/cjs-3/server.cjs
@@ -1,0 +1,9 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+exports.handler = async () => {
+  return 200;
+};

--- a/packages/aws-lambda-auto-wrap/test/functions/cjs-4/server
+++ b/packages/aws-lambda-auto-wrap/test/functions/cjs-4/server
@@ -1,0 +1,9 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+exports.handler = async () => {
+  return 200;
+};

--- a/packages/aws-lambda-auto-wrap/test/functions/cjs-5/server
+++ b/packages/aws-lambda-auto-wrap/test/functions/cjs-5/server
@@ -1,0 +1,9 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+exports.candle = async () => {
+  return 200;
+};

--- a/packages/aws-lambda-auto-wrap/test/functions/esm-1/server.js
+++ b/packages/aws-lambda-auto-wrap/test/functions/esm-1/server.js
@@ -1,0 +1,18 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+import https from 'https';
+
+export const handler = async (event, context) => {
+  const promise = new Promise(function (resolve, reject) {
+    https
+      .get('https://www.instana.com', res => {
+        resolve(res.statusCode);
+      })
+      .on('error', e => {
+        reject(Error(e));
+      });
+  });
+  return promise;
+};

--- a/packages/aws-lambda-auto-wrap/test/functions/esm-2/index.mjs
+++ b/packages/aws-lambda-auto-wrap/test/functions/esm-2/index.mjs
@@ -1,0 +1,18 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+import https from 'https';
+
+export const handler = async (event, context) => {
+  const promise = new Promise(function (resolve, reject) {
+    https
+      .get('https://www.instana.com', res => {
+        resolve(res.statusCode);
+      })
+      .on('error', e => {
+        reject(Error(e));
+      });
+  });
+  return promise;
+};

--- a/packages/aws-lambda-auto-wrap/test/functions/esm-3/index.js
+++ b/packages/aws-lambda-auto-wrap/test/functions/esm-3/index.js
@@ -1,0 +1,18 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+import https from 'https';
+
+export const handler = async (event, context) => {
+  const promise = new Promise(function (resolve, reject) {
+    https
+      .get('https://www.instana.com', res => {
+        resolve(res.statusCode);
+      })
+      .on('error', e => {
+        reject(Error(e));
+      });
+  });
+  return promise;
+};

--- a/packages/aws-lambda-auto-wrap/test/functions/esm-3/package.json
+++ b/packages/aws-lambda-auto-wrap/test/functions/esm-3/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/aws-lambda-auto-wrap/test/functions/esm-4/index.js
+++ b/packages/aws-lambda-auto-wrap/test/functions/esm-4/index.js
@@ -1,0 +1,18 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+import https from 'https';
+
+export const candle = async (event, context) => {
+  const promise = new Promise(function (resolve, reject) {
+    https
+      .get('https://www.instana.com', res => {
+        resolve(res.statusCode);
+      })
+      .on('error', e => {
+        reject(Error(e));
+      });
+  });
+  return promise;
+};

--- a/packages/aws-lambda-auto-wrap/test/functions/esm-4/package.json
+++ b/packages/aws-lambda-auto-wrap/test/functions/esm-4/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/aws-lambda/.eslintignore
+++ b/packages/aws-lambda/.eslintignore
@@ -1,2 +1,3 @@
 **/node_modules/*
 lambdas/serverless-framework/with-serverless-webpack/*
+lambdas/runtime_emulator/esm/*

--- a/packages/aws-lambda/lambdas/runtime_emulator/Dockerfile
+++ b/packages/aws-lambda/lambdas/runtime_emulator/Dockerfile
@@ -12,7 +12,11 @@ COPY --from=instana-layer /opt/extensions/ /opt/extensions/
 COPY --from=instana-layer /opt/nodejs/ /opt/nodejs/
 
 # Copy function code
+# COPY esm/app.js ${LAMBDA_TASK_ROOT}
+# COPY esm/package.json ${LAMBDA_TASK_ROOT}
 COPY app.js ${LAMBDA_TASK_ROOT}
 
+# Use `instana-aws-lambda-auto-wrap-esm` & esm/app.js when testing ES modules
+# CMD [ "instana-aws-lambda-auto-wrap-esm.handler" ]
 CMD [ "instana-aws-lambda-auto-wrap.handler" ]
 

--- a/packages/aws-lambda/lambdas/runtime_emulator/build-and-run.sh
+++ b/packages/aws-lambda/lambdas/runtime_emulator/build-and-run.sh
@@ -73,6 +73,8 @@ docker run \
   --env INSTANA_TIMEOUT=$instana_timeout \
   --env INSTANA_ENDPOINT_URL=$instana_endpoint_url \
   --env INSTANA_AGENT_KEY=$instana_agent_key \
+  # Use the line below if you want to test ES modules. Also checkout the Dockerfile
+  #--env LAMBDA_HANDLER='esm/app.handler' \
   --env LAMBDA_HANDLER=app.handler \
   -p 9000:8080 \
   --name $container_name \

--- a/packages/aws-lambda/lambdas/runtime_emulator/esm/app.js
+++ b/packages/aws-lambda/lambdas/runtime_emulator/esm/app.js
@@ -1,0 +1,18 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+import https from 'https';
+
+export const handler = async (event, context) => {
+  const promise = new Promise(function (resolve, reject) {
+    https
+      .get('https://www.instana.com', res => {
+        resolve(res.statusCode);
+      })
+      .on('error', e => {
+        reject(Error(e));
+      });
+  });
+  return promise;
+};

--- a/packages/aws-lambda/lambdas/runtime_emulator/esm/package.json
+++ b/packages/aws-lambda/lambdas/runtime_emulator/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/aws-lambda/layer/bin/publish-layer.sh
+++ b/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -274,6 +274,12 @@ mkdir -p extensions
 
 cp ../include/$LAMBDA_ARCHITECTURE/instana-lambda-extension extensions/instana-lambda-extension
 
+# ES module support for AWS Lambda
+# We copy the files manually, because we do not have to publish them to NPM
+mkdir nodejs/node_modules/instana-aws-lambda-auto-wrap-esm
+cp ../../../aws-lambda-auto-wrap/esm/index.js nodejs/node_modules/instana-aws-lambda-auto-wrap-esm
+cp ../../../aws-lambda-auto-wrap/src/utils.js nodejs/node_modules/instana-aws-lambda-auto-wrap-esm
+
 echo "step 5/9: creating local zip file with layer contents"
 zip -qr $ZIP_PREFIX .
 mv $ZIP_NAME ..


### PR DESCRIPTION
refs 104472

The plan:

- mark aws-lambda-auto-wrap npm package as deprecated (https://docs.npmjs.com/cli/v8/commands/npm-deprecate)
- remove publishing the package to npm in 3.x
- manually copy the commonjs handler to the layer zip in 3.x
- change the esm handler to a real ES module when AWS has fixed their layer bugs

Todo:

- [x] AWS support confirmed ES module bug in layer
- [x] add a simple test suite
- [x] create utils which both esm & cjs uses
- [x] code quality & code coverage
- [x] test docker container build
- [x] final test on AWS lambda

Docs updates coming soon