### PR TITLE
feat(tracing): improve robustness of custom service naming

### DIFF
--- a/packages/collector/test/tracing/common/app.js
+++ b/packages/collector/test/tracing/common/app.js
@@ -33,7 +33,7 @@ if (process.env.SCREW_AROUND_WITH_UP_ARRAY_FIND) {
   });
 }
 
-require('../../..')(config);
+const instana = require('../../..')(config);
 
 const http = require('http');
 const pino = require('pino')();
@@ -46,6 +46,11 @@ app.on('request', (req, res) => {
   }
   if (req.url.indexOf('with-log') >= 0) {
     pino.error('This error message should be traced, unless the pino instrumentation is disabled.');
+  } else if (req.url.indexOf('with-intermediate-and-exit-spans') >= 0) {
+    instana.sdk.callback.startIntermediateSpan('dummy-sdk-span', () => {
+      pino.warn('create an exit span');
+      instana.sdk.callback.completeIntermediateSpan();
+    });
   }
   res.end();
 });

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -249,7 +249,7 @@ function startSpan(spanName, kind, traceId, parentSpanId, w3cTraceContext) {
   const parentSpan = getCurrentSpan();
   const parentW3cTraceContext = getW3cTraceContext();
 
-  if (serviceName != null && !parentSpan) {
+  if (serviceName != null) {
     span.data.service = serviceName;
   }
 


### PR DESCRIPTION
Previously, we only added span.data.service to _entry_ spans. The requirements around this have changed, now we add this annotation to _all_ spans, if the service name has been configured via the environment variable INSTANA_SERVICE_NAME or the in-code configuration.