### PR TITLE
test: use the proper path for custom tags in markAsErroneous test

### DIFF
--- a/packages/collector/test/tracing/api/app.js
+++ b/packages/collector/test/tracing/api/app.js
@@ -63,7 +63,7 @@ app.get('/span/mark-as-erroneous', (req, res) => {
 
 app.get('/span/mark-as-erroneous-custom-message', (req, res) => {
   const span = instana.currentSpan();
-  span.markAsErroneous('custom error message', 'custom.path.error');
+  span.markAsErroneous('custom error message', 'sdk.custom.tags.error');
   res.json({
     span: serialize(span)
   });

--- a/packages/collector/test/tracing/api/app.mjs
+++ b/packages/collector/test/tracing/api/app.mjs
@@ -66,7 +66,7 @@ app.get('/span/mark-as-erroneous', (req, res) => {
 
 app.get('/span/mark-as-erroneous-custom-message', (req, res) => {
   const span = instana.currentSpan();
-  span.markAsErroneous('custom error message', 'custom.path.error');
+  span.markAsErroneous('custom error message', 'sdk.custom.tags.error');
   res.json({
     span: serialize(span)
   });

--- a/packages/collector/test/tracing/api/test.js
+++ b/packages/collector/test/tracing/api/test.js
@@ -106,7 +106,7 @@ mochaSuiteFn('tracing/api', function () {
           span => expect(span.n).to.equal('node.http.server'),
           span => expect(span.ec).to.equal(1),
           span => expect(span.data.http.error).to.not.exist,
-          span => expect(span.data.custom.path.error).to.equal('custom error message')
+          span => expect(span.data.sdk.custom.tags.error).to.equal('custom error message')
         ]);
       });
     });


### PR DESCRIPTION
Only tags in `sdk.custom.tags` will be shown in the call details in the UI, so we should also use that in our tests (because they are sometimes used as code examples etc.)