### PR TITLE
test: work around SIGTERM handling conflict between nyc and Prisma

### DIFF
--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -3,6 +3,8 @@
  * (c) Copyright Instana Inc. and contributors 2018
  */
 
+/* eslint-disable max-len */
+
 'use strict';
 
 const _ = require('lodash');
@@ -313,27 +315,67 @@ class ProcessControls {
     if (this.process.killed || this.dontKillInAfterHook) {
       // eslint-disable-next-line no-console
       console.log(
-        // eslint-disable-next-line max-len
         `[ProcessControls] ${this} - process has already been killed (${this.process.killed}) or is not meant to be killed in after hook (${this.dontKillInAfterHook}), done.`
       );
       return Promise.resolve();
     }
+
+    let killPromiseHasBeenResolved = false;
     return new Promise(resolve => {
       this.process.once('exit', () => {
         // eslint-disable-next-line no-console
         console.log(`[ProcessControls] ${this} - process exit event has been triggered, done.`);
         this.process.pid = null;
+        killPromiseHasBeenResolved = true;
         resolve();
       });
 
       // eslint-disable-next-line no-console
       console.log(`[ProcessControls] ${this} - calling process.kill() now.`);
+
+      // Sends SIGTERM to the child process to terminate it gracefully.
       this.process.kill();
+
+      // The code above is usually good enough to terminate the child process gracefully and return a resolved promise.
+      // However, Prisma and nyc (Istanbul's command line interface) both do fancy things with signal handling in
+      // Node.js. Thus, when running packages/collector/test/tracing/database/prisma/test.js _via nyc_ (as we do in the
+      // weekly test coverage job on CI), the Prisma app ignores the SIGTERM for some reason and just keeps running.
+      //
+      // This can be reproduced locally via
+      //
+      // cd packages/collector && WITH_STDOUT=true npm_package_name=@instana/collector ../../node_modules/.bin/nyc mocha --config=test/.mocharc.js --require test/hooks.js test/tracing/database/prisma/test.js
+      //
+      // This seems to be related to the hooks installed by Prisma in
+      // packages/collector/test/tracing/database/prisma/node_modules/@prisma/client/runtime/index.js, line 26888:
+      // (that is, the line `this.installHook("SIGTERM", true)` and friends). To resolve this conflict, we forcefully
+      // kill the child process by sending SIGKILL after one second, when SIGTERM does not have the desired effect of
+      // terminating the child process.
+      //
+      // All of this has been reported as an issue to the Prisma project: https://github.com/prisma/prisma/issues/18063.
+      setTimeout(() => {
+        if (!killPromiseHasBeenResolved) {
+          // eslint-disable-next-line no-console
+          console.log(
+            `[ProcessControls] ${this} - Child process ${this.process.pid} appears to not have terminated after one second after sending SIGTERM, sending SIGKILL now.`
+          );
+          this.process.kill('SIGKILL');
+
+          setTimeout(() => {
+            if (!killPromiseHasBeenResolved) {
+              // eslint-disable-next-line no-console
+              console.log(
+                `[ProcessControls] ${this} - The promise to kill process ${this.process.pid} has still not been resolved, even after sending SIGKILL. Resolving the promise now unconditionally to unblock the Mocha after hook.`
+              );
+              resolve();
+            }
+          }, 1000).unref();
+        }
+      }, 1000).unref();
     });
   }
 
   toString() {
-    return `${this.process ? this.process.pid : '-'} (${this.appPath})`;
+    return `${this.process && this.process.pid ? this.process.pid : '-'} (${this.appPath})`;
   }
 }
 

--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -52,8 +52,6 @@ class ProcessControls {
   static setUpSuiteHooksWithRetryTime(retryTime, ...allControls) {
     before(() => Promise.all(allControls.map(control => control.startAndWaitForAgentConnection(retryTime))));
     after(() => {
-      // eslint-disable-next-line no-console
-      console.log('[ProcessControls] (static) - after hook');
       return Promise.all(allControls.map(control => control.stop()));
     });
   }
@@ -218,11 +216,7 @@ class ProcessControls {
   }
 
   async stop() {
-    // eslint-disable-next-line no-console
-    console.log(`[ProcessControls] ${this} - ProcessControl#stop`);
     await this.kill();
-    // eslint-disable-next-line no-console
-    console.log(`[ProcessControls] ${this} - ProcessControl#stop done`);
   }
 
   async waitUntilServerIsUp(retryTime) {
@@ -305,33 +299,20 @@ class ProcessControls {
   }
 
   kill() {
-    // eslint-disable-next-line no-console
-    console.log(`[ProcessControls] ${this} - ProcessControl#kill`);
     if (!this.process) {
-      // eslint-disable-next-line no-console
-      console.log(`[ProcessControls] ${this} - no process to kill, done.`);
       return Promise.resolve();
     }
     if (this.process.killed || this.dontKillInAfterHook) {
-      // eslint-disable-next-line no-console
-      console.log(
-        `[ProcessControls] ${this} - process has already been killed (${this.process.killed}) or is not meant to be killed in after hook (${this.dontKillInAfterHook}), done.`
-      );
       return Promise.resolve();
     }
 
     let killPromiseHasBeenResolved = false;
     return new Promise(resolve => {
       this.process.once('exit', () => {
-        // eslint-disable-next-line no-console
-        console.log(`[ProcessControls] ${this} - process exit event has been triggered, done.`);
         this.process.pid = null;
         killPromiseHasBeenResolved = true;
         resolve();
       });
-
-      // eslint-disable-next-line no-console
-      console.log(`[ProcessControls] ${this} - calling process.kill() now.`);
 
       // Sends SIGTERM to the child process to terminate it gracefully.
       this.process.kill();

--- a/packages/collector/test/tracing/database/prisma/app.js
+++ b/packages/collector/test/tracing/database/prisma/app.js
@@ -102,7 +102,3 @@ app.post('/update', async (req, res) => {
 app.listen(port, () => {
   log(`Listening on port: ${port}`);
 });
-
-process.on('uncaughtException', err => {
-  log('Prisma uncaught exception', err);
-});

--- a/packages/collector/test/tracing/database/prisma/test.js
+++ b/packages/collector/test/tracing/database/prisma/test.js
@@ -68,23 +68,8 @@ mochaSuiteFn('tracing/prisma', function () {
       });
 
       after(async () => {
-        try {
-          // eslint-disable-next-line no-console
-          console.log(
-            `[Prisma test after hook (${provider})] deleting Prisma schema target file ${schemaTargetFile} now.`
-          );
-          await fs.rm(schemaTargetFile, { force: true });
-          // eslint-disable-next-line no-console
-          console.log(
-            `[Prisma test after hook (${provider})] Deleting migrations target directory ${migrationsTargetDir} now.`
-          );
-          await rimraf(migrationsTargetDir);
-          // eslint-disable-next-line no-console
-          console.log(`[Prisma test after hook (${provider})] Done.`);
-        } catch (err) {
-          // eslint-disable-next-line no-console
-          console.log('Prisma after hook error', err);
-        }
+        await fs.rm(schemaTargetFile, { force: true });
+        await rimraf(migrationsTargetDir);
       });
 
       globalAgent.setUpCleanUpHooks();

--- a/packages/collector/test/tracing/database/prisma/test.js
+++ b/packages/collector/test/tracing/database/prisma/test.js
@@ -39,7 +39,7 @@ mochaSuiteFn('tracing/prisma', function () {
     // be installed into node_modules relative to that file. This is why we do not install `@prisma/client` in our
     // root dependencies, as we do for other modules under test.
     // See also: https://www.prisma.io/docs/reference/api-reference/command-reference#generate
-    await executeAsync('npm install', appDir);
+    await executeAsync('npm install --no-audit', appDir);
   });
 
   providers.forEach(provider => {

--- a/packages/core/src/tracing/instrumentation/database/prisma.js
+++ b/packages/core/src/tracing/instrumentation/database/prisma.js
@@ -4,6 +4,10 @@
 
 'use strict';
 
+// Maintenance note: Test coverage reports for this file might not be accurate. See the comment in ProcessControls.js
+// about the conflict between nyc and Prisma. The workaround might lead to killing the Prisma app under test
+// via SIGKILL, which will deprive Istanbul of the opportunity to report test coverage for Prisma correctly.
+
 const shimmer = require('shimmer');
 
 let logger;


### PR DESCRIPTION
Both nyc and Prisma do fancy things with signal handling. For that
reason, the Prisma test app ignores the SIGTERM signal when the tests
are run via nyc.

This change works around this issue by sending a SIGKILL one second
later, when SIGTERM does not terminate the child process (the
application under test).