### PR TITLE
fix(collector): resolved elasticsearch legacy error "Cannot read property 'master' of undefined"

### DIFF
--- a/packages/core/src/tracing/instrumentation/database/elasticsearchLegacy.js
+++ b/packages/core/src/tracing/instrumentation/database/elasticsearchLegacy.js
@@ -40,6 +40,10 @@ function instrument(es) {
 
     return client;
   };
+
+  Object.keys(OriginalClient).forEach(key => {
+    es.Client[key] = OriginalClient[key];
+  });
 }
 
 function gatherClusterInfo(client, clusterInfo) {


### PR DESCRIPTION
Otherwise the overridden Client will loose properties such as:

```
require('@instana/collector')
const es = require('elasticsearch')
console.log(es.Client.apis.master)
```