### PR TITLE
docs: update support/ticket system links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to fill out this bug report. Please do not submit usage questions, support requests or feature requests here. Those need to be filed at [Instana's support portal](https://support.instana.com).
+        Thank you for taking the time to fill out this bug report. Please do not submit usage questions, support requests or feature requests here. Support requests need to be filed at [IBM's support portal](https://www.ibm.com/mysupport), while feature requests can be submitted via [IBM's ideas portal]<https://automation-management.ideas.ibm.com/?project=INSTANA>.
 
         Please also refrain from filing issues or support tickets if your audit tool (npm audit, Snyk, etc.) reported a CVE for a dependency of an Instana package -- we run these audits with every build and take appropriate action automatically.
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Instana Support Portal
-    url: https://support.instana.com
+    url: https://www.ibm.com/mysupport
     about: Please ask usage questions there.
   - name: Feature Requests
     url: https://automation-management.ideas.ibm.com/?project=INSTANA

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Checkout our [breaking changes documentation](https://www.ibm.com/docs/en/obi/cu
 
 ## Filing Issues
 
-If something is not working as expected or you have a question, instead of opening an issue in this repository, please open a ticket at <https://support.instana.com/hc/requests/new> instead. Please refrain from filing issues or tickets if your audit tool (npm audit, Snyk, etc.) reported a CVE for a dependency or a transitive dependency of `@instana/collector` -- we run these audits with every build and take appropriate action automatically.
+If something is not working as expected or you have a question, instead of opening an issue in this repository, please open a ticket at <https://www.ibm.com/mysupport> instead. Please refrain from filing issues or tickets if your audit tool (npm audit, Snyk, etc.) reported a CVE for a dependency or a transitive dependency of `@instana/collector` -- we run these audits with every build and take appropriate action automatically.
 
 ## Documentation
 

--- a/packages/collector/README.md
+++ b/packages/collector/README.md
@@ -57,5 +57,5 @@ In most cases it is enough to require and initialize `@instana/collector` and le
 
 ## Filing Issues
 
-If something is not working as expected or you have a question, instead of opening an issue in this repository, please open a ticket at <https://support.instana.com/hc/requests/new> instead. Please refrain from filing issues or tickets if your audit tool (npm audit, Snyk, etc.) reported a CVE for a dependency or a transitive dependency of `@instana/collector` -- we run these audits with every build and take appropriate action automatically.
+If something is not working as expected or you have a question, instead of opening an issue in this repository, please open a ticket at <https://www.ibm.com/mysupport> instead. Please refrain from filing issues or tickets if your audit tool (npm audit, Snyk, etc.) reported a CVE for a dependency or a transitive dependency of `@instana/collector` -- we run these audits with every build and take appropriate action automatically.
 


### PR DESCRIPTION
We still mentioned https://support.instana.com in a few places, but that domain does not exist anymore. Updated to https://www.ibm.com/mysupport, which is the external link for CSP.