### PR TITLE
fix: reduce warnings when exit span cannot be started

### DIFF
--- a/packages/core/src/tracing/opentelemetry-instrumentations/wrap.js
+++ b/packages/core/src/tracing/opentelemetry-instrumentations/wrap.js
@@ -59,7 +59,7 @@ module.exports.init = (_config, cls) => {
       return;
     }
 
-    if (kind === constants.EXIT && cls.skipExitTracing()) {
+    if (kind === constants.EXIT && cls.skipExitTracing({ log: false })) {
       return;
     }
 


### PR DESCRIPTION
Two customer reported seeing this warning a lot after 2.24.0.

One of them is definitely using socket.io. 

> Cannot start an exit span as this requires an active entry (or intermediate) span as parent. Currently, there is no span active at all

It was quite easy to reproduce it for socket.io.
I am pretty sure this is a just a warning we should not log. 
In this case below we should probably add more docs account socket.io.
There is no entry span when sending a socket.io emit from a worker.
I know we have already docs regarding SDK, but might be good to add socket.io examples?

server.js
```
require('@instana/collector')();

const { Server } = require('socket.io');
const { createClient } = require('redis');
const { createAdapter } = require('@socket.io/redis-adapter');

const io = new Server();
const pubClient = createClient({ host: 'localhost', port: 6379 });
const subClient = pubClient.duplicate();

Promise.all([pubClient.connect(), subClient.connect()]).then(() => {
  io.adapter(createAdapter(pubClient, subClient));
  io.listen(3033);

  io.on('connection', (_socket) => {
    console.log('Connected');
    _socket.on('test_reply', (msg) => {
      console.log('Received msg');
    });
  });

  // This is an exit span without entry span.
  setTimeout(() => {
    io.emit('test', 'my msg');
  }, 3000);
});
```

client.js
```
require('@instana/collector')()

const socketioclient = require('socket.io-client');
const express = require('express');
const port = 3302
const app = express();
const logPrefix = `SocketIO ClientApp (${process.pid}):\t`;

const ioClient = socketioclient.connect('http://localhost:3033');

ioClient.on('test', () => {
    log('Received msg for "test"');
    ioClient.emit('test_reply', 'welcome');
});

app.get('/', (req, res) => {
    res.sendStatus(200);
});

app.listen(port, () => {
    log(`Listening on port: ${port}`);
});

function log() {
    const args = Array.prototype.slice.call(arguments);
    args[0] = logPrefix + args[0];
    console.log.apply(console, args);
}
```

