### PR TITLE
fix: resolved missing dynamodb spans

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@aws-sdk/client-s3-2": "npm:@aws-sdk/client-s3@3.321.1",
         "@aws-sdk/client-sqs": "3.329.0",
         "@aws-sdk/client-sqs2": "npm:@aws-sdk/client-sqs@3.24.0",
+        "@aws-sdk/lib-dynamodb": "^3.395.0",
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@elastic/elasticsearch": "^8.6.0",
@@ -8975,6 +8976,22 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.395.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.395.0.tgz",
+      "integrity": "sha512-HNOx+XmG3RXVOj2Z9oH0fDmE6bYmQND5WgVHfYOx7xqRWHEOyt8cNlZVktzPiK9XDNNQbG2qm98ux8We2e44eA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/util-dynamodb": "3.395.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.0.0"
+      }
+    },
     "node_modules/@aws-sdk/md5-js": {
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.310.0.tgz",
@@ -10056,6 +10073,18 @@
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
       "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.395.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.395.0.tgz",
+      "integrity": "sha512-hc97G4f75+xoOn2stERwORvsuugZ6mYPJIdCuaapxWFckqHc8H0jBnEFA1z8XbPVIZdvtS23ixcXOOM4TBWXuA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -57060,6 +57089,16 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/lib-dynamodb": {
+      "version": "3.395.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.395.0.tgz",
+      "integrity": "sha512-HNOx+XmG3RXVOj2Z9oH0fDmE6bYmQND5WgVHfYOx7xqRWHEOyt8cNlZVktzPiK9XDNNQbG2qm98ux8We2e44eA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/util-dynamodb": "3.395.0",
+        "tslib": "^2.5.0"
+      }
+    },
     "@aws-sdk/md5-js": {
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.310.0.tgz",
@@ -57944,6 +57983,15 @@
             "tslib": "^2.5.0"
           }
         }
+      }
+    },
+    "@aws-sdk/util-dynamodb": {
+      "version": "3.395.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.395.0.tgz",
+      "integrity": "sha512-hc97G4f75+xoOn2stERwORvsuugZ6mYPJIdCuaapxWFckqHc8H0jBnEFA1z8XbPVIZdvtS23ixcXOOM4TBWXuA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-endpoints": {

--- a/package.json
+++ b/package.json
@@ -59,11 +59,12 @@
     "@apollo/gateway": "0.50.2",
     "@aws-sdk/client-dynamodb": "3.284.0",
     "@aws-sdk/client-dynamodb2": "npm:@aws-sdk/client-dynamodb@3.20.0",
+    "@aws-sdk/client-kinesis": "^3.379.1",
     "@aws-sdk/client-s3": "3.379.1",
     "@aws-sdk/client-s3-2": "npm:@aws-sdk/client-s3@3.321.1",
-    "@aws-sdk/client-kinesis": "^3.379.1",
     "@aws-sdk/client-sqs": "3.329.0",
     "@aws-sdk/client-sqs2": "npm:@aws-sdk/client-sqs@3.24.0",
+    "@aws-sdk/lib-dynamodb": "^3.395.0",
     "@commitlint/cli": "^14.1.0",
     "@commitlint/config-conventional": "^14.1.0",
     "@elastic/elasticsearch": "^8.6.0",
@@ -210,11 +211,11 @@
   },
   "optionalDependencies": {
     "grpc": "1.24.11",
+    "ibm_db": "^2.8.2",
     "kafka-avro": "3.1.1",
     "mali": "0.23.0",
     "node-rdkafka": "2.16.1",
-    "pg-native": "3.0.1",
-    "ibm_db": "^2.8.2"
+    "pg-native": "3.0.1"
   },
   "config": {
     "commitizen": {

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/app.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/app.js
@@ -19,7 +19,29 @@ require('../../../../../..')();
 
 const express = require('express');
 const fetch = require('node-fetch');
+const awsRegion = 'us-east-2';
+let dynamoDB;
+
 const awsSdk3 = require('@aws-sdk/client-dynamodb');
+
+if (process.env.USE_LIB_DYNAMODB) {
+  const { DynamoDBDocumentClient } = require('@aws-sdk/lib-dynamodb');
+
+  dynamoDB = DynamoDBDocumentClient.from(
+    new awsSdk3.DynamoDBClient({
+      region: awsRegion
+    }),
+    {
+      marshallOptions: {
+        removeUndefinedValues: true
+      }
+    }
+  );
+} else {
+  dynamoDB = new awsSdk3.DynamoDBClient({ region: awsRegion });
+}
+
+const dynamoDBv2 = new awsSdk3.DynamoDB({ region: awsRegion });
 const cls = require('../../../../../../../core/src/tracing/cls');
 
 const logPrefix = `AWS SDK v3 DynamoDB (${process.pid}):\t`;
@@ -28,10 +50,6 @@ const port = require('../../../../../test_util/app-port')();
 const agentPort = process.env.INSTANA_AGENT_PORT || 42699;
 const app = express();
 const tableName = process.env.AWS_DYNAMODB_TABLE_NAME || 'nodejs-team';
-const awsRegion = 'us-east-2';
-
-const dynamoDB = new awsSdk3.DynamoDBClient({ region: awsRegion });
-const dynamoDBv2 = new awsSdk3.DynamoDB({ region: awsRegion });
 
 const tableCreationParams = {
   TableName: tableName,

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/default/dynamodb_test.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/default/dynamodb_test.js
@@ -7,6 +7,6 @@
 const requestMethod = 'default-style';
 const version = '@aws-sdk/client-dynamodb';
 
-describe.only('tracing/cloud/aws-sdk/v3/dynamodb', function () {
+describe('tracing/cloud/aws-sdk/v3/dynamodb', function () {
   require('../test_definition').call(this, version, requestMethod);
 });

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/default/dynamodb_test.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/default/dynamodb_test.js
@@ -7,6 +7,6 @@
 const requestMethod = 'default-style';
 const version = '@aws-sdk/client-dynamodb';
 
-describe('tracing/cloud/aws-sdk/v3/dynamodb', function () {
+describe.only('tracing/cloud/aws-sdk/v3/dynamodb', function () {
   require('../test_definition').call(this, version, requestMethod);
 });

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/test_definition.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/test_definition.js
@@ -110,6 +110,35 @@ function start(version, requestMethod) {
       });
     });
 
+    describe('with @aws-sdk/lib-dynamodb', function () {
+      const tableName = createTableName();
+
+      const appControls = new ProcessControls({
+        appPath: path.join(__dirname, './app'),
+        useGlobalAgent: true,
+        env: {
+          AWS_DYNAMODB_TABLE_NAME: tableName,
+          AWS_SDK_CLIENT_DYNAMODB_REQUIRE: version,
+          USE_LIB_DYNAMODB: true
+        }
+      });
+
+      ProcessControls.setUpHooksWithRetryTime(retryTime, appControls);
+
+      after(() => cleanup(tableName));
+
+      it('should succeed', async () => {
+        const apiPath = `/listTables/${requestMethod}`;
+
+        const response = await appControls.sendRequest({
+          method: 'GET',
+          path: `${apiPath}`
+        });
+
+        return verify(appControls, response, apiPath, 'listTables', false, tableName);
+      });
+    });
+
     describe('should handle errors', function () {
       const tableName = createTableName();
 

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
@@ -49,9 +49,7 @@ exports.init = function init() {
   /**
    * @aws-sdk/smithly-client > 3.36.0
    */
-  requireHook.onModuleLoad('@smithy/smithy-client', function instrumentNewGlobalSmithy(Smithy) {
-    shimmer.wrap(Smithy.Client.prototype, 'send', shimSmithySend);
-  });
+  requireHook.onModuleLoad('@smithy/smithy-client', instrumentGlobalSmithy);
 };
 
 exports.isActive = function () {

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
@@ -28,7 +28,6 @@ awsProducts.forEach(awsProduct => {
 });
 
 let isActive = false;
-let onFileLoaded = false;
 
 exports.init = function init() {
   sqsConsumer.init();
@@ -50,7 +49,9 @@ exports.init = function init() {
   /**
    * @aws-sdk/smithly-client > 3.36.0
    */
-  requireHook.onModuleLoad('@smithy/smithy-client', instrumentGlobalSmithy);
+  requireHook.onModuleLoad('@smithy/smithy-client', function instrumentNewGlobalSmithy(Smithy) {
+    shimmer.wrap(Smithy.Client.prototype, 'send', shimSmithySend);
+  });
 };
 
 exports.isActive = function () {
@@ -66,12 +67,6 @@ exports.deactivate = function deactivate() {
 };
 
 function instrumentGlobalSmithy(Smithy) {
-  // NOTE: avoid instrumenting aws-sdk v3 twice, see init
-  if (onFileLoaded) {
-    return;
-  }
-
-  onFileLoaded = true;
   shimmer.wrap(Smithy.Client.prototype, 'send', shimSmithySend);
 }
 


### PR DESCRIPTION
refs 136351

Problem:
One library is using `@aws-sdk/smithy-client` and the other is already using `@smithy/smithy-client`.
If one is loaded earlier, the other one won't create spans.

@aws-sdk/client-dynamodb is currently using **3.188.0 on Lambda.**
This version still uses the **old smithy** `@aws-sdk/smithy-client`.

But `@aws-sdk/lib-dynamodb` uses already the new smithy `@smithy/smithy-client`. That's why the customer didn't see any spans.