### PR TITLE
fix(tracing): normalize incoming trace/span IDs from upstream tracers

### DIFF
--- a/packages/aws-lambda/test/integration_test/test_definition.js
+++ b/packages/aws-lambda/test/integration_test/test_definition.js
@@ -957,8 +957,8 @@ function registerTests(handlerDefinitionPath) {
       instanaEndpointUrl: backendBaseUrl,
       instanaAgentKey,
       statusCode: 201,
-      traceId: 'test-trace-id',
-      spanId: 'test-span-id'
+      traceId: '1234567890abcdef',
+      spanId: 'fedcba9876543210'
     });
 
     it('must recognize API gateway trigger (with proxy) with parent span', () =>
@@ -968,8 +968,8 @@ function registerTests(handlerDefinitionPath) {
         expectSpans: true,
         trigger: 'aws:api.gateway',
         parent: {
-          t: 'test-trace-id',
-          s: 'test-span-id'
+          t: '1234567890abcdef',
+          s: 'fedcba9876543210'
         }
       })
         .then(() => control.getSpans())
@@ -1252,8 +1252,8 @@ function registerTests(handlerDefinitionPath) {
       trigger: 'application-load-balancer',
       instanaEndpointUrl: backendBaseUrl,
       instanaAgentKey,
-      traceId: 'test-trace-id',
-      spanId: 'test-span-id'
+      traceId: '1234567890abcdef',
+      spanId: 'fedcba9876543210'
     });
 
     it('must recognize the application load balancer trigger and parent span', () =>
@@ -1263,8 +1263,8 @@ function registerTests(handlerDefinitionPath) {
         expectSpans: true,
         trigger: 'aws:application.load.balancer',
         parent: {
-          t: 'test-trace-id',
-          s: 'test-span-id'
+          t: '1234567890abcdef',
+          s: 'fedcba9876543210'
         }
       })
         .then(() => control.getSpans())
@@ -1288,8 +1288,8 @@ function registerTests(handlerDefinitionPath) {
       trigger: 'invoke-function',
       instanaEndpointUrl: backendBaseUrl,
       instanaAgentKey,
-      traceIdContext: 'test-trace-id',
-      spanIdContext: 'test-span-id',
+      traceIdContext: '1234567890abcdef',
+      spanIdContext: 'fedcba9876543210',
       traceLevelContext: '1'
     });
 
@@ -1300,8 +1300,8 @@ function registerTests(handlerDefinitionPath) {
         expectSpans: true,
         trigger: 'aws:lambda.invoke',
         parent: {
-          t: 'test-trace-id',
-          s: 'test-span-id'
+          t: '1234567890abcdef',
+          s: 'fedcba9876543210'
         }
       })
         .then(() => control.getSpans())
@@ -1320,8 +1320,8 @@ function registerTests(handlerDefinitionPath) {
       trigger: 'invoke-function',
       instanaEndpointUrl: backendBaseUrl,
       instanaAgentKey,
-      traceIdContext: 'test-trace-id',
-      spanIdContext: 'test-span-id',
+      traceIdContext: '1234567890abcdef',
+      spanIdContext: 'fedcba9876543210',
       traceLevelContext: '1',
       fillContext: true
     });
@@ -1333,8 +1333,8 @@ function registerTests(handlerDefinitionPath) {
         expectSpans: true,
         trigger: 'aws:lambda.invoke',
         parent: {
-          t: 'test-trace-id',
-          s: 'test-span-id'
+          t: '1234567890abcdef',
+          s: 'fedcba9876543210'
         }
       })
         .then(() => {
@@ -1358,8 +1358,8 @@ function registerTests(handlerDefinitionPath) {
       trigger: 'invoke-function',
       instanaEndpointUrl: backendBaseUrl,
       instanaAgentKey,
-      traceIdContext: 'test-trace-id',
-      spanIdContext: 'test-span-id',
+      traceIdContext: '1234567890abcdef',
+      spanIdContext: 'fedcba9876543210',
       traceLevelContext: '0'
     });
 
@@ -1526,8 +1526,8 @@ function registerTests(handlerDefinitionPath) {
       trigger: 'sqs',
       instanaEndpointUrl: backendBaseUrl,
       instanaAgentKey,
-      traceId: 'test-trace-id',
-      spanId: 'test-span-id'
+      traceId: '1234567890abcdef',
+      spanId: 'fedcba9876543210'
     });
 
     it('must continue trace from SQS message', () =>
@@ -1537,8 +1537,8 @@ function registerTests(handlerDefinitionPath) {
         expectSpans: true,
         trigger: 'aws:sqs',
         parent: {
-          t: 'test-trace-id',
-          s: 'test-span-id'
+          t: '1234567890abcdef',
+          s: 'fedcba9876543210'
         }
       })
         .then(() => control.getSpans())
@@ -1564,8 +1564,8 @@ function registerTests(handlerDefinitionPath) {
       trigger: 'sns-to-sqs',
       instanaEndpointUrl: backendBaseUrl,
       instanaAgentKey,
-      traceId: 'test-trace-id',
-      spanId: 'test-span-id'
+      traceId: '1234567890abcdef',
+      spanId: 'fedcba9876543210'
     });
 
     it('must continue trace from SQS message created from an SNS notification', () =>
@@ -1575,8 +1575,8 @@ function registerTests(handlerDefinitionPath) {
         expectSpans: true,
         trigger: 'aws:sqs',
         parent: {
-          t: 'test-trace-id',
-          s: 'test-span-id'
+          t: '1234567890abcdef',
+          s: 'fedcba9876543210'
         }
       })
         .then(() => control.getSpans())

--- a/packages/collector/test/tracing/database/elasticsearch_legacy/test.js
+++ b/packages/collector/test/tracing/database/elasticsearch_legacy/test.js
@@ -154,16 +154,16 @@ mochaSuiteFn('tracing/elasticsearch (legacy client)', function () {
       body: {
         title: titleA
       },
-      parentSpanId: '42',
-      traceId: '42'
+      parentSpanId: '0000000000000042',
+      traceId: '0000000000000042'
     })
       .then(() =>
         index({
           body: {
             title: titleB
           },
-          parentSpanId: '43',
-          traceId: '43'
+          parentSpanId: '0000000000000043',
+          traceId: '0000000000000043'
         })
       )
       .then(() =>
@@ -189,10 +189,10 @@ mochaSuiteFn('tracing/elasticsearch (legacy client)', function () {
 
         return retry(() =>
           agentControls.getSpans().then(spans => {
-            const index1Entry = verifyHttpEntry(spans, '/index', '42');
+            const index1Entry = verifyHttpEntry(spans, '/index', '0000000000000042');
             verifyElasticsearchExit(spans, index1Entry, 'index');
             verifyElasticsearchExit(spans, index1Entry, 'indices.refresh', null, '_all');
-            const index2Entry = verifyHttpEntry(spans, '/index', '43');
+            const index2Entry = verifyHttpEntry(spans, '/index', '0000000000000043');
             verifyElasticsearchExit(spans, index2Entry, 'index');
             verifyElasticsearchExit(spans, index2Entry, 'indices.refresh', null, '_all');
 
@@ -224,8 +224,8 @@ mochaSuiteFn('tracing/elasticsearch (legacy client)', function () {
       body: {
         title: titleA
       },
-      parentSpanId: '42',
-      traceId: '42'
+      parentSpanId: '0000000000000042',
+      traceId: '0000000000000042'
     })
       .then(res => {
         expect(res.error).to.not.exist;
@@ -235,8 +235,8 @@ mochaSuiteFn('tracing/elasticsearch (legacy client)', function () {
           body: {
             title: titleB
           },
-          parentSpanId: '43',
-          traceId: '43'
+          parentSpanId: '0000000000000043',
+          traceId: '0000000000000043'
         });
       })
       .then(res => {
@@ -247,8 +247,8 @@ mochaSuiteFn('tracing/elasticsearch (legacy client)', function () {
           body: {
             title: titleC
           },
-          parentSpanId: '44',
-          traceId: '44'
+          parentSpanId: '0000000000000044',
+          traceId: '0000000000000044'
         });
       })
       .then(res => {
@@ -281,12 +281,12 @@ mochaSuiteFn('tracing/elasticsearch (legacy client)', function () {
         expect(response2.docs[1]._source.title).to.deep.equal(titleC);
         return retry(() =>
           agentControls.getSpans().then(spans => {
-            verifyElasticsearchExit(spans, null, 'index', '42');
-            verifyElasticsearchExit(spans, null, 'indices.refresh', '42', '_all');
-            verifyElasticsearchExit(spans, null, 'index', '43');
-            verifyElasticsearchExit(spans, null, 'indices.refresh', '43', '_all');
-            verifyElasticsearchExit(spans, null, 'index', '44');
-            verifyElasticsearchExit(spans, null, 'indices.refresh', '44', '_all');
+            verifyElasticsearchExit(spans, null, 'index', '0000000000000042');
+            verifyElasticsearchExit(spans, null, 'indices.refresh', '0000000000000042', '_all');
+            verifyElasticsearchExit(spans, null, 'index', '0000000000000043');
+            verifyElasticsearchExit(spans, null, 'indices.refresh', '0000000000000043', '_all');
+            verifyElasticsearchExit(spans, null, 'index', '0000000000000044');
+            verifyElasticsearchExit(spans, null, 'indices.refresh', '0000000000000044', '_all');
 
             const mget1HttpEntry = verifyHttpEntry(spans, '/mget1');
             const mget1Exit = verifyElasticsearchExit(spans, mget1HttpEntry, 'mget');
@@ -311,16 +311,16 @@ mochaSuiteFn('tracing/elasticsearch (legacy client)', function () {
       body: {
         title: titleA
       },
-      parentSpanId: '42',
-      traceId: '42'
+      parentSpanId: '0000000000000042',
+      traceId: '0000000000000042'
     })
       .then(() =>
         index({
           body: {
             title: titleB
           },
-          parentSpanId: '43',
-          traceId: '43'
+          parentSpanId: '0000000000000043',
+          traceId: '0000000000000043'
         })
       )
       .then(() =>
@@ -328,8 +328,8 @@ mochaSuiteFn('tracing/elasticsearch (legacy client)', function () {
           body: {
             title: titleC
           },
-          parentSpanId: '44',
-          traceId: '44'
+          parentSpanId: '0000000000000044',
+          traceId: '0000000000000044'
         })
       )
       .then(() =>
@@ -356,12 +356,12 @@ mochaSuiteFn('tracing/elasticsearch (legacy client)', function () {
         expect(res.response.responses[1].hits.hits[0]._source.title).to.be.oneOf([titleA, titleB]);
         return retry(() =>
           agentControls.getSpans().then(spans => {
-            verifyElasticsearchExit(spans, null, 'index', '42');
-            verifyElasticsearchExit(spans, null, 'indices.refresh', '42', '_all');
-            verifyElasticsearchExit(spans, null, 'index', '43');
-            verifyElasticsearchExit(spans, null, 'indices.refresh', '43', '_all');
-            verifyElasticsearchExit(spans, null, 'index', '44');
-            verifyElasticsearchExit(spans, null, 'indices.refresh', '44', '_all');
+            verifyElasticsearchExit(spans, null, 'index', '0000000000000042');
+            verifyElasticsearchExit(spans, null, 'indices.refresh', '0000000000000042', '_all');
+            verifyElasticsearchExit(spans, null, 'index', '0000000000000043');
+            verifyElasticsearchExit(spans, null, 'indices.refresh', '0000000000000043', '_all');
+            verifyElasticsearchExit(spans, null, 'index', '0000000000000044');
+            verifyElasticsearchExit(spans, null, 'indices.refresh', '0000000000000044', '_all');
 
             const msearchEntrySpan = verifyHttpEntry(spans, '/msearch');
             const msearchExitSpan = verifyElasticsearchExit(spans, msearchEntrySpan, 'msearch');

--- a/packages/collector/test/tracing/database/elasticsearch_modern/test.js
+++ b/packages/collector/test/tracing/database/elasticsearch_modern/test.js
@@ -194,16 +194,16 @@ mochaSuiteFn('tracing/elasticsearch (modern client)', function () {
             body: {
               title: titleA
             },
-            parentSpanId: '42',
-            traceId: '42'
+            parentSpanId: '0000000000000042',
+            traceId: '0000000000000042'
           })
             .then(() =>
               index({
                 body: {
                   title: titleB
                 },
-                parentSpanId: '43',
-                traceId: '43'
+                parentSpanId: '0000000000000043',
+                traceId: '0000000000000043'
               })
             )
             .then(() =>
@@ -226,12 +226,12 @@ mochaSuiteFn('tracing/elasticsearch (modern client)', function () {
 
               return retry(() =>
                 agentControls.getSpans().then(spans => {
-                  const index1Entry = verifyHttpEntry(spans, '/index', '42');
+                  const index1Entry = verifyHttpEntry(spans, '/index', '0000000000000042');
 
                   verifyElasticsearchExit(spans, index1Entry, 'index');
                   verifyElasticsearchExit(spans, index1Entry, indicesKey, '_all', '/_all/_refresh');
 
-                  const index2Entry = verifyHttpEntry(spans, '/index', '43');
+                  const index2Entry = verifyHttpEntry(spans, '/index', '0000000000000043');
 
                   verifyElasticsearchExit(spans, index2Entry, 'index');
                   verifyElasticsearchExit(spans, index2Entry, indicesKey, '_all', '/_all/_refresh');
@@ -270,8 +270,8 @@ mochaSuiteFn('tracing/elasticsearch (modern client)', function () {
             body: {
               title: titleA
             },
-            parentSpanId: '42',
-            traceId: '42'
+            parentSpanId: '0000000000000042',
+            traceId: '0000000000000042'
           })
             .then(res => {
               expect(res.error).to.not.exist;
@@ -282,8 +282,8 @@ mochaSuiteFn('tracing/elasticsearch (modern client)', function () {
                 body: {
                   title: titleB
                 },
-                parentSpanId: '43',
-                traceId: '43'
+                parentSpanId: '0000000000000043',
+                traceId: '0000000000000043'
               });
             })
             .then(res => {
@@ -295,8 +295,8 @@ mochaSuiteFn('tracing/elasticsearch (modern client)', function () {
                 body: {
                   title: titleC
                 },
-                parentSpanId: '44',
-                traceId: '44'
+                parentSpanId: '0000000000000044',
+                traceId: '0000000000000044'
               });
             })
             .then(res => {
@@ -333,14 +333,14 @@ mochaSuiteFn('tracing/elasticsearch (modern client)', function () {
 
               return retry(() =>
                 agentControls.getSpans().then(spans => {
-                  verifyElasticsearchExit(spans, null, 'index', undefined, undefined, '42');
-                  verifyElasticsearchExit(spans, null, indicesKey, '_all', '/_all/_refresh', '42');
+                  verifyElasticsearchExit(spans, null, 'index', undefined, undefined, '0000000000000042');
+                  verifyElasticsearchExit(spans, null, indicesKey, '_all', '/_all/_refresh', '0000000000000042');
 
-                  verifyElasticsearchExit(spans, null, 'index', undefined, undefined, '43');
-                  verifyElasticsearchExit(spans, null, indicesKey, '_all', '/_all/_refresh', '43');
+                  verifyElasticsearchExit(spans, null, 'index', undefined, undefined, '0000000000000043');
+                  verifyElasticsearchExit(spans, null, indicesKey, '_all', '/_all/_refresh', '0000000000000043');
 
-                  verifyElasticsearchExit(spans, null, 'index', undefined, undefined, '44');
-                  verifyElasticsearchExit(spans, null, indicesKey, '_all', '/_all/_refresh', '44');
+                  verifyElasticsearchExit(spans, null, 'index', undefined, undefined, '0000000000000044');
+                  verifyElasticsearchExit(spans, null, indicesKey, '_all', '/_all/_refresh', '0000000000000044');
 
                   const mget1HttpEntry = verifyHttpEntry(spans, '/mget1');
                   const mget1Exit = verifyElasticsearchExit(
@@ -373,16 +373,16 @@ mochaSuiteFn('tracing/elasticsearch (modern client)', function () {
             body: {
               title: titleA
             },
-            parentSpanId: '42',
-            traceId: '42'
+            parentSpanId: '0000000000000042',
+            traceId: '0000000000000042'
           })
             .then(() =>
               index({
                 body: {
                   title: titleB
                 },
-                parentSpanId: '43',
-                traceId: '43'
+                parentSpanId: '0000000000000043',
+                traceId: '0000000000000043'
               })
             )
             .then(() =>
@@ -390,8 +390,8 @@ mochaSuiteFn('tracing/elasticsearch (modern client)', function () {
                 body: {
                   title: titleC
                 },
-                parentSpanId: '44',
-                traceId: '44'
+                parentSpanId: '0000000000000044',
+                traceId: '0000000000000044'
               })
             )
             .then(() =>
@@ -413,12 +413,12 @@ mochaSuiteFn('tracing/elasticsearch (modern client)', function () {
               expect(res.response.body.responses[1].hits.hits[0]._source.title).to.be.oneOf([titleA, titleB]);
               return retry(() =>
                 agentControls.getSpans().then(spans => {
-                  verifyElasticsearchExit(spans, null, 'index', undefined, undefined, '42');
-                  verifyElasticsearchExit(spans, null, indicesKey, '_all', '/_all/_refresh', '42');
-                  verifyElasticsearchExit(spans, null, 'index', undefined, undefined, '43');
-                  verifyElasticsearchExit(spans, null, indicesKey, '_all', '/_all/_refresh', '43');
-                  verifyElasticsearchExit(spans, null, 'index', undefined, undefined, '44');
-                  verifyElasticsearchExit(spans, null, indicesKey, '_all', '/_all/_refresh', '44');
+                  verifyElasticsearchExit(spans, null, 'index', undefined, undefined, '0000000000000042');
+                  verifyElasticsearchExit(spans, null, indicesKey, '_all', '/_all/_refresh', '0000000000000042');
+                  verifyElasticsearchExit(spans, null, 'index', undefined, undefined, '0000000000000043');
+                  verifyElasticsearchExit(spans, null, indicesKey, '_all', '/_all/_refresh', '0000000000000043');
+                  verifyElasticsearchExit(spans, null, 'index', undefined, undefined, '0000000000000044');
+                  verifyElasticsearchExit(spans, null, indicesKey, '_all', '/_all/_refresh', '0000000000000044');
 
                   const msearchEntrySpan = verifyHttpEntry(spans, '/msearch');
                   const msearchExitSpan = verifyElasticsearchExit(

--- a/packages/collector/test/tracing/sdk/test.js
+++ b/packages/collector/test/tracing/sdk/test.js
@@ -170,8 +170,8 @@ mochaSuiteFn('tracing/sdk', function () {
         });
 
         it('must create an entry span with trace ID and parent span ID', () => {
-          const traceId = 'trace-id';
-          const parentSpanId = 'parent-span-id';
+          const traceId = '1234567890abcdef';
+          const parentSpanId = 'fedcba9876543210';
           controls.sendViaIpc({
             command: 'start-entry',
             type: apiType,

--- a/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
@@ -462,6 +462,9 @@ function addTraceIdSpanIdToAllMessages(messages, span) {
     for (let msgIdx = 0; msgIdx < messages.length; msgIdx++) {
       if (messages[msgIdx].headers == null) {
         messages[msgIdx].headers = {
+          // Maintenance note (128-bit-trace-ids): We can remove the left-pad call here once we have switched to 128 bit
+          // trace IDs. We already left-pad to the trace ID length (currently 16) in cls.js, when continuing the trace
+          // from an upstream tracer.
           [constants.kafkaTraceIdHeaderName]: leftPad(span.t, 32),
           [constants.kafkaSpanIdHeaderName]: span.s
         };

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -352,11 +352,16 @@ function addTraceContextHeader(headers, span) {
 
   if (headers == null) {
     headers = [
+      // Maintenance note (128-bit-trace-ids): We can remove the left-pad call here once we have switched to 128 bit
+      // trace IDs. We already left-pad to the trace ID length (currently 16) in cls.js, when continuing the trace from
+      // an upstream tracer.
       { [constants.kafkaTraceIdHeaderName]: leftPad(span.t, 32) },
       { [constants.kafkaSpanIdHeaderName]: span.s },
       { [constants.kafkaTraceLevelHeaderName]: '1' }
     ];
   } else if (headers && Array.isArray(headers)) {
+    // Maintenance note (128-bit-trace-ids): We can remove the left-pad call here once we have switched to 128 bit trace
+    // IDs, see above.
     headers.push({ [constants.kafkaTraceIdHeaderName]: leftPad(span.t, 32) });
     headers.push({ [constants.kafkaSpanIdHeaderName]: span.s });
     headers.push({ [constants.kafkaTraceLevelHeaderName]: '1' });

--- a/packages/core/src/tracing/leftPad.js
+++ b/packages/core/src/tracing/leftPad.js
@@ -12,8 +12,8 @@
 
 module.exports = leftPad;
 
-// Even with 128 bit trace IDs we will only ever want to pad to max 32 characters, so keep a cache of the padding
-// strings for padding lengths 0 to 32.
+// We will only ever want to pad to at most 32 characters, so we keep a cache of the padding strings for padding lengths
+// 0 to 32.
 const cache = [
   '',
   '0',
@@ -49,6 +49,7 @@ const cache = [
   '0000000000000000000000000000000',
   '00000000000000000000000000000000'
 ];
+
 /**
  * @param {string} str
  * @param {number} len

--- a/packages/core/src/tracing/tracingHeaders.js
+++ b/packages/core/src/tracing/tracingHeaders.js
@@ -362,6 +362,7 @@ function readW3cTraceContext(headers) {
  * @returns {TracingHeaders}
  */
 exports.limitTraceId = function limitTraceId(result) {
+  // Maintenance note (128-bit-trace-ids): This function can be removed when we switch to 128 bit trace IDs.
   if (result.traceId && result.traceId.length >= 32) {
     result.longTraceId = result.traceId;
     result.traceId = result.traceId.substring(16, 32);

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -38,7 +38,8 @@ exports.getStackTrace = function getStackTrace(referenceFunction, drop) {
 };
 
 exports.generateRandomTraceId = function generateRandomTraceId() {
-  // Note: As soon as all Instana tracers support 128 bit trace IDs we can generate a string of length 32 here.
+  // Maintenance note (128-bit-trace-ids): As soon as all Instana tracers support 128 bit trace IDs we can generate a
+  // string of length 32 here.
   return exports.generateRandomId(16);
 };
 

--- a/packages/core/test/tracing/tracingHeaders_test.js
+++ b/packages/core/test/tracing/tracingHeaders_test.js
@@ -46,6 +46,7 @@ describe('tracing/headers', () => {
     expect(context.parentId).to.equal(instanaSpanId);
   });
 
+  // Maintenance note (128-bit-trace-ids): This test becomes obsolete when we switch to 128 bit trace IDs.
   it('should read 128 bit X-INSTANA-T and limit it to 64 bit', () => {
     const context = tracingHeaders.fromHttpRequest({
       headers: {

--- a/packages/core/test/tracing/tracingUtil_test.js
+++ b/packages/core/test/tracing/tracingUtil_test.js
@@ -29,11 +29,14 @@ describe('tracing/tracingUtil', () => {
   describe('generate random IDs', function () {
     this.timeout(config.getTestTimeout() * 10);
 
+    // Maintenance note (128-bit-trace-ids): The following line checks that 64 bit (16 char) IDs are generated okay. We
+    // need to replace the third parameter with 32 once we switch to 128 bit trace IDs.
     testRandomIds('trace', generateRandomTraceId, 16);
+
     testRandomIds('span', generateRandomSpanId, 16);
 
-    // The following line checks that 128 bit (32 char)  IDs are generated okay, although we do not yet need
-    // 128 bit IDs (yet). It can be removed once trace IDs are upped to 128 bit.
+    // Maintenance note (128-bit-trace-ids): The following line checks that 128 bit (32 char) IDs are generated okay,
+    // although we do not yet need 128 bit IDs (yet). It can be removed once trace IDs are switched to 128 bit length.
     testRandomIds('128 bit', generateRandomId.bind(null, 32), 32);
 
     const validIdRegex = /^[a-f0-9]+$/;


### PR DESCRIPTION
When an incoming trace correlation ID (trace ID or span ID) is shorter than the standard length, we now normalize it by left-padding it with "0" characters.

Additionally, do not throw an error in tracingUtil, instead simply log
an error.


Fixes:
```
Only supported hex string lengths are 16 and 32, got: ...
at Object.unsignedHexStringToBuffer (node_modules/@instana/core/src/tracing/tracingUtil.js:111:11)
at Object.unsignedHexStringsToBuffer (node_modules/@instana/core/src/tracing/tracingUtil.js:124:11)
at Object.renderTraceContextToBuffer (node_modules/@instana/core/src/tracing/tracingUtil.js:153:18)
at addLegacyTraceContextHeaderToAllMessages (node_modules/@instana/core/src/tracing/instrumentation/messaging/kafkaJs.js:452:23)
```

fixes #833