### PR TITLE
(v3) chore: unified docker base images

### DIFF
--- a/dockerfile-examples/Dockerfile.node-16.13.0
+++ b/dockerfile-examples/Dockerfile.node-16.13.0
@@ -2,7 +2,7 @@
 # Native addons will work since the base image (Debian Buster) has all
 # dependencies installed out of the box.
 
-FROM node:16.13.0
+FROM node:16
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install --only=production

--- a/packages/aws-fargate/images/instana-aws-fargate/Dockerfile-local
+++ b/packages/aws-fargate/images/instana-aws-fargate/Dockerfile-local
@@ -1,4 +1,4 @@
-FROM node:18-buster AS instana-aws-fargate-build-nodejs
+FROM node:18 AS instana-aws-fargate-build-nodejs
 
 WORKDIR /instana
 COPY package.json ./

--- a/packages/aws-fargate/images/instana-aws-fargate/Dockerfile-npm
+++ b/packages/aws-fargate/images/instana-aws-fargate/Dockerfile-npm
@@ -1,4 +1,4 @@
-FROM node:18.18.2-buster AS instana-aws-fargate-build-nodejs
+FROM node:18 AS instana-aws-fargate-build-nodejs
 
 ARG package_version
 WORKDIR /instana

--- a/packages/google-cloud-run/images/instana-google-cloud-run/Dockerfile-local
+++ b/packages/google-cloud-run/images/instana-google-cloud-run/Dockerfile-local
@@ -1,4 +1,4 @@
-FROM node:18-buster AS instana-google-cloud-run-build-nodejs
+FROM node:18 AS instana-google-cloud-run-build-nodejs
 
 WORKDIR /instana
 COPY package.json ./

--- a/packages/google-cloud-run/images/instana-google-cloud-run/Dockerfile-npm
+++ b/packages/google-cloud-run/images/instana-google-cloud-run/Dockerfile-npm
@@ -1,4 +1,4 @@
-FROM node:18-buster AS instana-google-cloud-run-build-nodejs
+FROM node:18 AS instana-google-cloud-run-build-nodejs
 
 ARG package_version
 WORKDIR /instana


### PR DESCRIPTION
- always go with latest debian
- no buster and co

[ci skip]