### PR TITLE
feat(sqs-consumer): support for sqs-consumer v7 -test branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -156,6 +156,7 @@
         "socket.io-client": "^4.6.0",
         "sqs-consumer": "5.7.0",
         "sqs-consumer-v6": "npm:sqs-consumer@^6.2.0",
+        "sqs-consumer-v7": "npm:sqs-consumer@^7.4.0",
         "superagent": "^6.1.0",
         "tsoa": "^3.14.1",
         "typescript": "^5.0.4",
@@ -46764,6 +46765,46 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/sqs-consumer-v7": {
+      "name": "sqs-consumer",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/sqs-consumer/-/sqs-consumer-7.4.0.tgz",
+      "integrity": "sha512-pDbvJKV86CKESLnsYLJg6/8Zw0BXnWbh5DW+H54rLoyxRWp/Wbe/7w1C8XCisWP0a/8PmgAl0sstsc9XmyuAjg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sqs": "^3.428.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sqs": "^3.428.0"
+      }
+    },
+    "node_modules/sqs-consumer-v7/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sqs-consumer-v7/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
     "node_modules/sqs-consumer/node_modules/debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -87412,6 +87453,33 @@
       "dev": true,
       "requires": {
         "@aws-sdk/client-sqs": "^3.241.0",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "sqs-consumer-v7": {
+      "version": "npm:sqs-consumer@7.4.0",
+      "resolved": "https://registry.npmjs.org/sqs-consumer/-/sqs-consumer-7.4.0.tgz",
+      "integrity": "sha512-pDbvJKV86CKESLnsYLJg6/8Zw0BXnWbh5DW+H54rLoyxRWp/Wbe/7w1C8XCisWP0a/8PmgAl0sstsc9XmyuAjg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-sqs": "^3.428.0",
         "debug": "^4.3.4"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,7 +155,6 @@
         "socket.io": "^4.6.0",
         "socket.io-client": "^4.6.0",
         "sqs-consumer": "5.7.0",
-        "sqs-consumer-v6": "npm:sqs-consumer@^6.2.0",
         "sqs-consumer-v7": "npm:sqs-consumer@^7.4.0",
         "superagent": "^6.1.0",
         "tsoa": "^3.14.1",
@@ -46728,43 +46727,6 @@
         "aws-sdk": "^2.1114.0"
       }
     },
-    "node_modules/sqs-consumer-v6": {
-      "name": "sqs-consumer",
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/sqs-consumer/-/sqs-consumer-6.2.0.tgz",
-      "integrity": "sha512-H6lzdD/kQ5FL8HMfvZbiTROadlS/Gkeg82tieFMBf/0cqdNHJa2Xc7Yx8X2W/kzUBwuD1rLeKQoGlxbCowUsnw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/client-sqs": "^3.241.0",
-        "debug": "^4.3.4"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sqs": "^3.241.0"
-      }
-    },
-    "node_modules/sqs-consumer-v6/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/sqs-consumer-v6/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node_modules/sqs-consumer-v7": {
       "name": "sqs-consumer",
       "version": "7.4.0",
@@ -87433,33 +87395,6 @@
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
-      }
-    },
-    "sqs-consumer-v6": {
-      "version": "npm:sqs-consumer@6.2.0",
-      "resolved": "https://registry.npmjs.org/sqs-consumer/-/sqs-consumer-6.2.0.tgz",
-      "integrity": "sha512-H6lzdD/kQ5FL8HMfvZbiTROadlS/Gkeg82tieFMBf/0cqdNHJa2Xc7Yx8X2W/kzUBwuD1rLeKQoGlxbCowUsnw==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/client-sqs": "^3.241.0",
-        "debug": "^4.3.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"

--- a/package.json
+++ b/package.json
@@ -201,7 +201,6 @@
     "socket.io": "^4.6.0",
     "socket.io-client": "^4.6.0",
     "sqs-consumer": "5.7.0",
-    "sqs-consumer-v6": "npm:sqs-consumer@^6.2.0",
     "sqs-consumer-v7": "npm:sqs-consumer@^7.4.0",
     "superagent": "^6.1.0",
     "tsoa": "^3.14.1",

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "socket.io-client": "^4.6.0",
     "sqs-consumer": "5.7.0",
     "sqs-consumer-v6": "npm:sqs-consumer@^6.2.0",
+    "sqs-consumer-v7": "npm:sqs-consumer@^7.4.0",
     "superagent": "^6.1.0",
     "tsoa": "^3.14.1",
     "typescript": "^5.0.4",

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sqs-consumer.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/sqs-consumer.js
@@ -10,7 +10,7 @@ if (process.env.AWS_SDK_CLIENT_SQS_REQUIRE !== '@aws-sdk/client-sqs') {
   mock('@aws-sdk/client-sqs', process.env.AWS_SDK_CLIENT_SQS_REQUIRE);
 }
 
-mock('sqs-consumer', 'sqs-consumer-v6');
+mock('sqs-consumer', 'sqs-consumer-v7');
 
 const instana = require('../../../../../../src')();
 const express = require('express');

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
@@ -586,9 +586,9 @@ function start(version) {
       if (withError !== 'publisher') {
         const sqsEntry = verifySQSEntry({ receiverControls, spans, parent: sqsExit, withError, isBatch });
         /**
-       * When receiving messages in batch, SQS may not send all messages in one batch and we cannot guarantee that all 
-       * messages will be in the batch. The expectation can vary for the no:of http exit spans sent per message  received.
-       * So we are expectign atleast one matching for http exit spans.
+       * When receiving messages in batch, SQS may not send all messages in one batch and we cannot guarantee that all
+       * messages will be in the batch. The expectation can vary for the no:of http exit spans sent per message
+       * received. So we are expectign atleast one matching for http exit spans.
        */
 
         if (isSQSConsumer) {

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
@@ -45,7 +45,7 @@ function start(version) {
     mochaSuiteFn = describe;
   }
 
-  mochaSuiteFn.only(`npm: ${version}`, function () {
+  mochaSuiteFn(`npm: ${version}`, function () {
     this.timeout(config.getTestTimeout() * 4);
 
     let queueName = 'nodejs-team';
@@ -184,7 +184,7 @@ function start(version) {
       });
 
       // See https://github.com/bbc/sqs-consumer/issues/356
-      if (version !== '@aws-sdk/client-sqs' && semver.gte(process.versions.node, '14.0.0')) {
+      if (version !== '@aws-sdk/client-sqs' && semver.gte(process.versions.node, '18.0.0')) {
         describe('sqs-consumer API', () => {
           describe('[handleMessage] message processed with success', () => {
             const sqsConsumerControls = new ProcessControls({

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
@@ -17,8 +17,7 @@ const {
   expectAtLeastOneMatching,
   retry,
   delay,
-  stringifyItems,
-  expectExactlyNMatching
+  stringifyItems
 } = require('../../../../../../../core/test/test_util');
 const ProcessControls = require('../../../../../test_util/ProcessControls');
 const globalAgent = require('../../../../../globalAgent');
@@ -586,6 +585,11 @@ function start(version) {
 
       if (withError !== 'publisher') {
         const sqsEntry = verifySQSEntry({ receiverControls, spans, parent: sqsExit, withError, isBatch });
+        /**
+       * When receiving messages in batch, SQS may not send all messages in one batch and we cannot guarantee that all 
+       * messages will be in the batch. The expectation can vary for the no:of http exit spans sent per message  received.
+       * So we are expectign atleast one matching for http exit spans.
+       */
 
         if (isSQSConsumer) {
           verifyHttpExit({

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/test_definition.js
@@ -45,7 +45,7 @@ function start(version) {
     mochaSuiteFn = describe;
   }
 
-  mochaSuiteFn(`npm: ${version}`, function () {
+  mochaSuiteFn.only(`npm: ${version}`, function () {
     this.timeout(config.getTestTimeout() * 4);
 
     let queueName = 'nodejs-team';
@@ -593,7 +593,7 @@ function start(version) {
             parent: sqsEntry,
             pid: String(receiverControls.getPid()),
             testMethod: (exitSpans, tests) => {
-              return expectExactlyNMatching(exitSpans, 4, tests);
+              return expectAtLeastOneMatching(exitSpans, tests);
             }
           });
         } else {


### PR DESCRIPTION
V7 has made node v18.X as minimum required version. Removed the testing for V6, since the instrumentation however remain the same and V7 still support aws sdk v3