### PR TITLE
Fixed db2 cloud tests

### DIFF
--- a/packages/collector/test/tracing/database/db2/app.js
+++ b/packages/collector/test/tracing/database/db2/app.js
@@ -97,7 +97,14 @@ const connect = () => {
     console.log('Successfully connected.');
 
     conn.querySync(`drop table ${DB2_TABLE_NAME_1} if exists`);
-    conn.querySync(`create table ${DB2_TABLE_NAME_1} (COLINT INTEGER, COLDATETIME TIMESTAMP, COLTEXT VARCHAR(255))`);
+
+    const result = conn.querySync(
+      `create table ${DB2_TABLE_NAME_1} (COLINT INTEGER, COLDATETIME TIMESTAMP, COLTEXT VARCHAR(255))`
+    );
+
+    if (!(result instanceof Array)) {
+      throw new Error(result);
+    }
 
     conn.prepare(`SELECT * FROM ${DB2_TABLE_NAME_1}`, (prepareErr, stmtObject) => {
       if (prepareErr) throw prepareErr;
@@ -305,7 +312,7 @@ app.get('/transaction-async', (req, res) => {
 
       // false === commit, true === rollback
       connection.endTransaction(Boolean(commit), function (subSubErr) {
-        if (subErr) return res.status(500).send({ err: subSubErr.message });
+        if (subSubErr) return res.status(500).send({ err: subSubErr.message });
 
         res.status(200).send({ data });
       });


### PR DESCRIPTION
Locally everything worked fine - even with the latest db2 docker image version.
FYI I am unable to connect to the Cloud from localhost because of security issues - I guess related to SSL.

At the end I had to recreate the db2 database.
I found out that I was getting a tablespace error via the Cloud UI when I tried to create a table, but I wasn't able to drop tablespace. The error was not handled in our app.js. I have added a handling to avoid running the tests.

> \"MSV01866.NCPRIKQU\" is an undefined name

There were ~20 tables, which were not cleaned up during broken builds. I guess we somehow reached space and their UI wasn't able to help me cleaning the target db.