### PR TITLE
test(aws): do not load @aws-sdk/client-dynamodb on old Node.js versions

### DIFF
--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/test_definition.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/test_definition.js
@@ -4,8 +4,7 @@
 
 'use strict';
 
-const checkTableExistence = require('./util').checkTableExistence;
-const cleanup = require('./util').cleanup;
+const { checkTableExistence, cleanup, minimumNodeJsVersion } = require('./util');
 const semver = require('semver');
 const { v4: uuid } = require('uuid');
 const path = require('path');
@@ -62,7 +61,7 @@ const createTableName = () => {
 };
 
 function start(version, requestMethod) {
-  if (!supportedVersion(process.versions.node)) {
+  if (!supportedVersion(process.versions.node) || semver.lt(process.versions.node, minimumNodeJsVersion)) {
     mochaSuiteFn = describe.skip;
   } else {
     mochaSuiteFn = describe;

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/util.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/util.js
@@ -5,6 +5,14 @@
 
 'use strict';
 
+exports.minimumNodeJsVersion = '14.0.0';
+
+if (require('semver').lte(process.versions.node, exports.minimumNodeJsVersion)) {
+  exports.checkTableExistence = function () {};
+  exports.cleanup = function () {};
+  return;
+}
+
 const AWS = require('@aws-sdk/client-dynamodb');
 const dynamoDB = new AWS.DynamoDB({ region: 'us-east-2' });
 const interval = 1000;


### PR DESCRIPTION
The tests are loading the package @aws-sdk/client-dynamodb directly, to check whether the required tables exist and clean up in the after hook. Version 3.201.0 of @aws-sdk/client-dynamodb dropped support for Node.js
12. Thus, the latest upgrade of that package broke the test suite on Node.js 10 and 12 because we tried to require code with syntax only supported on Node.js >= 14.

Fixed by not loading that package via require on older Node.js versions and also skipping the associated test cases.