### PR TITLE
test: revised localstack configuration for AWS Lambda invocation on arm64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,7 +189,7 @@ services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
     image: localstack/localstack:latest
-    hostname: localstack
+    platform: linux/amd64
     ports:
       - "4566:4566"            # LocalStack Gateway
       - "4510-4559:4510-4559"  # external services port range
@@ -199,4 +199,3 @@ services:
       - LAMBDA_INIT_USER=root
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
-      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,5 +196,7 @@ services:
     environment:
       - DEBUG=${DEBUG-}
       - DOCKER_HOST=unix:///var/run/docker.sock 
+      - LAMBDA_INIT_USER=root
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,9 +187,8 @@ services:
        - ./db2/db2_data:/db2_data
 
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
     image: localstack/localstack:latest
-    platform: linux/amd64
     ports:
       - "4566:4566"            # LocalStack Gateway
       - "4510-4559:4510-4559"  # external services port range

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/lambda/utils.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/lambda/utils.js
@@ -13,18 +13,18 @@ const {
 const AdmZip = require('adm-zip');
 const { isCI } = require('@instana/core/test/test_util');
 /**
- *  Local stack is disabled if running in CI environment or on an ARM64 architecture.
- *  Lambda invocation is currently not running on ARM64 architectures, and CircleCI requires additional configuration
+ *  Local stack is disabled if running in CI environment.
+ *  Lambda invocation is currently not running on CircleCI requires additional configuration
  *  to handle Lambda functions within LocalStack. This involves setting up a volume mount, which may not be
  *  supported with the current Docker executor options in circleci.
- *  GH issues: https://github.com/localstack/localstack/issues/8878, https://discuss.localstack.cloud
+ *  GH issues: https://discuss.localstack.cloud
  *  /t/lambda-is-currently-not-working-on-circleci-for-my-current-docker-configurations/535
  *  For more detailed information about CircleCI and LocalStack integration, please refer to the official documentation:
  *  CircleCI LocalStack Orb Executors. https://circleci.com/developer/orbs/orb/localstack/platform
- *  TODO: Implement support for running Lambda function tests on LocalStack with CircleCI and ARM64 architecture.
+ *  TODO: Implement support for running Lambda function tests on LocalStack with CircleCI.
  */
 exports.isLocalStackDisabled = function () {
-  return isCI() || process.arch === 'arm64';
+  return isCI();
 };
 
 exports.getClientConfig = function () {


### PR DESCRIPTION
The changes are related to the local stack timeout issue in arm64; for additional information, see localstack/localstack#8878 (comment).