### PR TITLE
fix(dynamodb): resolved all operation names

### DIFF
--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/test_definition.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/test_definition.js
@@ -24,17 +24,6 @@ const { promisifyNonSequentialCases } = require('../promisify_non_sequential');
 
 let mochaSuiteFn;
 
-const operationsInfo = {
-  createTable: 'create',
-  listTables: 'list',
-  scan: 'scan',
-  query: 'query',
-  getItem: 'get',
-  deleteItem: 'delete',
-  putItem: 'put',
-  updateItem: 'update'
-};
-
 const availableOperations = [
   'createTable',
   'putItem',
@@ -295,7 +284,7 @@ function start(version, requestMethod) {
         withError,
         pid: String(controls.getPid()),
         extraTests: [
-          span => expect(span.data.dynamodb.op).to.equal(operationsInfo[operation]),
+          span => expect(span.data.dynamodb.op).to.exist,
           span => expect(span.data.dynamodb.region).to.equal('us-east-2'),
           span => {
             let expected;

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
@@ -10,20 +10,6 @@ const { EXIT } = require('../../../../constants');
 const tracingUtil = require('../../../../tracingUtil');
 const { InstanaAWSProduct } = require('./instana_aws_product');
 
-const operationsInfo = {
-  CreateTableCommand: { op: 'create' },
-  DeleteTableCommand: { op: 'delete' },
-  ListTablesCommand: { op: 'list' },
-  ScanCommand: { op: 'scan' },
-  QueryCommand: { op: 'query' },
-  GetItemCommand: { op: 'get' },
-  DeleteItemCommand: { op: 'delete' },
-  PutItemCommand: { op: 'put' },
-  UpdateItemCommand: { op: 'update' }
-};
-
-const operations = Object.keys(operationsInfo);
-
 const SPAN_NAME = 'dynamodb';
 
 class InstanaAWSDynamoDB extends InstanaAWSProduct {
@@ -73,9 +59,8 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
   }
 
   buildSpanData(operation, params) {
-    const operationInfo = operationsInfo[operation];
     const spanData = {
-      op: operationInfo.op
+      op: this.convertOperationName(operation)
     };
 
     if (params && params.TableName) {
@@ -103,4 +88,4 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
   }
 }
 
-module.exports = new InstanaAWSDynamoDB(SPAN_NAME, operations);
+module.exports = new InstanaAWSDynamoDB(SPAN_NAME);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/instana_aws_product.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/instana_aws_product.js
@@ -53,6 +53,11 @@ class InstanaAWSProduct {
     }
   }
 
+  convertOperationName(operation) {
+    const convertedOperation = operation.replace(/Command$/, '');
+    return convertedOperation.charAt(0).toLowerCase() + convertedOperation.slice(1);
+  }
+
   supportsOperation(operation) {
     if (!this.operations || !this.operations.length) return true;
     return this.operations.includes(operation);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/kinesis.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/kinesis.js
@@ -76,11 +76,6 @@ class InstanaAWSKinesis extends InstanaAWSProduct {
 
     return spanData;
   }
-
-  convertOperationName(operation) {
-    const convertedOperation = operation.replace(/Command$/, '');
-    return convertedOperation.charAt(0).toLowerCase() + convertedOperation.slice(1);
-  }
 }
 
 module.exports = new InstanaAWSKinesis(SPAN_NAME);


### PR DESCRIPTION
e.g. lib-dynamodb is using PutCommand instead of PutItemCommand

This is an additional fix for the previous dynamodb fix. It wasn't working for the lib-dynamodb commands, because `operationInfo.op` crashed.