### PR TITLE
fix: disabling aws sdk instrumentation

### DIFF
--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -190,7 +190,8 @@ function initInstrumenations(_config) {
 
       const isInstrumentationDisabled =
         _config.tracing.disabledTracers.includes(extractedInstrumentationName.toLowerCase()) ||
-        _config.tracing.disabledTracers.includes(instrumentationModules[instrumentationKey].instrumentationName);
+        (instrumentationModules[instrumentationKey].instrumentationName &&
+          _config.tracing.disabledTracers.includes(instrumentationModules[instrumentationKey].instrumentationName));
 
       if (!isInstrumentationDisabled) {
         instrumentationModules[instrumentationKey].init(_config);
@@ -228,7 +229,8 @@ exports.activate = function activate(extraConfig = {}) {
 
         const isDisabled =
           config.tracing.disabledTracers.includes(extractedInstrumentationName.toLowerCase()) ||
-          config.tracing.disabledTracers.includes(instrumentationModules[instrumentationKey].instrumentationName);
+          (instrumentationModules[instrumentationKey].instrumentationName &&
+            config.tracing.disabledTracers.includes(instrumentationModules[instrumentationKey].instrumentationName));
 
         if (!isDisabled) {
           instrumentationModules[instrumentationKey].activate(extraConfig);

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -41,10 +41,8 @@ let processIdentityProvider = null;
 const instrumentations = [
   './instrumentation/cloud/aws-sdk/v2/index',
   './instrumentation/cloud/aws-sdk/v3/index',
-
   './instrumentation/cloud/aws-sdk/v2/sdk',
   './instrumentation/cloud/aws-sdk/v2/sqs',
-
   './instrumentation/cloud/gcp/pubsub',
   './instrumentation/cloud/gcp/storage',
   './instrumentation/control_flow/bluebird',

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/index.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/index.js
@@ -27,6 +27,8 @@ awsProducts.forEach(awsProduct => {
 
 let isActive = false;
 
+exports.instrumentationName = 'aws-sdk/v2';
+
 exports.isActive = function () {
   return isActive;
 };

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
@@ -30,6 +30,8 @@ awsProducts.forEach(awsProduct => {
 
 let isActive = false;
 
+exports.instrumentationName = 'aws-sdk/v3';
+
 exports.init = function init() {
   sqsConsumer.init();
 

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -16,6 +16,7 @@ const rdKafka = require('../../src/tracing/instrumentation/messaging/rdkafka');
 const grpc = require('../../src/tracing/instrumentation/protocols/grpc');
 const grpcJs = require('../../src/tracing/instrumentation/protocols/grpcJs');
 const awsSdkv2 = require('../../src/tracing/instrumentation/cloud/aws-sdk/v2/index');
+const awsSdkv3 = require('../../src/tracing/instrumentation/cloud/aws-sdk/v3/index');
 const testConfig = require('../config');
 
 const expect = chai.expect;
@@ -33,11 +34,14 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
   let activateStubKafkaJs;
   let activateStubRdKafka;
   let activateAwsSdkv2;
+  let activateAwsSdkv3;
 
   let initStubGrpc;
   let initStubGrpcJs;
   let initStubKafkaJs;
+  let initStubRdKafka;
   let initAwsSdkv2;
+  let initAwsSdkv3;
 
   before(() => {
     activateStubGrpc = sinon.stub(grpc, 'activate');
@@ -45,11 +49,14 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     activateStubKafkaJs = sinon.stub(kafkaJs, 'activate');
     activateStubRdKafka = sinon.stub(rdKafka, 'activate');
     activateAwsSdkv2 = sinon.stub(awsSdkv2, 'activate');
+    activateAwsSdkv3 = sinon.stub(awsSdkv3, 'activate');
 
     initStubGrpc = sinon.stub(grpc, 'init');
     initStubGrpcJs = sinon.stub(grpcJs, 'init');
     initStubKafkaJs = sinon.stub(kafkaJs, 'init');
+    initStubRdKafka = sinon.stub(rdKafka, 'init');
     initAwsSdkv2 = sinon.stub(awsSdkv2, 'init');
+    initAwsSdkv3 = sinon.stub(awsSdkv3, 'init');
   });
 
   beforeEach(() => {
@@ -64,11 +71,14 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     activateStubKafkaJs.reset();
     activateStubRdKafka.reset();
     activateAwsSdkv2.reset();
+    activateAwsSdkv3.reset();
 
     initStubGrpc.reset();
     initStubGrpcJs.reset();
     initStubKafkaJs.reset();
+    initStubRdKafka.reset();
     initAwsSdkv2.reset();
+    initAwsSdkv3.reset();
 
     delete process.env.INSTANA_DISABLED_TRACERS;
   });
@@ -78,15 +88,31 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
   });
 
   it('deactivate instrumentation via config', () => {
-    initAndActivate({ tracing: { disabledTracers: ['grpc', 'kafkajs', 'aws-sdk/v2/index'] } });
-    expect(activateStubGrpc).to.not.have.been.called;
-    expect(activateStubGrpcJs).to.have.been.called;
-    expect(activateStubKafkaJs).to.not.have.been.called;
-    expect(activateStubRdKafka).to.have.been.called;
-    expect(initStubGrpc).not.to.have.been.called;
+    initAndActivate({ tracing: { disabledTracers: ['grpc', 'kafkajs', 'aws-sdk/v2'] } });
 
+    // grpc instrumentation  has been disabled, make sure neither its init nor its activate method are called
+    expect(initStubGrpc).not.to.have.been.called;
+    expect(activateStubGrpc).to.not.have.been.called;
+
+    // grpcJs instrumentation has not been disabled, make sure its init and activate are called
+    expect(initStubGrpcJs).to.have.been.called;
+    expect(activateStubGrpcJs).to.have.been.called;
+
+    // kafkajs has been disabled...
+    expect(initStubKafkaJs).to.not.have.been.called;
+    expect(activateStubKafkaJs).to.not.have.been.called;
+
+    // ...but rdkafka has not been disabled
+    expect(initStubRdKafka).to.have.been.called;
+    expect(activateStubRdKafka).to.have.been.called;
+
+    // aws-sdk/v2 has been disabled (via aws-sdk/v2)
     expect(initAwsSdkv2).not.to.have.been.called;
     expect(activateAwsSdkv2).not.to.have.been.called;
+
+    // aws-sdk/v3 has not been disabled
+    expect(initAwsSdkv3).to.have.been.called;
+    expect(activateAwsSdkv3).to.have.been.called;
   });
 
   it('deactivate instrumentation via env', () => {
@@ -116,12 +142,16 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     expect(activateStubRdKafka).to.have.been.calledWith(extraConfigFromAgent);
   });
 
-  it('skip init step when instrumentation disabled', () => {
-    initAndActivate({ tracing: { disabledTracers: ['grpcjs', 'kafkajs', 'aws-sdk/v2'] } });
-    expect(initStubKafkaJs).not.to.have.been.called;
-    expect(initStubGrpcJs).not.to.have.been.called;
-    expect(initAwsSdkv2).to.not.have.been.called;
-    expect(initStubGrpc).to.have.been.called;
+  it('[deprecated] aws-sdk/v2/index', () => {
+    initAndActivate({ tracing: { disabledTracers: ['aws-sdk/v2/index'] } });
+
+    // aws-sdk/v2 has been disabled (via aws-sdk/v2/index)
+    expect(initAwsSdkv2).not.to.have.been.called;
+    expect(activateAwsSdkv2).not.to.have.been.called;
+
+    // aws-sdk/v3 has not been disabled
+    expect(initAwsSdkv3).to.have.been.called;
+    expect(activateAwsSdkv3).to.have.been.called;
   });
 
   function initAndActivate(initConfig, extraConfigForActivate) {

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -15,6 +15,7 @@ const kafkaJs = require('../../src/tracing/instrumentation/messaging/kafkaJs');
 const rdKafka = require('../../src/tracing/instrumentation/messaging/rdkafka');
 const grpc = require('../../src/tracing/instrumentation/protocols/grpc');
 const grpcJs = require('../../src/tracing/instrumentation/protocols/grpcJs');
+const awsSdkv2 = require('../../src/tracing/instrumentation/cloud/aws-sdk/v2/index');
 const testConfig = require('../config');
 
 const expect = chai.expect;
@@ -31,18 +32,24 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
   let activateStubGrpcJs;
   let activateStubKafkaJs;
   let activateStubRdKafka;
+  let activateAwsSdkv2;
+
   let initStubGrpc;
   let initStubGrpcJs;
   let initStubKafkaJs;
+  let initAwsSdkv2;
 
   before(() => {
     activateStubGrpc = sinon.stub(grpc, 'activate');
     activateStubGrpcJs = sinon.stub(grpcJs, 'activate');
     activateStubKafkaJs = sinon.stub(kafkaJs, 'activate');
     activateStubRdKafka = sinon.stub(rdKafka, 'activate');
+    activateAwsSdkv2 = sinon.stub(awsSdkv2, 'activate');
+
     initStubGrpc = sinon.stub(grpc, 'init');
     initStubGrpcJs = sinon.stub(grpcJs, 'init');
     initStubKafkaJs = sinon.stub(kafkaJs, 'init');
+    initAwsSdkv2 = sinon.stub(awsSdkv2, 'init');
   });
 
   beforeEach(() => {
@@ -56,9 +63,13 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     activateStubGrpcJs.reset();
     activateStubKafkaJs.reset();
     activateStubRdKafka.reset();
+    activateAwsSdkv2.reset();
+
     initStubGrpc.reset();
     initStubGrpcJs.reset();
     initStubKafkaJs.reset();
+    initAwsSdkv2.reset();
+
     delete process.env.INSTANA_DISABLED_TRACERS;
   });
 
@@ -67,21 +78,27 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
   });
 
   it('deactivate instrumentation via config', () => {
-    initAndActivate({ tracing: { disabledTracers: ['grpc', 'kafkajs'] } });
+    initAndActivate({ tracing: { disabledTracers: ['grpc', 'kafkajs', 'aws-sdk/v2/index'] } });
     expect(activateStubGrpc).to.not.have.been.called;
     expect(activateStubGrpcJs).to.have.been.called;
     expect(activateStubKafkaJs).to.not.have.been.called;
     expect(activateStubRdKafka).to.have.been.called;
     expect(initStubGrpc).not.to.have.been.called;
+
+    expect(initAwsSdkv2).not.to.have.been.called;
+    expect(activateAwsSdkv2).not.to.have.been.called;
   });
 
   it('deactivate instrumentation via env', () => {
     process.env.INSTANA_DISABLED_TRACERS = 'grpc';
     initAndActivate({});
+
     expect(activateStubGrpc).to.not.have.been.called;
     expect(activateStubGrpcJs).to.have.been.called;
     expect(activateStubKafkaJs).to.have.been.called;
     expect(activateStubRdKafka).to.have.been.called;
+    expect(activateAwsSdkv2).to.have.been.called;
+
     expect(initStubGrpc).not.to.have.been.called;
   });
 
@@ -100,9 +117,10 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
   });
 
   it('skip init step when instrumentation disabled', () => {
-    initAndActivate({ tracing: { disabledTracers: ['grpcjs', 'kafkajs'] } });
+    initAndActivate({ tracing: { disabledTracers: ['grpcjs', 'kafkajs', 'aws-sdk/v2'] } });
     expect(initStubKafkaJs).not.to.have.been.called;
     expect(initStubGrpcJs).not.to.have.been.called;
+    expect(initAwsSdkv2).to.not.have.been.called;
     expect(initStubGrpc).to.have.been.called;
   });
 


### PR DESCRIPTION
refs 139073

This is

a) not documented https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-configuration#disabling-individual-tracers
b) customers would need to use `aws/sdk/v2/index`, which is really not a good design

This is a first fix to this. 
In the next major release we could drop the support for the old syntax. The major ticket contains it already.
This PR ensures that we still support the old notation, because it could be that some customers are using this.

Another addition could be: add an optional function like `handleDisablingInstrumentation`  and each instrumentation can handle it on it's own if wished e.g. aws sdk could disable only certain instrumentations. Right now users can only disable the while library. 