### PR TITLE
build(deps): bump semver from 7.3.3 to 7.5.3

### DIFF
--- a/packages/autoprofile/package-lock.json
+++ b/packages/autoprofile/package-lock.json
@@ -14,7 +14,7 @@
 			},
 			"devDependencies": {
 				"no-code2": "2.0.0",
-				"semver": "7.3.3"
+				"semver": "7.5.3"
 			}
 		},
 		"node_modules/detect-libc": {
@@ -29,13 +29,15 @@
 			}
 		},
 		"node_modules/lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
 			"dependencies": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/nan": {
@@ -49,19 +51,13 @@
 			"integrity": "sha512-RX763SjA6J4G2ndDNAtTAt4waLujGuTiPWzYDEevNDD5a7W2eXRM/OmNWQmEQ1a2AtlHlxi9hRD8iIHPGjC4dg==",
 			"dev": true
 		},
-		"node_modules/pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
-		},
 		"node_modules/semver": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
-			"integrity": "sha512-kBGrn+sE2tyi6f4c9aFrrYRSTTF5yNOEVRBCdpcgykFp3jt2ZGlBwzIwWER9J9HZnQa9IF1TrR8Xy2UU+eaUhQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"dev": true,
 			"dependencies": {
-				"lru-cache": "^4.1.5"
+				"lru-cache": "^6.0.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
@@ -71,9 +67,9 @@
 			}
 		},
 		"node_modules/yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		}
 	},
@@ -84,13 +80,12 @@
 			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 		},
 		"lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"yallist": "^4.0.0"
 			}
 		},
 		"nan": {
@@ -104,25 +99,19 @@
 			"integrity": "sha512-RX763SjA6J4G2ndDNAtTAt4waLujGuTiPWzYDEevNDD5a7W2eXRM/OmNWQmEQ1a2AtlHlxi9hRD8iIHPGjC4dg==",
 			"dev": true
 		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
-		},
 		"semver": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
-			"integrity": "sha512-kBGrn+sE2tyi6f4c9aFrrYRSTTF5yNOEVRBCdpcgykFp3jt2ZGlBwzIwWER9J9HZnQa9IF1TrR8Xy2UU+eaUhQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^4.1.5"
+				"lru-cache": "^6.0.0"
 			}
 		},
 		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		}
 	}

--- a/packages/autoprofile/package.json
+++ b/packages/autoprofile/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "no-code2": "2.0.0",
-    "semver": "7.3.3"
+    "semver": "7.5.3"
   },
   "main": "index.js",
   "files": [

--- a/packages/collector/.ncurc.json
+++ b/packages/collector/.ncurc.json
@@ -1,3 +1,3 @@
 {
-  "reject": ["semver", "serialize-error"]
+  "reject": ["serialize-error"]
 }

--- a/packages/collector/package-lock.json
+++ b/packages/collector/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"bunyan": "^1.8.15",
-				"semver": "7.3.3",
+				"semver": "7.5.3",
 				"serialize-error": "^3.0.0"
 			},
 			"bin": {
@@ -1565,12 +1565,14 @@
 			"dev": true
 		},
 		"node_modules/lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dependencies": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/make-iterator": {
@@ -2024,11 +2026,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-		},
 		"node_modules/rechoir": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -2187,11 +2184,11 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
-			"integrity": "sha512-kBGrn+sE2tyi6f4c9aFrrYRSTTF5yNOEVRBCdpcgykFp3jt2ZGlBwzIwWER9J9HZnQa9IF1TrR8Xy2UU+eaUhQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"dependencies": {
-				"lru-cache": "^4.1.5"
+				"lru-cache": "^6.0.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
@@ -3071,9 +3068,9 @@
 			}
 		},
 		"node_modules/yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/yargs": {
 			"version": "17.7.2",
@@ -4271,12 +4268,11 @@
 			"dev": true
 		},
 		"lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"yallist": "^4.0.0"
 			}
 		},
 		"make-iterator": {
@@ -4643,11 +4639,6 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
 			"dev": true
 		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-		},
 		"rechoir": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -4761,11 +4752,11 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
-			"integrity": "sha512-kBGrn+sE2tyi6f4c9aFrrYRSTTF5yNOEVRBCdpcgykFp3jt2ZGlBwzIwWER9J9HZnQa9IF1TrR8Xy2UU+eaUhQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"requires": {
-				"lru-cache": "^4.1.5"
+				"lru-cache": "^6.0.0"
 			}
 		},
 		"serialize-error": {
@@ -5390,9 +5381,9 @@
 			"dev": true
 		},
 		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yargs": {
 			"version": "17.7.2",

--- a/packages/collector/package.json
+++ b/packages/collector/package.json
@@ -138,7 +138,7 @@
     "@instana/core": "2.25.2",
     "@instana/shared-metrics": "2.25.2",
     "bunyan": "^1.8.15",
-    "semver": "7.3.3",
+    "semver": "7.5.3",
     "serialize-error": "^3.0.0"
   },
   "optionalDependencies": {

--- a/packages/core/.ncurc.json
+++ b/packages/core/.ncurc.json
@@ -1,3 +1,0 @@
-{
-  "reject": ["semver"]
-}

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -19,7 +19,7 @@
 				"lru-cache": "6.0.0",
 				"methods": "^1.1.2",
 				"opentracing": "^0.14.5",
-				"semver": "7.3.3",
+				"semver": "7.5.3",
 				"shimmer": "1.2.1"
 			},
 			"devDependencies": {
@@ -269,11 +269,6 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
 		},
-		"node_modules/pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-		},
 		"node_modules/require-in-the-middle": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.1.1.tgz",
@@ -304,11 +299,11 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
-			"integrity": "sha512-kBGrn+sE2tyi6f4c9aFrrYRSTTF5yNOEVRBCdpcgykFp3jt2ZGlBwzIwWER9J9HZnQa9IF1TrR8Xy2UU+eaUhQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"dependencies": {
-				"lru-cache": "^4.1.5"
+				"lru-cache": "^6.0.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
@@ -316,20 +311,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/semver/node_modules/lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-			"dependencies": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
-			}
-		},
-		"node_modules/semver/node_modules/yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"node_modules/shimmer": {
 			"version": "1.2.1",
@@ -518,11 +499,6 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
 		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-		},
 		"require-in-the-middle": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.1.1.tgz",
@@ -544,27 +520,11 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
-			"integrity": "sha512-kBGrn+sE2tyi6f4c9aFrrYRSTTF5yNOEVRBCdpcgykFp3jt2ZGlBwzIwWER9J9HZnQa9IF1TrR8Xy2UU+eaUhQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"requires": {
-				"lru-cache": "^4.1.5"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-				}
+				"lru-cache": "^6.0.0"
 			}
 		},
 		"shimmer": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -134,7 +134,7 @@
     "lru-cache": "6.0.0",
     "methods": "^1.1.2",
     "opentracing": "^0.14.5",
-    "semver": "7.3.3",
+    "semver": "7.5.3",
     "shimmer": "1.2.1"
   },
   "devDependencies": {

--- a/packages/serverless/.ncurc.json
+++ b/packages/serverless/.ncurc.json
@@ -1,3 +1,0 @@
-{
-  "reject": ["semver"]
-}

--- a/packages/shared-metrics/.ncurc.json
+++ b/packages/shared-metrics/.ncurc.json
@@ -1,3 +1,3 @@
 {
-  "reject": ["semver", "tar"]
+  "reject": ["tar"]
 }

--- a/packages/shared-metrics/package-lock.json
+++ b/packages/shared-metrics/package-lock.json
@@ -12,7 +12,7 @@
 				"detect-libc": "^1.0.3",
 				"event-loop-lag": "^1.4.0",
 				"recursive-copy": "^2.0.13",
-				"semver": "7.3.3",
+				"semver": "7.5.3",
 				"tar": "^6.1.11"
 			},
 			"devDependencies": {
@@ -240,12 +240,14 @@
 			}
 		},
 		"node_modules/lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dependencies": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/maximatch": {
@@ -289,11 +291,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/minipass/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		},
 		"node_modules/minizlib": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
@@ -305,11 +302,6 @@
 			"engines": {
 				"node": ">= 8"
 			}
-		},
-		"node_modules/minizlib/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/mkdirp": {
 			"version": "0.5.6",
@@ -376,11 +368,6 @@
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
 			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
-		"node_modules/pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-		},
 		"node_modules/recursive-copy": {
 			"version": "2.0.14",
 			"resolved": "https://registry.npmjs.org/recursive-copy/-/recursive-copy-2.0.14.tgz",
@@ -409,11 +396,11 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
-			"integrity": "sha512-kBGrn+sE2tyi6f4c9aFrrYRSTTF5yNOEVRBCdpcgykFp3jt2ZGlBwzIwWER9J9HZnQa9IF1TrR8Xy2UU+eaUhQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"dependencies": {
-				"lru-cache": "^4.1.5"
+				"lru-cache": "^6.0.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
@@ -457,20 +444,15 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/tar/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"node_modules/yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		}
 	},
 	"dependencies": {
@@ -649,12 +631,11 @@
 			"integrity": "sha1-h75jSIZJy9ym9Tqzm+yczSNH9ZI="
 		},
 		"lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"yallist": "^4.0.0"
 			}
 		},
 		"maximatch": {
@@ -687,13 +668,6 @@
 			"integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
 			"requires": {
 				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
 			}
 		},
 		"minizlib": {
@@ -703,13 +677,6 @@
 			"requires": {
 				"minipass": "^3.0.0",
 				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
 			}
 		},
 		"mkdirp": {
@@ -768,11 +735,6 @@
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
 			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-		},
 		"recursive-copy": {
 			"version": "2.0.14",
 			"resolved": "https://registry.npmjs.org/recursive-copy/-/recursive-copy-2.0.14.tgz",
@@ -798,11 +760,11 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.3.tgz",
-			"integrity": "sha512-kBGrn+sE2tyi6f4c9aFrrYRSTTF5yNOEVRBCdpcgykFp3jt2ZGlBwzIwWER9J9HZnQa9IF1TrR8Xy2UU+eaUhQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"requires": {
-				"lru-cache": "^4.1.5"
+				"lru-cache": "^6.0.0"
 			}
 		},
 		"slash": {
@@ -827,11 +789,6 @@
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -841,9 +798,9 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		}
 	}
 }

--- a/packages/shared-metrics/package.json
+++ b/packages/shared-metrics/package.json
@@ -71,7 +71,7 @@
     "detect-libc": "^1.0.3",
     "event-loop-lag": "^1.4.0",
     "recursive-copy": "^2.0.13",
-    "semver": "7.3.3",
+    "semver": "7.5.3",
     "tar": "^6.1.11"
   },
   "devDependencies": {


### PR DESCRIPTION
The reason for pinning semver to 7.3.3 does no longer apply: We previously pinned semver to 7.3.3. because newer versions depended on lru-cache@6, which had dropped support for Node.js 8 and earlier. Since we no longer support Node.js 8, this is lo longer relevant.

This commit also removes semver from all .ncurc.json files.