### PR TITLE
feat(collector): added support for sqs-consumer@6.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,6 +135,7 @@
         "sinon": "^11.1.1",
         "sinon-chai": "^3.7.0",
         "sqs-consumer": "5.7.0",
+        "sqs-consumer-v6": "npm:sqs-consumer@^6.2.0",
         "superagent": "^6.1.0",
         "tsoa": "^3.14.1",
         "typescript": "^4.5.2",
@@ -8539,6 +8540,19 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
+    "node_modules/@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz",
@@ -8571,6 +8585,37 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-utf8/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/@aws-sdk/util-waiter": {
@@ -39410,6 +39455,1097 @@
         "aws-sdk": "^2.1114.0"
       }
     },
+    "node_modules/sqs-consumer-v6": {
+      "name": "sqs-consumer",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/sqs-consumer/-/sqs-consumer-6.2.0.tgz",
+      "integrity": "sha512-H6lzdD/kQ5FL8HMfvZbiTROadlS/Gkeg82tieFMBf/0cqdNHJa2Xc7Yx8X2W/kzUBwuD1rLeKQoGlxbCowUsnw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sqs": "^3.241.0",
+        "debug": "^4.3.4"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sqs": "^3.241.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.254.0.tgz",
+      "integrity": "sha512-ZBJFCCU7mIXGLk5GFXrSReyUR/kOBju0kzd7nVAAQQlfkmHZEuFhKFFMXkfJZG0SC0ezCbmR/EzIqJ2mTI+pRA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/client-sqs": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.256.0.tgz",
+      "integrity": "sha512-YO9xJztpuLCZ7ck2zpT7L194F08CjtXNjX8TkrDeRxfL2Jn96VN6GJY8dcQKy+zRvMr3pqlH/OWyH5pRnC4oeA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.256.0",
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/credential-provider-node": "3.256.0",
+        "@aws-sdk/fetch-http-handler": "3.254.0",
+        "@aws-sdk/hash-node": "3.254.0",
+        "@aws-sdk/invalid-dependency": "3.254.0",
+        "@aws-sdk/md5-js": "3.254.0",
+        "@aws-sdk/middleware-content-length": "3.254.0",
+        "@aws-sdk/middleware-endpoint": "3.254.0",
+        "@aws-sdk/middleware-host-header": "3.254.0",
+        "@aws-sdk/middleware-logger": "3.254.0",
+        "@aws-sdk/middleware-recursion-detection": "3.254.0",
+        "@aws-sdk/middleware-retry": "3.254.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.254.0",
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/middleware-signing": "3.254.0",
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/middleware-user-agent": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/node-http-handler": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/smithy-client": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+        "@aws-sdk/util-defaults-mode-node": "3.254.0",
+        "@aws-sdk/util-endpoints": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "@aws-sdk/util-user-agent-browser": "3.254.0",
+        "@aws-sdk/util-user-agent-node": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/client-sso": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.256.0.tgz",
+      "integrity": "sha512-e+BNJ95IqUU1nmmX51T3ehy8yqHDN8J4DH6FReK1vrFIMEra/wERGJBcm+pdojyllQ20FQRBvGtOzN/WspH74w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/fetch-http-handler": "3.254.0",
+        "@aws-sdk/hash-node": "3.254.0",
+        "@aws-sdk/invalid-dependency": "3.254.0",
+        "@aws-sdk/middleware-content-length": "3.254.0",
+        "@aws-sdk/middleware-endpoint": "3.254.0",
+        "@aws-sdk/middleware-host-header": "3.254.0",
+        "@aws-sdk/middleware-logger": "3.254.0",
+        "@aws-sdk/middleware-recursion-detection": "3.254.0",
+        "@aws-sdk/middleware-retry": "3.254.0",
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/middleware-user-agent": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/node-http-handler": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/smithy-client": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+        "@aws-sdk/util-defaults-mode-node": "3.254.0",
+        "@aws-sdk/util-endpoints": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "@aws-sdk/util-user-agent-browser": "3.254.0",
+        "@aws-sdk/util-user-agent-node": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.256.0.tgz",
+      "integrity": "sha512-HR57pMdL5zGpxHnKYx1HjgnbVYlhTDZwyBS7k9JfiEDwPnGH8y169aNgVs+iaX0rIRlv6AyVstjqjZXGxODS4w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/fetch-http-handler": "3.254.0",
+        "@aws-sdk/hash-node": "3.254.0",
+        "@aws-sdk/invalid-dependency": "3.254.0",
+        "@aws-sdk/middleware-content-length": "3.254.0",
+        "@aws-sdk/middleware-endpoint": "3.254.0",
+        "@aws-sdk/middleware-host-header": "3.254.0",
+        "@aws-sdk/middleware-logger": "3.254.0",
+        "@aws-sdk/middleware-recursion-detection": "3.254.0",
+        "@aws-sdk/middleware-retry": "3.254.0",
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/middleware-user-agent": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/node-http-handler": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/smithy-client": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+        "@aws-sdk/util-defaults-mode-node": "3.254.0",
+        "@aws-sdk/util-endpoints": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "@aws-sdk/util-user-agent-browser": "3.254.0",
+        "@aws-sdk/util-user-agent-node": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/client-sts": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.256.0.tgz",
+      "integrity": "sha512-6jqaM7/Lw41kuEz8CqLU+fOLDF8C6W+jG30zBQrAC+iYSTB0w9uGOzVxsan1Nesg1FpoBqnWcF7xWi6Ox+OeDg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/credential-provider-node": "3.256.0",
+        "@aws-sdk/fetch-http-handler": "3.254.0",
+        "@aws-sdk/hash-node": "3.254.0",
+        "@aws-sdk/invalid-dependency": "3.254.0",
+        "@aws-sdk/middleware-content-length": "3.254.0",
+        "@aws-sdk/middleware-endpoint": "3.254.0",
+        "@aws-sdk/middleware-host-header": "3.254.0",
+        "@aws-sdk/middleware-logger": "3.254.0",
+        "@aws-sdk/middleware-recursion-detection": "3.254.0",
+        "@aws-sdk/middleware-retry": "3.254.0",
+        "@aws-sdk/middleware-sdk-sts": "3.254.0",
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/middleware-signing": "3.254.0",
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/middleware-user-agent": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/node-http-handler": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/smithy-client": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+        "@aws-sdk/util-defaults-mode-node": "3.254.0",
+        "@aws-sdk/util-endpoints": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "@aws-sdk/util-user-agent-browser": "3.254.0",
+        "@aws-sdk/util-user-agent-node": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.254.0.tgz",
+      "integrity": "sha512-+t5mi/SrZdAbSgg/5b/q3zVZsNQSyty2XX+znaRvBdANtIWIBdFLEMQp/L5NA+PSiW6VUXu9eXcsj0kJlAhTgQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.254.0.tgz",
+      "integrity": "sha512-2CDwb7L1XGTY7Y8N3EsE1xqas0zNvrs4aOEv5XZNrKqE+9bvs8CiUwV4SB6VwSD+EPcOSm3QYEURUmj5EyLEZQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.254.0.tgz",
+      "integrity": "sha512-sM3N7FLz+svRGjTgwAybKBmu5tVfCJmd5HPEfKR0jfBWB1uq0u0J+65JiO/wfqn/ix+3ZyFfacSJDFjnSPu/KA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.256.0.tgz",
+      "integrity": "sha512-tZacj/dVnu2GuNSVpYaO6JHrpaWqz9wvOkf/lYxh1Ga993uhF6SWLfENM29gF/EjvV0Nn0beHfyz5Em7dFbw8g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.254.0",
+        "@aws-sdk/credential-provider-imds": "3.254.0",
+        "@aws-sdk/credential-provider-process": "3.254.0",
+        "@aws-sdk/credential-provider-sso": "3.256.0",
+        "@aws-sdk/credential-provider-web-identity": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.256.0.tgz",
+      "integrity": "sha512-A/C8379FjeDYzfG+KQOyMgUnH/Fr7MFoeyhH9pECp5KWzts6H4IIQ1XUN7H/dmeqGfFxU7E7Hya2k1BX4qrKwQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.254.0",
+        "@aws-sdk/credential-provider-imds": "3.254.0",
+        "@aws-sdk/credential-provider-ini": "3.256.0",
+        "@aws-sdk/credential-provider-process": "3.254.0",
+        "@aws-sdk/credential-provider-sso": "3.256.0",
+        "@aws-sdk/credential-provider-web-identity": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.254.0.tgz",
+      "integrity": "sha512-vNm1AHMu5Lg1kOMk4ucWgaNO4zNAD7aeRssdBMnC7WqRT2xB8CUEWi+zJGNjbxzEeTLXQZuMa1VeRT3nPjYrzg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.256.0.tgz",
+      "integrity": "sha512-5WV62oxuM1LM9udmouxkGbnkN7sKqF4drYBBt2DetQzq4NStaOtZgcY0fxcX/HFv0Q2wjSWCBtDQ31Jo1CJRew==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.256.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/token-providers": "3.256.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.254.0.tgz",
+      "integrity": "sha512-R/5qjAoCHEe7xmY5j0vges4xKpFpTgrwzdST822JVNWUobZmiDUqnn+1Xw4Qmomst625NOpgzsV4JuHsA4a8Ig==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.254.0.tgz",
+      "integrity": "sha512-/bbtNHe5JHFdKnCVr3Zx55sqs4c0F+7f1CC5cvTgH3O46wgIRM/6/rvE0YieXmfm3ho/GOhxBUzy59A0haKQGg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/querystring-builder": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/hash-node": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.254.0.tgz",
+      "integrity": "sha512-7FoB6BVbO+Z/NEOHeOAoUTyj8q+Pcdn4QpKvA4epRDrzMNcXy7MUNzzt148nkDssES09rgsN+KM8Zo2qgRYngg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.254.0.tgz",
+      "integrity": "sha512-ueV0tXyGndCTZXnEv+AMeTfu+IqV2QzmGMXcakiwxDjg48H9X/bLnj+C96Sexond8jD8K0ub9HWhkBrvvAXlPA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/md5-js": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.254.0.tgz",
+      "integrity": "sha512-J7PTkuX+E37ed4npAV41B6HDEyqM6f8xmorOPPP9Zu3uoR1FDeymK+U0jqOa8HCWxdOle8h1i3ZfghY1D8bozQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.254.0.tgz",
+      "integrity": "sha512-IT7nDZA6WsaZSNp9M79xfkk/us4kGV4SIZ2R9gHT9MFqdmpmbr3EGhFLKXUHcAZfCcOdw+JNV/wHJiiN1JD/hg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.254.0.tgz",
+      "integrity": "sha512-9fkDtSJdhEr91tWp4zLyKhHDGVyvUA0gDK+6wGYyorKCae2qX2TL+Fl6vsqY4PxrdTpXRBJDlJnEly9i48YKxg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/signature-v4": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/url-parser": "3.254.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.254.0.tgz",
+      "integrity": "sha512-JG+OoyCMivnqTYiPZxRF+sgYEyQG68+PMl2843owvSxQQ25nH2Ih6DzLqH10c/uAN0PsiA8s/FfJBzhw9Xf0KA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.254.0.tgz",
+      "integrity": "sha512-h3jEw58VUJkfqrwWMmp3Qc8293RFo4LMqxNAVsVwYEG6xb/RQ+JamsOx+t6aDsoOdKqhYngWwDGtgUZQ5wQQvg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.254.0.tgz",
+      "integrity": "sha512-/4tTvAXmIIMCs3giPIXN9aVJUGMoBMWw+9WS22u7nYNzwTe/k30DhS91uvwj7TLOOpFN0IBNXPCJ+T1OZn+ZXQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.254.0.tgz",
+      "integrity": "sha512-nHgris8NmtLzsH5iUA8geW6RAT1VRymjlieKFmM3CAYt2h2X8AtAiL/Wod+Pj3+jjRGk9YeGzOOGbzODHiRxnA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/service-error-classification": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "@aws-sdk/util-retry": "3.254.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.254.0.tgz",
+      "integrity": "sha512-XlzgCGa3gw6bo1upQI0zssuknt8XXdArz4Zs6UE0D0DJlwHuYLa/iLsUAcACl1iRrWAGajq8nEkn9jO640CQOg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.254.0.tgz",
+      "integrity": "sha512-Y074nmTp07thuOI6GePv8IKdL/OvkO1tn2l7QvnwQa3Sy/HyNai1V3MVtq4hRi1dgDjheKPVHPE+TnOmF3w5uA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/signature-v4": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.254.0.tgz",
+      "integrity": "sha512-YuItb2nlKADTBItcn68eA8amX4quuR1+0GyFRkwssKS/iTjbIk+3gJ2s1zxkUhlyozH3U38Jvvqd+W9+gNpYIg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.254.0.tgz",
+      "integrity": "sha512-HMVGf+yANjlKCUMFZJU2PNzbI9hbCgL+IX/Y4DGuQW9cp7EgZOxQre1LBKpcCqqPVQ4toIdfNH/K8uM2fpO6dg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/signature-v4": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.254.0.tgz",
+      "integrity": "sha512-yPWRnjeLC0lPAEQbiqbC3+hnqXZ+uCSoSevGndU5KWMMiXLxKZn7Y0B3kG8NAnNNuPid+wYFWWU9rKiBRvWR/w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.254.0.tgz",
+      "integrity": "sha512-hp5UYRg3ysZXMFMv34nYexyom6Z3pdx+OmisJz4w3AMigT8y57Ps30Vg+1QYaGlQkI4vfvcmdZX2Q+kp+mb9gQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.254.0.tgz",
+      "integrity": "sha512-3Bp3Gp2NOY9gab738xf07TysO5iB0Ib9qRNGDlxX8SX8fZDRnxrF2cn+Tjte42wrO54orwhSyuTaIlAqKeii8Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.254.0.tgz",
+      "integrity": "sha512-DX2WJ3pub+3FF9GpoF5doERCn06MxS/UmmbKnIIokWQHjPZVomNh/1P3Cf9Jn9jeIPgh4UOg0uPD8cUm/cwHQw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.254.0",
+        "@aws-sdk/protocol-http": "3.254.0",
+        "@aws-sdk/querystring-builder": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/property-provider": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.254.0.tgz",
+      "integrity": "sha512-BLZF/LDFjAgv2ZY0vhThU58k++Aw+SK7qNU7XT0D84q5iWlYRKptQEvSSvIkBSI/rZoppOFhK7W80I8kNNbh+Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.254.0.tgz",
+      "integrity": "sha512-4o/I/qhMUTp70njwWe3ttyRJSAKegnr8l3oVWAf1/q1ZHpcxbRRZEDvrkx4KSunFeXTTGHcff1oyLSRG/cKMsQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.254.0.tgz",
+      "integrity": "sha512-Er+pOGTrPxelrzggibduO+eB1ClaU2BhjA8gd0nORS3kqktQggG3tKmRSIilegi9WOa3awCk6CnnuAf0pBrbUA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.254.0.tgz",
+      "integrity": "sha512-WwRD99dwGo2aIrRjLHUAXaWCZ+3fj88IhIwciWTqrHBS3TQWXllOOQmYo7f+aMBB4Q1K6KdKITNi8L7aUuDv2g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.254.0.tgz",
+      "integrity": "sha512-8GHqMJBBF9yoMBG/Nf9PusUSMFjG8ygps/cSJPlgcG2vbFn8BCdBZVc4ptXqICZUnBB/6lrxy8nCmNUaru48jg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.254.0.tgz",
+      "integrity": "sha512-UH4YTXuG+q004vA+jNrVhrD5XQCIAgpL/eriObJnQpKUVef1mkkEDHZs8+8+ZPsk4p/iBrIJ3lXNf7iDA/BFzw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.254.0.tgz",
+      "integrity": "sha512-9FoEnipA9hAgEp6oqIT3+hobF+JgIXIn5QV8kAB7QGxEDqs/pdpEbGc9qbxi0ghdjvqzOSDir9gNI3w0cL8Aug==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.254.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.254.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.254.0.tgz",
+      "integrity": "sha512-SI0jz9JfWi1IaakDX/26xliKTIMJpzwwDoyQPEfZ/L0KKdpr2gNhljA3sR2pZ2EM1oqOaXpMHAunSzv7EBpBWg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/token-providers": {
+      "version": "3.256.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.256.0.tgz",
+      "integrity": "sha512-R8FnhJShIJsvmDzTG2y8WrJYijY7cmK2G4VqqhOx34jCuDFM1/Ml8BzN/o2RvHzJH/7qCqfUMTsJEpt+KOuMPA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.256.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/shared-ini-file-loader": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/types": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.254.0.tgz",
+      "integrity": "sha512-xDEDk6ZAGFO0URPgB6R2mvQANYlojHLjLC9zzOzl07F+uqYS30yZDIg4UFcqPt/x48v7mxlKZpbaZgYI2ZLgGA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/url-parser": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.254.0.tgz",
+      "integrity": "sha512-Za0JGUa9p5GQ8t2tVtKaRSjLUxrmEdnBlUiZ2zKm86wFxgQnjbMwzD3mvyJ5OaVsXScU5vzc3CXHIXSvS7h7Ng==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.254.0.tgz",
+      "integrity": "sha512-vj/s+BuqNKTHN9bsZ/HY7vpBWbo3F+4c3/ZoKSZa5Jc7jAuGCbx3zWwHdJFDgvbqLvsTBw80Q9d/CDy9pKj/tQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.254.0.tgz",
+      "integrity": "sha512-gvD2+Uf60c2BgUYv2d6R4dSpO/CbvybqblgF8lKZCsHkDWzfEdPv9nlJgUWM1cuMKQ0hBZ3cL3ilOwVKRVPyiQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.254.0",
+        "@aws-sdk/credential-provider-imds": "3.254.0",
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/property-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.254.0.tgz",
+      "integrity": "sha512-BzBIOnhVrs4RFTpGZErZfAV1VhqWglxn047VYijmCQe8Aejq4mJAaepSwHYar++XC0+pduD5YO8IidW8z/1vQQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.254.0.tgz",
+      "integrity": "sha512-gn7vInNTRBo2QatOB+uU99JwV53wf/zlTUnUK0qOuebtSDLMdiO+msiMi2ctz9vMIrtc2XMXNQro1aE0aUPy4w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-retry": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.254.0.tgz",
+      "integrity": "sha512-IVA4wAOJpVssEIbJmeq1fdDYvrkOqYFK9Pz4tERmMz33003fyY92dU468Lulw8MnsSALYiwWUoWSFg9L5RCTug==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.254.0.tgz",
+      "integrity": "sha512-2HvwH8l7ln4qTDsU3rgH9NvSSo5qhX+2Lenb6XvNnIMkL4r/tPhNIaGKtoQRfpzLH378Mm9XEQnJM5UXFRWuTA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.254.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.254.0.tgz",
+      "integrity": "sha512-6nc9bmRP+2JqbBJ5oRZZRU8l35X3VcWF5j8XvmamWjIABsanc6Gv6NV4qAa3imPjIyWNiShZn/YkTBYs1exsdg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.254.0",
+        "@aws-sdk/types": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dev": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
+    "node_modules/sqs-consumer-v6/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/sqs-consumer-v6/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
     "node_modules/sqs-consumer/node_modules/debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -49665,6 +50801,43 @@
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }
@@ -74593,6 +75766,929 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "sqs-consumer-v6": {
+      "version": "npm:sqs-consumer@6.2.0",
+      "resolved": "https://registry.npmjs.org/sqs-consumer/-/sqs-consumer-6.2.0.tgz",
+      "integrity": "sha512-H6lzdD/kQ5FL8HMfvZbiTROadlS/Gkeg82tieFMBf/0cqdNHJa2Xc7Yx8X2W/kzUBwuD1rLeKQoGlxbCowUsnw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-sqs": "^3.241.0",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@aws-crypto/ie11-detection": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "dev": true
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/ie11-detection": "^3.0.0",
+            "@aws-crypto/sha256-js": "^3.0.0",
+            "@aws-crypto/supports-web-crypto": "^3.0.0",
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "dev": true
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "dev": true
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "dev": true
+            }
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "dev": true
+            }
+          }
+        },
+        "@aws-sdk/abort-controller": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.254.0.tgz",
+          "integrity": "sha512-ZBJFCCU7mIXGLk5GFXrSReyUR/kOBju0kzd7nVAAQQlfkmHZEuFhKFFMXkfJZG0SC0ezCbmR/EzIqJ2mTI+pRA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sqs": {
+          "version": "3.256.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.256.0.tgz",
+          "integrity": "sha512-YO9xJztpuLCZ7ck2zpT7L194F08CjtXNjX8TkrDeRxfL2Jn96VN6GJY8dcQKy+zRvMr3pqlH/OWyH5pRnC4oeA==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/client-sts": "3.256.0",
+            "@aws-sdk/config-resolver": "3.254.0",
+            "@aws-sdk/credential-provider-node": "3.256.0",
+            "@aws-sdk/fetch-http-handler": "3.254.0",
+            "@aws-sdk/hash-node": "3.254.0",
+            "@aws-sdk/invalid-dependency": "3.254.0",
+            "@aws-sdk/md5-js": "3.254.0",
+            "@aws-sdk/middleware-content-length": "3.254.0",
+            "@aws-sdk/middleware-endpoint": "3.254.0",
+            "@aws-sdk/middleware-host-header": "3.254.0",
+            "@aws-sdk/middleware-logger": "3.254.0",
+            "@aws-sdk/middleware-recursion-detection": "3.254.0",
+            "@aws-sdk/middleware-retry": "3.254.0",
+            "@aws-sdk/middleware-sdk-sqs": "3.254.0",
+            "@aws-sdk/middleware-serde": "3.254.0",
+            "@aws-sdk/middleware-signing": "3.254.0",
+            "@aws-sdk/middleware-stack": "3.254.0",
+            "@aws-sdk/middleware-user-agent": "3.254.0",
+            "@aws-sdk/node-config-provider": "3.254.0",
+            "@aws-sdk/node-http-handler": "3.254.0",
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/smithy-client": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/url-parser": "3.254.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+            "@aws-sdk/util-defaults-mode-node": "3.254.0",
+            "@aws-sdk/util-endpoints": "3.254.0",
+            "@aws-sdk/util-retry": "3.254.0",
+            "@aws-sdk/util-user-agent-browser": "3.254.0",
+            "@aws-sdk/util-user-agent-node": "3.254.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.256.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.256.0.tgz",
+          "integrity": "sha512-e+BNJ95IqUU1nmmX51T3ehy8yqHDN8J4DH6FReK1vrFIMEra/wERGJBcm+pdojyllQ20FQRBvGtOzN/WspH74w==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.254.0",
+            "@aws-sdk/fetch-http-handler": "3.254.0",
+            "@aws-sdk/hash-node": "3.254.0",
+            "@aws-sdk/invalid-dependency": "3.254.0",
+            "@aws-sdk/middleware-content-length": "3.254.0",
+            "@aws-sdk/middleware-endpoint": "3.254.0",
+            "@aws-sdk/middleware-host-header": "3.254.0",
+            "@aws-sdk/middleware-logger": "3.254.0",
+            "@aws-sdk/middleware-recursion-detection": "3.254.0",
+            "@aws-sdk/middleware-retry": "3.254.0",
+            "@aws-sdk/middleware-serde": "3.254.0",
+            "@aws-sdk/middleware-stack": "3.254.0",
+            "@aws-sdk/middleware-user-agent": "3.254.0",
+            "@aws-sdk/node-config-provider": "3.254.0",
+            "@aws-sdk/node-http-handler": "3.254.0",
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/smithy-client": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/url-parser": "3.254.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+            "@aws-sdk/util-defaults-mode-node": "3.254.0",
+            "@aws-sdk/util-endpoints": "3.254.0",
+            "@aws-sdk/util-retry": "3.254.0",
+            "@aws-sdk/util-user-agent-browser": "3.254.0",
+            "@aws-sdk/util-user-agent-node": "3.254.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.256.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.256.0.tgz",
+          "integrity": "sha512-HR57pMdL5zGpxHnKYx1HjgnbVYlhTDZwyBS7k9JfiEDwPnGH8y169aNgVs+iaX0rIRlv6AyVstjqjZXGxODS4w==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.254.0",
+            "@aws-sdk/fetch-http-handler": "3.254.0",
+            "@aws-sdk/hash-node": "3.254.0",
+            "@aws-sdk/invalid-dependency": "3.254.0",
+            "@aws-sdk/middleware-content-length": "3.254.0",
+            "@aws-sdk/middleware-endpoint": "3.254.0",
+            "@aws-sdk/middleware-host-header": "3.254.0",
+            "@aws-sdk/middleware-logger": "3.254.0",
+            "@aws-sdk/middleware-recursion-detection": "3.254.0",
+            "@aws-sdk/middleware-retry": "3.254.0",
+            "@aws-sdk/middleware-serde": "3.254.0",
+            "@aws-sdk/middleware-stack": "3.254.0",
+            "@aws-sdk/middleware-user-agent": "3.254.0",
+            "@aws-sdk/node-config-provider": "3.254.0",
+            "@aws-sdk/node-http-handler": "3.254.0",
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/smithy-client": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/url-parser": "3.254.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+            "@aws-sdk/util-defaults-mode-node": "3.254.0",
+            "@aws-sdk/util-endpoints": "3.254.0",
+            "@aws-sdk/util-retry": "3.254.0",
+            "@aws-sdk/util-user-agent-browser": "3.254.0",
+            "@aws-sdk/util-user-agent-node": "3.254.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.256.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.256.0.tgz",
+          "integrity": "sha512-6jqaM7/Lw41kuEz8CqLU+fOLDF8C6W+jG30zBQrAC+iYSTB0w9uGOzVxsan1Nesg1FpoBqnWcF7xWi6Ox+OeDg==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.254.0",
+            "@aws-sdk/credential-provider-node": "3.256.0",
+            "@aws-sdk/fetch-http-handler": "3.254.0",
+            "@aws-sdk/hash-node": "3.254.0",
+            "@aws-sdk/invalid-dependency": "3.254.0",
+            "@aws-sdk/middleware-content-length": "3.254.0",
+            "@aws-sdk/middleware-endpoint": "3.254.0",
+            "@aws-sdk/middleware-host-header": "3.254.0",
+            "@aws-sdk/middleware-logger": "3.254.0",
+            "@aws-sdk/middleware-recursion-detection": "3.254.0",
+            "@aws-sdk/middleware-retry": "3.254.0",
+            "@aws-sdk/middleware-sdk-sts": "3.254.0",
+            "@aws-sdk/middleware-serde": "3.254.0",
+            "@aws-sdk/middleware-signing": "3.254.0",
+            "@aws-sdk/middleware-stack": "3.254.0",
+            "@aws-sdk/middleware-user-agent": "3.254.0",
+            "@aws-sdk/node-config-provider": "3.254.0",
+            "@aws-sdk/node-http-handler": "3.254.0",
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/smithy-client": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/url-parser": "3.254.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.254.0",
+            "@aws-sdk/util-defaults-mode-node": "3.254.0",
+            "@aws-sdk/util-endpoints": "3.254.0",
+            "@aws-sdk/util-retry": "3.254.0",
+            "@aws-sdk/util-user-agent-browser": "3.254.0",
+            "@aws-sdk/util-user-agent-node": "3.254.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.254.0.tgz",
+          "integrity": "sha512-+t5mi/SrZdAbSgg/5b/q3zVZsNQSyty2XX+znaRvBdANtIWIBdFLEMQp/L5NA+PSiW6VUXu9eXcsj0kJlAhTgQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/signature-v4": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.254.0.tgz",
+          "integrity": "sha512-2CDwb7L1XGTY7Y8N3EsE1xqas0zNvrs4aOEv5XZNrKqE+9bvs8CiUwV4SB6VwSD+EPcOSm3QYEURUmj5EyLEZQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.254.0.tgz",
+          "integrity": "sha512-sM3N7FLz+svRGjTgwAybKBmu5tVfCJmd5HPEfKR0jfBWB1uq0u0J+65JiO/wfqn/ix+3ZyFfacSJDFjnSPu/KA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.254.0",
+            "@aws-sdk/property-provider": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/url-parser": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.256.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.256.0.tgz",
+          "integrity": "sha512-tZacj/dVnu2GuNSVpYaO6JHrpaWqz9wvOkf/lYxh1Ga993uhF6SWLfENM29gF/EjvV0Nn0beHfyz5Em7dFbw8g==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.254.0",
+            "@aws-sdk/credential-provider-imds": "3.254.0",
+            "@aws-sdk/credential-provider-process": "3.254.0",
+            "@aws-sdk/credential-provider-sso": "3.256.0",
+            "@aws-sdk/credential-provider-web-identity": "3.254.0",
+            "@aws-sdk/property-provider": "3.254.0",
+            "@aws-sdk/shared-ini-file-loader": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.256.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.256.0.tgz",
+          "integrity": "sha512-A/C8379FjeDYzfG+KQOyMgUnH/Fr7MFoeyhH9pECp5KWzts6H4IIQ1XUN7H/dmeqGfFxU7E7Hya2k1BX4qrKwQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.254.0",
+            "@aws-sdk/credential-provider-imds": "3.254.0",
+            "@aws-sdk/credential-provider-ini": "3.256.0",
+            "@aws-sdk/credential-provider-process": "3.254.0",
+            "@aws-sdk/credential-provider-sso": "3.256.0",
+            "@aws-sdk/credential-provider-web-identity": "3.254.0",
+            "@aws-sdk/property-provider": "3.254.0",
+            "@aws-sdk/shared-ini-file-loader": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.254.0.tgz",
+          "integrity": "sha512-vNm1AHMu5Lg1kOMk4ucWgaNO4zNAD7aeRssdBMnC7WqRT2xB8CUEWi+zJGNjbxzEeTLXQZuMa1VeRT3nPjYrzg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.254.0",
+            "@aws-sdk/shared-ini-file-loader": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.256.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.256.0.tgz",
+          "integrity": "sha512-5WV62oxuM1LM9udmouxkGbnkN7sKqF4drYBBt2DetQzq4NStaOtZgcY0fxcX/HFv0Q2wjSWCBtDQ31Jo1CJRew==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.256.0",
+            "@aws-sdk/property-provider": "3.254.0",
+            "@aws-sdk/shared-ini-file-loader": "3.254.0",
+            "@aws-sdk/token-providers": "3.256.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.254.0.tgz",
+          "integrity": "sha512-R/5qjAoCHEe7xmY5j0vges4xKpFpTgrwzdST822JVNWUobZmiDUqnn+1Xw4Qmomst625NOpgzsV4JuHsA4a8Ig==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.254.0.tgz",
+          "integrity": "sha512-/bbtNHe5JHFdKnCVr3Zx55sqs4c0F+7f1CC5cvTgH3O46wgIRM/6/rvE0YieXmfm3ho/GOhxBUzy59A0haKQGg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/querystring-builder": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.254.0.tgz",
+          "integrity": "sha512-7FoB6BVbO+Z/NEOHeOAoUTyj8q+Pcdn4QpKvA4epRDrzMNcXy7MUNzzt148nkDssES09rgsN+KM8Zo2qgRYngg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.254.0.tgz",
+          "integrity": "sha512-ueV0tXyGndCTZXnEv+AMeTfu+IqV2QzmGMXcakiwxDjg48H9X/bLnj+C96Sexond8jD8K0ub9HWhkBrvvAXlPA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/md5-js": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.254.0.tgz",
+          "integrity": "sha512-J7PTkuX+E37ed4npAV41B6HDEyqM6f8xmorOPPP9Zu3uoR1FDeymK+U0jqOa8HCWxdOle8h1i3ZfghY1D8bozQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.254.0.tgz",
+          "integrity": "sha512-IT7nDZA6WsaZSNp9M79xfkk/us4kGV4SIZ2R9gHT9MFqdmpmbr3EGhFLKXUHcAZfCcOdw+JNV/wHJiiN1JD/hg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.254.0.tgz",
+          "integrity": "sha512-9fkDtSJdhEr91tWp4zLyKhHDGVyvUA0gDK+6wGYyorKCae2qX2TL+Fl6vsqY4PxrdTpXRBJDlJnEly9i48YKxg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.254.0",
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/signature-v4": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/url-parser": "3.254.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.254.0.tgz",
+          "integrity": "sha512-JG+OoyCMivnqTYiPZxRF+sgYEyQG68+PMl2843owvSxQQ25nH2Ih6DzLqH10c/uAN0PsiA8s/FfJBzhw9Xf0KA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.254.0.tgz",
+          "integrity": "sha512-h3jEw58VUJkfqrwWMmp3Qc8293RFo4LMqxNAVsVwYEG6xb/RQ+JamsOx+t6aDsoOdKqhYngWwDGtgUZQ5wQQvg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.254.0.tgz",
+          "integrity": "sha512-/4tTvAXmIIMCs3giPIXN9aVJUGMoBMWw+9WS22u7nYNzwTe/k30DhS91uvwj7TLOOpFN0IBNXPCJ+T1OZn+ZXQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.254.0.tgz",
+          "integrity": "sha512-nHgris8NmtLzsH5iUA8geW6RAT1VRymjlieKFmM3CAYt2h2X8AtAiL/Wod+Pj3+jjRGk9YeGzOOGbzODHiRxnA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/service-error-classification": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/util-middleware": "3.254.0",
+            "@aws-sdk/util-retry": "3.254.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sqs": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.254.0.tgz",
+          "integrity": "sha512-XlzgCGa3gw6bo1upQI0zssuknt8XXdArz4Zs6UE0D0DJlwHuYLa/iLsUAcACl1iRrWAGajq8nEkn9jO640CQOg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.254.0.tgz",
+          "integrity": "sha512-Y074nmTp07thuOI6GePv8IKdL/OvkO1tn2l7QvnwQa3Sy/HyNai1V3MVtq4hRi1dgDjheKPVHPE+TnOmF3w5uA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.254.0",
+            "@aws-sdk/property-provider": "3.254.0",
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/signature-v4": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.254.0.tgz",
+          "integrity": "sha512-YuItb2nlKADTBItcn68eA8amX4quuR1+0GyFRkwssKS/iTjbIk+3gJ2s1zxkUhlyozH3U38Jvvqd+W9+gNpYIg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.254.0.tgz",
+          "integrity": "sha512-HMVGf+yANjlKCUMFZJU2PNzbI9hbCgL+IX/Y4DGuQW9cp7EgZOxQre1LBKpcCqqPVQ4toIdfNH/K8uM2fpO6dg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.254.0",
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/signature-v4": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/util-middleware": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.254.0.tgz",
+          "integrity": "sha512-yPWRnjeLC0lPAEQbiqbC3+hnqXZ+uCSoSevGndU5KWMMiXLxKZn7Y0B3kG8NAnNNuPid+wYFWWU9rKiBRvWR/w==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.254.0.tgz",
+          "integrity": "sha512-hp5UYRg3ysZXMFMv34nYexyom6Z3pdx+OmisJz4w3AMigT8y57Ps30Vg+1QYaGlQkI4vfvcmdZX2Q+kp+mb9gQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.254.0.tgz",
+          "integrity": "sha512-3Bp3Gp2NOY9gab738xf07TysO5iB0Ib9qRNGDlxX8SX8fZDRnxrF2cn+Tjte42wrO54orwhSyuTaIlAqKeii8Q==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.254.0",
+            "@aws-sdk/shared-ini-file-loader": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.254.0.tgz",
+          "integrity": "sha512-DX2WJ3pub+3FF9GpoF5doERCn06MxS/UmmbKnIIokWQHjPZVomNh/1P3Cf9Jn9jeIPgh4UOg0uPD8cUm/cwHQw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/abort-controller": "3.254.0",
+            "@aws-sdk/protocol-http": "3.254.0",
+            "@aws-sdk/querystring-builder": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.254.0.tgz",
+          "integrity": "sha512-BLZF/LDFjAgv2ZY0vhThU58k++Aw+SK7qNU7XT0D84q5iWlYRKptQEvSSvIkBSI/rZoppOFhK7W80I8kNNbh+Q==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.254.0.tgz",
+          "integrity": "sha512-4o/I/qhMUTp70njwWe3ttyRJSAKegnr8l3oVWAf1/q1ZHpcxbRRZEDvrkx4KSunFeXTTGHcff1oyLSRG/cKMsQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.254.0.tgz",
+          "integrity": "sha512-Er+pOGTrPxelrzggibduO+eB1ClaU2BhjA8gd0nORS3kqktQggG3tKmRSIilegi9WOa3awCk6CnnuAf0pBrbUA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.254.0.tgz",
+          "integrity": "sha512-WwRD99dwGo2aIrRjLHUAXaWCZ+3fj88IhIwciWTqrHBS3TQWXllOOQmYo7f+aMBB4Q1K6KdKITNi8L7aUuDv2g==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.254.0.tgz",
+          "integrity": "sha512-8GHqMJBBF9yoMBG/Nf9PusUSMFjG8ygps/cSJPlgcG2vbFn8BCdBZVc4ptXqICZUnBB/6lrxy8nCmNUaru48jg==",
+          "dev": true
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.254.0.tgz",
+          "integrity": "sha512-UH4YTXuG+q004vA+jNrVhrD5XQCIAgpL/eriObJnQpKUVef1mkkEDHZs8+8+ZPsk4p/iBrIJ3lXNf7iDA/BFzw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.254.0.tgz",
+          "integrity": "sha512-9FoEnipA9hAgEp6oqIT3+hobF+JgIXIn5QV8kAB7QGxEDqs/pdpEbGc9qbxi0ghdjvqzOSDir9gNI3w0cL8Aug==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.254.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.254.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "@aws-sdk/util-utf8": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.254.0.tgz",
+          "integrity": "sha512-SI0jz9JfWi1IaakDX/26xliKTIMJpzwwDoyQPEfZ/L0KKdpr2gNhljA3sR2pZ2EM1oqOaXpMHAunSzv7EBpBWg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.256.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.256.0.tgz",
+          "integrity": "sha512-R8FnhJShIJsvmDzTG2y8WrJYijY7cmK2G4VqqhOx34jCuDFM1/Ml8BzN/o2RvHzJH/7qCqfUMTsJEpt+KOuMPA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.256.0",
+            "@aws-sdk/property-provider": "3.254.0",
+            "@aws-sdk/shared-ini-file-loader": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.254.0.tgz",
+          "integrity": "sha512-xDEDk6ZAGFO0URPgB6R2mvQANYlojHLjLC9zzOzl07F+uqYS30yZDIg4UFcqPt/x48v7mxlKZpbaZgYI2ZLgGA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.254.0.tgz",
+          "integrity": "sha512-Za0JGUa9p5GQ8t2tVtKaRSjLUxrmEdnBlUiZ2zKm86wFxgQnjbMwzD3mvyJ5OaVsXScU5vzc3CXHIXSvS7h7Ng==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.254.0.tgz",
+          "integrity": "sha512-vj/s+BuqNKTHN9bsZ/HY7vpBWbo3F+4c3/ZoKSZa5Jc7jAuGCbx3zWwHdJFDgvbqLvsTBw80Q9d/CDy9pKj/tQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.254.0.tgz",
+          "integrity": "sha512-gvD2+Uf60c2BgUYv2d6R4dSpO/CbvybqblgF8lKZCsHkDWzfEdPv9nlJgUWM1cuMKQ0hBZ3cL3ilOwVKRVPyiQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/config-resolver": "3.254.0",
+            "@aws-sdk/credential-provider-imds": "3.254.0",
+            "@aws-sdk/node-config-provider": "3.254.0",
+            "@aws-sdk/property-provider": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.254.0.tgz",
+          "integrity": "sha512-BzBIOnhVrs4RFTpGZErZfAV1VhqWglxn047VYijmCQe8Aejq4mJAaepSwHYar++XC0+pduD5YO8IidW8z/1vQQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.254.0.tgz",
+          "integrity": "sha512-gn7vInNTRBo2QatOB+uU99JwV53wf/zlTUnUK0qOuebtSDLMdiO+msiMi2ctz9vMIrtc2XMXNQro1aE0aUPy4w==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-retry": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.254.0.tgz",
+          "integrity": "sha512-IVA4wAOJpVssEIbJmeq1fdDYvrkOqYFK9Pz4tERmMz33003fyY92dU468Lulw8MnsSALYiwWUoWSFg9L5RCTug==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/service-error-classification": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.254.0.tgz",
+          "integrity": "sha512-2HvwH8l7ln4qTDsU3rgH9NvSSo5qhX+2Lenb6XvNnIMkL4r/tPhNIaGKtoQRfpzLH378Mm9XEQnJM5UXFRWuTA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.254.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.254.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.254.0.tgz",
+          "integrity": "sha512-6nc9bmRP+2JqbBJ5oRZZRU8l35X3VcWF5j8XvmamWjIABsanc6Gv6NV4qAa3imPjIyWNiShZn/YkTBYs1exsdg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.254.0",
+            "@aws-sdk/types": "3.254.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+          "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+          "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.0.11",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+          "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+          "dev": true,
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
     "sqs-consumer": "5.7.0",
+    "sqs-consumer-v6": "npm:sqs-consumer@^6.2.0",
     "superagent": "^6.1.0",
     "tsoa": "^3.14.1",
     "typescript": "^4.5.2",

--- a/packages/collector/src/agentConnection.js
+++ b/packages/collector/src/agentConnection.js
@@ -263,9 +263,6 @@ exports.sendMetrics = function sendMetrics(data, cb) {
  * @param {(...args: *) => *} cb
  */
 exports.sendSpans = function sendSpans(spans, cb) {
-  spans.forEach(sp => {
-    // console.log(sp);
-  });
   const callback = atMostOnce('callback for sendSpans', err => {
     if (err && !maxContentErrorHasBeenLogged && err instanceof PayloadTooLargeError) {
       logLargeSpans(spans);

--- a/packages/collector/src/agentConnection.js
+++ b/packages/collector/src/agentConnection.js
@@ -263,6 +263,9 @@ exports.sendMetrics = function sendMetrics(data, cb) {
  * @param {(...args: *) => *} cb
  */
 exports.sendSpans = function sendSpans(spans, cb) {
+  spans.forEach(sp => {
+    // console.log(sp);
+  });
   const callback = atMostOnce('callback for sendSpans', err => {
     if (err && !maxContentErrorHasBeenLogged && err instanceof PayloadTooLargeError) {
       logLargeSpans(spans);

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sqs-consumer.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sqs-consumer.js
@@ -1,0 +1,85 @@
+/*
+ * (c) Copyright IBM Corp. 2022
+ */
+
+'use strict';
+
+const mock = require('mock-require');
+
+/**
+ * The newest version of @aws-sdk/client-sqs is somehow not working
+ * with sqs-consumer package.
+ */
+mock('@aws-sdk/client-sqs', '@aws-sdk/client-sqs2');
+mock('sqs-consumer', 'sqs-consumer-v6');
+
+const instana = require('../../../../../../src')();
+const express = require('express');
+const awsSdk3 = require('@aws-sdk/client-sqs');
+const { Consumer } = require('sqs-consumer');
+const request = require('request-promise');
+const { sendToParent } = require('../../../../../../../core/test/test_util');
+const delay = require('../../../../../../../core/test/test_util/delay');
+
+const awsRegion = 'us-east-2';
+const port = process.env.APP_PORT || 3216;
+const agentPort = process.env.INSTANA_AGENT_PORT || 42699;
+const withError = process.env.AWS_SQS_RECEIVER_ERROR === 'true';
+const app = express();
+
+const queueURL = process.env.AWS_SQS_QUEUE_URL;
+const logPrefix = `AWS SQS Consumer API (${process.pid}):\t`;
+let hasStartedPolling = false;
+
+function log() {
+  /* eslint-disable no-console */
+  const args = Array.prototype.slice.call(arguments);
+  args[0] = `${logPrefix}${args[0]}`;
+  console.log.apply(console, args);
+  /* eslint-enable no-console */
+}
+
+const sqs = new awsSdk3.SQSClient({ region: awsRegion });
+
+const consumerApp = Consumer.create({
+  queueUrl: queueURL,
+  sqs,
+  handleMessage: async message => {
+    // make sure the span took at least one second to complete
+    await delay(1000);
+    sendToParent(message);
+    await delay(200);
+
+    await request(`http://localhost:${agentPort}?msg=${message.Body}`);
+    log(`Sent an HTTP request after receiving message of id ${message.MessageId}`);
+
+    if (withError) {
+      throw new Error('Forced error');
+    }
+  }
+});
+
+app.get('/', (_req, res) => {
+  if (hasStartedPolling) {
+    res.send('OK');
+  } else {
+    res.status(500).send('Not ready yet.');
+  }
+});
+
+app.listen(port, () => {
+  log(`App started at port ${port}`);
+});
+
+async function startPollingWhenReady() {
+  // Make sure we are connected to the agent before calling sqs.receiveMessage for the first time.
+  if (instana.isConnected()) {
+    consumerApp.start();
+    hasStartedPolling = true;
+  } else {
+    await delay(50);
+    setImmediate(startPollingWhenReady);
+  }
+}
+
+startPollingWhenReady();

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sqs-consumer.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sqs-consumer.js
@@ -6,10 +6,6 @@
 
 const mock = require('mock-require');
 
-/**
- * The newest version of @aws-sdk/client-sqs is somehow not working
- * with sqs-consumer package.
- */
 if (process.env.AWS_SDK_CLIENT_SQS_REQUIRE !== '@aws-sdk/client-sqs') {
   mock('@aws-sdk/client-sqs', process.env.AWS_SDK_CLIENT_SQS_REQUIRE);
 }

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sqs-consumer.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sqs-consumer.js
@@ -24,6 +24,7 @@ const awsRegion = 'us-east-2';
 const port = process.env.APP_PORT || 3216;
 const agentPort = process.env.INSTANA_AGENT_PORT || 42699;
 const withError = process.env.AWS_SQS_RECEIVER_ERROR === 'true';
+const handleMessageBatch = process.env.HANDLE_MESSAGE_BATCH === 'true';
 const app = express();
 
 const queueURL = process.env.AWS_SQS_QUEUE_URL;
@@ -40,23 +41,53 @@ function log() {
 
 const sqs = new awsSdk3.SQSClient({ region: awsRegion });
 
-const consumerApp = Consumer.create({
-  queueUrl: queueURL,
-  sqs,
-  handleMessage: async message => {
-    // make sure the span took at least one second to complete
-    await delay(1000);
-    sendToParent(message);
-    await delay(200);
+const handleMessageFn = async message => {
+  // make sure the span took at least one second to complete
+  await delay(1000);
+  sendToParent(message);
+  await delay(200);
 
-    await request(`http://localhost:${agentPort}?msg=${message.Body}`);
-    log(`Sent an HTTP request after receiving message of id ${message.MessageId}`);
+  await request(`http://localhost:${agentPort}?msg=${message.Body}`);
+  log(`Sent an HTTP request after receiving message of id ${message.MessageId}`);
 
-    if (withError) {
-      throw new Error('Forced error');
-    }
+  if (withError) {
+    throw new Error('Forced error');
   }
-});
+};
+
+const handleMessageBatchFn = async messages => {
+  // make sure the span took at least one second to complete
+  await delay(1000);
+
+  messages.forEach(async function (m) {
+    sendToParent(m);
+    await request(`http://localhost:${agentPort}?msg=${m.Body}`);
+    log(`Sent an HTTP request after receiving message of id ${m.MessageId}`);
+  });
+
+  await delay(200);
+
+  if (withError) {
+    throw new Error('Forced error');
+  }
+};
+const fn = handleMessageBatch ? { handleMessageBatch: handleMessageBatchFn } : { handleMessage: handleMessageFn };
+
+const consumerApp = Consumer.create(
+  Object.assign(
+    {
+      // MaxNumberOfMessages
+      batchSize: 10,
+      waitTimeSeconds: 2,
+      // We sometimes receives Messages: undefined, which made the tests flaky
+      // https://github.com/aws/aws-sdk-js-v3/issues/1394
+      visibilityTimeout: 1,
+      queueUrl: queueURL,
+      sqs
+    },
+    fn
+  )
+);
 
 app.get('/', (_req, res) => {
   if (hasStartedPolling) {

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sqs-consumer.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sqs-consumer.js
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright IBM Corp. 2022
+ * (c) Copyright IBM Corp. 2023
  */
 
 'use strict';

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sqs-consumer.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sqs-consumer.js
@@ -10,7 +10,10 @@ const mock = require('mock-require');
  * The newest version of @aws-sdk/client-sqs is somehow not working
  * with sqs-consumer package.
  */
-mock('@aws-sdk/client-sqs', '@aws-sdk/client-sqs2');
+if (process.env.AWS_SDK_CLIENT_SQS_REQUIRE !== '@aws-sdk/client-sqs') {
+  mock('@aws-sdk/client-sqs', process.env.AWS_SDK_CLIENT_SQS_REQUIRE);
+}
+
 mock('sqs-consumer', 'sqs-consumer-v6');
 
 const instana = require('../../../../../../src')();

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
@@ -188,7 +188,8 @@ function start(version) {
         });
       });
 
-      if (semver.gte(process.versions.node, '14.0.0')) {
+      // See https://github.com/bbc/sqs-consumer/issues/356
+      if (version !== '@aws-sdk/client-sqs' && semver.gte(process.versions.node, '14.0.0')) {
         describe('sqs-consumer API', () => {
           describe('message processed with success', () => {
             const sqsConsumerControls = new ProcessControls({
@@ -196,7 +197,8 @@ function start(version) {
               port: 3216,
               useGlobalAgent: true,
               env: {
-                AWS_SQS_QUEUE_URL: `${queueUrlPrefix}${queueName}-consumer`
+                AWS_SQS_QUEUE_URL: `${queueUrlPrefix}${queueName}-consumer`,
+                AWS_SDK_CLIENT_SQS_REQUIRE: version
               }
             });
 
@@ -228,6 +230,7 @@ function start(version) {
               useGlobalAgent: true,
               env: {
                 AWS_SQS_QUEUE_URL: `${queueUrlPrefix}${queueName}-consumer`,
+                AWS_SDK_CLIENT_SQS_REQUIRE: version,
                 AWS_SQS_RECEIVER_ERROR: 'true'
               }
             });

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
@@ -190,7 +190,7 @@ function start(version) {
 
       // See https://github.com/bbc/sqs-consumer/issues/356
       if (version !== '@aws-sdk/client-sqs' && semver.gte(process.versions.node, '14.0.0')) {
-        describe.only('sqs-consumer API', () => {
+        describe('sqs-consumer API', () => {
           describe('message processed with success', () => {
             const sqsConsumerControls = new ProcessControls({
               appPath: path.join(__dirname, 'sqs-consumer'),

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
@@ -190,7 +190,7 @@ function start(version) {
 
       // See https://github.com/bbc/sqs-consumer/issues/356
       if (version !== '@aws-sdk/client-sqs' && semver.gte(process.versions.node, '14.0.0')) {
-        describe('sqs-consumer API', () => {
+        describe.only('sqs-consumer API', () => {
           describe('message processed with success', () => {
             const sqsConsumerControls = new ProcessControls({
               appPath: path.join(__dirname, 'sqs-consumer'),

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
@@ -6,7 +6,6 @@
 'use strict';
 
 const shimmer = require('shimmer');
-const cls = require('../../../../cls');
 const requireHook = require('../../../../../util/requireHook');
 const { getFunctionArguments } = require('../../../../../util/function_arguments');
 
@@ -17,6 +16,8 @@ const awsProducts = [
   require('./s3'),
   require('./sqs')
 ];
+
+const sqsConsumer = require('./sqs-consumer');
 
 /** @type {Object.<string, import('./instana_aws_product').InstanaAWSProduct} */
 const operationMap = {};
@@ -29,7 +30,8 @@ let isActive = false;
 let onFileLoaded = false;
 
 exports.init = function init() {
-  requireHook.onModuleLoad('sqs-consumer', instrumentSQSConsumer);
+  sqsConsumer.init();
+
   /**
    * @aws-sdk/smithly-client >= 3.36.0 changed how the dist structure gets delivered
    * https://github.com/aws/aws-sdk-js-v3/blob/main/packages/smithy-client/CHANGELOG.md#3360-2021-10-08
@@ -54,40 +56,6 @@ exports.activate = function activate() {
 exports.deactivate = function deactivate() {
   isActive = false;
 };
-
-function instrumentSQSConsumer(SQSConsumer) {
-  shimmer.wrap(SQSConsumer.Consumer.prototype, 'executeHandler', function (orig) {
-    return function instanaExecuteHandler() {
-      const message = arguments[0];
-
-      if (message && message.instanaAsyncContext) {
-        return cls.runInAsyncContext(message.instanaAsyncContext, () => {
-          const span = cls.getCurrentSpan();
-          span.disableAutoEnd();
-
-          delete arguments[0].instanaAsyncContext;
-          const res = orig.apply(this, arguments);
-
-          res
-            .then(() => {
-              span.d = Date.now() - span.ts;
-              span.transmitManual();
-            })
-            .catch(err => {
-              span.ec = 1;
-              span.data.sqs.error = err.message || err.code || JSON.stringify(err);
-              span.d = Date.now() - span.ts;
-              span.transmitManual();
-            });
-
-          return res;
-        });
-      }
-
-      return orig.apply(this, arguments);
-    };
-  });
-}
 
 function instrumentGlobalSmithy(Smithy) {
   // NOTE: avoid instrumenting aws-sdk v3 twice, see init

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
@@ -60,7 +60,7 @@ function instrumentSQSConsumer(SQSConsumer) {
     return function instanaExecuteHandler() {
       const message = arguments[0];
 
-      if (message.instanaAsyncContext) {
+      if (message && message.instanaAsyncContext) {
         return cls.runInAsyncContext(message.instanaAsyncContext, () => {
           const span = cls.getCurrentSpan();
           span.disableAutoEnd();

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
@@ -55,12 +55,9 @@ exports.deactivate = function deactivate() {
   isActive = false;
 };
 
-let SQSConsumer;
-function instrumentSQSConsumer(_SQSConsumer) {
-  SQSConsumer = _SQSConsumer;
-
+function instrumentSQSConsumer(SQSConsumer) {
   shimmer.wrap(SQSConsumer.Consumer.prototype, 'executeHandler', function (orig) {
-    return function executeHandler() {
+    return function instanaExecuteHandler() {
       const message = arguments[0];
 
       if (message.instanaAsyncContext) {
@@ -112,7 +109,7 @@ function shimSmithySend(originalSend) {
       const awsProduct = operationMap[command.constructor.name];
 
       if (awsProduct) {
-        return awsProduct.instrumentedSmithySend(self, originalSend, smithySendArgs, SQSConsumer);
+        return awsProduct.instrumentedSmithySend(self, originalSend, smithySendArgs);
       }
 
       return originalSend.apply(self, smithySendArgs);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs-consumer.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs-consumer.js
@@ -42,6 +42,37 @@ function instrument(SQSConsumer) {
       return orig.apply(this, arguments);
     };
   });
+
+  shimmer.wrap(SQSConsumer.Consumer.prototype, 'executeBatchHandler', function (orig) {
+    return function instanaExecuteBatchHandler() {
+      const messages = arguments[0];
+
+      if (messages) {
+        const message = messages.find(msg => msg.instanaAsyncContext);
+
+        return cls.runInAsyncContext(message.instanaAsyncContext, () => {
+          const span = cls.getCurrentSpan();
+          span.disableAutoEnd();
+          const res = orig.apply(this, arguments);
+
+          res
+            .then(() => {
+              span.d = Date.now() - span.ts;
+              span.transmitManual();
+            })
+            .catch(err => {
+              span.ec = 1;
+              span.data.sqs.error = err.message || err.code || JSON.stringify(err);
+              span.d = Date.now() - span.ts;
+              span.transmitManual();
+            });
+
+          return res;
+        });
+      }
+      return orig.apply(this, arguments);
+    };
+  });
 }
 
 module.exports = {

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs-consumer.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs-consumer.js
@@ -1,0 +1,51 @@
+/*
+ * (c) Copyright IBM Corp. 2023
+ */
+
+'use strict';
+
+const shimmer = require('shimmer');
+const requireHook = require('../../../../../util/requireHook');
+const cls = require('../../../../cls');
+
+function init() {
+  requireHook.onModuleLoad('sqs-consumer', instrument);
+}
+
+function instrument(SQSConsumer) {
+  shimmer.wrap(SQSConsumer.Consumer.prototype, 'executeHandler', function (orig) {
+    return function instanaExecuteHandler() {
+      const message = arguments[0];
+
+      if (message && message.instanaAsyncContext) {
+        return cls.runInAsyncContext(message.instanaAsyncContext, () => {
+          const span = cls.getCurrentSpan();
+          span.disableAutoEnd();
+
+          delete arguments[0].instanaAsyncContext;
+          const res = orig.apply(this, arguments);
+
+          res
+            .then(() => {
+              span.d = Date.now() - span.ts;
+              span.transmitManual();
+            })
+            .catch(err => {
+              span.ec = 1;
+              span.data.sqs.error = err.message || err.code || JSON.stringify(err);
+              span.d = Date.now() - span.ts;
+              span.transmitManual();
+            });
+
+          return res;
+        });
+      }
+
+      return orig.apply(this, arguments);
+    };
+  });
+}
+
+module.exports = {
+  init
+};

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs-consumer.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs-consumer.js
@@ -21,8 +21,6 @@ function instrument(SQSConsumer) {
         return cls.runInAsyncContext(message.instanaAsyncContext, () => {
           const span = cls.getCurrentSpan();
           span.disableAutoEnd();
-
-          delete arguments[0].instanaAsyncContext;
           const res = orig.apply(this, arguments);
 
           res

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
@@ -258,12 +258,11 @@ class InstanaAWSSQS extends InstanaAWSProduct {
               span.cancel();
             }
 
-            // NOTE: attach the async context to continue with it if sqs-consumer is used, see index.js
-            //       sqs-consumer messages are dependend on the customer's `handleMessage` function
+            // NOTE: attach the async context to the last message to be able to
+            //       finish the span with the correct end time and error in the sqs-consuemr `handleMessage` function.
+            // 1x ReceiveMessageCommand with multiple messages (batchSize>1) == 1 sqs entry with size 4
             if (data && data.Messages && data.Messages) {
-              data.Messages.forEach(message => {
-                message.instanaAsyncContext = cls.getAsyncContext();
-              });
+              data.Messages[data.Messages.length - 1].instanaAsyncContext = cls.getAsyncContext();
             }
 
             return data;

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
@@ -151,7 +151,7 @@ class InstanaAWSSQS extends InstanaAWSProduct {
     });
   }
 
-  instrumentEntry(ctx, originalSend, smithySendArgs, operation, SQSConsumer) {
+  instrumentEntry(ctx, originalSend, smithySendArgs, operation) {
     const parentSpan = cls.getCurrentSpan();
     if (parentSpan) {
       logger.warn(

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
@@ -39,14 +39,14 @@ const operations = Object.keys(operationsInfo);
 const SPAN_NAME = 'sqs';
 
 class InstanaAWSSQS extends InstanaAWSProduct {
-  instrumentedSmithySend(ctx, originalSend, smithySendArgs, SQSConsumer) {
+  instrumentedSmithySend(ctx, originalSend, smithySendArgs) {
     const commandName = smithySendArgs[0].constructor.name;
     const operation = operationsInfo[commandName];
 
     if (operation && operation.sort === 'exit') {
-      return this.instrumentExit(ctx, originalSend, smithySendArgs, operation, SQSConsumer);
+      return this.instrumentExit(ctx, originalSend, smithySendArgs, operation);
     } else if (operation && operation.sort === 'entry') {
-      return this.instrumentEntry(ctx, originalSend, smithySendArgs, operation, SQSConsumer);
+      return this.instrumentEntry(ctx, originalSend, smithySendArgs, operation);
     }
 
     return originalSend.apply(ctx, smithySendArgs);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
@@ -229,7 +229,7 @@ class InstanaAWSSQS extends InstanaAWSProduct {
       } else {
         const request = originalSend.apply(ctx, smithySendArgs);
 
-        // NOTE: This is promise chain for the "send" method only!
+        // NOTE: This is promise chain for the "send" method from @awsk-sdk/smithy-client, not from sqs-consumer!
         request
           .then(data => {
             if (data && data.error) {

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
@@ -260,9 +260,11 @@ class InstanaAWSSQS extends InstanaAWSProduct {
 
             // NOTE: attach the async context to continue with it if sqs-consumer is used, see index.js
             //       sqs-consumer messages are dependend on the customer's `handleMessage` function
-            data.Messages.forEach(message => {
-              message.instanaAsyncContext = cls.getAsyncContext();
-            });
+            if (data && data.Messages && data.Messages) {
+              data.Messages.forEach(message => {
+                message.instanaAsyncContext = cls.getAsyncContext();
+              });
+            }
 
             return data;
           })


### PR DESCRIPTION
sqs-consumer@6.2.0 is using aws-sdk@3 under the hood.

FYI: When using the latest version of `@aws-sdk/client-sqs` to send a message to the receiver, it does not work and throws an error. Reported.