### PR TITLE
test: fix bunyan, q, DB2 & OpenTracing tests for Node.js 10 & 12

### DIFF
--- a/packages/collector/test/test_util/isOTelIntegrationEnabled.js
+++ b/packages/collector/test/test_util/isOTelIntegrationEnabled.js
@@ -1,0 +1,13 @@
+/*
+ * (c) Copyright IBM Corp. 2023
+ */
+
+'use strict';
+
+const semver = require('semver');
+
+const minimumNodeJsVersionForOTelIntegration =
+  require('../../../core/src/tracing/opentelemetry-instrumentations/wrap').minimumNodeJsVersion;
+const oTelIntegrationIsEnabled = semver.gte(process.versions.node, minimumNodeJsVersionForOTelIntegration);
+
+module.exports = exports = oTelIntegrationIsEnabled;

--- a/packages/collector/test/tracing/database/db2/test.js
+++ b/packages/collector/test/tracing/database/db2/test.js
@@ -14,6 +14,8 @@ const config = require('../../../../../core/test/config');
 const ProcessControls = require('../../../test_util/ProcessControls');
 const globalAgent = require('../../../globalAgent');
 
+const oTelIntegrationIsEnabled = require('../../../test_util/isOTelIntegrationEnabled');
+
 const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 
 if (testUtils.isCI() && !process.env.DB2_CONNECTION_STR) {
@@ -879,9 +881,9 @@ mochaSuiteFn('tracing/db2', function () {
           testUtils.retry(() =>
             verifySpans(agentControls, controls, {
               // 11 queries splitted from the file
-              // 5 fs operations on top (ours + from db2 internally fs-extra)
+              // 4 fs operations on top (ours + from db2 internally fs-extra)
               // https://github.com/ibmdb/node-ibm_db/blob/fb25937524d74d25917e9aa67fb4737971317986/lib/odbc.js#L916
-              numberOfSpans: 15,
+              numberOfSpans: oTelIntegrationIsEnabled ? 15 : 11,
               verifyCustom: (entrySpan, spans) => {
                 const stmtsToExpect = [
                   `create table ${TABLE_NAME_3}(no integer,name varchar(10))`,
@@ -928,7 +930,7 @@ mochaSuiteFn('tracing/db2', function () {
           testUtils.retry(() =>
             verifySpans(agentControls, controls, {
               // 11 queries + fs calls
-              numberOfSpans: 16,
+              numberOfSpans: oTelIntegrationIsEnabled ? 16 : 11,
               verifyCustom: (entrySpan, spans) => {
                 const stmtsToExpect = [
                   `create table ${TABLE_NAME_3}(no integer,name varchar(10))`,
@@ -975,7 +977,7 @@ mochaSuiteFn('tracing/db2', function () {
           testUtils.retry(() =>
             verifySpans(agentControls, controls, {
               // 11 queries + fs calls
-              numberOfSpans: 16,
+              numberOfSpans: oTelIntegrationIsEnabled ? 16 : 11,
               verifyCustom: (entrySpan, spans) => {
                 const stmtsToExpect = [
                   `create table ${TABLE_NAME_3}(no integer,name varchar(10))`,

--- a/packages/collector/test/tracing/logger/bunyan/test.js
+++ b/packages/collector/test/tracing/logger/bunyan/test.js
@@ -13,6 +13,8 @@ const config = require('../../../../../core/test/config');
 const testUtils = require('../../../../../core/test/test_util');
 const globalAgent = require('../../../globalAgent');
 
+const oTelIntegrationIsEnabled = require('../../../test_util/isOTelIntegrationEnabled');
+
 const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 
 mochaSuiteFn('tracing/logger/bunyan', function () {
@@ -66,7 +68,7 @@ mochaSuiteFn('tracing/logger/bunyan', function () {
         // eslint-disable-next-line max-len
         '{"_id":"638dea148cff492d47e792ea","index":0,"guid":"01b61bfa-fe4c-4d75-9224-389c4c04de10","isActive":false,"balance":"$1,919.18","picture":"http://placehold.it/32x32","age":37,"eyeColor":"blue","name":"Manning Brady","gender":"male","company":"ZYTRAC","email":"manningbrady@zytrac.com","phone":"+1 (957) 538-2183","address":"146 Bushwick Court, Gilgo, New York, 2992","about":"Ullamco cillum reprehenderit eu proident veniam laboris tempor voluptate. Officia deserunt velit incididunt consequat la...',
         500,
-        4
+        oTelIntegrationIsEnabled ? 4 : 3
       ));
 
     it("must capture an error object's message and an additional string", () =>

--- a/packages/core/src/tracing/opentelemetry-instrumentations/wrap.js
+++ b/packages/core/src/tracing/opentelemetry-instrumentations/wrap.js
@@ -16,13 +16,15 @@ const instrumentations = {
   '@opentelemetry/instrumentation-socket.io': { name: 'socket.io' }
 };
 
+module.exports.minimumNodeJsVersion = '14.0.0';
+
 // NOTE: using a logger might create a recursive execution
 //       logger.debug -> creates fs call -> calls transformToInstanaSpan -> calls logger.debug
 //       use uninstrumented logger, but useless for production
 module.exports.init = (_config, cls) => {
   // CASE: otel offically does not support Node < 14
   // https://github.com/open-telemetry/opentelemetry-js/tree/main#supported-runtimes
-  if (semver.lt(process.versions.node, '14.0.0')) {
+  if (semver.lt(process.versions.node, module.exports.minimumNodeJsVersion)) {
     return;
   }
 


### PR DESCRIPTION
The OTel integration is disabled for Node.js 10 and 12, the expectations
in the tests that have file system access need to accomodate for that.