### PR TITLE
chore: fixed sqs queue name and improved naming criteria on aws

### DIFF
--- a/bin/clean-aws.js
+++ b/bin/clean-aws.js
@@ -22,7 +22,7 @@ const dynamoDbInfo = {
   api: dynamoDb,
   listFunction: 'listTables',
   listProperty: 'TableNames',
-  criteria: 'nodejs-team-',
+  criteria: 'nodejs-team',
   limit: 50,
   attributesFunction: 'describeTable',
   getAttributesParams(item) {
@@ -103,7 +103,7 @@ const kinesisInfo = {
   listProperty: 'StreamNames',
   // itemAttribute: 'Name', // if item is not a string but an object, we can do item[itemAttribute]
   // itemDateAttribute: 'CreationDate', // if the item object already has a date value, so we use this instead
-  criteria: 'nodejs-team-',
+  criteria: 'nodejs-team',
   attributesFunction: 'describeStream',
   getAttributesParams(item) {
     return { StreamName: item };
@@ -128,7 +128,7 @@ const sqsInfo = {
   api: sqs,
   listFunction: 'listQueues',
   listProperty: 'QueueUrls',
-  criteria: 'https://sqs.us-east-2.amazonaws.com/410797082306/nodejs-team-',
+  criteria: 'https://sqs.us-east-2.amazonaws.com/410797082306/nodejs-team',
   attributesFunction: 'getQueueAttributes',
   getAttributesParams(item) {
     return { QueueUrl: item, AttributeNames: ['LastModifiedTimestamp'] };
@@ -156,7 +156,7 @@ const snsInfo = {
   listFunction: 'listTopics',
   listProperty: 'Topics',
   itemAttribute: 'TopicArn',
-  criteria: 'arn:aws:sns:us-east-2:410797082306:nodejs-team-',
+  criteria: 'arn:aws:sns:us-east-2:410797082306:nodejs-team',
   attributesFunction: 'getTopicAttributes',
   getAttributesParams(item) {
     return item;

--- a/packages/collector/test/tracing/cloud/aws-sdk/v2/sqs/test.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v2/sqs/test.js
@@ -29,7 +29,7 @@ const defaultPrefix = 'https://sqs.us-east-2.amazonaws.com/410797082306/';
 const queueUrlPrefix = process.env.SQS_QUEUE_URL_PREFIX || defaultPrefix;
 
 const queueNamePrefix = process.env.SQS_QUEUE_NAME || 'nodejs-team';
-const queueName = `${queueNamePrefix}${semver.major(process.versions.node)}-${uuid()}`;
+const queueName = `${queueNamePrefix}-${semver.major(process.versions.node)}-${uuid()}`;
 const queueURL = `${queueUrlPrefix}${queueName}`;
 
 let mochaSuiteFn;


### PR DESCRIPTION
- background: we had dead sqs queues in aws again, yey