### PR TITLE
build: removed usage of :latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,10 +91,10 @@ jobs:
             git --no-pager diff --cached
             git --no-pager diff
           elif [[ $FROM_PACKAGE = true ]]; then
-            npx lerna publish --yes --no-verify-access from-package
+            npx lerna publish --dist-tag v2 --yes --no-verify-access from-package
             git log -p -n1
           else
-            npx lerna publish --yes --no-verify-access
+            npx lerna publish --dist-tag v2 --yes --no-verify-access
             git log -p -n1
           fi
 

--- a/packages/aws-lambda/layer/bin/publish-layer.sh
+++ b/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -393,7 +393,7 @@ if [[ -z $SKIP_DOCKER_IMAGE ]]; then
   echo "step 7/9: building docker image for container image based Lambda layer"
   docker build . -t "$DOCKER_IMAGE_NAME:$VERSION"
 
-  # NOTE: serverless/ci/pipeline.yaml passes PACKAGE_VERSION=1 for 1.x branch
+  # NOTE: serverless/ci/pipeline.yaml passes PACKAGE_VERSION=X for e.g. 1.x or 2.x branch
   if [[ $PACKAGE_VERSION == latest ]]; then
     docker tag $DOCKER_IMAGE_NAME:$VERSION $DOCKER_IMAGE_NAME:latest
   fi

--- a/packages/serverless/ci/pipeline.yaml
+++ b/packages/serverless/ci/pipeline.yaml
@@ -47,7 +47,8 @@ resources:
       repository: icr.io/instana/aws-fargate-nodejs
       username: ((concourse-icr-containers-public.apikey))
       password: ((concourse-icr-containers-public.password))
-      tag: latest
+      # NOTE: Deliberately omitting `tag: latest` here on the branch for 2.x so
+      # we do not accidentally tag 2.x image versions with `latest`.
 
   - name: aws-fargate-nodejs-image-containers-instana-io
     type: registry-image
@@ -61,7 +62,8 @@ resources:
       repository: delivery.instana.io/rel-docker-agent-local/agent/aws/fargate/nodejs
       username: ((delivery-instana-io-release-project-artifact-read-writer-creds.username))
       password: ((delivery-instana-io-release-project-artifact-read-writer-creds.password))
-      tag: latest
+      # NOTE: Deliberately omitting `tag: latest` here on the branch for 2.x so
+      # we do not accidentally tag 2.x image versions with `latest`.
 
   - name: instana-google-cloud-run-npm-package
     type: npm-resource
@@ -79,7 +81,8 @@ resources:
       repository: icr.io/instana/google-cloud-run-nodejs
       username: ((concourse-icr-containers-public.apikey))
       password: ((concourse-icr-containers-public.password))
-      tag: latest
+      # NOTE: Deliberately omitting `tag: latest` here on the branch for 2.x so
+      # we do not accidentally tag 2.x image versions with `latest`.
 
   - name: google-cloud-run-nodejs-image-containers-instana-io
     type: registry-image
@@ -93,7 +96,8 @@ resources:
       repository: delivery.instana.io/rel-docker-agent-local/agent/google/cloud-run/nodejs
       username: ((delivery-instana-io-release-project-artifact-read-writer-creds.username))
       password: ((delivery-instana-io-release-project-artifact-read-writer-creds.password))
-      tag: latest
+      # NOTE: Deliberately omitting `tag: latest` here on the branch for 2.x so
+      # we do not accidentally tag 2.x image versions with `latest`.
 
   - name: instana-aws-lambda-npm-package
     type: npm-resource
@@ -176,6 +180,7 @@ jobs:
       - put: aws-fargate-nodejs-image-icr
         params:
           image: image/image.tar
+          # In fact, on the branch for 2.x, this will be the only tag, not an _additional_ tag.
           additional_tags: instana-aws-fargate-npm-package/version
         get_params:
           skip_download: true
@@ -183,6 +188,7 @@ jobs:
       - put: aws-fargate-nodejs-image-containers-instana-io
         params:
           image: image/image.tar
+          # In fact, on the branch for 1.x, this will be the only tag, not an _additional_ tag.
           additional_tags: instana-aws-fargate-npm-package/version
         get_params:
           skip_download: true
@@ -264,12 +270,14 @@ jobs:
       - put: google-cloud-run-nodejs-image-icr
         params:
           image: image/image.tar
+          # In fact, on the branch for 1.x, this will be the only tag, not an _additional_ tag.
           additional_tags: instana-google-cloud-run-npm-package/version
         get_params:
           skip_download: true
       - put: google-cloud-run-nodejs-image-containers-instana-io
         params:
           image: image/image.tar
+          # In fact, on the branch for 1.x, this will be the only tag, not an _additional_ tag.
           additional_tags: instana-google-cloud-run-npm-package/version
         get_params:
           skip_download: true
@@ -355,12 +363,15 @@ jobs:
           platform: linux
           inputs:
             - name: nodejs-repository
+          # Passing in PACKAGE_VERSION=2 will use the latest 2.x package and also avoid tagging the resulting
+          # container image as latest.            
           run:
             path: entrypoint.sh
             args:
             - bash
             - -ceux
             - |
+                PACKAGE_VERSION=2 \
                 BUILD_LAYER_WITH=npm \
                 NO_PROMPT=true \
                 CONTAINER_REGISTRY_USER=iamapikey \
@@ -378,12 +389,15 @@ jobs:
           platform: linux
           inputs:
             - name: nodejs-repository
+          # Passing in PACKAGE_VERSION=2 will use the latest 2.x package and also avoid tagging the resulting
+          # container image as latest.
           run:
             path: entrypoint.sh
             args:
             - bash
             - -ceux
             - |
+                PACKAGE_VERSION=2 \
                 BUILD_LAYER_WITH=npm \
                 NO_PROMPT=true \
                 LAMBDA_ARCHITECTURE=arm64 \


### PR DESCRIPTION
This change prevents 2.x images as being tagged as latest.

[skip ci]