### PR TITLE
chore: fixed coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,5 +220,10 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "nyc": {
+    "exclude": [
+      "packages/core/src/tracing/opentelemetry-instrumentations/files"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -220,10 +220,5 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
-  },
-  "nyc": {
-    "exclude": [
-      "packages/core/src/tracing/opentelemetry-instrumentations/files"
-    ]
   }
 }

--- a/packages/core/src/tracing/opentelemetry-instrumentations/files/invalid-span-constants.js
+++ b/packages/core/src/tracing/opentelemetry-instrumentations/files/invalid-span-constants.js
@@ -23,4 +23,3 @@ exports.INVALID_SPAN_CONTEXT = {
   spanId: exports.INVALID_SPANID,
   traceFlags: trace_flags_1.TraceFlags.NONE
 };
-//# sourceMappingURL=invalid-span-constants.js.map

--- a/packages/core/src/tracing/opentelemetry-instrumentations/files/trace_flags.js
+++ b/packages/core/src/tracing/opentelemetry-instrumentations/files/trace_flags.js
@@ -22,4 +22,3 @@ var TraceFlags;
   /** Bit to represent whether trace is sampled in trace flags. */
   TraceFlags[(TraceFlags['SAMPLED'] = 1)] = 'SAMPLED';
 })((TraceFlags = exports.TraceFlags || (exports.TraceFlags = {})));
-//# sourceMappingURL=trace_flags.js.map


### PR DESCRIPTION
`nyc` has an inbuilt feature to use `.map` files instead of `.js` files if they exist.
The Otel assets had a reference to a `.map` file, which did not exist.