### PR TITLE
test(prisma): do not disconnect manually from DB at end of test

### DIFF
--- a/packages/collector/test/tracing/database/prisma/app.js
+++ b/packages/collector/test/tracing/database/prisma/app.js
@@ -98,12 +98,6 @@ app.post('/update', async (req, res) => {
   }
 });
 
-app.post('/disconnect', async (req, res) => {
-  await prisma.$disconnect();
-  ready = false;
-  res.sendStatus(204);
-});
-
 app.listen(process.env.APP_PORT, () => {
   log(`Listening on port: ${process.env.APP_PORT}`);
 });

--- a/packages/collector/test/tracing/database/prisma/test.js
+++ b/packages/collector/test/tracing/database/prisma/test.js
@@ -68,15 +68,6 @@ mochaSuiteFn('tracing/prisma', function () {
       });
 
       after(async () => {
-        // eslint-disable-next-line no-use-before-define
-        if (controls) {
-          // eslint-disable-next-line no-use-before-define
-          await controls.sendRequest({
-            method: 'POST',
-            path: '/disconnect'
-          });
-        }
-
         await fs.rm(schemaTargetFile, { force: true });
         await rimraf(migrationsTargetDir);
       });


### PR DESCRIPTION
We do not need this explicit disconnect step, since we are about to terminate the Prisma integration test app at that point anyway. None of the other DB integration test apps has such a manual disconnect step. Furthermore, a recent CI run failed because the `after` hook of the Prisma test suite failed, leaving the Prisma app running after the test was finished. This blocked the test apps for all subsequent tests from starting (because they all try to open the same port, 3215, and that port was still blocked by the Prisma app.)