### PR TITLE
feat(w3c): support W3C trace context level 2

### DIFF
--- a/packages/collector/test/tracing/misc/specification_compliance/tracer_compliance_test_cases.json
+++ b/packages/collector/test/tracing/misc/specification_compliance/tracer_compliance_test_cases.json
@@ -11,7 +11,7 @@
     "X-INSTANA-T out": "$new_64_bit_trace_id",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id_2-01",
+    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id_2-03",
     "tracestate out": "in=$new_64_bit_trace_id;$new_span_id_2",
     "index": 1
   },
@@ -30,7 +30,7 @@
     "X-INSTANA-T out": "fa2375d711a4ca0f",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-01",
+    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-03",
     "tracestate out": "in=fa2375d711a4ca0f;$new_span_id_2",
     "index": 2
   },
@@ -50,7 +50,7 @@
     "X-INSTANA-T out": "3483a5fe1cd42e30",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0373e5f7aca1cdef3483a5fe1cd42e30-$new_span_id_2-01",
+    "traceparent out": "00-0373e5f7aca1cdef3483a5fe1cd42e30-$new_span_id_2-03",
     "tracestate out": "in=3483a5fe1cd42e30;$new_span_id_2",
     "index": 3
   },
@@ -234,7 +234,7 @@
     "What to do?": "Don’t create spans, send X-INSTANA-L=0 and spec headers downstream with sampled=0",
     "X-INSTANA-L in": "0",
     "X-INSTANA-L out": "0",
-    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id-00",
+    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id-02",
     "index": 12
   },
   {
@@ -244,7 +244,7 @@
     "X-INSTANA-S in": "37cb2d6e9b1c078a",
     "X-INSTANA-L in": "0",
     "X-INSTANA-L out": "0",
-    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id-00",
+    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id-02",
     "index": 13
   },
   {
@@ -285,7 +285,7 @@
     "X-INSTANA-T out": "fa2375d711a4ca0f",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-01",
+    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-03",
     "tracestate out": "in=fa2375d711a4ca0f;$new_span_id_2",
     "index": 16
   },
@@ -306,7 +306,7 @@
     "X-INSTANA-T out": "$new_64_bit_trace_id",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id_2-01",
+    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id_2-03",
     "tracestate out": "in=$new_64_bit_trace_id;$new_span_id_2",
     "index": 17
   },
@@ -323,7 +323,7 @@
     "X-INSTANA-T out": "$new_64_bit_trace_id",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id_2-01",
+    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id_2-03",
     "tracestate out": "in=$new_64_bit_trace_id;$new_span_id_2",
     "index": 18
   },
@@ -343,7 +343,7 @@
     "X-INSTANA-T out": "fa2375d711a4ca0f",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-01",
+    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-03",
     "tracestate out": "in=fa2375d711a4ca0f;$new_span_id_2",
     "index": 19
   },
@@ -364,7 +364,7 @@
     "X-INSTANA-T out": "3483a5fe1cd42e30",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0373e5f7aca1cdef3483a5fe1cd42e30-$new_span_id_2-01",
+    "traceparent out": "00-0373e5f7aca1cdef3483a5fe1cd42e30-$new_span_id_2-03",
     "tracestate out": "in=3483a5fe1cd42e30;$new_span_id_2",
     "index": 20
   },
@@ -519,7 +519,7 @@
     "INSTANA_DISABLE_W3C_TRACE_CORRELATION": "yes_please",
     "X-INSTANA-L in": "0",
     "X-INSTANA-L out": "0",
-    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id-00",
+    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id-02",
     "index": 28
   },
   {
@@ -530,7 +530,7 @@
     "X-INSTANA-S in": "37cb2d6e9b1c078a",
     "X-INSTANA-L in": "0",
     "X-INSTANA-L out": "0",
-    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id-00",
+    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id-02",
     "index": 29
   },
   {
@@ -568,7 +568,7 @@
     "X-INSTANA-T out": "$new_64_bit_trace_id",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id_2-01",
+    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id_2-03",
     "tracestate out": "in=$new_64_bit_trace_id;$new_span_id_2",
     "index": 32
   },
@@ -585,7 +585,7 @@
     "X-INSTANA-T out": "$new_64_bit_trace_id",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id_2-01",
+    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id_2-03",
     "tracestate out": "in=$new_64_bit_trace_id;$new_span_id_2",
     "index": 33
   },
@@ -649,7 +649,7 @@
     "X-INSTANA-T out": "$new_64_bit_trace_id",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id_2-01",
+    "traceparent out": "00-0000000000000000$new_64_bit_trace_id-$new_span_id_2-03",
     "tracestate out": "in=$new_64_bit_trace_id;$new_span_id_2",
     "index": 36
   },
@@ -670,7 +670,7 @@
     "X-INSTANA-T out": "fa2375d711a4ca0f",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-01",
+    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-03",
     "tracestate out": "in=fa2375d711a4ca0f;$new_span_id_2",
     "index": 37
   },
@@ -690,7 +690,7 @@
     "X-INSTANA-T out": "fa2375d711a4ca0f",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-01",
+    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-03",
     "tracestate out": "in=fa2375d711a4ca0f;$new_span_id_2",
     "index": 38
   },
@@ -710,7 +710,7 @@
     "X-INSTANA-T out": "fa2375d711a4ca0f",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-01",
+    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-03",
     "tracestate out": "in=fa2375d711a4ca0f;$new_span_id_2",
     "index": 39
   },
@@ -730,8 +730,48 @@
     "X-INSTANA-T out": "fa2375d711a4ca0f",
     "X-INSTANA-S out": "$new_span_id_2",
     "X-INSTANA-L out": "1",
-    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-01",
+    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-03",
     "tracestate out": "in=fa2375d711a4ca0f;$new_span_id_2",
     "index": 40
+  },
+  {
+    "Scenario": "INSTANA_SERVICE_NAME support / entry span",
+    "What to do?": "add span.data.service on entry span",
+    "X-INSTANA-T in": "fa2375d711a4ca0f",
+    "X-INSTANA-S in": "37cb2d6e9b1c078a",
+    "Server-Timing": "intid;desc=fa2375d711a4ca0f",
+    "entrySpan.t": "fa2375d711a4ca0f",
+    "entrySpan.p": "37cb2d6e9b1c078a",
+    "entrySpan.s": "$new_span_id_1",
+    "entrySpan.data.service": "Tracer Test Suite Service",
+    "exitSpan.t": "fa2375d711a4ca0f",
+    "exitSpan.p": "$new_span_id_1",
+    "exitSpan.s": "$new_span_id_2",
+    "X-INSTANA-T out": "fa2375d711a4ca0f",
+    "X-INSTANA-S out": "$new_span_id_2",
+    "X-INSTANA-L out": "1",
+    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-03",
+    "tracestate out": "in=fa2375d711a4ca0f;$new_span_id_2",
+    "index": 41
+  },
+  {
+    "Scenario": "INSTANA_SERVICE_NAME support / exit span",
+    "What to do?": "add span.data.service on exit span",
+    "X-INSTANA-T in": "fa2375d711a4ca0f",
+    "X-INSTANA-S in": "37cb2d6e9b1c078a",
+    "Server-Timing": "intid;desc=fa2375d711a4ca0f",
+    "entrySpan.t": "fa2375d711a4ca0f",
+    "entrySpan.p": "37cb2d6e9b1c078a",
+    "entrySpan.s": "$new_span_id_1",
+    "exitSpan.t": "fa2375d711a4ca0f",
+    "exitSpan.p": "$new_span_id_1",
+    "exitSpan.s": "$new_span_id_2",
+    "exitSpan.data.service": "Tracer Test Suite Service",
+    "X-INSTANA-T out": "fa2375d711a4ca0f",
+    "X-INSTANA-S out": "$new_span_id_2",
+    "X-INSTANA-L out": "1",
+    "traceparent out": "00-0000000000000000fa2375d711a4ca0f-$new_span_id_2-03",
+    "tracestate out": "in=fa2375d711a4ca0f;$new_span_id_2",
+    "index": 42
   }
 ]

--- a/packages/core/src/tracing/w3c_trace_context/parse.js
+++ b/packages/core/src/tracing/w3c_trace_context/parse.js
@@ -57,9 +57,12 @@ function parseTraceParent(traceParentRaw, parsed) {
   }
   parsed.traceParentTraceId = match[1];
   parsed.traceParentParentId = match[2];
+
   const flags = parseInt(match[3], 16);
   // eslint-disable-next-line no-bitwise
   parsed.sampled = (flags & W3cTraceContext.SAMPLED_BITMASK) === W3cTraceContext.SAMPLED_BITMASK;
+  // eslint-disable-next-line no-bitwise
+  parsed.randomTraceId = (flags & W3cTraceContext.RANDOM_TRACE_ID_BITMASK) === W3cTraceContext.RANDOM_TRACE_ID_BITMASK;
 
   if (parsed.traceParentTraceId === '00000000000000000000000000000000') {
     return;

--- a/packages/core/test/tracing/w3c_trace_context/create_test.js
+++ b/packages/core/test/tracing/w3c_trace_context/create_test.js
@@ -23,7 +23,7 @@ describe('tracing/w3c-trace-context create', () => {
     const instanaTraceId = longTraceId ? traceId32Char : traceid16Char;
     const expectedTraceId = longTraceId ? traceId32Char : `0000000000000000${traceid16Char}`;
     const expectedSampled = sampled !== false;
-    const expectedFlags = sampled !== false ? '01' : '00';
+    const expectedFlags = sampled !== false ? '03' : '02';
 
     const testTitleSuffix = `(${idLengthTitle(longTraceId)}, sampled: ${sampled})`;
 
@@ -35,6 +35,7 @@ describe('tracing/w3c-trace-context create', () => {
       expect(traceContext.traceParentTraceId).to.equal(expectedTraceId);
       expect(traceContext.traceParentParentId).to.equal(parentId);
       expect(traceContext.sampled).to.equal(expectedSampled);
+      expect(traceContext.randomTraceId).to.be.true;
       expect(traceContext.renderTraceParent()).to.equal(`${version00}-${expectedTraceId}-${parentId}-${expectedFlags}`);
 
       expect(traceContext.traceStateValid).to.be.true;
@@ -65,7 +66,8 @@ describe('tracing/w3c-trace-context create', () => {
       expect(traceContext.traceParentTraceId).to.equal(expectedTraceId);
       expect(traceContext.traceParentParentId).to.equal(parentId);
       expect(traceContext.sampled).to.be.false;
-      expect(traceContext.renderTraceParent()).to.equal(`${version00}-${expectedTraceId}-${parentId}-00`);
+      expect(traceContext.randomTraceId).to.be.true;
+      expect(traceContext.renderTraceParent()).to.equal(`${version00}-${expectedTraceId}-${parentId}-02`);
 
       expect(traceContext.traceStateValid).to.be.true;
       expect(traceContext.traceStateHead).to.not.exist;

--- a/packages/core/test/tracing/w3c_trace_context/parser_test.js
+++ b/packages/core/test/tracing/w3c_trace_context/parser_test.js
@@ -104,25 +104,65 @@ describe('tracing/w3c-trace-context parser', () => {
     });
 
     describe('traceparent flags', () => {
-      it('should parse a traceparent header with sampled = 1 when other flags are present', () => {
-        const parsed = parse(`${traceParentWithoutFlags}-ff`);
+      it('should parse the sampled flag', () => {
+        const parsed = parse(`${traceParentWithoutFlags}-01`);
         expect(parsed.sampled).to.be.true;
         expect(parsed.traceParentValid).to.be.true;
-        expect(parsed.traceStateValid).to.be.false;
+        expect(parsed.renderFlags()).to.equal('01');
       });
 
-      it('should parse a traceparent header with sampled = 0', () => {
-        const parsed = parse(`${traceParentWithoutFlags}-00`);
-        expect(parsed.sampled).to.be.false;
+      it('should parse the random trace ID flag', () => {
+        const parsed = parse(`${traceParentWithoutFlags}-02`);
+        expect(parsed.randomTraceId).to.be.true;
+        expect(parsed.traceParentValid).to.be.true;
+        expect(parsed.renderFlags()).to.equal('02');
+      });
+
+      it('should parse the sampled flag and the random trace ID flag', () => {
+        const parsed = parse(`${traceParentWithoutFlags}-03`);
+        expect(parsed.sampled).to.be.true;
+        expect(parsed.randomTraceId).to.be.true;
+        expect(parsed.traceParentValid).to.be.true;
+        expect(parsed.renderFlags()).to.equal('03');
+      });
+
+      it('should parse a traceparent header when unknown flags are present', () => {
+        // all possible flags are set
+        const parsed = parse(`${traceParentWithoutFlags}-ff`);
+        expect(parsed.sampled).to.be.true;
+        expect(parsed.randomTraceId).to.be.true;
         expect(parsed.traceParentValid).to.be.true;
         expect(parsed.traceStateValid).to.be.false;
+        expect(parsed.renderFlags()).to.equal('03');
       });
 
-      it('should parse a traceparent header with sampled = 0 when other flags are present', () => {
+      it('should parse a traceparent header with sampled = 0 when unknown flags are present', () => {
+        // every flag is set except for sampled
         const parsed = parse(`${traceParentWithoutFlags}-fe`);
         expect(parsed.sampled).to.be.false;
+        expect(parsed.randomTraceId).to.be.true;
         expect(parsed.traceParentValid).to.be.true;
         expect(parsed.traceStateValid).to.be.false;
+        expect(parsed.renderFlags()).to.equal('02');
+      });
+
+      it('should parse a traceparent header with random trace ID = 0 when unknown flags are present', () => {
+        // every flag is set except for randomg trace ID
+        const parsed = parse(`${traceParentWithoutFlags}-fd`);
+        expect(parsed.sampled).to.be.true;
+        expect(parsed.randomTraceId).to.be.false;
+        expect(parsed.traceParentValid).to.be.true;
+        expect(parsed.traceStateValid).to.be.false;
+        expect(parsed.renderFlags()).to.equal('01');
+      });
+
+      it('should parse a traceparent header when no flags are set', () => {
+        const parsed = parse(`${traceParentWithoutFlags}-00`);
+        expect(parsed.sampled).to.be.false;
+        expect(parsed.randomTraceId).to.be.false;
+        expect(parsed.traceParentValid).to.be.true;
+        expect(parsed.traceStateValid).to.be.false;
+        expect(parsed.renderFlags()).to.equal('00');
       });
     });
 


### PR DESCRIPTION
- set the flag that the trace ID has been generated randomly when we generated id
- pass on the incoming flag for the randomness of the trace ID unchanged when a traceparent header is received on incoming HTTP requests

See also: https://www.w3.org/TR/trace-context-2/, in particular section 3.2.2.5.2 "Random Trace ID Flag".