### PR TITLE
chore: ignore some file endings for requireHook absolute matching

### DIFF
--- a/packages/core/src/util/requireHook.js
+++ b/packages/core/src/util/requireHook.js
@@ -57,7 +57,8 @@ function patchedModuleLoad(moduleName) {
   // CASE: when using ESM, the Node runtime passes a full path to Module._load
   //       we try to grab the module name to being able to patch the target module
   //       with our instrumentation
-  if (path.isAbsolute(moduleName)) {
+  // CASE: we ignore all file endings, which we are not interested in. Any module can load any file.
+  if (path.isAbsolute(moduleName) && ['.node', '.json', '.ts'].indexOf(path.extname(moduleName)) === -1) {
     // EDGE CASE for ESM: mysql2/promise.js
     if (moduleName.indexOf('node_modules/mysql2/promise.js') !== -1) {
       moduleName = 'mysql2/promise';


### PR DESCRIPTION
e.g. ibm_db loads native c++ files, which are absolute


https://app.circleci.com/pipelines/github/instana/nodejs/4814/workflows/2e056cff-bc2a-4d05-97c7-1b1044da2b26/jobs/18146

> @instana/collector: {"name":"@instana/collector","thread":0,"__in":1,"hostname":"d6e7980b826a","pid":30769,"module":"util/requireHook","level":50,"msg":"Cannot instrument ibm_db due to an error in instrumentation: TypeError: Cannot read properties of undefined (reading 'prototype')","time":"2023-01-30T14:56:59.289Z","v":0}
@instana/collector: {"name":"@instana/collector","thread":0,"__in":1,"hostname":"d6e7980b826a","pid":30769,"module":"util/requireHook","level":50,"msg":"Cannot read properties of undefined (reading 'prototype')","time":"2023-01-30T14:56:59.290Z","v":0}
