### PR TITLE
fix: adds version information for all NPM packages

### DIFF
--- a/packages/aws-fargate/src/index.js
+++ b/packages/aws-fargate/src/index.js
@@ -4,9 +4,11 @@
 
 'use strict';
 
+const path = require('path');
 // MAINTENANCE NOTE: All code in this file needs to be compatible with all Node.js versions >= 6.0.0.
 
 try {
+  console.log('@instana/aws-fargate module version:', require(path.join(__dirname, '..', 'package.json')).version);
   const nodeJsVersion = process.version;
   if (typeof nodeJsVersion !== 'string') {
     return;

--- a/packages/aws-fargate/src/index.js
+++ b/packages/aws-fargate/src/index.js
@@ -8,6 +8,7 @@ const path = require('path');
 // MAINTENANCE NOTE: All code in this file needs to be compatible with all Node.js versions >= 6.0.0.
 
 try {
+  // eslint-disable-next-line no-console
   console.log('@instana/aws-fargate module version:', require(path.join(__dirname, '..', 'package.json')).version);
   const nodeJsVersion = process.version;
   if (typeof nodeJsVersion !== 'string') {

--- a/packages/aws-lambda/src/index.js
+++ b/packages/aws-lambda/src/index.js
@@ -19,6 +19,7 @@ if (isNodeJsTooOld()) {
 const { environment: environmentUtil } = require('@instana/serverless');
 const ssm = require('./ssm');
 const path = require('path');
+// eslint-disable-next-line no-console
 console.log('@instana/aws-lambda module version:', require(path.join(__dirname, '..', 'package.json')).version);
 
 environmentUtil.validate({

--- a/packages/aws-lambda/src/index.js
+++ b/packages/aws-lambda/src/index.js
@@ -18,6 +18,8 @@ if (isNodeJsTooOld()) {
 
 const { environment: environmentUtil } = require('@instana/serverless');
 const ssm = require('./ssm');
+const path = require('path');
+console.log('@instana/aws-lambda module version:', require(path.join(__dirname, '..', 'package.json')).version);
 
 environmentUtil.validate({
   validateInstanaAgentKey: ssm.validate

--- a/packages/google-cloud-run/src/index.js
+++ b/packages/google-cloud-run/src/index.js
@@ -4,10 +4,12 @@
 
 'use strict';
 
+const path = require('path');
 // MAINTENANCE NOTE: All code in this file needs to be compatible with all Node.js versions >= 6.0.0.
 
 try {
   const nodeJsVersion = process.version;
+  console.log('@instana/google-cloud-run module version:', require(path.join(__dirname, '..', 'package.json')).version);
   if (typeof nodeJsVersion !== 'string') {
     return;
   }

--- a/packages/google-cloud-run/src/index.js
+++ b/packages/google-cloud-run/src/index.js
@@ -8,9 +8,9 @@ const path = require('path');
 // MAINTENANCE NOTE: All code in this file needs to be compatible with all Node.js versions >= 6.0.0.
 
 try {
-  const nodeJsVersion = process.version;
   // eslint-disable-next-line no-console
   console.log('@instana/google-cloud-run module version:', require(path.join(__dirname, '..', 'package.json')).version);
+  const nodeJsVersion = process.version;
   if (typeof nodeJsVersion !== 'string') {
     return;
   }

--- a/packages/google-cloud-run/src/index.js
+++ b/packages/google-cloud-run/src/index.js
@@ -9,6 +9,7 @@ const path = require('path');
 
 try {
   const nodeJsVersion = process.version;
+  // eslint-disable-next-line no-console
   console.log('@instana/google-cloud-run module version:', require(path.join(__dirname, '..', 'package.json')).version);
   if (typeof nodeJsVersion !== 'string') {
     return;


### PR DESCRIPTION
This change adds a version information for any NPM packages: aws-lambda, fargate and Google Cloud Run