### PR TITLE
build(deps): remove unused package async-hook-jl

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "2.18.1",
 			"license": "MIT",
 			"dependencies": {
-				"async-hook-jl": "^1.7.6",
 				"cls-bluebird": "^2.1.0",
 				"lru-cache": "6.0.0",
 				"methods": "^1.1.2",
@@ -20,17 +19,6 @@
 			},
 			"devDependencies": {
 				"no-code2": "2.0.0"
-			}
-		},
-		"node_modules/async-hook-jl": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-			"integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-			"dependencies": {
-				"stack-chain": "^1.3.7"
-			},
-			"engines": {
-				"node": "^4.7 || >=6.9 || >=7.3"
 			}
 		},
 		"node_modules/cls-bluebird": {
@@ -126,11 +114,6 @@
 			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
 			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
 		},
-		"node_modules/stack-chain": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-			"integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
-		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -138,14 +121,6 @@
 		}
 	},
 	"dependencies": {
-		"async-hook-jl": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-			"integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-			"requires": {
-				"stack-chain": "^1.3.7"
-			}
-		},
 		"cls-bluebird": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
@@ -222,11 +197,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
 			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-		},
-		"stack-chain": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-			"integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
 		},
 		"yallist": {
 			"version": "4.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -124,7 +124,6 @@
   },
   "homepage": "https://github.com/instana/nodejs/blob/main/packages/core/README.md",
   "dependencies": {
-    "async-hook-jl": "^1.7.6",
     "cls-bluebird": "^2.1.0",
     "lru-cache": "6.0.0",
     "methods": "^1.1.2",


### PR DESCRIPTION
The usage of this package has already been removed with commit 388fbdf4d60be15d274a2ad6004fdc0b63720497 when the legacy cls context implementation based on AsyncWrap for Node.js versions < 8 was removed.