### PR TITLE
feat(aws-lambda): added support for Node.js 20 AWS Lambda runtime

### DIFF
--- a/packages/aws-lambda/layer/bin/publish-layer.sh
+++ b/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -357,7 +357,7 @@ if [[ -z $SKIP_AWS_PUBLISH_LAYER ]]; then
           --license-info $LICENSE \
           --zip-file fileb://$ZIP_NAME \
           --output json \
-          --compatible-runtimes nodejs14.x nodejs16.x nodejs18.x \
+          --compatible-runtimes nodejs14.x nodejs16.x nodejs18.x nodejs20.x \
           | jq '.Version' \
       )
 


### PR DESCRIPTION
Node.js 20.x runtime now available in AWS Lambda, [reference](**url**) 