### PR TITLE
fix(collector): keep EOL events open instead of recreating them

### DIFF
--- a/packages/collector/src/agentConnection.js
+++ b/packages/collector/src/agentConnection.js
@@ -49,11 +49,12 @@ exports.AgentEventSeverity = {
  * */
 
 /**
- * @typedef {Object} AgentConnectionEvent
+ * @typedef {Object} Event
  * @property {string} [title]
  * @property {string} [text]
  * @property {string} [plugin]
  * @property {number} [pid]
+ * @property {string} [path]
  * @property {number} [id]
  * @property {string} [code]
  * @property {string} [category]
@@ -294,7 +295,7 @@ exports.sendProfiles = function sendProfiles(profiles, cb) {
 };
 
 /**
- * @param {AgentConnectionEvent} eventData
+ * @param {Event} eventData
  * @param {(...args: *) => *} cb
  */
 exports.sendEvent = function sendEvent(eventData, cb) {
@@ -311,7 +312,7 @@ exports.sendEvent = function sendEvent(eventData, cb) {
  * @param {(...args: *) => *} cb
  */
 exports.sendAgentMonitoringEvent = function sendAgentMonitoringEvent(code, category, cb) {
-  /** @type {AgentConnectionEvent} */
+  /** @type {Event} */
   const event = {
     plugin: 'com.instana.forge.infrastructure.runtime.nodejs.NodeJsRuntimePlatform',
     pid: pidStore.pid,

--- a/packages/collector/src/uncaught/index.js
+++ b/packages/collector/src/uncaught/index.js
@@ -116,7 +116,7 @@ function onUnhandledRejection(reason) {
 
 /**
  * @param {Error} reason
- * @returns {import('../agentConnection').AgentConnectionEvent}
+ * @returns {import('../agentConnection').Event}
  */
 function createEventForUnhandledRejection(reason) {
   return createEvent(reason, 'An unhandled promise rejection occured in a Node.js process.', 5, true);
@@ -127,7 +127,7 @@ function createEventForUnhandledRejection(reason) {
  * @param {string} title
  * @param {import('../agentConnection').ProblemSeverity} severity
  * @param {boolean} isPromiseRejection
- * @returns {import('../agentConnection').AgentConnectionEvent}
+ * @returns {import('../agentConnection').Event}
  */
 function createEvent(error, title, severity, isPromiseRejection) {
   /** @type {string} */

--- a/packages/collector/src/util/eol.js
+++ b/packages/collector/src/util/eol.js
@@ -10,9 +10,9 @@ const { satisfies } = require('semver');
 /**
  * This function has to be updated from time to time.
  * You can check active versions in https://nodejs.org/en/about/releases/.
- * It's also possible to test the semver match here: https://semver.npmjs.com/
+ *
  * @returns {boolean}
  */
 exports.isNodeVersionEOL = function () {
-  return satisfies(process.versions.node, '<12 || 15 || 13');
+  return satisfies(process.versions.node, '<16 || 17');
 };

--- a/packages/collector/test/util/isNodeVersionEOL_test.js
+++ b/packages/collector/test/util/isNodeVersionEOL_test.js
@@ -1,0 +1,48 @@
+/*
+ * (c) Copyright IBM Corp. 2023
+ */
+
+'use strict';
+
+const { expect } = require('chai');
+
+const { isNodeVersionEOL } = require('../../src/util/eol');
+
+describe('util/eol', () => {
+  let originalPropertyDescriptor;
+
+  before(() => {
+    originalPropertyDescriptor = Object.getOwnPropertyDescriptor(process.versions, 'node');
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.versions, 'node', originalPropertyDescriptor);
+  });
+
+  it('should not be detected as EOL when the Node.js version is not EOL', () => {
+    Object.defineProperty(process.versions, 'node', {
+      value: '42.43.44',
+      writable: false
+    });
+
+    expect(isNodeVersionEOL()).to.be.false;
+  });
+
+  runEolTest('0.10.1');
+  runEolTest('0.12.1');
+  runEolTest('4.7.1');
+  runEolTest('6.999.1111');
+  runEolTest('14.13.3');
+  runEolTest('15.16.17');
+  runEolTest('17.0.0');
+
+  function runEolTest(version) {
+    it(`EOL should be detected when the Node.js version is EOL (${version})`, () => {
+      Object.defineProperty(process.versions, 'node', {
+        value: version,
+        writable: false
+      });
+      expect(isNodeVersionEOL()).to.be.true;
+    });
+  }
+});

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -31,13 +31,13 @@ const util = require('./util');
  * @property {import('./tracing/index')} tracing
  */
 
-/** @typedef {import('../../collector/src/agentConnection').AgentConnectionEvent} AgentConnectionEvent */
+/** @typedef {import('../../collector/src/agentConnection').Event} Event */
 
 /**
  * This type is based on /nodejs/packages/collector/src/agentConnection.js
  * @typedef {Object} DownstreamConnection
  * @property {(spans: *, cb: Function) => void} sendSpans
- * @property {(eventData: AgentConnectionEvent, cb: (...args: *) => *) => void} sendEvent
+ * @property {(eventData: Event, cb: (...args: *) => *) => void} sendEvent
  */
 
 /**


### PR DESCRIPTION
Issue events that are sent to the Instana agent (and thereby indirectly to the Instana backend), are discarded when they expire according to their "duration" property. To keep them open for the entire lifetime of the entity (which makes sense for the EOL events we are dealing with here), we are ought to resend them before they expire in a heartbeat- like fashion. The backend requires a unique "path" attributes on these events to be able to group them together and to know that it is supposed to keep the already created issue open instead of opening a new issue. This commit adds that "path" attribute.

Also:
- change the duration of the event from 10 minutes to 6 hours
- rename the misnamed AgentConnectionEvent type to just Event