### PR TITLE
test: replace requests to instana.com

### DIFF
--- a/packages/aws-lambda-auto-wrap/test/functions/esm-1/server.js
+++ b/packages/aws-lambda-auto-wrap/test/functions/esm-1/server.js
@@ -7,7 +7,7 @@ import https from 'https';
 export const handler = async (event, context) => {
   const promise = new Promise(function (resolve, reject) {
     https
-      .get('https://www.instana.com', res => {
+      .get('https://www.example.com', res => {
         resolve(res.statusCode);
       })
       .on('error', e => {

--- a/packages/aws-lambda-auto-wrap/test/functions/esm-2/index.mjs
+++ b/packages/aws-lambda-auto-wrap/test/functions/esm-2/index.mjs
@@ -7,7 +7,7 @@ import https from 'https';
 export const handler = async (event, context) => {
   const promise = new Promise(function (resolve, reject) {
     https
-      .get('https://www.instana.com', res => {
+      .get('https://www.example.com', res => {
         resolve(res.statusCode);
       })
       .on('error', e => {

--- a/packages/aws-lambda-auto-wrap/test/functions/esm-3/index.js
+++ b/packages/aws-lambda-auto-wrap/test/functions/esm-3/index.js
@@ -7,7 +7,7 @@ import https from 'https';
 export const handler = async (event, context) => {
   const promise = new Promise(function (resolve, reject) {
     https
-      .get('https://www.instana.com', res => {
+      .get('https://www.example.com', res => {
         resolve(res.statusCode);
       })
       .on('error', e => {

--- a/packages/aws-lambda-auto-wrap/test/functions/esm-4/index.js
+++ b/packages/aws-lambda-auto-wrap/test/functions/esm-4/index.js
@@ -7,7 +7,7 @@ import https from 'https';
 export const candle = async (event, context) => {
   const promise = new Promise(function (resolve, reject) {
     https
-      .get('https://www.instana.com', res => {
+      .get('https://www.example.com', res => {
         resolve(res.statusCode);
       })
       .on('error', e => {

--- a/packages/collector/test/tracing/frameworks/got/app.js
+++ b/packages/collector/test/tracing/frameworks/got/app.js
@@ -26,6 +26,8 @@ const port = require('../../../test_util/app-port')();
 const app = express();
 const logPrefix = `Got App (${process.pid}):\t`;
 
+const agentPort = process.env.INSTANA_AGENT_PORT;
+
 if (process.env.WITH_STDOUT) {
   app.use(morgan(`${logPrefix}:method :url :status`));
 }
@@ -37,7 +39,7 @@ app.get('/', async (req, res) => {
 });
 
 app.get('/request', async (req, res) => {
-  await got.get('https://www.instana.com');
+  await got.get(`http://127.0.0.1:${agentPort}`);
 
   res.json();
 });

--- a/packages/collector/test/tracing/frameworks/got/app.mjs
+++ b/packages/collector/test/tracing/frameworks/got/app.mjs
@@ -26,6 +26,8 @@ import got from 'got';
 const app = express();
 const logPrefix = `Got App (${process.pid}):\t`;
 
+const agentPort = process.env.INSTANA_AGENT_PORT;
+
 if (process.env.WITH_STDOUT) {
   app.use(morgan(`${logPrefix}:method :url :status`));
 }
@@ -37,7 +39,7 @@ app.get('/', async (req, res) => {
 });
 
 app.get('/request', async (req, res) => {
-  await got.get('https://www.instana.com');
+  await got.get(`http://127.0.0.1:${agentPort}`);
 
   res.json();
 });

--- a/packages/collector/test/tracing/frameworks/got/test.js
+++ b/packages/collector/test/tracing/frameworks/got/test.js
@@ -53,7 +53,7 @@ mochaSuiteFn('tracing/got', function () {
               extraTests: [
                 span => {
                   expect(span.data.http.method).to.equal('GET');
-                  expect(span.data.http.url).to.equal('https://www.instana.com/');
+                  expect(span.data.http.url).to.equal(`http://127.0.0.1:${agentControls.agentPort}/`);
                   expect(span.data.http.status).to.equal(200);
                 }
               ]

--- a/packages/opentelemetry-exporter/test/app.js
+++ b/packages/opentelemetry-exporter/test/app.js
@@ -23,7 +23,7 @@ const app = express();
 
 app.get('/otel-test', (_req, res) => {
   delay(500)
-    .then(() => request('https://www.instana.com'))
+    .then(() => request('https://www.example.com'))
     .then(text => {
       res.send({ ok: true, data: `${text.substr(0, 10)}...` });
     })
@@ -34,7 +34,7 @@ app.get('/otel-test', (_req, res) => {
 
 app.post('/otel-post', (_req, res) => {
   delay(500)
-    .then(() => request('https://www.instana.com'))
+    .then(() => request('https://www.example.com'))
     .then(text => {
       res.send({ ok: true, data: `${text.substr(0, 10)}...` });
     })

--- a/packages/opentelemetry-exporter/test/test.js
+++ b/packages/opentelemetry-exporter/test/test.js
@@ -183,7 +183,7 @@ mochaSuiteFn('Instana OpenTelemetry Exporter', function () {
 
 function verifySpans(spans, appControls) {
   // ENTRY /otel-test
-  // EXIT www.instana.com
+  // EXIT www.example.com
   // 2 x express middleware, 1 x request handler
   // 1 x tlc connect, 1 x tls connect
   expectExactlyNMatching(spans, 7, [

--- a/packages/opentelemetry-sampler/test/app.js
+++ b/packages/opentelemetry-sampler/test/app.js
@@ -38,7 +38,7 @@ const app = express();
 
 app.get('/otel-test', (_req, res) => {
   delay(500)
-    .then(() => request('https://www.instana.com'))
+    .then(() => request('https://www.example.com'))
     .then(() => {
       res.status(200).json({ success: true });
     })
@@ -68,7 +68,7 @@ app.get('/get-otel-spans', (_req, res) => {
 
 app.post('/otel-post', (_req, res) => {
   delay(500)
-    .then(() => request('https://www.instana.com'))
+    .then(() => request('https://www.example.com'))
     .then(() => {
       res.status(200).json({ success: true });
     })


### PR DESCRIPTION
instana.com now responds with a redirect to ibm.com, which changed which spans are produced and broke some tests.