### PR TITLE
fix: ignored opentelemetry spans which are not traces by us

### DIFF
--- a/packages/core/src/tracing/opentelemetry-instrumentations/wrap.js
+++ b/packages/core/src/tracing/opentelemetry-instrumentations/wrap.js
@@ -53,6 +53,10 @@ module.exports.init = (_config, cls) => {
       if (targetInstrumentationModule.transform) {
         otelSpan = targetInstrumentationModule.transform(otelSpan);
       }
+    } else {
+      // CASE: A customer has installed an Opentelemetry instrumentation, but
+      //       we do not want to capture these spans. We only support our own set of modules.
+      return;
     }
 
     if (cls.tracingSuppressed()) {


### PR DESCRIPTION
- install any opentelemetry instrumentation inside the client / customer appliation + use our Instana collector
- it will add Otel spans for this instrumentation although we do not support it as part of our integration
- found this issue in https://github.com/instana/nodejs/pull/967