### PR TITLE
fix: reduced noisy log warnings when active entry could not be found

### DIFF
--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -546,13 +546,16 @@ function call(fn) {
  * @param {Object.<string, *>} options
  */
 function skipExitTracing(options) {
-  const opts = Object.assign({}, options, {
-    isActive: true,
-    extendedResponse: false,
-    skipParentSpanCheck: false,
-    log: true,
-    skipIsTracing: false
-  });
+  const opts = Object.assign(
+    {
+      isActive: true,
+      extendedResponse: false,
+      skipParentSpanCheck: false,
+      log: true,
+      skipIsTracing: false
+    },
+    options
+  );
 
   const parentSpan = getCurrentSpan();
   const suppressed = tracingSuppressed();

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -545,20 +545,28 @@ function call(fn) {
  *
  * @param {Object.<string, *>} options
  */
-function skipExitTracing(
-  options = {
+function skipExitTracing(options) {
+  const opts = Object.assign({}, options, {
     isActive: true,
     extendedResponse: false,
     skipParentSpanCheck: false,
     log: true,
     skipIsTracing: false
-  }
-) {
+  });
+
   const parentSpan = getCurrentSpan();
   const suppressed = tracingSuppressed();
   const isExitSpanResult = isExitSpan(parentSpan);
-  if (!options.skipParentSpanCheck && (!parentSpan || isExitSpanResult)) {
-    if (options.log) {
+
+  // CASE: first ask for suppressed, because if we skip the entry span, we won't have a parentSpan
+  //       on the exit span, which would create noisy log messages.
+  if (suppressed) {
+    if (opts.extendedResponse) return { skip: true, suppressed, isExitSpan: isExitSpanResult };
+    return true;
+  }
+
+  if (!opts.skipParentSpanCheck && (!parentSpan || isExitSpanResult)) {
+    if (opts.log) {
       logger.warn(
         // eslint-disable-next-line max-len
         `Cannot start an exit span as this requires an active entry (or intermediate) span as parent. ${
@@ -569,14 +577,14 @@ function skipExitTracing(
       );
     }
 
-    if (options.extendedResponse) return { skip: true, suppressed, isExitSpan: isExitSpanResult };
+    if (opts.extendedResponse) return { skip: true, suppressed, isExitSpan: isExitSpanResult };
     else return true;
   }
 
-  const skipIsActive = options.isActive === false;
-  const skipIsTracing = !options.skipIsTracing ? !isTracing() : false;
-  const skip = skipIsActive || skipIsTracing || suppressed;
-  if (options.extendedResponse) return { skip, suppressed, isExitSpan: isExitSpanResult };
+  const skipIsActive = opts.isActive === false;
+  const skipIsTracing = !opts.skipIsTracing ? !isTracing() : false;
+  const skip = skipIsActive || skipIsTracing;
+  if (opts.extendedResponse) return { skip, suppressed, isExitSpan: isExitSpanResult };
   else return skip;
 }
 


### PR DESCRIPTION
I noticed when running tests for suppressed tests, that we are seeing:

> Cannot start an exit span as this requires an active entry (or intermediate) span as parent

This is not right. When a trace is suppressed, then we do not create an entry span.
Therefor the check to skip the exit span won't have a parent span.

Found two things which we had to optimize:

1. `options` need to be merged. Bug.
2. Reorder suppress and parentSpan check. IMO this is okay.