### PR TITLE
chore(aws-lambda): do not use `setTimeout` for span buffer

### DIFF
--- a/packages/aws-lambda/src/wrapper.js
+++ b/packages/aws-lambda/src/wrapper.js
@@ -374,7 +374,6 @@ function postHandler(entrySpan, error, result, callback) {
   spanBuffer.setTransmitImmediate(true);
 
   const metricsData = metrics.gatherData();
-
   const metricsPayload = {
     plugins: [{ name: 'com.instana.plugin.aws.lambda', entityId: identityProvider.getEntityId(), data: metricsData }]
   };

--- a/packages/aws-lambda/test/long_running/test.js
+++ b/packages/aws-lambda/test/long_running/test.js
@@ -95,14 +95,14 @@ describe('long running lambdas', () => {
         ]).then(([spans, metrics, rawBundles, rawSpanArrays]) => {
           verifySpans(spans, opts);
           verifyMetrics(metrics);
-          // The lambda runs 13 seconds and creates a span every second. We also send spans to serverless acceptor
-          // every second + the final bundle. Thus, we should see around 11-12 intermittent POST requests to /traces and
-          // one to /bundle.
+
+          // The lambda runs x seconds and creates a span every second.
+          // We send all these spans in the the final bundle.
           expect(rawSpanArrays).to.be.an('array');
-          expect(rawSpanArrays).to.have.lengthOf.at.least(10);
-          expect(rawSpanArrays).to.have.lengthOf.at.most(13);
+          expect(rawSpanArrays).to.have.lengthOf(0);
           expect(rawBundles).to.be.an('array');
           expect(rawBundles).to.have.lengthOf(1);
+          expect(rawBundles[0].spans).to.have.lengthOf(14);
         });
       }));
   });

--- a/packages/aws-lambda/test/long_running/test.js
+++ b/packages/aws-lambda/test/long_running/test.js
@@ -144,6 +144,7 @@ describe('long running lambdas', () => {
         const duration = Date.now() - control.startedAt;
         verifyResponse(control);
         expect(duration).to.be.at.most(opts.expectedLambdaRuntime);
+
         return Promise.all([
           //
           control.getSpans(),
@@ -154,15 +155,9 @@ describe('long running lambdas', () => {
         ]).then(([spans, metrics, rawBundles, rawSpanArrays, rawMetrics]) => {
           expect(spans).to.have.lengthOf(0);
           expect(metrics).to.have.lengthOf(0);
-
-          // The first POST /spans fails...
-          expect(rawSpanArrays).to.have.lengthOf(1);
-          // ...and we expect @instana/aws-lambda to stop sending spans after that. In particular, we expect the
-          // POST /bundle at the end to not happen.
-          expect(rawBundles).to.have.lengthOf(0);
-
-          // @instana/aws-lambda never sends metrics while running, it only reports them at the end together with the
-          // bundle.
+          expect(rawSpanArrays).to.have.lengthOf(0);
+          expect(rawBundles).to.have.lengthOf(1);
+          expect(rawBundles[0].spans).to.have.lengthOf(31);
           expect(rawMetrics).to.have.lengthOf(0);
         });
       }));

--- a/packages/aws-lambda/test/multiple_data/lambda.js
+++ b/packages/aws-lambda/test/multiple_data/lambda.js
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const instana = require('../..');
+
+const https = require('https');
+const url = 'https://www.instana.com';
+
+const sendReq = async () => {
+  return new Promise(function (resolve, reject) {
+    https
+      .get(url, () => {
+        resolve();
+      })
+      .on('error', e => {
+        reject(Error(e));
+      });
+  });
+};
+
+exports.handler = instana.wrap(async () => {
+  await sendReq();
+  await sendReq();
+  await sendReq();
+
+  setTimeout(async () => {
+    await sendReq();
+  }, 500);
+
+  setTimeout(async () => {
+    await sendReq();
+  }, 1000);
+
+  return {
+    statusCode: 200,
+    body: {
+      message: 'Stan says hi!'
+    }
+  };
+});

--- a/packages/aws-lambda/test/multiple_data/test.js
+++ b/packages/aws-lambda/test/multiple_data/test.js
@@ -1,0 +1,128 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const { expect } = require('chai');
+const path = require('path');
+const constants = require('@instana/core').tracing.constants;
+
+const Control = require('../Control');
+const { delay, expectExactlyNMatching, expectExactlyOneMatching } = require('../../../core/test/test_util');
+const config = require('../../../serverless/test/config');
+
+const functionName = 'functionName';
+const unqualifiedArn = `arn:aws:lambda:us-east-2:410797082306:function:${functionName}`;
+const version = '$LATEST';
+const qualifiedArn = `${unqualifiedArn}:${version}`;
+
+const backendPort = 8443;
+const backendBaseUrl = `https://localhost:${backendPort}/serverless`;
+const downstreamDummyPort = 3456;
+const downstreamDummyUrl = `http://localhost:${downstreamDummyPort}/`;
+const instanaAgentKey = 'aws-lambda-dummy-key';
+
+describe('multiple data lambda handler', function () {
+  this.timeout(config.getTestTimeout());
+  const control = new Control({
+    faasRuntimePath: path.join(__dirname, '../runtime_mock'),
+    handlerDefinitionPath: path.join(__dirname, './lambda'),
+    startBackend: true,
+    backendPort,
+    backendBaseUrl,
+    downstreamDummyUrl,
+    env: {
+      INSTANA_ENDPOINT_URL: backendBaseUrl,
+      INSTANA_AGENT_KEY: instanaAgentKey,
+      WITH_CONFIG: 'true'
+    }
+  });
+
+  control.registerTestHooks();
+
+  it('must capture metrics and all spans', () =>
+    control
+      .runHandler()
+      .then(() => {
+        const duration = Date.now() - control.startedAt;
+        expect(duration).to.be.at.most(1000 * 2);
+        verifyResponse(1);
+      })
+      .then(() => {
+        return delay(1000 * 4);
+      })
+      .then(() => {
+        return Promise.all([
+          //
+          control.getSpans(),
+          control.getRawBundles(),
+          control.getRawSpanArrays()
+        ]).then(([spans, rawBundles, rawSpanArrays]) => {
+          verifySpans(spans);
+          expect(rawSpanArrays).to.be.an('array');
+          expect(rawSpanArrays).to.have.lengthOf(2);
+          expect(rawBundles).to.be.an('array');
+          expect(rawBundles).to.have.lengthOf.at.least(1);
+          expect(rawBundles).to.have.lengthOf.at.most(4);
+        });
+      }));
+
+  function verifyResponse(numberOfResults) {
+    /* eslint-disable no-console */
+    if (control.getLambdaErrors() && control.getLambdaErrors().length > 0) {
+      console.log('Unexpected Errors:');
+      console.log(JSON.stringify(control.getLambdaErrors()));
+    }
+    expect(control.getLambdaErrors()).to.be.empty;
+    const results = control.getLambdaResults();
+    expect(results.length).to.equal(numberOfResults);
+    for (let i = 0; i < results.length; i++) {
+      const result = control.getLambdaResults()[i];
+      expect(result).to.exist;
+      const body = result.body;
+      expect(body.message).to.equal('Stan says hi!');
+    }
+  }
+
+  function verifySpans(spans) {
+    verifyLambdaEntries(spans);
+    verifyHttpExit(spans);
+  }
+
+  function verifyHttpExit(spans) {
+    return expectExactlyNMatching(spans, 5, span => {
+      expect(span.s).to.exist;
+      expect(span.n).to.equal('node.http.client');
+      expect(span.k).to.equal(constants.EXIT);
+      expect(span.f).to.be.an('object');
+      expect(span.f.h).to.not.exist;
+      expect(span.f.hl).to.be.true;
+      expect(span.f.cp).to.equal('aws');
+      expect(span.data.http).to.be.an('object');
+      expect(span.data.http.method).to.equal('GET');
+      expect(span.data.http.url).to.equal('https://www.instana.com/');
+    });
+  }
+
+  function verifyLambdaEntries(spans) {
+    return expectExactlyOneMatching(spans, span => {
+      expect(span.t).to.exist;
+      expect(span.p).to.not.exist;
+      expect(span.s).to.exist;
+      expect(span.n).to.equal('aws.lambda.entry');
+      expect(span.k).to.equal(constants.ENTRY);
+      expect(span.f).to.be.an('object');
+      expect(span.f.h).to.not.exist;
+      expect(span.f.hl).to.be.true;
+      expect(span.f.cp).to.equal('aws');
+      expect(span.f.e).to.equal(qualifiedArn);
+      expect(span.async).to.not.exist;
+      expect(span.data.lambda).to.be.an('object');
+      expect(span.data.lambda.runtime).to.equal('nodejs');
+      expect(span.data.lambda.error).to.not.exist;
+      expect(span.error).to.not.exist;
+      expect(span.ec).to.equal(0);
+    });
+  }
+});

--- a/packages/core/test/tracing/spanBuffer_test.js
+++ b/packages/core/test/tracing/spanBuffer_test.js
@@ -6,8 +6,9 @@
 'use strict';
 
 const { expect } = require('chai');
-
+const sinon = require('sinon');
 const spanBuffer = require('../../src/tracing/spanBuffer');
+const delay = require('../test_util/delay');
 const { generateRandomSpanId, generateRandomTraceId } = require('../../src/tracing/tracingUtil');
 
 describe('tracing/spanBuffer', () => {
@@ -17,30 +18,47 @@ describe('tracing/spanBuffer', () => {
   const traceId2 = generateRandomTraceId();
   const parentId1 = generateRandomSpanId();
   const parentId2 = generateRandomSpanId();
+  let downstreamConnectionStub;
 
-  before(() => {
-    spanBuffer.init(
-      {
-        tracing: {
-          maxBufferedSpans: 1000,
-          forceTransmissionStartingAt: 500,
-          transmissionDelay: 1000
-        }
-      },
-      {
-        /* downstreamConnection */
-        sendSpans: function () {}
-      }
-    );
-    spanBuffer.addBatchableSpanName('batchable');
-  });
+  describe('isFaaS: true', () => {
+    before(() => {
+      sinon.spy(global, 'setTimeout');
 
-  beforeEach(() => spanBuffer.activate());
+      downstreamConnectionStub = {
+        sendSpans: sinon.stub()
+      };
 
-  afterEach(() => spanBuffer.deactivate());
+      spanBuffer.init(
+        {
+          tracing: {
+            maxBufferedSpans: 1000,
+            forceTransmissionStartingAt: 500,
+            transmissionDelay: 1000
+          }
+        },
+        downstreamConnectionStub
+      );
 
-  describe('adding spans', () => {
-    it('should add span', () => {
+      spanBuffer.setIsFaaS(true);
+      spanBuffer.addBatchableSpanName('batchable');
+    });
+
+    beforeEach(() => {
+      spanBuffer.activate();
+      expect(global.setTimeout.called).to.be.false;
+
+      global.setTimeout.resetHistory();
+    });
+
+    afterEach(() => {
+      spanBuffer.deactivate();
+    });
+
+    after(() => {
+      sinon.restore();
+    });
+
+    it('should add span and send not immediately', () => {
       const span = {
         n: 'some-span-name',
         t: traceId1,
@@ -54,383 +72,499 @@ describe('tracing/spanBuffer', () => {
 
       const spans = spanBuffer.getAndResetSpans();
       expect(spans).to.have.lengthOf(1);
-      expect(spans[0]).to.equal(span);
+      expect(downstreamConnectionStub.sendSpans.called).to.be.false;
+      expect(global.setTimeout.called).to.be.false;
+    });
+
+    it('should add span and send immediately', () => {
+      spanBuffer.setTransmitImmediate(true);
+
+      const span = {
+        n: 'some-span-name',
+        t: traceId1,
+        p: parentId1,
+        s: '1',
+        ts: timestamp(Date.now()),
+        d: 47,
+        ec: 0
+      };
+      spanBuffer.addSpan(span);
+
+      const spans = spanBuffer.getAndResetSpans();
+      expect(spans).to.have.lengthOf(0);
+      expect(downstreamConnectionStub.sendSpans.called).to.be.true;
+      expect(global.setTimeout.called).to.be.false;
     });
   });
 
-  describe('batching', () => {
-    // Batching is opt-in for now, thus we need to explicitly enable it. The before-hook calling spanBuffer.init and
-    // the beforeEach/afterEach calling activate/deactivate can be removed here when it becomes opt-out. (There is
-    // an init call in the before-hook for the whole spanBuffer suite.)
-
+  describe('isFaaS: false', () => {
     before(() => {
+      sinon.spy(global, 'setTimeout');
+
+      downstreamConnectionStub = {
+        sendSpans: sinon.stub()
+      };
+
       spanBuffer.init(
         {
           tracing: {
             maxBufferedSpans: 1000,
-            forceTransmissionStartingAt: 500,
-            transmissionDelay: 1000,
-            spanBatchingEnabled: true
+            forceTransmissionStartingAt: 2,
+            transmissionDelay: 200
           }
         },
-        {
-          /* downstreamConnection */
-          sendSpans: function () {}
-        }
+        downstreamConnectionStub
       );
+
       spanBuffer.addBatchableSpanName('batchable');
     });
 
-    beforeEach(() => spanBuffer.activate());
+    beforeEach(() => {
+      spanBuffer.activate();
+      expect(global.setTimeout.called).to.be.true;
+      global.setTimeout.resetHistory();
+    });
 
-    afterEach(() => spanBuffer.deactivate());
+    afterEach(() => {
+      spanBuffer.deactivate();
+    });
 
-    describe('batching enabled', () => {
-      it('should not merge a new span with duration 10 ms or longer', () => {
-        const [span1, span2] = createSpans(7, 5, 10);
-        verifyNoBatching(span1, span2);
-      });
+    after(() => {
+      sinon.restore();
+    });
 
-      it('should not merge a new a root span', () => {
-        const [span1, span2] = createSpans(7, 5, 6);
-        delete span2.p;
-        verifyNoBatching(span1, span2);
-      });
-
-      it('should not merge a new unbatchable span', () => {
-        const [span1, span2] = createSpans(7, 5, 6);
-        span2.n = 'not-batchable'; // not in span buffers list of batcheable span types
-        verifyNoBatching(span1, span2);
-      });
-
-      it('should not merge with an existing span with duration 10 ms or longer', () => {
-        const [span1, span2] = createSpans(10, 5, 6);
-        verifyNoBatching(span1, span2);
-      });
-
-      it('should not merge spans from different traces', () => {
-        const [span1, span2] = createSpans(7, 5, 6);
-        span2.t = traceId2;
-        verifyNoBatching(span1, span2);
-      });
-
-      it('should not merge spans from with different parents', () => {
-        const [span1, span2] = createSpans(7, 5, 6);
-        span2.p = parentId2;
-        verifyNoBatching(span1, span2);
-      });
-
-      it('should not merge with an existing span of a of different type', () => {
-        const [span1, span2] = createSpans(7, 5, 6);
-        span2.t = 'other';
-        verifyNoBatching(span1, span2);
-      });
-
-      it('should not merge when the gap is 10 ms or longer', () => {
-        const [span1, span2] = createSpans(7, 10, 6);
-        verifyNoBatching(span1, span2);
-      });
-
-      it('should not merge when the gap is 10 ms or longer (chronologically later span comes in first)', () => {
-        const [span1, span2] = createSpans(7, 10, 6);
-        verifyNoBatching(span2, span1);
-      });
-
-      it('should merge two spans', () => {
-        const [span1, span2] = createSpans(7, 5, 6);
-
-        const batched = verifyBatching(span1, span2);
-
-        expect(batched).to.equal(span1);
-        expect(batched.s).to.equal('1');
-        expect(batched.ts).to.equal(timestamp(0));
-        expect(batched.d).to.equal(18);
-        expect(batched.b.s).to.equal(2);
-        expect(batched.b.d).to.equal(13);
-      });
-
-      it('should merge two spans with max distance and all possible  offsets to bucket borders', () => {
-        const bucketWidth = 18;
-        for (let offset = 0; offset <= bucketWidth + 1; offset++) {
-          const [span1, span2] = createSpans(9, 9, 9, offset);
-          const batched = verifyBatching(span1, span2);
-          expect(batched).to.equal(span1);
-          expect(batched.s).to.equal('1');
-          expect(batched.ts).to.equal(timestamp(offset));
-          expect(batched.d).to.equal(27);
-          expect(batched.b.s).to.equal(2);
-          expect(batched.b.d).to.equal(18);
-        }
-      });
-
-      it('should merge multiple consecutive spans', () => {
-        const span1 = createSpan(0, 7, '1'); // 1000-1007
-        const span2 = createSpan(14, 8, '2'); // 1014-1022
-        const span3 = createSpan(31, 3, '3'); // 1031-1034
-        const span4 = createSpan(40, 5, '4'); // 1040-1045
-
-        spanBuffer.addSpan(span1);
-        spanBuffer.addSpan(span2);
-        spanBuffer.addSpan(span3);
-        spanBuffer.addSpan(span4);
+    describe('adding spans', () => {
+      it('should add span and not send immediately', () => {
+        const span = {
+          n: 'some-span-name',
+          t: traceId1,
+          p: parentId1,
+          s: '1',
+          ts: timestamp(Date.now()),
+          d: 47,
+          ec: 0
+        };
+        spanBuffer.addSpan(span);
 
         const spans = spanBuffer.getAndResetSpans();
         expect(spans).to.have.lengthOf(1);
-        const batched = spans[0];
+        expect(spans[0]).to.equal(span);
 
-        expect(batched).to.equal(span2);
-        expect(batched.s).to.equal('2');
-        expect(batched.ts).to.equal(timestamp(0));
-        expect(batched.d).to.equal(45);
-        expect(batched.b.s).to.equal(4);
-        expect(batched.b.d).to.equal(23);
+        expect(downstreamConnectionStub.sendSpans.called).to.be.false;
+        expect(global.setTimeout.called).to.be.false;
       });
 
-      it('span with ec != 0 should be more significant', () => {
-        let span1;
-        let span2;
-        let batched;
+      it('should add span and send immediately', async () => {
+        // NOTE: wait for the initial timeout to occur, otherwise it will send out our spans to test
+        await delay(1100);
+        downstreamConnectionStub.sendSpans.resetHistory();
 
-        [span1, span2] = createSpans(7, 5, 6);
-        span1.ec = 1;
-        batched = verifyBatching(span1, span2);
-        expect(batched).to.equal(span1);
-        expect(batched.s).to.equal('1');
-        expect(batched.ec).to.equal(1);
+        const span1 = {
+          n: 'some-span-name-1',
+          t: traceId1,
+          p: parentId1,
+          s: '1',
+          ts: timestamp(Date.now()),
+          d: 47,
+          ec: 0
+        };
+        const span2 = {
+          n: 'some-span-name-2',
+          t: traceId1,
+          p: parentId1,
+          s: '1',
+          ts: timestamp(Date.now()),
+          d: 47,
+          ec: 0
+        };
 
-        [span1, span2] = createSpans(7, 5, 6);
-        span2.ec = 1;
-        batched = verifyBatching(span1, span2);
-        expect(batched).to.equal(span2);
-        expect(batched.s).to.equal('2');
-        expect(batched.ec).to.equal(1);
-
-        // error count has higher priority than duration
-        [span1, span2] = createSpans(3, 5, 4);
-        span1.ec = 1;
-        batched = verifyBatching(span1, span2);
-        expect(batched).to.equal(span1);
-        expect(batched.s).to.equal('1');
-        expect(batched.ec).to.equal(1);
-      });
-
-      it('longer span should be more significant', () => {
-        let span1;
-        let span2;
-        let batched;
-
-        [span1, span2] = createSpans(7, 5, 6);
-        batched = verifyBatching(span1, span2);
-        expect(batched).to.equal(span1);
-        expect(batched.s).to.equal('1');
-        expect(batched.d).to.equal(18);
-        expect(batched.b.d).to.equal(13);
-
-        [span1, span2] = createSpans(6, 5, 7);
-        batched = verifyBatching(span1, span2);
-        expect(batched).to.equal(span2);
-        expect(batched.s).to.equal('2');
-        expect(batched.d).to.equal(18);
-        expect(batched.b.d).to.equal(13);
-      });
-
-      it('span starting earlier should be more significant (chronologically later span comes in first)', () => {
-        const [span1, span2] = createSpans(5, 7, 5);
+        spanBuffer.addSpan(span1);
+        expect(spanBuffer.isEmpty()).to.be.false;
 
         spanBuffer.addSpan(span2);
-        spanBuffer.addSpan(span1); // adding span1 later than span2
+        expect(spanBuffer.isEmpty()).to.be.true;
 
-        // Note: The algorithm we use is optimized by only guaranteeing that spans that can be batched are batched if
-        // the arrive in the correct order in the span buffer. So in general the case where the span that starts earlier
-        // is not guaranteed to be batched. This particular case works because both spans land in the same bucket.
-
-        // Even though span1 arrived later, both spans should still merge into span1, because that started earlier
-        // according to span1.ts
-        const batched = expectBatching();
-        expect(batched).to.equal(span1);
-        expect(batched.s).to.equal('1');
-        expect(batched.ts).to.equal(timestamp(0));
-        expect(batched.d).to.equal(17);
-        expect(batched.b.s).to.equal(2);
-        expect(batched.b.d).to.equal(10);
-      });
-
-      it('should determine batch duration', () => {
-        let span1;
-        let span2;
-        let batched;
-
-        // target span is a batched span itself
-        [span1, span2] = createSpans(7, 5, 6);
-        span1.b = { d: 22 };
-        batched = verifyBatching(span1, span2);
-        expect(batched.b.d).to.equal(28); // 22 + 6
-
-        // source span is a batched span itself
-        [span1, span2] = createSpans(7, 5, 6);
-        span2.b = { d: 22 };
-        batched = verifyBatching(span1, span2);
-        expect(batched.b.d).to.equal(29); // 22 + 7
-
-        // both spans are a batched span
-        [span1, span2] = createSpans(7, 5, 6);
-        span1.b = { d: 27 };
-        span2.b = { d: 28 };
-        batched = verifyBatching(span1, span2);
-        expect(batched.b.d).to.equal(55);
-      });
-
-      it('should determine timestamp and span duration', () => {
-        let span1;
-        let span2;
-        let batched;
-
-        // cases
-        // ------------------------------------------> time
-        //
-        // gap between spans, target span started earlier
-        // | target |           | source |
-        //          |----gap----|
-        [span1, span2] = createSpans(8, 3, 4);
-        span1.ec = 1; // throughout this test we use span.ec to control which span becomes the target span
-        batched = verifyBatching(span1, span2);
-        expect(batched.ts).to.equal(timestamp(0));
-        expect(batched.d).to.equal(15);
-        // gap between spans, source span started earlier
-        // | source |           | target |
-        //          |----gap----|
-        [span1, span2] = createSpans(8, 3, 4);
-        span2.ec = 1;
-        batched = verifyBatching(span1, span2);
-        expect(batched.ts).to.equal(timestamp(0));
-        expect(batched.d).to.equal(15);
-
-        // no gap between spans, target span started earlier
-        // | target | source |
-        [span1, span2] = createSpans(8, 0, 4);
-        span1.ec = 1;
-        batched = verifyBatching(span1, span2);
-        expect(batched.ts).to.equal(timestamp(0));
-        expect(batched.d).to.equal(12);
-        // no gap between spans, source span started earlier
-        // | source | target |
-        [span1, span2] = createSpans(8, 0, 4);
-        span2.ec = 1;
-        batched = verifyBatching(span1, span2);
-        expect(batched.ts).to.equal(timestamp(0));
-        expect(batched.d).to.equal(12);
-
-        // overlapping spans, target span started earlier
-        // | target |
-        //     | source |
-        [span1, span2] = createSpans(8, -3, 7);
-        span1.ec = 1;
-        batched = verifyBatching(span1, span2);
-        expect(batched.ts).to.equal(timestamp(0));
-        expect(batched.d).to.equal(12);
-        // overlapping spans, source span started earlier
-        // | source |
-        //     | target |
-        [span1, span2] = createSpans(8, -3, 7);
-        span2.ec = 1;
-        batched = verifyBatching(span1, span2);
-        expect(batched.ts).to.equal(timestamp(0));
-        expect(batched.d).to.equal(12);
-
-        // one spans "contains" the other
-        // |     target      |
-        //     | source |
-        [span1, span2] = createSpans(9, 0, 4);
-        span2.ts = timestamp(2);
-        span1.ec = 1;
-        batched = verifyBatching(span1, span2);
-        expect(batched.ts).to.equal(timestamp(0));
-        expect(batched.d).to.equal(9);
-        // |     source      |
-        //     | target |
-        [span1, span2] = createSpans(9, 0, 4);
-        span2.ts = timestamp(2);
-        span2.ec = 1;
-        batched = verifyBatching(span1, span2);
-        expect(batched.ts).to.equal(timestamp(0));
-        expect(batched.d).to.equal(9);
-      });
-
-      it('should determine error count', () => {
-        let span1;
-        let span2;
-        let batched;
-
-        [span1, span2] = createSpans(7, 5, 6);
-        span1.ec = 3;
-        batched = verifyBatching(span1, span2);
-        expect(batched.ec).to.equal(3);
-
-        [span1, span2] = createSpans(7, 5, 6);
-        span2.ec = 4;
-        batched = verifyBatching(span1, span2);
-        expect(batched.ec).to.equal(4);
-
-        [span1, span2] = createSpans(7, 5, 6);
-        span1.ec = 3;
-        span2.ec = 4;
-        batched = verifyBatching(span1, span2);
-        expect(batched.ec).to.equal(7);
-      });
-
-      it('should determine batch size', () => {
-        let span1;
-        let span2;
-        let batched;
-
-        // target span is a batched span itself
-        [span1, span2] = createSpans(7, 5, 6);
-        span1.b = { s: 7 };
-        batched = verifyBatching(span1, span2);
-        expect(batched.b.s).to.equal(8);
-
-        // source span is a batched span itself
-        [span1, span2] = createSpans(7, 5, 6);
-        span2.b = { s: 7 };
-        batched = verifyBatching(span1, span2);
-        expect(batched.b.s).to.equal(8);
-
-        // both spans are a batched span
-        [span1, span2] = createSpans(7, 5, 6);
-        span1.b = { s: 7 };
-        span2.b = { s: 8 };
-        batched = verifyBatching(span1, span2);
-        expect(batched.b.s).to.equal(15);
+        expect(downstreamConnectionStub.sendSpans.called).to.be.true;
+        expect(global.setTimeout.called).to.be.true;
       });
     });
-  });
 
-  describe('batching disabled', () => {
-    before(() => {
-      spanBuffer.init(
-        {
-          tracing: {
-            maxBufferedSpans: 1000,
-            forceTransmissionStartingAt: 500,
-            transmissionDelay: 1000,
-            spanBatchingEnabled: false
+    describe('batching', () => {
+      // Batching is opt-in for now, thus we need to explicitly enable it. The before-hook calling spanBuffer.init and
+      // the beforeEach/afterEach calling activate/deactivate can be removed here when it becomes opt-out. (There is
+      // an init call in the before-hook for the whole spanBuffer suite.)
+
+      before(() => {
+        spanBuffer.init(
+          {
+            tracing: {
+              maxBufferedSpans: 1000,
+              forceTransmissionStartingAt: 500,
+              transmissionDelay: 1000,
+              spanBatchingEnabled: true
+            }
+          },
+          {
+            /* downstreamConnection */
+            sendSpans: function () {}
           }
-        },
-        {
-          /* downstreamConnection */
-          sendSpans: function () {}
-        }
-      );
-      spanBuffer.addBatchableSpanName('batchable');
+        );
+        spanBuffer.addBatchableSpanName('batchable');
+      });
+
+      beforeEach(() => spanBuffer.activate());
+
+      afterEach(() => spanBuffer.deactivate());
+
+      describe('batching enabled', () => {
+        it('should not merge a new span with duration 10 ms or longer', () => {
+          const [span1, span2] = createSpans(7, 5, 10);
+          verifyNoBatching(span1, span2);
+        });
+
+        it('should not merge a new a root span', () => {
+          const [span1, span2] = createSpans(7, 5, 6);
+          delete span2.p;
+          verifyNoBatching(span1, span2);
+        });
+
+        it('should not merge a new unbatchable span', () => {
+          const [span1, span2] = createSpans(7, 5, 6);
+          span2.n = 'not-batchable'; // not in span buffers list of batcheable span types
+          verifyNoBatching(span1, span2);
+        });
+
+        it('should not merge with an existing span with duration 10 ms or longer', () => {
+          const [span1, span2] = createSpans(10, 5, 6);
+          verifyNoBatching(span1, span2);
+        });
+
+        it('should not merge spans from different traces', () => {
+          const [span1, span2] = createSpans(7, 5, 6);
+          span2.t = traceId2;
+          verifyNoBatching(span1, span2);
+        });
+
+        it('should not merge spans from with different parents', () => {
+          const [span1, span2] = createSpans(7, 5, 6);
+          span2.p = parentId2;
+          verifyNoBatching(span1, span2);
+        });
+
+        it('should not merge with an existing span of a of different type', () => {
+          const [span1, span2] = createSpans(7, 5, 6);
+          span2.t = 'other';
+          verifyNoBatching(span1, span2);
+        });
+
+        it('should not merge when the gap is 10 ms or longer', () => {
+          const [span1, span2] = createSpans(7, 10, 6);
+          verifyNoBatching(span1, span2);
+        });
+
+        it('should not merge when the gap is 10 ms or longer (chronologically later span comes in first)', () => {
+          const [span1, span2] = createSpans(7, 10, 6);
+          verifyNoBatching(span2, span1);
+        });
+
+        it('should merge two spans', () => {
+          const [span1, span2] = createSpans(7, 5, 6);
+
+          const batched = verifyBatching(span1, span2);
+
+          expect(batched).to.equal(span1);
+          expect(batched.s).to.equal('1');
+          expect(batched.ts).to.equal(timestamp(0));
+          expect(batched.d).to.equal(18);
+          expect(batched.b.s).to.equal(2);
+          expect(batched.b.d).to.equal(13);
+        });
+
+        it('should merge two spans with max distance and all possible  offsets to bucket borders', () => {
+          const bucketWidth = 18;
+          for (let offset = 0; offset <= bucketWidth + 1; offset++) {
+            const [span1, span2] = createSpans(9, 9, 9, offset);
+            const batched = verifyBatching(span1, span2);
+            expect(batched).to.equal(span1);
+            expect(batched.s).to.equal('1');
+            expect(batched.ts).to.equal(timestamp(offset));
+            expect(batched.d).to.equal(27);
+            expect(batched.b.s).to.equal(2);
+            expect(batched.b.d).to.equal(18);
+          }
+        });
+
+        it('should merge multiple consecutive spans', () => {
+          const span1 = createSpan(0, 7, '1'); // 1000-1007
+          const span2 = createSpan(14, 8, '2'); // 1014-1022
+          const span3 = createSpan(31, 3, '3'); // 1031-1034
+          const span4 = createSpan(40, 5, '4'); // 1040-1045
+
+          spanBuffer.addSpan(span1);
+          spanBuffer.addSpan(span2);
+          spanBuffer.addSpan(span3);
+          spanBuffer.addSpan(span4);
+
+          const spans = spanBuffer.getAndResetSpans();
+          expect(spans).to.have.lengthOf(1);
+          const batched = spans[0];
+
+          expect(batched).to.equal(span2);
+          expect(batched.s).to.equal('2');
+          expect(batched.ts).to.equal(timestamp(0));
+          expect(batched.d).to.equal(45);
+          expect(batched.b.s).to.equal(4);
+          expect(batched.b.d).to.equal(23);
+        });
+
+        it('span with ec != 0 should be more significant', () => {
+          let span1;
+          let span2;
+          let batched;
+
+          [span1, span2] = createSpans(7, 5, 6);
+          span1.ec = 1;
+          batched = verifyBatching(span1, span2);
+          expect(batched).to.equal(span1);
+          expect(batched.s).to.equal('1');
+          expect(batched.ec).to.equal(1);
+
+          [span1, span2] = createSpans(7, 5, 6);
+          span2.ec = 1;
+          batched = verifyBatching(span1, span2);
+          expect(batched).to.equal(span2);
+          expect(batched.s).to.equal('2');
+          expect(batched.ec).to.equal(1);
+
+          // error count has higher priority than duration
+          [span1, span2] = createSpans(3, 5, 4);
+          span1.ec = 1;
+          batched = verifyBatching(span1, span2);
+          expect(batched).to.equal(span1);
+          expect(batched.s).to.equal('1');
+          expect(batched.ec).to.equal(1);
+        });
+
+        it('longer span should be more significant', () => {
+          let span1;
+          let span2;
+          let batched;
+
+          [span1, span2] = createSpans(7, 5, 6);
+          batched = verifyBatching(span1, span2);
+          expect(batched).to.equal(span1);
+          expect(batched.s).to.equal('1');
+          expect(batched.d).to.equal(18);
+          expect(batched.b.d).to.equal(13);
+
+          [span1, span2] = createSpans(6, 5, 7);
+          batched = verifyBatching(span1, span2);
+          expect(batched).to.equal(span2);
+          expect(batched.s).to.equal('2');
+          expect(batched.d).to.equal(18);
+          expect(batched.b.d).to.equal(13);
+        });
+
+        it('span starting earlier should be more significant (chronologically later span comes in first)', () => {
+          const [span1, span2] = createSpans(5, 7, 5);
+
+          spanBuffer.addSpan(span2);
+          spanBuffer.addSpan(span1); // adding span1 later than span2
+
+          // Note: The algorithm we use is optimized by only guaranteeing that spans that can be batched are batched if
+          // the arrive in the correct order in the span buffer. So in general the case where the span that starts
+          // earlier is not guaranteed to be batched. This particular case works because both spans land in the
+          // same bucket.
+
+          // Even though span1 arrived later, both spans should still merge into span1, because that started earlier
+          // according to span1.ts
+          const batched = expectBatching();
+          expect(batched).to.equal(span1);
+          expect(batched.s).to.equal('1');
+          expect(batched.ts).to.equal(timestamp(0));
+          expect(batched.d).to.equal(17);
+          expect(batched.b.s).to.equal(2);
+          expect(batched.b.d).to.equal(10);
+        });
+
+        it('should determine batch duration', () => {
+          let span1;
+          let span2;
+          let batched;
+
+          // target span is a batched span itself
+          [span1, span2] = createSpans(7, 5, 6);
+          span1.b = { d: 22 };
+          batched = verifyBatching(span1, span2);
+          expect(batched.b.d).to.equal(28); // 22 + 6
+
+          // source span is a batched span itself
+          [span1, span2] = createSpans(7, 5, 6);
+          span2.b = { d: 22 };
+          batched = verifyBatching(span1, span2);
+          expect(batched.b.d).to.equal(29); // 22 + 7
+
+          // both spans are a batched span
+          [span1, span2] = createSpans(7, 5, 6);
+          span1.b = { d: 27 };
+          span2.b = { d: 28 };
+          batched = verifyBatching(span1, span2);
+          expect(batched.b.d).to.equal(55);
+        });
+
+        it('should determine timestamp and span duration', () => {
+          let span1;
+          let span2;
+          let batched;
+
+          // cases
+          // ------------------------------------------> time
+          //
+          // gap between spans, target span started earlier
+          // | target |           | source |
+          //          |----gap----|
+          [span1, span2] = createSpans(8, 3, 4);
+          span1.ec = 1; // throughout this test we use span.ec to control which span becomes the target span
+          batched = verifyBatching(span1, span2);
+          expect(batched.ts).to.equal(timestamp(0));
+          expect(batched.d).to.equal(15);
+          // gap between spans, source span started earlier
+          // | source |           | target |
+          //          |----gap----|
+          [span1, span2] = createSpans(8, 3, 4);
+          span2.ec = 1;
+          batched = verifyBatching(span1, span2);
+          expect(batched.ts).to.equal(timestamp(0));
+          expect(batched.d).to.equal(15);
+
+          // no gap between spans, target span started earlier
+          // | target | source |
+          [span1, span2] = createSpans(8, 0, 4);
+          span1.ec = 1;
+          batched = verifyBatching(span1, span2);
+          expect(batched.ts).to.equal(timestamp(0));
+          expect(batched.d).to.equal(12);
+          // no gap between spans, source span started earlier
+          // | source | target |
+          [span1, span2] = createSpans(8, 0, 4);
+          span2.ec = 1;
+          batched = verifyBatching(span1, span2);
+          expect(batched.ts).to.equal(timestamp(0));
+          expect(batched.d).to.equal(12);
+
+          // overlapping spans, target span started earlier
+          // | target |
+          //     | source |
+          [span1, span2] = createSpans(8, -3, 7);
+          span1.ec = 1;
+          batched = verifyBatching(span1, span2);
+          expect(batched.ts).to.equal(timestamp(0));
+          expect(batched.d).to.equal(12);
+          // overlapping spans, source span started earlier
+          // | source |
+          //     | target |
+          [span1, span2] = createSpans(8, -3, 7);
+          span2.ec = 1;
+          batched = verifyBatching(span1, span2);
+          expect(batched.ts).to.equal(timestamp(0));
+          expect(batched.d).to.equal(12);
+
+          // one spans "contains" the other
+          // |     target      |
+          //     | source |
+          [span1, span2] = createSpans(9, 0, 4);
+          span2.ts = timestamp(2);
+          span1.ec = 1;
+          batched = verifyBatching(span1, span2);
+          expect(batched.ts).to.equal(timestamp(0));
+          expect(batched.d).to.equal(9);
+          // |     source      |
+          //     | target |
+          [span1, span2] = createSpans(9, 0, 4);
+          span2.ts = timestamp(2);
+          span2.ec = 1;
+          batched = verifyBatching(span1, span2);
+          expect(batched.ts).to.equal(timestamp(0));
+          expect(batched.d).to.equal(9);
+        });
+
+        it('should determine error count', () => {
+          let span1;
+          let span2;
+          let batched;
+
+          [span1, span2] = createSpans(7, 5, 6);
+          span1.ec = 3;
+          batched = verifyBatching(span1, span2);
+          expect(batched.ec).to.equal(3);
+
+          [span1, span2] = createSpans(7, 5, 6);
+          span2.ec = 4;
+          batched = verifyBatching(span1, span2);
+          expect(batched.ec).to.equal(4);
+
+          [span1, span2] = createSpans(7, 5, 6);
+          span1.ec = 3;
+          span2.ec = 4;
+          batched = verifyBatching(span1, span2);
+          expect(batched.ec).to.equal(7);
+        });
+
+        it('should determine batch size', () => {
+          let span1;
+          let span2;
+          let batched;
+
+          // target span is a batched span itself
+          [span1, span2] = createSpans(7, 5, 6);
+          span1.b = { s: 7 };
+          batched = verifyBatching(span1, span2);
+          expect(batched.b.s).to.equal(8);
+
+          // source span is a batched span itself
+          [span1, span2] = createSpans(7, 5, 6);
+          span2.b = { s: 7 };
+          batched = verifyBatching(span1, span2);
+          expect(batched.b.s).to.equal(8);
+
+          // both spans are a batched span
+          [span1, span2] = createSpans(7, 5, 6);
+          span1.b = { s: 7 };
+          span2.b = { s: 8 };
+          batched = verifyBatching(span1, span2);
+          expect(batched.b.s).to.equal(15);
+        });
+      });
     });
 
-    beforeEach(() => spanBuffer.activate());
+    describe('batching disabled', () => {
+      before(() => {
+        spanBuffer.init(
+          {
+            tracing: {
+              maxBufferedSpans: 1000,
+              forceTransmissionStartingAt: 500,
+              transmissionDelay: 1000,
+              spanBatchingEnabled: false
+            }
+          },
+          {
+            /* downstreamConnection */
+            sendSpans: function () {}
+          }
+        );
 
-    afterEach(() => spanBuffer.deactivate());
+        spanBuffer.addBatchableSpanName('batchable');
+      });
 
-    it('should not merge two spans even if they are batchable', () => {
-      const [span1, span2] = createSpans(7, 5, 6);
-      verifyNoBatching(span1, span2);
+      beforeEach(() => spanBuffer.activate());
+
+      afterEach(() => spanBuffer.deactivate());
+
+      it('should not merge two spans even if they are batchable', () => {
+        const [span1, span2] = createSpans(7, 5, 6);
+        verifyNoBatching(span1, span2);
+      });
     });
   });
 


### PR DESCRIPTION
refs 109158

We want to avoid using `setTimeout` in Faas, because the AWS Lambda runtime will execute the timeout handlers in a different lambda execution context. This is out of our control and can flood executions.