### PR TITLE
fix(aws-lambda): fixed INSTANA_LOG_LEVEL not being used

### DIFF
--- a/packages/aws-lambda/src/wrapper.js
+++ b/packages/aws-lambda/src/wrapper.js
@@ -225,7 +225,11 @@ function init(event, arnInfo, _config) {
 
   if (config.logger) {
     logger = config.logger;
-  } else if (process.env.INSTANA_DEBUG || config.level || process.env.INSTANA_LOG_LEVEL) {
+  } else {
+    config.logger = logger;
+  }
+
+  if (process.env.INSTANA_DEBUG || config.level || process.env.INSTANA_LOG_LEVEL) {
     logger.setLevel(process.env.INSTANA_DEBUG ? 'debug' : config.level || process.env.INSTANA_LOG_LEVEL);
   }
 


### PR DESCRIPTION
Problem: when the core module is initialized, we need to pass in the correct serverless logger, otherwise we will see e.g. INFO logs from the core module although we have set `INSTANA_LOG_LEVEL=error`

