### PR TITLE
build(deps-dev): bump @aws-sdk/client-s3 from 3.52.0 to 3.252.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/gateway": "0.50.2",
         "@aws-sdk/client-dynamodb": "3.81.0",
         "@aws-sdk/client-dynamodb2": "npm:@aws-sdk/client-dynamodb@3.20.0",
-        "@aws-sdk/client-s3": "3.52.0",
+        "@aws-sdk/client-s3": "3.252.0",
         "@aws-sdk/client-s3-2": "npm:@aws-sdk/client-s3@3.21.0",
         "@aws-sdk/client-sqs": "3.53.0",
         "@aws-sdk/client-sqs2": "npm:@aws-sdk/client-sqs@3.24.0",
@@ -612,6 +612,23 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
+      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
@@ -622,6 +639,26 @@
       }
     },
     "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
+      "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
@@ -718,43 +755,34 @@
       "dev": true
     },
     "node_modules/@aws-sdk/chunked-blob-reader": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.52.0.tgz",
-      "integrity": "sha512-BAZhriHHfvnGOd0P9xcnGu8DGyxOa0lgmEw+Tc6nZpXJzx0P+1Sd76q5gE5d/IZ0r5VTB6rfwwKUoG6iShNCwQ==",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
+      "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.52.0.tgz",
-      "integrity": "sha512-/hVzC0Q12/mWRMBBQD3v82xsLSxZ4RwG6N44XP7MuJoHy4ui4T7D9RSuvBpzzr/4fqF0w9M7XYv6aM4BD2pFIQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
+      "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/chunked-blob-reader-native/node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.52.0.tgz",
-      "integrity": "sha512-xjv/cQ4goWXAiGEC/AIL/GtlHg4p4RkQKs6/zxn9jOxo1OnbppLMJ0LjCtv4/JVYIVGHrx0VJ8Exyod7Ln+NeA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/chunked-blob-reader-native/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/chunked-blob-reader/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/client-dynamodb": {
@@ -1701,63 +1729,69 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.52.0.tgz",
-      "integrity": "sha512-QTY12zuKqWbtLG1H2RV13JG+NFNDeDAR2Ffka/qNHU6NMUqyQnyf/1h2UCVIekTmSaR6L6bYGgHl//kxMSUwCw==",
+      "version": "3.252.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.252.0.tgz",
+      "integrity": "sha512-VsTDuztgrwwBnkTZKm3t3cyXNTnWRCxDN4fCeEabw8/GB6KKSrs1a9pYXyWXuXtuvV5lFG4tIZMcXF7UkVXqyg==",
       "dev": true,
       "dependencies": {
+        "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.52.0",
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/credential-provider-node": "3.52.0",
-        "@aws-sdk/eventstream-serde-browser": "3.52.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.52.0",
-        "@aws-sdk/eventstream-serde-node": "3.52.0",
-        "@aws-sdk/fetch-http-handler": "3.52.0",
-        "@aws-sdk/hash-blob-browser": "3.52.0",
-        "@aws-sdk/hash-node": "3.52.0",
-        "@aws-sdk/hash-stream-node": "3.52.0",
-        "@aws-sdk/invalid-dependency": "3.52.0",
-        "@aws-sdk/md5-js": "3.52.0",
-        "@aws-sdk/middleware-apply-body-checksum": "3.52.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.52.0",
-        "@aws-sdk/middleware-content-length": "3.52.0",
-        "@aws-sdk/middleware-expect-continue": "3.52.0",
-        "@aws-sdk/middleware-host-header": "3.52.0",
-        "@aws-sdk/middleware-location-constraint": "3.52.0",
-        "@aws-sdk/middleware-logger": "3.52.0",
-        "@aws-sdk/middleware-retry": "3.52.0",
-        "@aws-sdk/middleware-sdk-s3": "3.52.0",
-        "@aws-sdk/middleware-serde": "3.52.0",
-        "@aws-sdk/middleware-signing": "3.52.0",
-        "@aws-sdk/middleware-ssec": "3.52.0",
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/middleware-user-agent": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/node-http-handler": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/smithy-client": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "@aws-sdk/util-base64-node": "3.52.0",
-        "@aws-sdk/util-body-length-browser": "3.52.0",
-        "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-        "@aws-sdk/util-defaults-mode-node": "3.52.0",
-        "@aws-sdk/util-user-agent-browser": "3.52.0",
-        "@aws-sdk/util-user-agent-node": "3.52.0",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
-        "@aws-sdk/util-waiter": "3.52.0",
-        "@aws-sdk/xml-builder": "3.52.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/client-sts": "3.252.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.252.0",
+        "@aws-sdk/eventstream-serde-browser": "3.226.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.226.0",
+        "@aws-sdk/eventstream-serde-node": "3.226.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-blob-browser": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/hash-stream-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/md5-js": "3.226.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-expect-continue": "3.226.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-location-constraint": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-sdk-s3": "3.231.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-ssec": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4-multi-region": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-stream-browser": "3.226.0",
+        "@aws-sdk/util-stream-node": "3.226.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.226.0",
+        "@aws-sdk/xml-builder": "3.201.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3-2": {
@@ -2868,754 +2902,767 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.52.0.tgz",
-      "integrity": "sha512-Z+4uVtgwbKSChruh6R/WIrGb5uvvXi/d6EQ7zC6hyghtn9EGQc+WJ3BVB4bIUshwMunlgjA3nDiPb5V3t5zv8Q==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+      "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.52.0.tgz",
-      "integrity": "sha512-IvtZlZopWlWg6xnKSXAodWQaPcRySNBJLj68K6HJ8OVvBCgcXr53nNREArgPi0+KDzLsXqAZTRxvU5do/99PrA==",
+      "version": "3.252.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.252.0.tgz",
+      "integrity": "sha512-VgBqJvvCU4y9zAHJwYj5nOeNGcCxKdCO4edUxWQVHcpLsVWu49maOVtWuteq9MOrHYeWfQi8bVWGt8MPvv9+bA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/fetch-http-handler": "3.52.0",
-        "@aws-sdk/hash-node": "3.52.0",
-        "@aws-sdk/invalid-dependency": "3.52.0",
-        "@aws-sdk/middleware-content-length": "3.52.0",
-        "@aws-sdk/middleware-host-header": "3.52.0",
-        "@aws-sdk/middleware-logger": "3.52.0",
-        "@aws-sdk/middleware-retry": "3.52.0",
-        "@aws-sdk/middleware-serde": "3.52.0",
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/middleware-user-agent": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/node-http-handler": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/smithy-client": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "@aws-sdk/util-base64-node": "3.52.0",
-        "@aws-sdk/util-body-length-browser": "3.52.0",
-        "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-        "@aws-sdk/util-defaults-mode-node": "3.52.0",
-        "@aws-sdk/util-user-agent-browser": "3.52.0",
-        "@aws-sdk/util-user-agent-node": "3.52.0",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.52.0.tgz",
-      "integrity": "sha512-tPLHYY9RdWehBQlyrwOaw4B31PqW1HmNNKJ3+Hc6KnEaiOwMAwQd8L7BFbSVG8ajQBDAEBUTDAkSaZ8jTYdfQQ==",
+      "version": "3.252.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.252.0.tgz",
+      "integrity": "sha512-wzfsWOlDFLdmeML8R7DUJWGl9wcRKf2uiunfB1aWzpdlgms0Z7FkHWgkDYHjCPyYHL6EBm84ajGl1UkE7AcmqQ==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/credential-provider-node": "3.52.0",
-        "@aws-sdk/fetch-http-handler": "3.52.0",
-        "@aws-sdk/hash-node": "3.52.0",
-        "@aws-sdk/invalid-dependency": "3.52.0",
-        "@aws-sdk/middleware-content-length": "3.52.0",
-        "@aws-sdk/middleware-host-header": "3.52.0",
-        "@aws-sdk/middleware-logger": "3.52.0",
-        "@aws-sdk/middleware-retry": "3.52.0",
-        "@aws-sdk/middleware-sdk-sts": "3.52.0",
-        "@aws-sdk/middleware-serde": "3.52.0",
-        "@aws-sdk/middleware-signing": "3.52.0",
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/middleware-user-agent": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/node-http-handler": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/smithy-client": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "@aws-sdk/util-base64-node": "3.52.0",
-        "@aws-sdk/util-body-length-browser": "3.52.0",
-        "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-        "@aws-sdk/util-defaults-mode-node": "3.52.0",
-        "@aws-sdk/util-user-agent-browser": "3.52.0",
-        "@aws-sdk/util-user-agent-node": "3.52.0",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.252.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-sdk-sts": "3.226.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.52.0.tgz",
-      "integrity": "sha512-XKUCpPLMwdlqPtwutdMfAHWqGEPTDd14Dp01WyNhVtmTmsHkpFfLPpELLO1BczDS+jyoMUj+UDj9jHm4YLvXXg==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-config-provider": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.52.0.tgz",
-      "integrity": "sha512-9R8kTMQ3udNz7fyY/0rkU6Yhu0ALYQJZQ0lFCrxtNo2Nlo9taQtZgxhtRcv+EeqbTcJs91voNNz70HLbedtBUw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
+      "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.52.0.tgz",
-      "integrity": "sha512-939kfHSkMLsOfQtO2nBqC/zAE1ecTOCAs72pKvVxrluGzDry4UtwlyQ4YGC04pYBRQeRIqvIOoVbADYJy4XjmQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+      "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.52.0.tgz",
-      "integrity": "sha512-MCzWWPYoZjZ3C/X8UXXf9eRqgGJc3Y1QyFXIuQzNrVhffrFkYOkOUQsG4s5TuDr1MmGfxe83XtHQgATJ0fe3zw==",
+      "version": "3.252.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.252.0.tgz",
+      "integrity": "sha512-OfpU8xMYK7+6XQ2dUO4rN0gUhhb/ZLV7iwSL6Ji2pI9gglGhKdOSfmbn6fBfCB50kzWZRNoiQJVaBu/d0Kr0EQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.52.0",
-        "@aws-sdk/credential-provider-imds": "3.52.0",
-        "@aws-sdk/credential-provider-sso": "3.52.0",
-        "@aws-sdk/credential-provider-web-identity": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-credentials": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.252.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.52.0.tgz",
-      "integrity": "sha512-SUl+t2S7xKHxAkIfuyvucKQ/JemJ/bCsuCk2qtjTSiVjrLx65Rnfw14j+44JU8U5mP+xodpKNCpgIF5PHu1kKQ==",
+      "version": "3.252.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.252.0.tgz",
+      "integrity": "sha512-Jt854JnB7izkJ/gb3S0hBFqAQPUNUP3eL8gXX2uqk9A9bQFQdS57/Ci0FXaEPwOXzJwAAPazD8dTf6HXMhnm3w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.52.0",
-        "@aws-sdk/credential-provider-imds": "3.52.0",
-        "@aws-sdk/credential-provider-ini": "3.52.0",
-        "@aws-sdk/credential-provider-process": "3.52.0",
-        "@aws-sdk/credential-provider-sso": "3.52.0",
-        "@aws-sdk/credential-provider-web-identity": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-credentials": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-ini": "3.252.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.252.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.52.0.tgz",
-      "integrity": "sha512-DGaSprlcEGgFuCiXNH9moksa6/1vBmX/G/tt/ulpgFEJmKljoazIEgUse/6oPJT7t5jazydAqMRVp1HK3Jp/0A==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
+      "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-credentials": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.52.0.tgz",
-      "integrity": "sha512-8Q0X4wro+sPMYkbZE/ZW+CBpjxGq/x/vv4yQh7zdHpNfANhqjTSR8tUCApemVcfPtwNhQNPpW8KrlWUIMguHdg==",
+      "version": "3.252.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.252.0.tgz",
+      "integrity": "sha512-2JGoojMOBjG9/DenctEszjdPechq0uDTpH5nx+z1xxIAugA5+HYG/ncNfpwhmUBCrnOxpRaQViTNqXddEPHlAg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-credentials": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/client-sso": "3.252.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/token-providers": "3.252.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.52.0.tgz",
-      "integrity": "sha512-+4qz0PZn9u6HRRNBO9YfIixdItukixPOtLP8tNlgriCh66BC6M1mAXXP/uq2x7kIaMRZtTo3Eey4T/tA0QMkOg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
+      "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.52.0.tgz",
-      "integrity": "sha512-pFXkCeEIcrgH8esRyUab1nnIo1cjUjrheqwb/MK3gJ363/kenT6IqYXOq0UO4mF7bn6IOz/yxODlhQIU6i1Vww==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+      "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/querystring-builder": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/hash-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.52.0.tgz",
-      "integrity": "sha512-pN2dSSyyy0emFFtK6jgmzYXcJHITbfdPqR7UTQ1fj1wFvbURPN19C1f4uYbVDjuiUQX01hLclJDLnPy1BIzTGQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+      "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-buffer-from": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.52.0.tgz",
-      "integrity": "sha512-TjRzfFFiY4i/a9ry5llCQMiIwpyhIyriM2QuPgAdRaRPM076I01FohUzlAc7zgwwhCa5rpI4zRZ+auGPrU44Gw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+      "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
-      "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/md5-js": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.52.0.tgz",
-      "integrity": "sha512-M0oHeBDvXCapQvvGzzlMrkW1vRfExngB/Gn93Vmdpt97+ieHkfHgo9fU/erQKb+HwnlZbhVJW3vEgfHPLvql6A==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.226.0.tgz",
+      "integrity": "sha512-ENigJRNudqyh6xsch166SZ4gggHd3XzZJ8gkCU4CWPne04HcR3BkWSO774IuWooCHt8zkaEHKecPurRz6qR+Vw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.52.0.tgz",
-      "integrity": "sha512-U+aa8UswtEvEdt4vvX+C4b+vetSpG6PZVeGN/hZ2J0j3jQxODQtjKHU3VIO+Fvp8m9rSCtcfAPly5CcejHLeKw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+      "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.52.0.tgz",
-      "integrity": "sha512-t7y0gtJyFNrS6bwluR7N2LtppA7B0SDk+uNlvOJOYnJRms89fXltyMJWl8wrv8IHHvrhRLwNEP22vvOhn3hriA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+      "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.52.0.tgz",
-      "integrity": "sha512-YbFuJAsOPvbYe64gpqmS6XmEQXwyAGwH3Y4iOp3CnrGAz/zXbwWwzb653Uby+h4PVkTZ1+RviCO/A6si9bUkhw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+      "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.52.0.tgz",
-      "integrity": "sha512-O+4mfn7OPv1POYagKwOgdlc16AQFWa4bY05g6Y94KZ2400ywNpK+Y2cwdskyNU3OTGOlluVGR21W5eO1b+XhNg==",
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+      "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/service-error-classification": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.52.0.tgz",
-      "integrity": "sha512-NB1wHvOp+I6DXi5fPutyl9dAWvJYqzRqdi8lMeu02ub/d6nybrAjoB56za1LvGblcoEiYClf1A6dTKtmydgzFQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
+      "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.52.0.tgz",
-      "integrity": "sha512-4ZooINTdOI4+T6pEiu8xte5EEhOqbE/wqOwBzvOASk3JKElZ93u6xKP2u7UKVD6asBBYK2mDrYSy1PsU4fNl4A==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+      "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.52.0.tgz",
-      "integrity": "sha512-7FUqmZQ5DzaDJYCJ3YmOHRFEyFeohtsDQ1akWD2qekcjp16ftBtk05Fi9am5/L7pO8svVzobji/wg00Tlq183A==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
+      "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.52.0.tgz",
-      "integrity": "sha512-4OTbQ+tWc6Le7es3kSnXBzCyddcUw6Sk2GupR/1+PD9v4/qvtKXXK+uD4bMDDMfi6dTNV+2riOGBniOtBVsayw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+      "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.52.0.tgz",
-      "integrity": "sha512-sfdJvAp/f4PHmQvSklFAuCpD7gqloG502gSmBAMrXKqYykvQ5SAGyr6sCZPWf8CZxKtn5n4ftg8CLKywwrKwmg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+      "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.52.0.tgz",
-      "integrity": "sha512-vfeTzkfVtGaNQrnhCRMObqid0shxFtNFEnnU1Nnx7HsgBfag2/T6fnsDzdVGaliQ6nmfg+RMrhzw2VECyBTHQQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+      "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.52.0.tgz",
-      "integrity": "sha512-MjLkndwLuWye1kavyFnDw5BvK8Rg4YpMULTne++OL/uEsxWO786K+QQMyLWkirPe+ELMEYu/3eOrQTly2tqHsA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+      "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/querystring-builder": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/abort-controller": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/property-provider": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.52.0.tgz",
-      "integrity": "sha512-Ooam7CvGefHKhMwQ413MiEtDTFw70xbCduJCF7Bg1F0WKrf700M/Yte+q3E0ljlXWJ28rwJNgwW3ptZaSXMGPg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
-      "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.52.0.tgz",
-      "integrity": "sha512-RfNXqKeR6mdg2n2LO5Vs2Bz+f47/KN5k36HWk04bSwIbhnBtslXBp0F1KgSPkeP56KEgmmUWldRD7g8BvDkgAw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-uri-escape": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.52.0.tgz",
-      "integrity": "sha512-/A6PauieStZajbkxX3sZSBBDacGDc3I/Sk7rjJulmg1GnizeVcUgx1OUdDh1JasdqA1h9E3ks/Y2Lu3xUMctLw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.52.0.tgz",
-      "integrity": "sha512-2bpSIZCx5VGp2CBTeXK6PxlBYWrn2wiqxBVYstDRExZ8P7edcwPRgWi8qaKgPM2wvstZwJieF774niiuLddIpg==",
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
       "dev": true,
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.52.0.tgz",
-      "integrity": "sha512-tALb8u8IVcI4pT7yFZpl4O6kgeY5EAXyphZoRPgQSCDhmEyFUIi/sXbCN8HQiHjnHdWfXdaNE1YsZcW3GpcuoQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.52.0.tgz",
-      "integrity": "sha512-lSlDASXGLup5v12kclzT2ZLoUnnVLknSRcMXrTVjnX7spmHMbs6s7LOcN0RXZzFIACs7vW+930KUzhBxt8UiFQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-hex-encoding": "3.52.0",
-        "@aws-sdk/util-uri-escape": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.52.0.tgz",
-      "integrity": "sha512-GuOJuoA1kky/v2p7byOZGq7YOiu2Ov8DA3d58gM6L/q7XavBjnzwNB/BYU7SPU3Ly6S7qGxBJFeadufic4bCYg==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+      "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/url-parser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.52.0.tgz",
-      "integrity": "sha512-/9OJwol/384jsISiAs5JX7fkgd9mv7hJsHFCVXnByim5qTZu1V9fMcJYJ1L3iRmfCRy0w75UDJljIx2RZnwAYw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.52.0.tgz",
-      "integrity": "sha512-xjv/cQ4goWXAiGEC/AIL/GtlHg4p4RkQKs6/zxn9jOxo1OnbppLMJ0LjCtv4/JVYIVGHrx0VJ8Exyod7Ln+NeA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-base64-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.52.0.tgz",
-      "integrity": "sha512-V96YIXBuIiVu7Zk72Y9dly7Io9cYOT30Hjf77KAkBeizlFgT5gWklWYGcytPY8FxLuEy4dPLeHRmgwQnlDwgPA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.52.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
+        "@aws-sdk/querystring-parser": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.52.0.tgz",
-      "integrity": "sha512-8omOgIGmopUtwg3XaeyvqacxrIrCsDKUVQp5n+8iLmyYt5mQM70vXbUC273GJzKDtibGDfxiN4FqSLBlo9F/oQ==",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.52.0.tgz",
-      "integrity": "sha512-1WWsGh0hip4y1uvOLFV2v3Nvq3W35dmW5YniCi0gQDBLc5JHES8Zka7yoCDYOfaYFUodVH5mC/jFBjGRQ3TpDw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.52.0.tgz",
-      "integrity": "sha512-hsG0lMlHjJUFoXIy59QLn6x4QU/vp/e0t3EjdD0t8aymB9iuJ43UeLjYTZdrOgtbWb8MXEF747vwg+P6n+4Lxw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.52.0.tgz",
-      "integrity": "sha512-1wonBNkOOLJpMZnz2Kn69ToFgSoTTyGzJInir8WC5sME3zpkb5j41kTuEVbImNJhVv9MKjmGYrMeZbBVniLRPw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-credentials": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.52.0.tgz",
-      "integrity": "sha512-fNcm2cNzDHWt5Pr6xD2FXA40jkcgClsbumuI0VBhLEyNLfoetwPImKTpqbxo1XfWVxhqIbT/ELnrbS2OYBRIXg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
-      "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
-      "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.52.0.tgz",
-      "integrity": "sha512-zmw9pJ91QAr1oF3uqLKuo/3++NrSEagLwz3xnuID5wN8WLAgbC6MkvM7FG+r11CHSoUX3IeB6YDqoBMQW8en8w==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+      "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.226.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.52.0.tgz",
-      "integrity": "sha512-jqbyb6R4goWOTIESizmNPy1i3Xa25Q3QG0xt6Pct0DwLQUSVpnPHw07NmfRhql+eYBoD4uxpXDX9lWsuLUBi0w==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+      "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.52.0.tgz",
-      "integrity": "sha512-LuOMa9ajWu5fQuYkmvTlQZfHaITkSle+tM/vhbU4JquRN44VUKACjRGT7UEhoU3lCL1BD0JFGMQGHI+5Mmuwfg==",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.52.0.tgz",
-      "integrity": "sha512-fujr7zeobZ2y5nnOnQZrCPPc+lCAhtNF/LEVslsQfd+AQ0bYWiosrKNetodQVWlfh10E2+i6/5g+1SBJ5kjsLw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-waiter": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.52.0.tgz",
-      "integrity": "sha512-8Gx0NunIg1RFpnKSA3nwzDl5j8mJ42kWjy5sHgd4wfUyiXRSvTl69sV6O8qhleI9OMDV0iS4xHZBCLK11HdIoA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
+      "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/abort-controller": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dev": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/client-sqs": {
@@ -5327,6 +5374,529 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.252.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.252.0.tgz",
+      "integrity": "sha512-OOwfEXFS+UliGZorEleARsXXUp3ObZSXo9/YY+8XF7/8froAqYjKCEi0tflghgYlh7d6qe7wzD7/6gDL1a/qgA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+      "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+      "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/hash-node": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+      "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+      "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+      "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+      "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+      "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+      "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+      "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+      "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+      "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+      "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+      "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/property-provider": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+      "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/url-parser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+      "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+      "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
     "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-defaults-mode-browser": {
       "version": "3.78.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.78.0.tgz",
@@ -5647,160 +6217,173 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
-    "node_modules/@aws-sdk/eventstream-marshaller": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.52.0.tgz",
-      "integrity": "sha512-RK5uWIOwae3Yzog8og3+e+k8kpRnjrg9hhOLmq2xG4m5seo7v7S5jfmb0uLX/Uqgd1vWMK5wKFJsdGhnAqykcQ==",
+    "node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.226.0.tgz",
+      "integrity": "sha512-6uPtR8vSwz3fqoZk9hrb6qBYdp3PJ22+JxV5Wimdesvow4kJXSgDQXIxEkxbv6SxB9tNRB4uJHD84RetHEi15Q==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-hex-encoding": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "tslib": "^2.3.1"
       }
     },
-    "node_modules/@aws-sdk/eventstream-marshaller/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-marshaller/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
-      "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+    "node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/eventstream-marshaller/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+    "node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-codec/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/eventstream-serde-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.52.0.tgz",
-      "integrity": "sha512-Lo1RzjOCvOGDoyq1hdxO7YWsdyc5ZMo0+jf/SDm64ZM8jE4eRUh1iGj0kCOKIIr/tCbzhbvP4SoNDfehJ2rqfA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.226.0.tgz",
+      "integrity": "sha512-otYC5aZE9eJUqAlKpy8w0rPDQ1eKGvZPtgxWXmFYSO2lDVGfI1nBBNmdZ4MdHqNuQ7ucsKMQYF8BFJ65K2tYPA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/eventstream-marshaller": "3.52.0",
-        "@aws-sdk/eventstream-serde-universal": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/eventstream-serde-universal": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-browser/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-browser/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.52.0.tgz",
-      "integrity": "sha512-yCfYf2MepHPpRTsbGNNLVDbN22woSmNDM2bEeK5gDbyV23MGlnLxjekLKdBbH5M6FUqfMbpsM60gDgJgas3ovA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.226.0.tgz",
+      "integrity": "sha512-A56Gypg+lyEfA5cna+EUH9XTrj0SvRG1gwNW7lrUzviN36SeA/LFTUIOEjxVML3Lowy+EPAcrSZ67h6aepoAig==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/eventstream-serde-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.52.0.tgz",
-      "integrity": "sha512-hL067bWZ875oL+l+Q1Wrhkq/V9727fHeJ1J4Kr/o84hGRnIkN7OiNDLIMyUTrGdc0I4diGUbc8FVJiRtZRmphw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.226.0.tgz",
+      "integrity": "sha512-KWLnKkKDzI9RNkiK6OiSYpG/XjZfue6Bsp/vRG+H5z3fbXdHv4X2+iW+Efu2Kvn7jsUyUv82TCl57DyJ/HKYhQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/eventstream-marshaller": "3.52.0",
-        "@aws-sdk/eventstream-serde-universal": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/eventstream-serde-universal": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-node/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-node/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/eventstream-serde-universal": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.52.0.tgz",
-      "integrity": "sha512-CDMcBJDNDJfGWz2Vk2p1Ef6JbZDVZVZDG8F7Gdhn7RsiMsFf7QiF4vcNEJwQIX25ZSerRqEitBT8nEZEDxEYGw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.226.0.tgz",
+      "integrity": "sha512-Q8viYM1Sv90/yIUqyWNeG1GEvyVlAI3GIrInQcCMC+xT59jS+IKGy2y7ojCvSWXnhf5/HMXKcmG092QsqeKy0Q==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/eventstream-marshaller": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/eventstream-codec": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-universal/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-universal/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
@@ -5823,30 +6406,33 @@
       "dev": true
     },
     "node_modules/@aws-sdk/hash-blob-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.52.0.tgz",
-      "integrity": "sha512-EhEXgO/cb67EHXl/F1D3vtdv695n1nIrAQLdiTOcNvdMRWLpjb2MkR3GI9tppkTabF4o3allgZVebKVeqINSMQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.226.0.tgz",
+      "integrity": "sha512-5DCvWE6L4xGoViEHyjcPFuUe1G2EtNx8TqswWaoaKgyasP/yuRm4H99Ra7rqIrjCcSTAGD9NVsUQvVVw1bGt9w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/chunked-blob-reader": "3.52.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/chunked-blob-reader": "3.188.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.208.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/hash-blob-browser/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/hash-blob-browser/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/hash-node": {
@@ -5870,31 +6456,34 @@
       "dev": true
     },
     "node_modules/@aws-sdk/hash-stream-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.52.0.tgz",
-      "integrity": "sha512-Khgy6DM2Kpcqbom8dYQtH7GmxnprdQVHsKvhmkReqfksxvrwNwo+S2RCDlceGTVIkELuvyfnVd19JLQO7BnqTw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.226.0.tgz",
+      "integrity": "sha512-cgNTGlF8SdHaQXtjEmuLXz2U8SLM2JDKtIVPku/lHTMsUsEn+fuv2C+h1f/hvd4aNw5t1zggym7sO1/h/rv56Q==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/hash-stream-node/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/hash-stream-node/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/invalid-dependency": {
@@ -6005,115 +6594,63 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
     },
-    "node_modules/@aws-sdk/middleware-apply-body-checksum": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.52.0.tgz",
-      "integrity": "sha512-f5ynflavshbkmV4ZpcwW2WoYAP69bOpv8bUPNsiKEzL07q6ZperkIaYre9BajNMxGN+UNSoE5CQIvRGcwC6UxA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-apply-body-checksum/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
-      "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-apply-body-checksum/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
-      "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-apply-body-checksum/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-apply-body-checksum/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
-    },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.52.0.tgz",
-      "integrity": "sha512-KOq8kTzhWYiwits89pnCduL7ojijthfFR5PRvLW6IwQbPxIg/AjdO5gYbMUTLaVAO1b7LoI3ztk+lmLQ2yvjOA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.226.0.tgz",
+      "integrity": "sha512-A1Vq5W2X7jgTfjqcKPmjoHohF0poP+9fxwL97fQMvzcwmjhtoCV3bLEpo6CGYx0pKPiSlRJXZkRwRPj2hDHDmA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-arn-parser": "3.52.0",
-        "@aws-sdk/util-config-provider": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
-      "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.52.0.tgz",
-      "integrity": "sha512-1wonBNkOOLJpMZnz2Kn69ToFgSoTTyGzJInir8WC5sME3zpkb5j41kTuEVbImNJhVv9MKjmGYrMeZbBVniLRPw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/middleware-content-length": {
@@ -6135,6 +6672,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
+      "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
       "version": "3.80.0",
@@ -6158,89 +6714,254 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
-    "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.52.0.tgz",
-      "integrity": "sha512-1rpD1I/HwDdVAW9wBtLv34gxrfkfLEyTEj2Y/1Qh/62rMX7KbBT0CmbbO33upOqyrsJDW961Mu/d5cVZW1N3XQ==",
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-header-default": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+      "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/url-parser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.226.0.tgz",
+      "integrity": "sha512-YxvQKTV/eA9P8AgW0hXOgj5Qa+TSnNFfyOkfeP089aP3f6p92b1cESf33TEOKsddive2mHT5LRCN6MuPcgWWrA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
-      "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
-    "node_modules/@aws-sdk/middleware-header-default": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.52.0.tgz",
-      "integrity": "sha512-ts5kuAnLjC9HW9W/vkCrlMa4a5DG45BkOjhYhD4YZCDBt9+E/N5Pt/14jmTdTO5LQ26zVC6Z3ByBXXayDKEIow==",
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.226.0.tgz",
+      "integrity": "sha512-8A9Ot9A7794UP5tMGl2MnfTW/UM/jYy1wRWF9YkR/hPIcPb7OmE0hmlwIQGzb/7grxpYw66ETKf0WeH/41YfeQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-crypto/crc32c": "2.0.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-header-default/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
-      "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-header-default/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
       "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-header-default/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/middleware-host-header": {
@@ -6264,31 +6985,34 @@
       "dev": true
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.52.0.tgz",
-      "integrity": "sha512-P+RfKVXL6X+vu7e54vu73TNje15y+Jo1VEbBpFGz5wYsLlBO58e6utDYLOYLwj+WzLqShSzZX9ejZzxrOSYQdQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.226.0.tgz",
+      "integrity": "sha512-qHiYaBYPc2R37KxG2uqsUUwh4usrQMHfGkrpTUnx5d4rGzM3mC+muPsTpSHnAL63K2/yJOHQJFjss3GGwV4SSA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/middleware-logger": {
@@ -6308,6 +7032,51 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
+      "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/middleware-retry": {
@@ -6334,102 +7103,49 @@
       "dev": true
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.52.0.tgz",
-      "integrity": "sha512-M9ivvdTEPFoFUgfGLdFeRxFGRh/Edq6tevSnWjdOoLTgbzq8tnuKkj9v3gKsIN+a1QWP6Ef0ThH/jyuFDcBEnQ==",
+      "version": "3.231.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.231.0.tgz",
+      "integrity": "sha512-UGaSvevd2TanfKgStF46dDSHkh4bxOr1gdUkyHm9i+1pF5lx4KdbnBZv/5SKnn7XifhHRXrs1M3lTzemXREhTA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-arn-parser": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/signature-v4-crt": "^3.31.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
-      "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
-      "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.52.0.tgz",
-      "integrity": "sha512-lSlDASXGLup5v12kclzT2ZLoUnnVLknSRcMXrTVjnX7spmHMbs6s7LOcN0RXZzFIACs7vW+930KUzhBxt8UiFQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-hex-encoding": "3.52.0",
-        "@aws-sdk/util-uri-escape": "3.52.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
-      "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
-      "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
@@ -6538,31 +7254,34 @@
       "dev": true
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.52.0.tgz",
-      "integrity": "sha512-lEswW+Hf5tvkPs6aNRbPF5/Iizh62lq4NK6bZjvQF6kqyUoIGhOehQOZMmTm6jw0058KVhrzNIKipBpi7LuF6w==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.226.0.tgz",
+      "integrity": "sha512-DR97oWoLHiMdaUP/wu99HtzG7/ijvCrjZGDH37WBO1rxFtEti6L7T09wgHzwxMN8gtL8FJA7dU8IrffGSC9VmA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/middleware-stack": {
@@ -6767,111 +7486,125 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-crt": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.52.0.tgz",
-      "integrity": "sha512-+9b8WDHxCJ9OoXWMhV91Xt2nQtjqYatR2NA+gUUHjOiHbSSY0nG0jMsgKQU7MP6OAEWpZnRWEpeZtwwJm+gatg==",
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.226.0.tgz",
+      "integrity": "sha512-QHxNuf9ynK208v7Y3imdsa3Cz8ynYV7ZOf3sBJdItuEtHN6uy/KxaOrtvpF8I5Hyn48Hc8z5miTSMujFKT7GEw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/querystring-parser": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/util-hex-encoding": "3.52.0",
-        "@aws-sdk/util-uri-escape": "3.52.0",
-        "aws-crt": "^1.9.7",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/signature-v4-crt": "^3.118.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/signature-v4-crt": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@aws-sdk/signature-v4-crt/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
-      "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-crt/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.52.0.tgz",
-      "integrity": "sha512-/A6PauieStZajbkxX3sZSBBDacGDc3I/Sk7rjJulmg1GnizeVcUgx1OUdDh1JasdqA1h9E3ks/Y2Lu3xUMctLw==",
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-crt/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.52.0.tgz",
-      "integrity": "sha512-lSlDASXGLup5v12kclzT2ZLoUnnVLknSRcMXrTVjnX7spmHMbs6s7LOcN0RXZzFIACs7vW+930KUzhBxt8UiFQ==",
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-hex-encoding": "3.52.0",
-        "@aws-sdk/util-uri-escape": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-crt/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-crt/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
-      "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-crt/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
-      "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-crt/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
       "dev": true,
-      "peer": true
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
     },
     "node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
       "version": "2.4.0",
@@ -6897,6 +7630,66 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.252.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.252.0.tgz",
+      "integrity": "sha512-xi3pUP31tyKF4lJFCOgtkwSWESE9W1vE23Vybsq53wzXEYfnRql8RP+C9FFkUouAR6ixPHEcEYplB+l92CY49g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.252.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/property-provider": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/types": {
@@ -6926,22 +7719,35 @@
       "dev": true
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.52.0.tgz",
-      "integrity": "sha512-mMsoYJ70+BGkVpdfQbu942v4fAGzx+pIL8+QnQhzUmcU0HbNkI0vYliMWfzz7ka9CHgbijUI/ANKA319zgKtvA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
+      "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
+    },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@aws-sdk/util-base64-browser": {
       "version": "3.58.0",
@@ -6975,6 +7781,37 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-base64/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/util-body-length-browser": {
@@ -7048,237 +7885,289 @@
       "dev": true
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.52.0.tgz",
-      "integrity": "sha512-N2/DHJ/OfiQ5zP97k9cJ8jSGiWDjtR7oFqXR+wbKZzKOww6vencMPYlndU6v1uZOKEjoj+NBr5N0jPEjCz+6+g==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
+      "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/@aws-sdk/property-provider": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.52.0.tgz",
-      "integrity": "sha512-Ooam7CvGefHKhMwQ413MiEtDTFw70xbCduJCF7Bg1F0WKrf700M/Yte+q3E0ljlXWJ28rwJNgwW3ptZaSXMGPg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.52.0.tgz",
-      "integrity": "sha512-vmbvirg5edfNKBin8Mup2noxgqIYzYPnvk+BgIx3jFPvwT57WGRs/ahOMNqHgv/6xAdVaUjz8g7gw9Yy3mwP3A==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
+      "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/credential-provider-imds": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.52.0.tgz",
-      "integrity": "sha512-XKUCpPLMwdlqPtwutdMfAHWqGEPTDd14Dp01WyNhVtmTmsHkpFfLPpELLO1BczDS+jyoMUj+UDj9jHm4YLvXXg==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-config-provider": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.52.0.tgz",
-      "integrity": "sha512-939kfHSkMLsOfQtO2nBqC/zAE1ecTOCAs72pKvVxrluGzDry4UtwlyQ4YGC04pYBRQeRIqvIOoVbADYJy4XjmQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+      "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
-      "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.52.0.tgz",
-      "integrity": "sha512-vfeTzkfVtGaNQrnhCRMObqid0shxFtNFEnnU1Nnx7HsgBfag2/T6fnsDzdVGaliQ6nmfg+RMrhzw2VECyBTHQQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+      "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/property-provider": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.52.0.tgz",
-      "integrity": "sha512-Ooam7CvGefHKhMwQ413MiEtDTFw70xbCduJCF7Bg1F0WKrf700M/Yte+q3E0ljlXWJ28rwJNgwW3ptZaSXMGPg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+      "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.52.0.tgz",
-      "integrity": "sha512-/A6PauieStZajbkxX3sZSBBDacGDc3I/Sk7rjJulmg1GnizeVcUgx1OUdDh1JasdqA1h9E3ks/Y2Lu3xUMctLw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+      "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.52.0.tgz",
-      "integrity": "sha512-tALb8u8IVcI4pT7yFZpl4O6kgeY5EAXyphZoRPgQSCDhmEyFUIi/sXbCN8HQiHjnHdWfXdaNE1YsZcW3GpcuoQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+      "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.52.0.tgz",
-      "integrity": "sha512-lSlDASXGLup5v12kclzT2ZLoUnnVLknSRcMXrTVjnX7spmHMbs6s7LOcN0RXZzFIACs7vW+930KUzhBxt8UiFQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+      "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-hex-encoding": "3.52.0",
-        "@aws-sdk/util-uri-escape": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-      "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
       "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/url-parser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.52.0.tgz",
-      "integrity": "sha512-/9OJwol/384jsISiAs5JX7fkgd9mv7hJsHFCVXnByim5qTZu1V9fMcJYJ1L3iRmfCRy0w75UDJljIx2RZnwAYw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+      "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/querystring-parser": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.52.0.tgz",
-      "integrity": "sha512-1wonBNkOOLJpMZnz2Kn69ToFgSoTTyGzJInir8WC5sME3zpkb5j41kTuEVbImNJhVv9MKjmGYrMeZbBVniLRPw==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
-      "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+      "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
-      "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
+      "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/util-hex-encoding": {
@@ -7333,6 +8222,265 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
+      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+      "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-stream-browser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.226.0.tgz",
+      "integrity": "sha512-ZvjlA1ySaLd0DqUWTKmL7LsxfPhroAONpzsinaHmw9aZVL40s2cADU9eWgBdHTuAOeFklL7NP0cc6UiTFHKe8g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+      "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-stream-node": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.226.0.tgz",
+      "integrity": "sha512-HADXiIgDGoXcCLSKuPnjCLENf0iC0lzqqnymZu9H2FoACZhJB7DvJ9LnP51Pvw9lfCu+yvLzbMqSPdbXtMbRWg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+      "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+      "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/querystring-builder": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+      "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+      "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/types": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+      "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/util-uri-escape": {
@@ -7445,21 +8593,21 @@
       "dev": true
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.52.0.tgz",
-      "integrity": "sha512-GMdcxdwDZuIMlGnewdB48bpj8eqA3nubs3biy6vRFX8zhv8OqD+m5fMinoEwD8/MGqWE3WD7VZlbbdwYtNVWzQ==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
+      "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@azure/abort-controller": {
@@ -11954,69 +13102,6 @@
         "@hapi/boom": "9.x.x",
         "@hapi/bourne": "2.x.x",
         "@hapi/hoek": "9.x.x"
-      }
-    },
-    "node_modules/@httptoolkit/websocket-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@httptoolkit/websocket-stream/-/websocket-stream-6.0.0.tgz",
-      "integrity": "sha512-EC8m9JbhpGX2okfvLakqrmy4Le0VyNKR7b3IdvFZR/BfFO4ruh/XceBvXhCFHkykchnFxuOSlRwFiqNSXlwcGA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@types/ws": "*",
-        "duplexify": "^3.5.1",
-        "inherits": "^2.0.1",
-        "isomorphic-ws": "^4.0.1",
-        "readable-stream": "^2.3.3",
-        "safe-buffer": "^5.1.2",
-        "ws": "*",
-        "xtend": "^4.0.0"
-      }
-    },
-    "node_modules/@httptoolkit/websocket-stream/node_modules/duplexify": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
-    "node_modules/@httptoolkit/websocket-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@httptoolkit/websocket-stream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/@httptoolkit/websocket-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -16889,13 +17974,6 @@
       "integrity": "sha1-7HmjlpsC0uzytyJUJ5v5m8eoOTI=",
       "dev": true
     },
-    "node_modules/ansi": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -18141,56 +19219,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
-    "node_modules/aws-crt": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.11.0.tgz",
-      "integrity": "sha512-qIBDRLOKRFuPTjkOAt3Al5zbcR6YyjfEl3TUc0R/xZ64aDxWGGXDStfDpkGCLSgV7jH+o7KQ47U9PM3URiFNFg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "peer": true,
-      "dependencies": {
-        "@httptoolkit/websocket-stream": "^6.0.0",
-        "axios": "^0.24.0",
-        "cmake-js": "6.3.0",
-        "crypto-js": "^4.0.0",
-        "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "mqtt": "^4.3.4",
-        "tar": "^6.1.11",
-        "ws": "^7.5.5"
-      }
-    },
-    "node_modules/aws-crt/node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
-    "node_modules/aws-crt/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/aws-sdk": {
       "version": "2.1163.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1163.0.tgz",
@@ -18249,7 +19277,7 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
@@ -18968,13 +19996,6 @@
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
       "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
       "dev": true
-    },
-    "node_modules/buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-      "dev": true,
-      "peer": true
     },
     "node_modules/buffer-writer": {
       "version": "2.0.0",
@@ -19845,338 +20866,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/cmake-js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.0.tgz",
-      "integrity": "sha512-1uqTOmFt6BIqKlrX+39/aewU/JVhyZWDqwAL+6psToUwxj3yWPJiwxiZFmV0XdcoWmqGs7peZTxTbJtAcH8hxw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "axios": "^0.21.1",
-        "debug": "^4",
-        "fs-extra": "^5.0.0",
-        "is-iojs": "^1.0.1",
-        "lodash": "^4",
-        "memory-stream": "0",
-        "npmlog": "^1.2.0",
-        "rc": "^1.2.7",
-        "semver": "^5.0.3",
-        "splitargs": "0",
-        "tar": "^4",
-        "unzipper": "^0.8.13",
-        "url-join": "0",
-        "which": "^1.0.9",
-        "yargs": "^3.6.0"
-      },
-      "bin": {
-        "cmake-js": "bin/cmake-js"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/are-we-there-yet": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-      "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.0 || ^1.1.13"
-      }
-    },
-    "node_modules/cmake-js/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/cmake-js/node_modules/cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/cmake-js/node_modules/fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/fs-minipass": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "minipass": "^2.6.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/gauge": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-      "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi": "^0.3.0",
-        "has-unicode": "^2.0.0",
-        "lodash.pad": "^4.1.0",
-        "lodash.padend": "^4.1.0",
-        "lodash.padstart": "^4.1.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/cmake-js/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/cmake-js/node_modules/minipass": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/minizlib": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "minipass": "^2.9.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/cmake-js/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/cmake-js/node_modules/npmlog": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-      "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi": "~0.3.0",
-        "are-we-there-yet": "~1.0.0",
-        "gauge": "~1.2.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/cmake-js/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/tar": {
-      "version": "4.4.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "chownr": "^1.1.4",
-        "fs-minipass": "^1.2.7",
-        "minipass": "^2.9.0",
-        "minizlib": "^1.3.3",
-        "mkdirp": "^0.5.5",
-        "safe-buffer": "^5.2.1",
-        "yallist": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=4.5"
-      }
-    },
-    "node_modules/cmake-js/node_modules/tar/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "peer": true
-    },
-    "node_modules/cmake-js/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/cmake-js/node_modules/wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/cmake-js/node_modules/y18n": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/cmake-js/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/cmake-js/node_modules/yargs": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-      "integrity": "sha512-ONJZiimStfZzhKamYvR/xvmgW3uEkAUFSP91y2caTEPhzF6uP2JfPiVZcq66b/YR0C3uitxSV7+T1x8p5bkmMg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -20327,24 +21016,6 @@
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
       "dev": true,
       "optional": true
-    },
-    "node_modules/commist": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
-      "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "leven": "^2.1.0",
-        "minimist": "^1.1.0"
-      }
-    },
-    "node_modules/commist/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/commitizen": {
       "version": "4.2.5",
@@ -21499,13 +22170,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -24064,13 +24728,6 @@
         "type": "paypal",
         "url": "https://paypal.me/naturalintelligence"
       }
-    },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/fastify": {
       "version": "1.14.6",
@@ -27199,17 +27856,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/help-me": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
-      "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.6",
-        "readable-stream": "^3.6.0"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -27907,7 +28553,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28326,13 +28972,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-iojs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
-      "integrity": "sha1-TBEDO11dlNbqs3dd7cm+fQCDJfE=",
-      "dev": true,
-      "peer": true
     },
     "node_modules/is-lambda": {
       "version": "1.0.1",
@@ -28972,13 +29611,6 @@
       "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
       "dev": true
     },
-    "node_modules/js-sdsl": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
-      "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -29614,7 +30246,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "invert-kv": "^1.0.0"
       },
@@ -29888,27 +30520,6 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
-    },
-    "node_modules/lodash.pad": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
-      "dev": true,
-      "peer": true
     },
     "node_modules/lodash.pick": {
       "version": "4.4.0",
@@ -30578,29 +31189,6 @@
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "dev": true,
       "optional": true
-    },
-    "node_modules/memory-stream": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
-      "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "readable-stream": "~1.0.26-2"
-      }
-    },
-    "node_modules/memory-stream/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
     },
     "node_modules/meow": {
       "version": "8.1.2",
@@ -31831,201 +32419,6 @@
       "dev": true,
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/mqtt": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.6.tgz",
-      "integrity": "sha512-1dgQbkbh1Bba9iAGDNIrhSZ4nLDjbhmNHjOEvsmKI1Bb+2orj0gHwjqUKJ5CKUMKBYbkQYRM1fy+N1/2iZOj5w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "commist": "^1.0.0",
-        "concat-stream": "^2.0.0",
-        "debug": "^4.1.1",
-        "duplexify": "^4.1.1",
-        "help-me": "^3.0.0",
-        "inherits": "^2.0.3",
-        "lru-cache": "^6.0.0",
-        "minimist": "^1.2.5",
-        "mqtt-packet": "^6.8.0",
-        "number-allocator": "^1.0.9",
-        "pump": "^3.0.0",
-        "readable-stream": "^3.6.0",
-        "reinterval": "^1.1.0",
-        "rfdc": "^1.3.0",
-        "split2": "^3.1.0",
-        "ws": "^7.5.5",
-        "xtend": "^4.0.2"
-      },
-      "bin": {
-        "mqtt": "bin/mqtt.js",
-        "mqtt_pub": "bin/pub.js",
-        "mqtt_sub": "bin/sub.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/mqtt-packet": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
-      "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "bl": "^4.0.2",
-        "debug": "^4.1.1",
-        "process-nextick-args": "^2.0.1"
-      }
-    },
-    "node_modules/mqtt-packet/node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/mqtt-packet/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/mqtt-packet/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mqtt-packet/node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/mqtt-packet/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/mqtt/node_modules/concat-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-      "dev": true,
-      "engines": [
-        "node >= 6.0"
-      ],
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/mqtt/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mqtt/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/mqtt/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/mqtt/node_modules/split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "readable-stream": "^3.0.0"
-      }
-    },
-    "node_modules/mqtt/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/mquery": {
@@ -33790,42 +34183,6 @@
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
       "dev": true
     },
-    "node_modules/number-allocator": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.9.tgz",
-      "integrity": "sha512-sIIF0dZKMs3roPUD7rLreH8H3x47QKV9dHZ+PeSnH24gL0CxKxz/823woGZC0hLBSb2Ar/rOOeHiNbnPBum/Mw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "^4.3.1",
-        "js-sdsl": "^2.1.2"
-      }
-    },
-    "node_modules/number-allocator/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/number-allocator/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -34518,7 +34875,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "lcid": "^1.0.0"
       },
@@ -37275,13 +37632,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/reinterval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
-      "integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc=",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/relay-compiler": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-10.1.0.tgz",
@@ -39065,13 +39415,6 @@
         "through2": "^2.0.2"
       }
     },
-    "node_modules/splitargs": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
-      "integrity": "sha1-/p965lc3GzOxDLgNoUPPgknPazs=",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -39467,6 +39810,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
     },
     "node_modules/strong-log-transformer": {
       "version": "2.1.0",
@@ -40951,61 +41300,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/unzipper": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
-      "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "~1.0.10",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.1.5",
-        "setimmediate": "~1.0.4"
-      }
-    },
-    "node_modules/unzipper/node_modules/bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/unzipper/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/unzipper/node_modules/process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/unzipper/node_modules/readable-stream": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-      "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
-      }
-    },
     "node_modules/upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -41217,13 +41511,6 @@
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       }
-    },
-    "node_modules/url-join": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-      "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g=",
-      "dev": true,
-      "peer": true
     },
     "node_modules/url-parse": {
       "version": "1.5.1",
@@ -41668,7 +41955,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
       "integrity": "sha512-2thx4pB0cV3h+Bw7QmMXcEbdmOzv9t0HFplJH/Lz6yu60hXYy5RT8rUu+wlIreVxWsGN20mo+MHeCSfUpQBwPw==",
-      "devOptional": true,
+      "optional": true,
       "bin": {
         "window-size": "cli.js"
       },
@@ -42556,12 +42843,53 @@
         }
       }
     },
+    "@aws-crypto/crc32c": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
+      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
     "@aws-crypto/ie11-detection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
       "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
       "dev": true,
       "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-crypto/sha1-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
+      "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -42671,45 +42999,36 @@
       }
     },
     "@aws-sdk/chunked-blob-reader": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.52.0.tgz",
-      "integrity": "sha512-BAZhriHHfvnGOd0P9xcnGu8DGyxOa0lgmEw+Tc6nZpXJzx0P+1Sd76q5gE5d/IZ0r5VTB6rfwwKUoG6iShNCwQ==",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
+      "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
       "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
     },
     "@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.52.0.tgz",
-      "integrity": "sha512-/hVzC0Q12/mWRMBBQD3v82xsLSxZ4RwG6N44XP7MuJoHy4ui4T7D9RSuvBpzzr/4fqF0w9M7XYv6aM4BD2pFIQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
+      "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
-        "@aws-sdk/util-base64-browser": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.52.0.tgz",
-          "integrity": "sha512-xjv/cQ4goWXAiGEC/AIL/GtlHg4p4RkQKs6/zxn9jOxo1OnbppLMJ0LjCtv4/JVYIVGHrx0VJ8Exyod7Ln+NeA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -43530,682 +43849,689 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.52.0.tgz",
-      "integrity": "sha512-QTY12zuKqWbtLG1H2RV13JG+NFNDeDAR2Ffka/qNHU6NMUqyQnyf/1h2UCVIekTmSaR6L6bYGgHl//kxMSUwCw==",
+      "version": "3.252.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.252.0.tgz",
+      "integrity": "sha512-VsTDuztgrwwBnkTZKm3t3cyXNTnWRCxDN4fCeEabw8/GB6KKSrs1a9pYXyWXuXtuvV5lFG4tIZMcXF7UkVXqyg==",
       "dev": true,
       "requires": {
+        "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.52.0",
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/credential-provider-node": "3.52.0",
-        "@aws-sdk/eventstream-serde-browser": "3.52.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.52.0",
-        "@aws-sdk/eventstream-serde-node": "3.52.0",
-        "@aws-sdk/fetch-http-handler": "3.52.0",
-        "@aws-sdk/hash-blob-browser": "3.52.0",
-        "@aws-sdk/hash-node": "3.52.0",
-        "@aws-sdk/hash-stream-node": "3.52.0",
-        "@aws-sdk/invalid-dependency": "3.52.0",
-        "@aws-sdk/md5-js": "3.52.0",
-        "@aws-sdk/middleware-apply-body-checksum": "3.52.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.52.0",
-        "@aws-sdk/middleware-content-length": "3.52.0",
-        "@aws-sdk/middleware-expect-continue": "3.52.0",
-        "@aws-sdk/middleware-host-header": "3.52.0",
-        "@aws-sdk/middleware-location-constraint": "3.52.0",
-        "@aws-sdk/middleware-logger": "3.52.0",
-        "@aws-sdk/middleware-retry": "3.52.0",
-        "@aws-sdk/middleware-sdk-s3": "3.52.0",
-        "@aws-sdk/middleware-serde": "3.52.0",
-        "@aws-sdk/middleware-signing": "3.52.0",
-        "@aws-sdk/middleware-ssec": "3.52.0",
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/middleware-user-agent": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/node-http-handler": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/smithy-client": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "@aws-sdk/util-base64-node": "3.52.0",
-        "@aws-sdk/util-body-length-browser": "3.52.0",
-        "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-        "@aws-sdk/util-defaults-mode-node": "3.52.0",
-        "@aws-sdk/util-user-agent-browser": "3.52.0",
-        "@aws-sdk/util-user-agent-node": "3.52.0",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
-        "@aws-sdk/util-waiter": "3.52.0",
-        "@aws-sdk/xml-builder": "3.52.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/client-sts": "3.252.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.252.0",
+        "@aws-sdk/eventstream-serde-browser": "3.226.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.226.0",
+        "@aws-sdk/eventstream-serde-node": "3.226.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-blob-browser": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/hash-stream-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/md5-js": "3.226.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-expect-continue": "3.226.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-location-constraint": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-sdk-s3": "3.231.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-ssec": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4-multi-region": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-stream-browser": "3.226.0",
+        "@aws-sdk/util-stream-node": "3.226.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.226.0",
+        "@aws-sdk/xml-builder": "3.201.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/abort-controller": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.52.0.tgz",
-          "integrity": "sha512-Z+4uVtgwbKSChruh6R/WIrGb5uvvXi/d6EQ7zC6hyghtn9EGQc+WJ3BVB4bIUshwMunlgjA3nDiPb5V3t5zv8Q==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+          "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/client-sso": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.52.0.tgz",
-          "integrity": "sha512-IvtZlZopWlWg6xnKSXAodWQaPcRySNBJLj68K6HJ8OVvBCgcXr53nNREArgPi0+KDzLsXqAZTRxvU5do/99PrA==",
+          "version": "3.252.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.252.0.tgz",
+          "integrity": "sha512-VgBqJvvCU4y9zAHJwYj5nOeNGcCxKdCO4edUxWQVHcpLsVWu49maOVtWuteq9MOrHYeWfQi8bVWGt8MPvv9+bA==",
           "dev": true,
           "requires": {
             "@aws-crypto/sha256-browser": "2.0.0",
             "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.52.0",
-            "@aws-sdk/fetch-http-handler": "3.52.0",
-            "@aws-sdk/hash-node": "3.52.0",
-            "@aws-sdk/invalid-dependency": "3.52.0",
-            "@aws-sdk/middleware-content-length": "3.52.0",
-            "@aws-sdk/middleware-host-header": "3.52.0",
-            "@aws-sdk/middleware-logger": "3.52.0",
-            "@aws-sdk/middleware-retry": "3.52.0",
-            "@aws-sdk/middleware-serde": "3.52.0",
-            "@aws-sdk/middleware-stack": "3.52.0",
-            "@aws-sdk/middleware-user-agent": "3.52.0",
-            "@aws-sdk/node-config-provider": "3.52.0",
-            "@aws-sdk/node-http-handler": "3.52.0",
-            "@aws-sdk/protocol-http": "3.52.0",
-            "@aws-sdk/smithy-client": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/url-parser": "3.52.0",
-            "@aws-sdk/util-base64-browser": "3.52.0",
-            "@aws-sdk/util-base64-node": "3.52.0",
-            "@aws-sdk/util-body-length-browser": "3.52.0",
-            "@aws-sdk/util-body-length-node": "3.52.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-            "@aws-sdk/util-defaults-mode-node": "3.52.0",
-            "@aws-sdk/util-user-agent-browser": "3.52.0",
-            "@aws-sdk/util-user-agent-node": "3.52.0",
-            "@aws-sdk/util-utf8-browser": "3.52.0",
-            "@aws-sdk/util-utf8-node": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/fetch-http-handler": "3.226.0",
+            "@aws-sdk/hash-node": "3.226.0",
+            "@aws-sdk/invalid-dependency": "3.226.0",
+            "@aws-sdk/middleware-content-length": "3.226.0",
+            "@aws-sdk/middleware-endpoint": "3.226.0",
+            "@aws-sdk/middleware-host-header": "3.226.0",
+            "@aws-sdk/middleware-logger": "3.226.0",
+            "@aws-sdk/middleware-recursion-detection": "3.226.0",
+            "@aws-sdk/middleware-retry": "3.235.0",
+            "@aws-sdk/middleware-serde": "3.226.0",
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/middleware-user-agent": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/node-http-handler": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/smithy-client": "3.234.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+            "@aws-sdk/util-defaults-mode-node": "3.234.0",
+            "@aws-sdk/util-endpoints": "3.245.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "@aws-sdk/util-user-agent-browser": "3.226.0",
+            "@aws-sdk/util-user-agent-node": "3.226.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/client-sts": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.52.0.tgz",
-          "integrity": "sha512-tPLHYY9RdWehBQlyrwOaw4B31PqW1HmNNKJ3+Hc6KnEaiOwMAwQd8L7BFbSVG8ajQBDAEBUTDAkSaZ8jTYdfQQ==",
+          "version": "3.252.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.252.0.tgz",
+          "integrity": "sha512-wzfsWOlDFLdmeML8R7DUJWGl9wcRKf2uiunfB1aWzpdlgms0Z7FkHWgkDYHjCPyYHL6EBm84ajGl1UkE7AcmqQ==",
           "dev": true,
           "requires": {
             "@aws-crypto/sha256-browser": "2.0.0",
             "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.52.0",
-            "@aws-sdk/credential-provider-node": "3.52.0",
-            "@aws-sdk/fetch-http-handler": "3.52.0",
-            "@aws-sdk/hash-node": "3.52.0",
-            "@aws-sdk/invalid-dependency": "3.52.0",
-            "@aws-sdk/middleware-content-length": "3.52.0",
-            "@aws-sdk/middleware-host-header": "3.52.0",
-            "@aws-sdk/middleware-logger": "3.52.0",
-            "@aws-sdk/middleware-retry": "3.52.0",
-            "@aws-sdk/middleware-sdk-sts": "3.52.0",
-            "@aws-sdk/middleware-serde": "3.52.0",
-            "@aws-sdk/middleware-signing": "3.52.0",
-            "@aws-sdk/middleware-stack": "3.52.0",
-            "@aws-sdk/middleware-user-agent": "3.52.0",
-            "@aws-sdk/node-config-provider": "3.52.0",
-            "@aws-sdk/node-http-handler": "3.52.0",
-            "@aws-sdk/protocol-http": "3.52.0",
-            "@aws-sdk/smithy-client": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/url-parser": "3.52.0",
-            "@aws-sdk/util-base64-browser": "3.52.0",
-            "@aws-sdk/util-base64-node": "3.52.0",
-            "@aws-sdk/util-body-length-browser": "3.52.0",
-            "@aws-sdk/util-body-length-node": "3.52.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-            "@aws-sdk/util-defaults-mode-node": "3.52.0",
-            "@aws-sdk/util-user-agent-browser": "3.52.0",
-            "@aws-sdk/util-user-agent-node": "3.52.0",
-            "@aws-sdk/util-utf8-browser": "3.52.0",
-            "@aws-sdk/util-utf8-node": "3.52.0",
-            "entities": "2.2.0",
-            "fast-xml-parser": "3.19.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/credential-provider-node": "3.252.0",
+            "@aws-sdk/fetch-http-handler": "3.226.0",
+            "@aws-sdk/hash-node": "3.226.0",
+            "@aws-sdk/invalid-dependency": "3.226.0",
+            "@aws-sdk/middleware-content-length": "3.226.0",
+            "@aws-sdk/middleware-endpoint": "3.226.0",
+            "@aws-sdk/middleware-host-header": "3.226.0",
+            "@aws-sdk/middleware-logger": "3.226.0",
+            "@aws-sdk/middleware-recursion-detection": "3.226.0",
+            "@aws-sdk/middleware-retry": "3.235.0",
+            "@aws-sdk/middleware-sdk-sts": "3.226.0",
+            "@aws-sdk/middleware-serde": "3.226.0",
+            "@aws-sdk/middleware-signing": "3.226.0",
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/middleware-user-agent": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/node-http-handler": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/smithy-client": "3.234.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+            "@aws-sdk/util-defaults-mode-node": "3.234.0",
+            "@aws-sdk/util-endpoints": "3.245.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "@aws-sdk/util-user-agent-browser": "3.226.0",
+            "@aws-sdk/util-user-agent-node": "3.226.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/config-resolver": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.52.0.tgz",
-          "integrity": "sha512-XKUCpPLMwdlqPtwutdMfAHWqGEPTDd14Dp01WyNhVtmTmsHkpFfLPpELLO1BczDS+jyoMUj+UDj9jHm4YLvXXg==",
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+          "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
           "dev": true,
           "requires": {
-            "@aws-sdk/signature-v4": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-config-provider": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.52.0.tgz",
-          "integrity": "sha512-9R8kTMQ3udNz7fyY/0rkU6Yhu0ALYQJZQ0lFCrxtNo2Nlo9taQtZgxhtRcv+EeqbTcJs91voNNz70HLbedtBUw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
+          "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
           "dev": true,
           "requires": {
-            "@aws-sdk/property-provider": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/credential-provider-imds": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.52.0.tgz",
-          "integrity": "sha512-939kfHSkMLsOfQtO2nBqC/zAE1ecTOCAs72pKvVxrluGzDry4UtwlyQ4YGC04pYBRQeRIqvIOoVbADYJy4XjmQ==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+          "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
           "dev": true,
           "requires": {
-            "@aws-sdk/node-config-provider": "3.52.0",
-            "@aws-sdk/property-provider": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/url-parser": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.52.0.tgz",
-          "integrity": "sha512-MCzWWPYoZjZ3C/X8UXXf9eRqgGJc3Y1QyFXIuQzNrVhffrFkYOkOUQsG4s5TuDr1MmGfxe83XtHQgATJ0fe3zw==",
+          "version": "3.252.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.252.0.tgz",
+          "integrity": "sha512-OfpU8xMYK7+6XQ2dUO4rN0gUhhb/ZLV7iwSL6Ji2pI9gglGhKdOSfmbn6fBfCB50kzWZRNoiQJVaBu/d0Kr0EQ==",
           "dev": true,
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.52.0",
-            "@aws-sdk/credential-provider-imds": "3.52.0",
-            "@aws-sdk/credential-provider-sso": "3.52.0",
-            "@aws-sdk/credential-provider-web-identity": "3.52.0",
-            "@aws-sdk/property-provider": "3.52.0",
-            "@aws-sdk/shared-ini-file-loader": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-credentials": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/credential-provider-env": "3.226.0",
+            "@aws-sdk/credential-provider-imds": "3.226.0",
+            "@aws-sdk/credential-provider-process": "3.226.0",
+            "@aws-sdk/credential-provider-sso": "3.252.0",
+            "@aws-sdk/credential-provider-web-identity": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.52.0.tgz",
-          "integrity": "sha512-SUl+t2S7xKHxAkIfuyvucKQ/JemJ/bCsuCk2qtjTSiVjrLx65Rnfw14j+44JU8U5mP+xodpKNCpgIF5PHu1kKQ==",
+          "version": "3.252.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.252.0.tgz",
+          "integrity": "sha512-Jt854JnB7izkJ/gb3S0hBFqAQPUNUP3eL8gXX2uqk9A9bQFQdS57/Ci0FXaEPwOXzJwAAPazD8dTf6HXMhnm3w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.52.0",
-            "@aws-sdk/credential-provider-imds": "3.52.0",
-            "@aws-sdk/credential-provider-ini": "3.52.0",
-            "@aws-sdk/credential-provider-process": "3.52.0",
-            "@aws-sdk/credential-provider-sso": "3.52.0",
-            "@aws-sdk/credential-provider-web-identity": "3.52.0",
-            "@aws-sdk/property-provider": "3.52.0",
-            "@aws-sdk/shared-ini-file-loader": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-credentials": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/credential-provider-env": "3.226.0",
+            "@aws-sdk/credential-provider-imds": "3.226.0",
+            "@aws-sdk/credential-provider-ini": "3.252.0",
+            "@aws-sdk/credential-provider-process": "3.226.0",
+            "@aws-sdk/credential-provider-sso": "3.252.0",
+            "@aws-sdk/credential-provider-web-identity": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.52.0.tgz",
-          "integrity": "sha512-DGaSprlcEGgFuCiXNH9moksa6/1vBmX/G/tt/ulpgFEJmKljoazIEgUse/6oPJT7t5jazydAqMRVp1HK3Jp/0A==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
+          "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
           "dev": true,
           "requires": {
-            "@aws-sdk/property-provider": "3.52.0",
-            "@aws-sdk/shared-ini-file-loader": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-credentials": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.52.0.tgz",
-          "integrity": "sha512-8Q0X4wro+sPMYkbZE/ZW+CBpjxGq/x/vv4yQh7zdHpNfANhqjTSR8tUCApemVcfPtwNhQNPpW8KrlWUIMguHdg==",
+          "version": "3.252.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.252.0.tgz",
+          "integrity": "sha512-2JGoojMOBjG9/DenctEszjdPechq0uDTpH5nx+z1xxIAugA5+HYG/ncNfpwhmUBCrnOxpRaQViTNqXddEPHlAg==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-sso": "3.52.0",
-            "@aws-sdk/property-provider": "3.52.0",
-            "@aws-sdk/shared-ini-file-loader": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-credentials": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/client-sso": "3.252.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/token-providers": "3.252.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.52.0.tgz",
-          "integrity": "sha512-+4qz0PZn9u6HRRNBO9YfIixdItukixPOtLP8tNlgriCh66BC6M1mAXXP/uq2x7kIaMRZtTo3Eey4T/tA0QMkOg==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
+          "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
           "dev": true,
           "requires": {
-            "@aws-sdk/property-provider": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/fetch-http-handler": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.52.0.tgz",
-          "integrity": "sha512-pFXkCeEIcrgH8esRyUab1nnIo1cjUjrheqwb/MK3gJ363/kenT6IqYXOq0UO4mF7bn6IOz/yxODlhQIU6i1Vww==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+          "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
           "dev": true,
           "requires": {
-            "@aws-sdk/protocol-http": "3.52.0",
-            "@aws-sdk/querystring-builder": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-base64-browser": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/querystring-builder": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/hash-node": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.52.0.tgz",
-          "integrity": "sha512-pN2dSSyyy0emFFtK6jgmzYXcJHITbfdPqR7UTQ1fj1wFvbURPN19C1f4uYbVDjuiUQX01hLclJDLnPy1BIzTGQ==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+          "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-buffer-from": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/invalid-dependency": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.52.0.tgz",
-          "integrity": "sha512-TjRzfFFiY4i/a9ry5llCQMiIwpyhIyriM2QuPgAdRaRPM076I01FohUzlAc7zgwwhCa5rpI4zRZ+auGPrU44Gw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+          "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/is-array-buffer": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
-          "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/md5-js": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.52.0.tgz",
-          "integrity": "sha512-M0oHeBDvXCapQvvGzzlMrkW1vRfExngB/Gn93Vmdpt97+ieHkfHgo9fU/erQKb+HwnlZbhVJW3vEgfHPLvql6A==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.226.0.tgz",
+          "integrity": "sha512-ENigJRNudqyh6xsch166SZ4gggHd3XzZJ8gkCU4CWPne04HcR3BkWSO774IuWooCHt8zkaEHKecPurRz6qR+Vw==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-utf8-browser": "3.52.0",
-            "@aws-sdk/util-utf8-node": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/middleware-content-length": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.52.0.tgz",
-          "integrity": "sha512-U+aa8UswtEvEdt4vvX+C4b+vetSpG6PZVeGN/hZ2J0j3jQxODQtjKHU3VIO+Fvp8m9rSCtcfAPly5CcejHLeKw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+          "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
           "dev": true,
           "requires": {
-            "@aws-sdk/protocol-http": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/middleware-host-header": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.52.0.tgz",
-          "integrity": "sha512-t7y0gtJyFNrS6bwluR7N2LtppA7B0SDk+uNlvOJOYnJRms89fXltyMJWl8wrv8IHHvrhRLwNEP22vvOhn3hriA==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+          "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
           "dev": true,
           "requires": {
-            "@aws-sdk/protocol-http": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/middleware-logger": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.52.0.tgz",
-          "integrity": "sha512-YbFuJAsOPvbYe64gpqmS6XmEQXwyAGwH3Y4iOp3CnrGAz/zXbwWwzb653Uby+h4PVkTZ1+RviCO/A6si9bUkhw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+          "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/middleware-retry": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.52.0.tgz",
-          "integrity": "sha512-O+4mfn7OPv1POYagKwOgdlc16AQFWa4bY05g6Y94KZ2400ywNpK+Y2cwdskyNU3OTGOlluVGR21W5eO1b+XhNg==",
+          "version": "3.235.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+          "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
           "dev": true,
           "requires": {
-            "@aws-sdk/protocol-http": "3.52.0",
-            "@aws-sdk/service-error-classification": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/service-error-classification": "3.229.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "tslib": "^2.3.1",
             "uuid": "^8.3.2"
           }
         },
         "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.52.0.tgz",
-          "integrity": "sha512-NB1wHvOp+I6DXi5fPutyl9dAWvJYqzRqdi8lMeu02ub/d6nybrAjoB56za1LvGblcoEiYClf1A6dTKtmydgzFQ==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
+          "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
           "dev": true,
           "requires": {
-            "@aws-sdk/middleware-signing": "3.52.0",
-            "@aws-sdk/property-provider": "3.52.0",
-            "@aws-sdk/protocol-http": "3.52.0",
-            "@aws-sdk/signature-v4": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/middleware-signing": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/middleware-serde": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.52.0.tgz",
-          "integrity": "sha512-4ZooINTdOI4+T6pEiu8xte5EEhOqbE/wqOwBzvOASk3JKElZ93u6xKP2u7UKVD6asBBYK2mDrYSy1PsU4fNl4A==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+          "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/middleware-signing": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.52.0.tgz",
-          "integrity": "sha512-7FUqmZQ5DzaDJYCJ3YmOHRFEyFeohtsDQ1akWD2qekcjp16ftBtk05Fi9am5/L7pO8svVzobji/wg00Tlq183A==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
+          "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
           "dev": true,
           "requires": {
-            "@aws-sdk/property-provider": "3.52.0",
-            "@aws-sdk/protocol-http": "3.52.0",
-            "@aws-sdk/signature-v4": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/middleware-stack": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.52.0.tgz",
-          "integrity": "sha512-4OTbQ+tWc6Le7es3kSnXBzCyddcUw6Sk2GupR/1+PD9v4/qvtKXXK+uD4bMDDMfi6dTNV+2riOGBniOtBVsayw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+          "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/middleware-user-agent": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.52.0.tgz",
-          "integrity": "sha512-sfdJvAp/f4PHmQvSklFAuCpD7gqloG502gSmBAMrXKqYykvQ5SAGyr6sCZPWf8CZxKtn5n4ftg8CLKywwrKwmg==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+          "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
           "dev": true,
           "requires": {
-            "@aws-sdk/protocol-http": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/node-config-provider": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.52.0.tgz",
-          "integrity": "sha512-vfeTzkfVtGaNQrnhCRMObqid0shxFtNFEnnU1Nnx7HsgBfag2/T6fnsDzdVGaliQ6nmfg+RMrhzw2VECyBTHQQ==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+          "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/property-provider": "3.52.0",
-            "@aws-sdk/shared-ini-file-loader": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/node-http-handler": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.52.0.tgz",
-          "integrity": "sha512-MjLkndwLuWye1kavyFnDw5BvK8Rg4YpMULTne++OL/uEsxWO786K+QQMyLWkirPe+ELMEYu/3eOrQTly2tqHsA==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+          "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
           "dev": true,
           "requires": {
-            "@aws-sdk/abort-controller": "3.52.0",
-            "@aws-sdk/protocol-http": "3.52.0",
-            "@aws-sdk/querystring-builder": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/abort-controller": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/querystring-builder": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/property-provider": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.52.0.tgz",
-          "integrity": "sha512-Ooam7CvGefHKhMwQ413MiEtDTFw70xbCduJCF7Bg1F0WKrf700M/Yte+q3E0ljlXWJ28rwJNgwW3ptZaSXMGPg==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+          "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/protocol-http": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
-          "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/querystring-builder": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.52.0.tgz",
-          "integrity": "sha512-RfNXqKeR6mdg2n2LO5Vs2Bz+f47/KN5k36HWk04bSwIbhnBtslXBp0F1KgSPkeP56KEgmmUWldRD7g8BvDkgAw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+          "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-uri-escape": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/querystring-parser": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.52.0.tgz",
-          "integrity": "sha512-/A6PauieStZajbkxX3sZSBBDacGDc3I/Sk7rjJulmg1GnizeVcUgx1OUdDh1JasdqA1h9E3ks/Y2Lu3xUMctLw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+          "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/service-error-classification": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.52.0.tgz",
-          "integrity": "sha512-2bpSIZCx5VGp2CBTeXK6PxlBYWrn2wiqxBVYstDRExZ8P7edcwPRgWi8qaKgPM2wvstZwJieF774niiuLddIpg==",
+          "version": "3.229.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+          "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
           "dev": true
         },
         "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.52.0.tgz",
-          "integrity": "sha512-tALb8u8IVcI4pT7yFZpl4O6kgeY5EAXyphZoRPgQSCDhmEyFUIi/sXbCN8HQiHjnHdWfXdaNE1YsZcW3GpcuoQ==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+          "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/signature-v4": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.52.0.tgz",
-          "integrity": "sha512-lSlDASXGLup5v12kclzT2ZLoUnnVLknSRcMXrTVjnX7spmHMbs6s7LOcN0RXZzFIACs7vW+930KUzhBxt8UiFQ==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+          "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
           "dev": true,
           "requires": {
-            "@aws-sdk/is-array-buffer": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-hex-encoding": "3.52.0",
-            "@aws-sdk/util-uri-escape": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/smithy-client": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.52.0.tgz",
-          "integrity": "sha512-GuOJuoA1kky/v2p7byOZGq7YOiu2Ov8DA3d58gM6L/q7XavBjnzwNB/BYU7SPU3Ly6S7qGxBJFeadufic4bCYg==",
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+          "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
           "dev": true,
           "requires": {
-            "@aws-sdk/middleware-stack": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "@aws-sdk/url-parser": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.52.0.tgz",
-          "integrity": "sha512-/9OJwol/384jsISiAs5JX7fkgd9mv7hJsHFCVXnByim5qTZu1V9fMcJYJ1L3iRmfCRy0w75UDJljIx2RZnwAYw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+          "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
           "dev": true,
           "requires": {
-            "@aws-sdk/querystring-parser": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@aws-sdk/util-base64-browser": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.52.0.tgz",
-          "integrity": "sha512-xjv/cQ4goWXAiGEC/AIL/GtlHg4p4RkQKs6/zxn9jOxo1OnbppLMJ0LjCtv4/JVYIVGHrx0VJ8Exyod7Ln+NeA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
-        "@aws-sdk/util-base64-node": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.52.0.tgz",
-          "integrity": "sha512-V96YIXBuIiVu7Zk72Y9dly7Io9cYOT30Hjf77KAkBeizlFgT5gWklWYGcytPY8FxLuEy4dPLeHRmgwQnlDwgPA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/querystring-parser": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-body-length-browser": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.52.0.tgz",
-          "integrity": "sha512-8omOgIGmopUtwg3XaeyvqacxrIrCsDKUVQp5n+8iLmyYt5mQM70vXbUC273GJzKDtibGDfxiN4FqSLBlo9F/oQ==",
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-body-length-node": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.52.0.tgz",
-          "integrity": "sha512-1WWsGh0hip4y1uvOLFV2v3Nvq3W35dmW5YniCi0gQDBLc5JHES8Zka7yoCDYOfaYFUodVH5mC/jFBjGRQ3TpDw==",
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-buffer-from": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.52.0.tgz",
-          "integrity": "sha512-hsG0lMlHjJUFoXIy59QLn6x4QU/vp/e0t3EjdD0t8aymB9iuJ43UeLjYTZdrOgtbWb8MXEF747vwg+P6n+4Lxw==",
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
           "dev": true,
           "requires": {
-            "@aws-sdk/is-array-buffer": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-config-provider": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.52.0.tgz",
-          "integrity": "sha512-1wonBNkOOLJpMZnz2Kn69ToFgSoTTyGzJInir8WC5sME3zpkb5j41kTuEVbImNJhVv9MKjmGYrMeZbBVniLRPw==",
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
-        "@aws-sdk/util-credentials": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.52.0.tgz",
-          "integrity": "sha512-fNcm2cNzDHWt5Pr6xD2FXA40jkcgClsbumuI0VBhLEyNLfoetwPImKTpqbxo1XfWVxhqIbT/ELnrbS2OYBRIXg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/shared-ini-file-loader": "3.52.0",
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-hex-encoding": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
-          "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+          "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-uri-escape": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
-          "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-user-agent-browser": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.52.0.tgz",
-          "integrity": "sha512-zmw9pJ91QAr1oF3uqLKuo/3++NrSEagLwz3xnuID5wN8WLAgbC6MkvM7FG+r11CHSoUX3IeB6YDqoBMQW8en8w==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+          "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
+            "@aws-sdk/types": "3.226.0",
             "bowser": "^2.11.0",
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-user-agent-node": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.52.0.tgz",
-          "integrity": "sha512-jqbyb6R4goWOTIESizmNPy1i3Xa25Q3QG0xt6Pct0DwLQUSVpnPHw07NmfRhql+eYBoD4uxpXDX9lWsuLUBi0w==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+          "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
           "dev": true,
           "requires": {
-            "@aws-sdk/node-config-provider": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-utf8-browser": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.52.0.tgz",
-          "integrity": "sha512-LuOMa9ajWu5fQuYkmvTlQZfHaITkSle+tM/vhbU4JquRN44VUKACjRGT7UEhoU3lCL1BD0JFGMQGHI+5Mmuwfg==",
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-utf8-node": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.52.0.tgz",
-          "integrity": "sha512-fujr7zeobZ2y5nnOnQZrCPPc+lCAhtNF/LEVslsQfd+AQ0bYWiosrKNetodQVWlfh10E2+i6/5g+1SBJ5kjsLw==",
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+          "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
           "dev": true,
           "requires": {
-            "@aws-sdk/util-buffer-from": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-waiter": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.52.0.tgz",
-          "integrity": "sha512-8Gx0NunIg1RFpnKSA3nwzDl5j8mJ42kWjy5sHgd4wfUyiXRSvTl69sV6O8qhleI9OMDV0iS4xHZBCLK11HdIoA==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
+          "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
           "dev": true,
           "requires": {
-            "@aws-sdk/abort-controller": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/abort-controller": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.0.11",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+          "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+          "dev": true,
+          "requires": {
+            "strnum": "^1.0.5"
           }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -46651,6 +46977,430 @@
         }
       }
     },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.252.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.252.0.tgz",
+      "integrity": "sha512-OOwfEXFS+UliGZorEleARsXXUp3ObZSXo9/YY+8XF7/8froAqYjKCEi0tflghgYlh7d6qe7wzD7/6gDL1a/qgA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+          "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+          "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+          "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/querystring-builder": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
+          "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
+          "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
+          "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
+          "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
+          "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.235.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+          "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/service-error-classification": "3.229.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+          "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
+          "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
+          "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+          "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+          "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/abort-controller": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/querystring-builder": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+          "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+          "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+          "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.229.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+          "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+          "dev": true
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+          "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+          "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+          "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+          "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+          "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
+          "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
+          "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+          "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
     "@aws-sdk/client-sts": {
       "version": "3.81.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.81.0.tgz",
@@ -46917,138 +47667,151 @@
         }
       }
     },
-    "@aws-sdk/eventstream-marshaller": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.52.0.tgz",
-      "integrity": "sha512-RK5uWIOwae3Yzog8og3+e+k8kpRnjrg9hhOLmq2xG4m5seo7v7S5jfmb0uLX/Uqgd1vWMK5wKFJsdGhnAqykcQ==",
+    "@aws-sdk/eventstream-codec": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.226.0.tgz",
+      "integrity": "sha512-6uPtR8vSwz3fqoZk9hrb6qBYdp3PJ22+JxV5Wimdesvow4kJXSgDQXIxEkxbv6SxB9tNRB4uJHD84RetHEi15Q==",
       "dev": true,
       "requires": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-hex-encoding": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
-          "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
           }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.52.0.tgz",
-      "integrity": "sha512-Lo1RzjOCvOGDoyq1hdxO7YWsdyc5ZMo0+jf/SDm64ZM8jE4eRUh1iGj0kCOKIIr/tCbzhbvP4SoNDfehJ2rqfA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.226.0.tgz",
+      "integrity": "sha512-otYC5aZE9eJUqAlKpy8w0rPDQ1eKGvZPtgxWXmFYSO2lDVGfI1nBBNmdZ4MdHqNuQ7ucsKMQYF8BFJ65K2tYPA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.52.0",
-        "@aws-sdk/eventstream-serde-universal": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/eventstream-serde-universal": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.52.0.tgz",
-      "integrity": "sha512-yCfYf2MepHPpRTsbGNNLVDbN22woSmNDM2bEeK5gDbyV23MGlnLxjekLKdBbH5M6FUqfMbpsM60gDgJgas3ovA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.226.0.tgz",
+      "integrity": "sha512-A56Gypg+lyEfA5cna+EUH9XTrj0SvRG1gwNW7lrUzviN36SeA/LFTUIOEjxVML3Lowy+EPAcrSZ67h6aepoAig==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.52.0.tgz",
-      "integrity": "sha512-hL067bWZ875oL+l+Q1Wrhkq/V9727fHeJ1J4Kr/o84hGRnIkN7OiNDLIMyUTrGdc0I4diGUbc8FVJiRtZRmphw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.226.0.tgz",
+      "integrity": "sha512-KWLnKkKDzI9RNkiK6OiSYpG/XjZfue6Bsp/vRG+H5z3fbXdHv4X2+iW+Efu2Kvn7jsUyUv82TCl57DyJ/HKYhQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.52.0",
-        "@aws-sdk/eventstream-serde-universal": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/eventstream-serde-universal": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.52.0.tgz",
-      "integrity": "sha512-CDMcBJDNDJfGWz2Vk2p1Ef6JbZDVZVZDG8F7Gdhn7RsiMsFf7QiF4vcNEJwQIX25ZSerRqEitBT8nEZEDxEYGw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.226.0.tgz",
+      "integrity": "sha512-Q8viYM1Sv90/yIUqyWNeG1GEvyVlAI3GIrInQcCMC+xT59jS+IKGy2y7ojCvSWXnhf5/HMXKcmG092QsqeKy0Q==",
       "dev": true,
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/eventstream-codec": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -47075,27 +47838,30 @@
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.52.0.tgz",
-      "integrity": "sha512-EhEXgO/cb67EHXl/F1D3vtdv695n1nIrAQLdiTOcNvdMRWLpjb2MkR3GI9tppkTabF4o3allgZVebKVeqINSMQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.226.0.tgz",
+      "integrity": "sha512-5DCvWE6L4xGoViEHyjcPFuUe1G2EtNx8TqswWaoaKgyasP/yuRm4H99Ra7rqIrjCcSTAGD9NVsUQvVVw1bGt9w==",
       "dev": true,
       "requires": {
-        "@aws-sdk/chunked-blob-reader": "3.52.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/chunked-blob-reader": "3.188.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.208.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -47120,25 +47886,28 @@
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.52.0.tgz",
-      "integrity": "sha512-Khgy6DM2Kpcqbom8dYQtH7GmxnprdQVHsKvhmkReqfksxvrwNwo+S2RCDlceGTVIkELuvyfnVd19JLQO7BnqTw==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.226.0.tgz",
+      "integrity": "sha512-cgNTGlF8SdHaQXtjEmuLXz2U8SLM2JDKtIVPku/lHTMsUsEn+fuv2C+h1f/hvd4aNw5t1zggym7sO1/h/rv56Q==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -47242,93 +48011,51 @@
         }
       }
     },
-    "@aws-sdk/middleware-apply-body-checksum": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.52.0.tgz",
-      "integrity": "sha512-f5ynflavshbkmV4ZpcwW2WoYAP69bOpv8bUPNsiKEzL07q6ZperkIaYre9BajNMxGN+UNSoE5CQIvRGcwC6UxA==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
-      },
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
-          "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
-          "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
-        },
-        "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-          "dev": true
-        }
-      }
-    },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.52.0.tgz",
-      "integrity": "sha512-KOq8kTzhWYiwits89pnCduL7ojijthfFR5PRvLW6IwQbPxIg/AjdO5gYbMUTLaVAO1b7LoI3ztk+lmLQ2yvjOA==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.226.0.tgz",
+      "integrity": "sha512-A1Vq5W2X7jgTfjqcKPmjoHohF0poP+9fxwL97fQMvzcwmjhtoCV3bLEpo6CGYx0pKPiSlRJXZkRwRPj2hDHDmA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-arn-parser": "3.52.0",
-        "@aws-sdk/util-config-provider": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/protocol-http": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
-          "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "@aws-sdk/util-config-provider": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.52.0.tgz",
-          "integrity": "sha512-1wonBNkOOLJpMZnz2Kn69ToFgSoTTyGzJInir8WC5sME3zpkb5j41kTuEVbImNJhVv9MKjmGYrMeZbBVniLRPw==",
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -47348,6 +48075,139 @@
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
+      "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
+          "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+          "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+          "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+          "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+          "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -47374,72 +48234,89 @@
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.52.0.tgz",
-      "integrity": "sha512-1rpD1I/HwDdVAW9wBtLv34gxrfkfLEyTEj2Y/1Qh/62rMX7KbBT0CmbbO33upOqyrsJDW961Mu/d5cVZW1N3XQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.226.0.tgz",
+      "integrity": "sha512-YxvQKTV/eA9P8AgW0hXOgj5Qa+TSnNFfyOkfeP089aP3f6p92b1cESf33TEOKsddive2mHT5LRCN6MuPcgWWrA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-header-default": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/protocol-http": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
-          "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
     },
-    "@aws-sdk/middleware-header-default": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.52.0.tgz",
-      "integrity": "sha512-ts5kuAnLjC9HW9W/vkCrlMa4a5DG45BkOjhYhD4YZCDBt9+E/N5Pt/14jmTdTO5LQ26zVC6Z3ByBXXayDKEIow==",
+    "@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.226.0.tgz",
+      "integrity": "sha512-8A9Ot9A7794UP5tMGl2MnfTW/UM/jYy1wRWF9YkR/hPIcPb7OmE0hmlwIQGzb/7grxpYw66ETKf0WeH/41YfeQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-crypto/crc32c": "2.0.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
-          "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -47464,25 +48341,28 @@
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.52.0.tgz",
-      "integrity": "sha512-P+RfKVXL6X+vu7e54vu73TNje15y+Jo1VEbBpFGz5wYsLlBO58e6utDYLOYLwj+WzLqShSzZX9ejZzxrOSYQdQ==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.226.0.tgz",
+      "integrity": "sha512-qHiYaBYPc2R37KxG2uqsUUwh4usrQMHfGkrpTUnx5d4rGzM3mC+muPsTpSHnAL63K2/yJOHQJFjss3GGwV4SSA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -47501,6 +48381,44 @@
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
+      "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -47528,78 +48446,40 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.52.0.tgz",
-      "integrity": "sha512-M9ivvdTEPFoFUgfGLdFeRxFGRh/Edq6tevSnWjdOoLTgbzq8tnuKkj9v3gKsIN+a1QWP6Ef0ThH/jyuFDcBEnQ==",
+      "version": "3.231.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.231.0.tgz",
+      "integrity": "sha512-UGaSvevd2TanfKgStF46dDSHkh4bxOr1gdUkyHm9i+1pF5lx4KdbnBZv/5SKnn7XifhHRXrs1M3lTzemXREhTA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-arn-parser": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
-          "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
         "@aws-sdk/protocol-http": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
-          "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.52.0.tgz",
-          "integrity": "sha512-lSlDASXGLup5v12kclzT2ZLoUnnVLknSRcMXrTVjnX7spmHMbs6s7LOcN0RXZzFIACs7vW+930KUzhBxt8UiFQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-hex-encoding": "3.52.0",
-            "@aws-sdk/util-uri-escape": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
-        },
-        "@aws-sdk/util-hex-encoding": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
-          "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
-          }
-        },
-        "@aws-sdk/util-uri-escape": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
-          "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -47700,25 +48580,28 @@
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.52.0.tgz",
-      "integrity": "sha512-lEswW+Hf5tvkPs6aNRbPF5/Iizh62lq4NK6bZjvQF6kqyUoIGhOehQOZMmTm6jw0058KVhrzNIKipBpi7LuF6w==",
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.226.0.tgz",
+      "integrity": "sha512-DR97oWoLHiMdaUP/wu99HtzG7/ijvCrjZGDH37WBO1rxFtEti6L7T09wgHzwxMN8gtL8FJA7dU8IrffGSC9VmA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -47918,90 +48801,93 @@
         }
       }
     },
-    "@aws-sdk/signature-v4-crt": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.52.0.tgz",
-      "integrity": "sha512-+9b8WDHxCJ9OoXWMhV91Xt2nQtjqYatR2NA+gUUHjOiHbSSY0nG0jMsgKQU7MP6OAEWpZnRWEpeZtwwJm+gatg==",
+    "@aws-sdk/signature-v4-multi-region": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.226.0.tgz",
+      "integrity": "sha512-QHxNuf9ynK208v7Y3imdsa3Cz8ynYV7ZOf3sBJdItuEtHN6uy/KxaOrtvpF8I5Hyn48Hc8z5miTSMujFKT7GEw==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/querystring-parser": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/util-hex-encoding": "3.52.0",
-        "@aws-sdk/util-uri-escape": "3.52.0",
-        "aws-crt": "^1.9.7",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/is-array-buffer": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
-          "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
           "dev": true,
-          "peer": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.52.0.tgz",
-          "integrity": "sha512-/A6PauieStZajbkxX3sZSBBDacGDc3I/Sk7rjJulmg1GnizeVcUgx1OUdDh1JasdqA1h9E3ks/Y2Lu3xUMctLw==",
+        "@aws-sdk/protocol-http": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
           "dev": true,
-          "peer": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/signature-v4": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.52.0.tgz",
-          "integrity": "sha512-lSlDASXGLup5v12kclzT2ZLoUnnVLknSRcMXrTVjnX7spmHMbs6s7LOcN0RXZzFIACs7vW+930KUzhBxt8UiFQ==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+          "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
           "dev": true,
-          "peer": true,
           "requires": {
-            "@aws-sdk/is-array-buffer": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-hex-encoding": "3.52.0",
-            "@aws-sdk/util-uri-escape": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
           "dev": true,
-          "peer": true
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "@aws-sdk/util-hex-encoding": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
-          "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
           "dev": true,
-          "peer": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+          "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-uri-escape": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
-          "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
           "dev": true,
-          "peer": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-          "dev": true,
-          "peer": true
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
         }
       }
     },
@@ -48020,6 +48906,56 @@
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.252.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.252.0.tgz",
+      "integrity": "sha512-xi3pUP31tyKF4lJFCOgtkwSWESE9W1vE23Vybsq53wzXEYfnRql8RP+C9FFkUouAR6ixPHEcEYplB+l92CY49g==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.252.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/property-provider": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+          "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+          "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -48050,18 +48986,55 @@
       }
     },
     "@aws-sdk/util-arn-parser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.52.0.tgz",
-      "integrity": "sha512-mMsoYJ70+BGkVpdfQbu942v4fAGzx+pIL8+QnQhzUmcU0HbNkI0vYliMWfzz7ka9CHgbijUI/ANKA319zgKtvA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
+      "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
       "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -48171,191 +49144,236 @@
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.52.0.tgz",
-      "integrity": "sha512-N2/DHJ/OfiQ5zP97k9cJ8jSGiWDjtR7oFqXR+wbKZzKOww6vencMPYlndU6v1uZOKEjoj+NBr5N0jPEjCz+6+g==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
+      "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/property-provider": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.52.0.tgz",
-          "integrity": "sha512-Ooam7CvGefHKhMwQ413MiEtDTFw70xbCduJCF7Bg1F0WKrf700M/Yte+q3E0ljlXWJ28rwJNgwW3ptZaSXMGPg==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+          "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.52.0.tgz",
-      "integrity": "sha512-vmbvirg5edfNKBin8Mup2noxgqIYzYPnvk+BgIx3jFPvwT57WGRs/ahOMNqHgv/6xAdVaUjz8g7gw9Yy3mwP3A==",
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
+      "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
       "dev": true,
       "requires": {
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/credential-provider-imds": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@aws-sdk/config-resolver": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.52.0.tgz",
-          "integrity": "sha512-XKUCpPLMwdlqPtwutdMfAHWqGEPTDd14Dp01WyNhVtmTmsHkpFfLPpELLO1BczDS+jyoMUj+UDj9jHm4YLvXXg==",
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+          "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
           "dev": true,
           "requires": {
-            "@aws-sdk/signature-v4": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-config-provider": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/credential-provider-imds": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.52.0.tgz",
-          "integrity": "sha512-939kfHSkMLsOfQtO2nBqC/zAE1ecTOCAs72pKvVxrluGzDry4UtwlyQ4YGC04pYBRQeRIqvIOoVbADYJy4XjmQ==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
+          "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
           "dev": true,
           "requires": {
-            "@aws-sdk/node-config-provider": "3.52.0",
-            "@aws-sdk/property-provider": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/url-parser": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/is-array-buffer": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
-          "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/node-config-provider": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.52.0.tgz",
-          "integrity": "sha512-vfeTzkfVtGaNQrnhCRMObqid0shxFtNFEnnU1Nnx7HsgBfag2/T6fnsDzdVGaliQ6nmfg+RMrhzw2VECyBTHQQ==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
+          "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/property-provider": "3.52.0",
-            "@aws-sdk/shared-ini-file-loader": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/property-provider": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.52.0.tgz",
-          "integrity": "sha512-Ooam7CvGefHKhMwQ413MiEtDTFw70xbCduJCF7Bg1F0WKrf700M/Yte+q3E0ljlXWJ28rwJNgwW3ptZaSXMGPg==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
+          "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/querystring-parser": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.52.0.tgz",
-          "integrity": "sha512-/A6PauieStZajbkxX3sZSBBDacGDc3I/Sk7rjJulmg1GnizeVcUgx1OUdDh1JasdqA1h9E3ks/Y2Lu3xUMctLw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
+          "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
           "dev": true,
           "requires": {
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.52.0.tgz",
-          "integrity": "sha512-tALb8u8IVcI4pT7yFZpl4O6kgeY5EAXyphZoRPgQSCDhmEyFUIi/sXbCN8HQiHjnHdWfXdaNE1YsZcW3GpcuoQ==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
+          "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/signature-v4": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.52.0.tgz",
-          "integrity": "sha512-lSlDASXGLup5v12kclzT2ZLoUnnVLknSRcMXrTVjnX7spmHMbs6s7LOcN0RXZzFIACs7vW+930KUzhBxt8UiFQ==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
+          "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
           "dev": true,
           "requires": {
-            "@aws-sdk/is-array-buffer": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "@aws-sdk/util-hex-encoding": "3.52.0",
-            "@aws-sdk/util-uri-escape": "3.52.0",
-            "tslib": "^2.3.0"
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.52.0.tgz",
-          "integrity": "sha512-5deI1v6Fr7/a+TT9hPuiy6I/L/7uJTda3q3DEvUd0CsGbBB/fcDXJg8jlnMHcmw7mkfP9vE553ZJQS3Cb0v4vg==",
-          "dev": true
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.52.0.tgz",
-          "integrity": "sha512-/9OJwol/384jsISiAs5JX7fkgd9mv7hJsHFCVXnByim5qTZu1V9fMcJYJ1L3iRmfCRy0w75UDJljIx2RZnwAYw==",
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
           "dev": true,
           "requires": {
-            "@aws-sdk/querystring-parser": "3.52.0",
-            "@aws-sdk/types": "3.52.0",
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
+          "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-config-provider": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.52.0.tgz",
-          "integrity": "sha512-1wonBNkOOLJpMZnz2Kn69ToFgSoTTyGzJInir8WC5sME3zpkb5j41kTuEVbImNJhVv9MKjmGYrMeZbBVniLRPw==",
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-hex-encoding": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
-          "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
+          "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
           }
         },
         "@aws-sdk/util-uri-escape": {
-          "version": "3.52.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
-          "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
           "dev": true,
           "requires": {
-            "tslib": "^2.3.0"
+            "tslib": "^2.3.1"
           }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
+      "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -48407,6 +49425,223 @@
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-retry": {
+      "version": "3.229.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
+      "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/service-error-classification": {
+          "version": "3.229.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
+          "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-stream-browser": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.226.0.tgz",
+      "integrity": "sha512-ZvjlA1ySaLd0DqUWTKmL7LsxfPhroAONpzsinaHmw9aZVL40s2cADU9eWgBdHTuAOeFklL7NP0cc6UiTFHKe8g==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
+          "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/querystring-builder": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+          "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-stream-node": {
+      "version": "3.226.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.226.0.tgz",
+      "integrity": "sha512-HADXiIgDGoXcCLSKuPnjCLENf0iC0lzqqnymZu9H2FoACZhJB7DvJ9LnP51Pvw9lfCu+yvLzbMqSPdbXtMbRWg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
+          "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
+          "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/abort-controller": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/querystring-builder": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
+          "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
+          "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.226.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
+          "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -48521,18 +49756,18 @@
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.52.0.tgz",
-      "integrity": "sha512-GMdcxdwDZuIMlGnewdB48bpj8eqA3nubs3biy6vRFX8zhv8OqD+m5fMinoEwD8/MGqWE3WD7VZlbbdwYtNVWzQ==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
+      "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
       "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -52340,71 +53575,6 @@
         "@hapi/boom": "9.x.x",
         "@hapi/bourne": "2.x.x",
         "@hapi/hoek": "9.x.x"
-      }
-    },
-    "@httptoolkit/websocket-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@httptoolkit/websocket-stream/-/websocket-stream-6.0.0.tgz",
-      "integrity": "sha512-EC8m9JbhpGX2okfvLakqrmy4Le0VyNKR7b3IdvFZR/BfFO4ruh/XceBvXhCFHkykchnFxuOSlRwFiqNSXlwcGA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@types/ws": "*",
-        "duplexify": "^3.5.1",
-        "inherits": "^2.0.1",
-        "isomorphic-ws": "^4.0.1",
-        "readable-stream": "^2.3.3",
-        "safe-buffer": "^5.1.2",
-        "ws": "*",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "duplexify": {
-          "version": "3.7.1",
-          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-          "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "end-of-stream": "^1.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0",
-            "stream-shift": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true,
-          "peer": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -56555,13 +57725,6 @@
         }
       }
     },
-    "ansi": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
-      "dev": true,
-      "peer": true
-    },
     "ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -57552,43 +58715,6 @@
         }
       }
     },
-    "aws-crt": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.11.0.tgz",
-      "integrity": "sha512-qIBDRLOKRFuPTjkOAt3Al5zbcR6YyjfEl3TUc0R/xZ64aDxWGGXDStfDpkGCLSgV7jH+o7KQ47U9PM3URiFNFg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@httptoolkit/websocket-stream": "^6.0.0",
-        "axios": "^0.24.0",
-        "cmake-js": "6.3.0",
-        "crypto-js": "^4.0.0",
-        "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "mqtt": "^4.3.4",
-        "tar": "^6.1.11",
-        "ws": "^7.5.5"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "follow-redirects": "^1.14.4"
-          }
-        },
-        "ws": {
-          "version": "7.5.9",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {}
-        }
-      }
-    },
     "aws-sdk": {
       "version": "2.1163.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1163.0.tgz",
@@ -57637,7 +58763,7 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "follow-redirects": "^1.14.0"
       }
@@ -58216,13 +59342,6 @@
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
       "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
       "dev": true
-    },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-      "dev": true,
-      "peer": true
     },
     "buffer-writer": {
       "version": "2.0.0",
@@ -58886,296 +60005,6 @@
       "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
       "dev": true
     },
-    "cmake-js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.0.tgz",
-      "integrity": "sha512-1uqTOmFt6BIqKlrX+39/aewU/JVhyZWDqwAL+6psToUwxj3yWPJiwxiZFmV0XdcoWmqGs7peZTxTbJtAcH8hxw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "axios": "^0.21.1",
-        "debug": "^4",
-        "fs-extra": "^5.0.0",
-        "is-iojs": "^1.0.1",
-        "lodash": "^4",
-        "memory-stream": "0",
-        "npmlog": "^1.2.0",
-        "rc": "^1.2.7",
-        "semver": "^5.0.3",
-        "splitargs": "0",
-        "tar": "^4",
-        "unzipper": "^0.8.13",
-        "url-join": "0",
-        "which": "^1.0.9",
-        "yargs": "^3.6.0"
-      },
-      "dependencies": {
-        "are-we-there-yet": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-          "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.0 || ^1.1.13"
-          }
-        },
-        "chownr": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-          "dev": true,
-          "peer": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "fs-extra": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "fs-minipass": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "minipass": "^2.6.0"
-          }
-        },
-        "gauge": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ansi": "^0.3.0",
-            "has-unicode": "^2.0.0",
-            "lodash.pad": "^4.1.0",
-            "lodash.padend": "^4.1.0",
-            "lodash.padstart": "^4.1.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true,
-          "peer": true
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true,
-          "peer": true
-        },
-        "minipass": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "minipass": "^2.9.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true,
-          "peer": true
-        },
-        "npmlog": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-          "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ansi": "~0.3.0",
-            "are-we-there-yet": "~1.0.0",
-            "gauge": "~1.2.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "tar": {
-          "version": "4.4.19",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-          "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "chownr": "^1.1.4",
-            "fs-minipass": "^1.2.7",
-            "minipass": "^2.9.0",
-            "minizlib": "^1.3.3",
-            "mkdirp": "^0.5.5",
-            "safe-buffer": "^5.2.1",
-            "yallist": "^3.1.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-              "dev": true,
-              "peer": true
-            }
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          }
-        },
-        "y18n": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-          "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-          "dev": true,
-          "peer": true
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true,
-          "peer": true
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-          "integrity": "sha512-ONJZiimStfZzhKamYvR/xvmgW3uEkAUFSP91y2caTEPhzF6uP2JfPiVZcq66b/YR0C3uitxSV7+T1x8p5bkmMg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "camelcase": "^2.0.1",
-            "cliui": "^3.0.3",
-            "decamelize": "^1.1.1",
-            "os-locale": "^1.4.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.1.4",
-            "y18n": "^3.2.0"
-          }
-        }
-      }
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -59304,26 +60133,6 @@
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
       "dev": true,
       "optional": true
-    },
-    "commist": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
-      "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "leven": "^2.1.0",
-        "minimist": "^1.1.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true,
-          "peer": true
-        }
-      }
     },
     "commitizen": {
       "version": "4.2.5",
@@ -60248,13 +61057,6 @@
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
       "dev": true
-    },
-    "crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
-      "dev": true,
-      "peer": true
     },
     "crypto-random-string": {
       "version": "2.0.0",
@@ -62287,13 +63089,6 @@
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
       "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
       "dev": true
-    },
-    "fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "dev": true,
-      "peer": true
     },
     "fastify": {
       "version": "1.14.6",
@@ -64765,17 +65560,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "help-me": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
-      "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "glob": "^7.1.6",
-        "readable-stream": "^3.6.0"
-      }
-    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -65349,7 +66133,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
-      "devOptional": true
+      "optional": true
     },
     "ioredis": {
       "version": "4.28.2",
@@ -65637,13 +66421,6 @@
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true
-    },
-    "is-iojs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
-      "integrity": "sha1-TBEDO11dlNbqs3dd7cm+fQCDJfE=",
-      "dev": true,
-      "peer": true
     },
     "is-lambda": {
       "version": "1.0.1",
@@ -66123,13 +66900,6 @@
       "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
       "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
       "dev": true
-    },
-    "js-sdsl": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
-      "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A==",
-      "dev": true,
-      "peer": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -66667,7 +67437,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "invert-kv": "^1.0.0"
       }
@@ -66919,27 +67689,6 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
-    },
-    "lodash.pad": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
-      "dev": true,
-      "peer": true
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-      "dev": true,
-      "peer": true
-    },
-    "lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
-      "dev": true,
-      "peer": true
     },
     "lodash.pick": {
       "version": "4.4.0",
@@ -67473,31 +68222,6 @@
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "dev": true,
       "optional": true
-    },
-    "memory-stream": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
-      "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "readable-stream": "~1.0.26-2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        }
-      }
     },
     "meow": {
       "version": "8.1.2",
@@ -68412,150 +69136,6 @@
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
       "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==",
       "dev": true
-    },
-    "mqtt": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.6.tgz",
-      "integrity": "sha512-1dgQbkbh1Bba9iAGDNIrhSZ4nLDjbhmNHjOEvsmKI1Bb+2orj0gHwjqUKJ5CKUMKBYbkQYRM1fy+N1/2iZOj5w==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "commist": "^1.0.0",
-        "concat-stream": "^2.0.0",
-        "debug": "^4.1.1",
-        "duplexify": "^4.1.1",
-        "help-me": "^3.0.0",
-        "inherits": "^2.0.3",
-        "lru-cache": "^6.0.0",
-        "minimist": "^1.2.5",
-        "mqtt-packet": "^6.8.0",
-        "number-allocator": "^1.0.9",
-        "pump": "^3.0.0",
-        "readable-stream": "^3.6.0",
-        "reinterval": "^1.1.0",
-        "rfdc": "^1.3.0",
-        "split2": "^3.1.0",
-        "ws": "^7.5.5",
-        "xtend": "^4.0.2"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.0.2",
-            "typedarray": "^0.0.6"
-          }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true,
-          "peer": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true,
-          "peer": true
-        },
-        "split2": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-          "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "readable-stream": "^3.0.0"
-          }
-        },
-        "ws": {
-          "version": "7.5.9",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {}
-        }
-      }
-    },
-    "mqtt-packet": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
-      "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "bl": "^4.0.2",
-        "debug": "^4.1.1",
-        "process-nextick-args": "^2.0.1"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          }
-        },
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true,
-          "peer": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true,
-          "peer": true
-        }
-      }
     },
     "mquery": {
       "version": "3.2.5",
@@ -69958,36 +70538,6 @@
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
       "dev": true
     },
-    "number-allocator": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.9.tgz",
-      "integrity": "sha512-sIIF0dZKMs3roPUD7rLreH8H3x47QKV9dHZ+PeSnH24gL0CxKxz/823woGZC0hLBSb2Ar/rOOeHiNbnPBum/Mw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "debug": "^4.3.1",
-        "js-sdsl": "^2.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true,
-          "peer": true
-        }
-      }
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -70519,7 +71069,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "lcid": "^1.0.0"
       }
@@ -72676,13 +73226,6 @@
         "rc": "1.2.8"
       }
     },
-    "reinterval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
-      "integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc=",
-      "dev": true,
-      "peer": true
-    },
     "relay-compiler": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-10.1.0.tgz",
@@ -74081,13 +74624,6 @@
         "through2": "^2.0.2"
       }
     },
-    "splitargs": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
-      "integrity": "sha1-/p965lc3GzOxDLgNoUPPgknPazs=",
-      "dev": true,
-      "peer": true
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -74393,6 +74929,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "dev": true
     },
     "strong-log-transformer": {
@@ -75553,63 +76095,6 @@
       "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
       "dev": true
     },
-    "unzipper": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
-      "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "~1.0.10",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.1.5",
-        "setimmediate": "~1.0.4"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.4.7",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-          "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
-          "dev": true,
-          "peer": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true,
-          "peer": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true,
-          "peer": true
-        },
-        "readable-stream": {
-          "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-          "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "buffer-shims": "^1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        }
-      }
-    },
     "upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -75760,13 +76245,6 @@
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       }
-    },
-    "url-join": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-      "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g=",
-      "dev": true,
-      "peer": true
     },
     "url-parse": {
       "version": "1.5.1",
@@ -76110,7 +76588,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
       "integrity": "sha512-2thx4pB0cV3h+Bw7QmMXcEbdmOzv9t0HFplJH/Lz6yu60hXYy5RT8rUu+wlIreVxWsGN20mo+MHeCSfUpQBwPw==",
-      "devOptional": true
+      "optional": true
     },
     "windows-release": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@apollo/gateway": "0.50.2",
     "@aws-sdk/client-dynamodb": "3.81.0",
     "@aws-sdk/client-dynamodb2": "npm:@aws-sdk/client-dynamodb@3.20.0",
-    "@aws-sdk/client-s3": "3.52.0",
+    "@aws-sdk/client-s3": "3.252.0",
     "@aws-sdk/client-s3-2": "npm:@aws-sdk/client-s3@3.21.0",
     "@aws-sdk/client-sqs": "3.53.0",
     "@aws-sdk/client-sqs2": "npm:@aws-sdk/client-sqs@3.24.0",

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/s3/test_definition.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/s3/test_definition.js
@@ -43,7 +43,7 @@ const retryTime = config.getTestTimeout() * 2;
 function start(version) {
   let mochaSuiteFn;
 
-  if (!supportedVersion(process.versions.node)) {
+  if (!supportedVersion(process.versions.node) || semver.lt(process.versions.node, '14.0.0')) {
     mochaSuiteFn = describe.skip;
   } else {
     mochaSuiteFn = describe;

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/s3/util.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/s3/util.js
@@ -5,20 +5,30 @@
 
 'use strict';
 
-const awsSdk3 = require('@aws-sdk/client-s3');
-const s3 = new awsSdk3.S3({ region: 'us-east-2' });
+const semver = require('semver');
 
-/**
- * Attempts to delete a previous created bucket before the test starts
- * @param {string} bucketName
- */
-exports.cleanup = async function (bucketName) {
-  try {
-    await s3.deleteBucket({
-      Bucket: bucketName
-    });
-    return Promise.resolve('Bucket deleted');
-  } catch (err) {
-    return Promise.resolve('Bucket did not exist');
-  }
-};
+const minNodeJsVersion = '14.0.0';
+
+if (semver.lt(process.versions.node, minNodeJsVersion)) {
+  exports.cleanup = async function () {
+    throw new Error(`Requires Node.js >= ${minNodeJsVersion} but this is ${process.versions.node}.`);
+  };
+} else {
+  const awsSdk3 = require('@aws-sdk/client-s3');
+  const s3 = new awsSdk3.S3({ region: 'us-east-2' });
+
+  /**
+   * Attempts to delete a previous created bucket before the test starts
+   * @param {string} bucketName
+   */
+  exports.cleanup = async function (bucketName) {
+    try {
+      await s3.deleteBucket({
+        Bucket: bucketName
+      });
+      return Promise.resolve('Bucket deleted');
+    } catch (err) {
+      return Promise.resolve('Bucket did not exist');
+    }
+  };
+}


### PR DESCRIPTION
The main intention for this is to fix a segfault when running the tests on MacOS Ventura locally: https://github.com/awslabs/aws-crt-nodejs/issues/372

> Signal received: 11, errno: 0
>   SIGSEGV @ 0x0x1d9
> ################################################################################
> Stack trace:
> ################################################################################
> 1   aws-crt-nodejs.node                 0x0000000132010e83 s_print_stack_trace + 19
> 2   libsystem_platform.dylib            0x00007ff808641c1d _sigtramp + 29

Apparently that issue is caused by the native add-on aws-crt, which is an optional peer dependency of @aws-sdk/client-s3. Updating client-s3 to latest removed aws-crt completely from package-lock.json. Apparently our tests did not depend on that package being present, the S3 tests still pass. Additionally, I am not sure how aws-crt ended up in package-lock.json in the first place as we did not declare it as an explicit dependency (but for some time npm v2 used to install peer dependencies automatically so it might have been added to package-lock.json inadvertently by npm at some point).

Since the latest version of @aws-sdk/client-s3 requires Node.js >= 14, the associated tests are skipped for older Node.js versions now.