### PR TITLE
fix: deprecated request module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,7 +139,6 @@
         "recursive-copy": "^2.0.14",
         "redis": "^4.3.1",
         "redis-v3": "npm:redis@^3.1.2",
-        "request": "^2.88.0",
         "request-promise": "^4.2.2",
         "request-promise-native": "^1.0.5",
         "restify": "^8.6.1",
@@ -19379,6 +19378,7 @@
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -19387,7 +19387,8 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/axe-core": {
       "version": "4.8.2",
@@ -20377,7 +20378,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/ccount": {
       "version": "1.1.0",
@@ -24691,6 +24693,7 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -25684,6 +25687,7 @@
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -25694,6 +25698,7 @@
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "deprecated": "this library is no longer supported",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -27303,7 +27308,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -32749,6 +32755,7 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -33775,7 +33782,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/pg": {
       "version": "8.11.3",
@@ -36035,6 +36043,7 @@
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -36118,6 +36127,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -36132,6 +36142,7 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -36142,6 +36153,7 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
+      "peer": true,
       "bin": {
         "uuid": "bin/uuid"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,6 +151,7 @@
         "socket.io-client": "^4.6.0",
         "sqs-consumer": "^7.4.0",
         "sqs-consumer-v5": "npm:sqs-consumer@^5.7.0",
+        "stealthy-require": "1.1.1",
         "superagent": "^8.1.2",
         "tsoa": "^3.14.1",
         "typescript": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "socket.io-client": "^4.6.0",
     "sqs-consumer": "^7.4.0",
     "sqs-consumer-v5": "npm:sqs-consumer@^5.7.0",
+    "stealthy-require": "1.1.1",
     "superagent": "^8.1.2",
     "tsoa": "^3.14.1",
     "typescript": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,6 @@
     "recursive-copy": "^2.0.14",
     "redis": "^4.3.1",
     "redis-v3": "npm:redis@^3.1.2",
-    "request": "^2.88.0",
     "request-promise": "^4.2.2",
     "request-promise-native": "^1.0.5",
     "restify": "^8.6.1",

--- a/packages/collector/dummy-app/package.json
+++ b/packages/collector/dummy-app/package.json
@@ -9,7 +9,6 @@
     "@instana/collector": "latest",
     "dotenv": "^5.0.1",
     "express": "^4.16.3",
-    "request": "^2.85.0",
     "request-promise": "^4.2.5"
   }
 }

--- a/packages/collector/test/tracing/control_flow/async_await/app.js
+++ b/packages/collector/test/tracing/control_flow/async_await/app.js
@@ -5,8 +5,8 @@
 
 'use strict';
 
+const fetch = require('node-fetch');
 const rp = require('request-promise');
-const request = require('request');
 
 require('../../../..')({
   agentPort: process.env.AGENT_PORT,
@@ -68,20 +68,17 @@ async function sendRequest(requestOptions) {
     return response;
   }
 
-  // a custom wrapper around request. Yes, this exists out of the box for request, but this
-  // is supposed to be a repro case for a customer issue.
-  const response = await new Promise((resolve, reject) => {
-    request(requestOptions, (error, res) => {
-      if (error) {
-        reject(error);
-      } else if (res.statusCode >= 200 && res.statusCode <= 299) {
-        resolve(res);
-      } else {
-        reject(res);
-      }
-    });
+  const url = `${requestOptions.uri}${requestOptions.query ? `?${new URLSearchParams(requestOptions.query)}` : ''}`;
+  const response = await fetch(url, {
+    method: requestOptions.method
   });
-  return response;
+  if (response.ok) {
+    return {
+      statusCode: response.status
+    };
+  } else {
+    throw response;
+  }
 }
 
 app.listen(port, () => {

--- a/packages/collector/test/tracing/control_flow/native_promise/app.js
+++ b/packages/collector/test/tracing/control_flow/native_promise/app.js
@@ -6,8 +6,7 @@
 'use strict';
 
 const instana = require('../../../..')();
-
-const request = require('request');
+const fetch = require('node-fetch');
 const bodyParser = require('body-parser');
 const EventEmitter = require('events');
 const express = require('express');
@@ -51,13 +50,16 @@ app.get('/rejected', (req, res) => {
 
 app.get('/childHttpCall', (req, res) => {
   new Promise((resolve, reject) => {
-    request('http://127.0.0.1:65212', (err, response) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(response);
-      }
-    });
+    fetch('http://127.0.0.1:65212')
+      .then(response => {
+        if (!response.ok) {
+          // eslint-disable-next-line prefer-promise-reject-errors
+          reject(`HTTP error! Status: ${response.status}`);
+        } else {
+          resolve(response);
+        }
+      })
+      .catch(err => reject(err));
   })
     .catch(() => delay(20))
     .then(() => {

--- a/packages/collector/test/tracing/misc/require_hook/app.js
+++ b/packages/collector/test/tracing/misc/require_hook/app.js
@@ -12,6 +12,7 @@ require('../../../..')();
 const bodyParser = require('body-parser');
 const express = require('express');
 const morgan = require('morgan');
+const fetch = require('node-fetch');
 const port = require('../../../test_util/app-port')();
 const app = express();
 const logPrefix = `requireHook App (${process.pid}):\t`;
@@ -26,11 +27,16 @@ app.get('/', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/requireRequestPromiseMultipleTimes', (req, res) => {
-  require('request');
-  require('request-promise'); // executes stealthy-require
-  require('request-promise-native'); // executes stealthy-require
-  res.sendStatus(200);
+app.get('/requireRequestPromiseMultipleTimes', async (req, res) => {
+  try {
+    await fetch('https://example.com/test1');
+    await fetch('https://example.com/test2');
+    await fetch('https://example.com/test3');
+    res.sendStatus(200);
+  } catch (error) {
+    console.error(error);
+    res.sendStatus(500);
+  }
 });
 
 app.listen(port, () => {

--- a/packages/collector/test/tracing/misc/require_hook/app.js
+++ b/packages/collector/test/tracing/misc/require_hook/app.js
@@ -32,7 +32,11 @@ app.get('/multipleRequireWithStealthyRequire', async (req, res) => {
   const firstInstanceOfGot = stealthyRequire(require.cache, () => require('got'));
   const secondInstanceOfGot = stealthyRequire(require.cache, () => require('got'));
 
-  // Check if the two instances of 'got' are different
+  // Verify that the two instances of the 'got' module are different. In this scenario, we emulate the behavior of
+  // stealthy-require, ensuring that each time we load the module, it is a fresh instance. This precaution is taken
+  // to prevent require caching, and to guarantee the loading of a new module each time, as discussed and resolved
+  // in the following PR: https://github.com/instana/nodejs/pull/71
+
   if (firstInstanceOfGot !== secondInstanceOfGot) {
     res.sendStatus(200);
   } else {

--- a/packages/collector/test/tracing/misc/require_hook/test.js
+++ b/packages/collector/test/tracing/misc/require_hook/test.js
@@ -32,7 +32,7 @@ mochaSuiteFn('tracing/requireHook', function () {
       controls
         .sendRequest({
           method: 'GET',
-          path: '/multipleRequestsWithStealthyRequire'
+          path: '/multipleRequireWithStealthyRequire'
         })
         .then(() =>
           testUtils.retry(() =>

--- a/packages/collector/test/tracing/misc/require_hook/test.js
+++ b/packages/collector/test/tracing/misc/require_hook/test.js
@@ -32,7 +32,7 @@ mochaSuiteFn('tracing/requireHook', function () {
       controls
         .sendRequest({
           method: 'GET',
-          path: '/requireRequestPromiseMultipleTimes'
+          path: '/multipleRequestsWithStealthyRequire'
         })
         .then(() =>
           testUtils.retry(() =>

--- a/packages/collector/test/tracing/misc/stack_trace/test.js
+++ b/packages/collector/test/tracing/misc/stack_trace/test.js
@@ -11,6 +11,7 @@ const supportedVersion = require('@instana/core').tracing.supportedVersion;
 const config = require('../../../../../core/test/config');
 const testUtils = require('../../../../../core/test/test_util');
 const globalAgent = require('../../../globalAgent');
+const constants = require('@instana/core').tracing.constants;
 
 const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 
@@ -97,8 +98,9 @@ mochaSuiteFn('tracing/stackTraces', function () {
             agentControls.getSpans().then(spans => {
               testUtils.expectAtLeastOneMatching(spans, [
                 span => expect(span.n).to.equal('node.http.client'),
-                span => expect(span.stack[0].m).to.equal('Request.Request.start [as start]'),
-                span => expect(span.stack[0].c).to.match(/request\.js$/i)
+                span => expect(span.k).to.equal(constants.EXIT),
+                span => expect(span.stack[2].m).to.equal('fetch'),
+                span => expect(span.stack[2].c).to.contains('node-fetch')
               ]);
             })
           )

--- a/packages/collector/test/tracing/protocols/http/proxy/expressProxy.js
+++ b/packages/collector/test/tracing/protocols/http/proxy/expressProxy.js
@@ -20,7 +20,6 @@ require('../../../../..')({
 });
 
 const express = require('express');
-const request = require('request');
 const fetch = require('node-fetch');
 const port = require('../../../../test_util/app-port')();
 const app = express();
@@ -40,38 +39,17 @@ app.use((req, res) => {
       url = `http://localhost:${process.env.UPSTREAM_PORT}/proxy-call${req.url}`;
     }
 
-    if (req.query.httpLib === 'node-fetch') {
-      // use node-fetch
-      fetch(url, {
-        method: req.method,
-        timeout: 500
+    fetch(url, {
+      method: req.method,
+      timeout: 500
+    })
+      .then(response => {
+        res.sendStatus(response.status);
       })
-        .then(response => {
-          res.sendStatus(response.status);
-        })
-        .catch(err => {
-          res.sendStatus(500);
-          log('Unexpected error', err);
-        });
-    } else {
-      // use request package
-      request(
-        {
-          method: req.method,
-          url,
-          qs: req.query,
-          timeout: 500
-        },
-        (err, response) => {
-          if (err) {
-            res.sendStatus(500);
-            log('Unexpected error', err);
-          } else {
-            res.sendStatus(response.statusCode);
-          }
-        }
-      );
-    }
+      .catch(err => {
+        res.sendStatus(500);
+        log('Unexpected error', err);
+      });
   }, delay * 0.25);
 });
 

--- a/packages/collector/test/tracing/protocols/http/proxy/test.js
+++ b/packages/collector/test/tracing/protocols/http/proxy/test.js
@@ -99,8 +99,7 @@ mochaSuiteFn('http with proxy', function () {
         .sendRequest({
           method: 'POST',
           path: '/checkout',
-          responseStatus: 200,
-          httpLib: 'node-fetch'
+          responseStatus: 200
         })
         .then(() =>
           retry(() =>
@@ -187,15 +186,14 @@ mochaSuiteFn('http with proxy', function () {
           retry(() =>
             agentControls.getSpans().then(spans => {
               expectAtLeastOneMatching(spans, [
-                span => expect(span.n).to.equal('node.http.client'),
+                span => expect(span.n).to.equal('node.http.server'),
                 span => expect(span.error).to.not.exist,
                 span => expect(span.ec).to.equal(1),
                 span => expect(span.f.e).to.equal(String(expressProxyControls.getPid())),
                 span => expect(span.f.h).to.equal('agent-stub-uuid'),
                 span => expect(span.async).to.not.exist,
-                span => expect(span.data.http.error).to.be.a('string'),
                 span => expect(span.data.http.method).to.equal('POST'),
-                span => expect(span.data.http.url).to.equal('http://10.123.456.555:49162/foobar')
+                span => expect(span.data.http.url).to.equal('/callNonExistingTarget')
               ]);
             })
           )

--- a/packages/collector/test/tracing/protocols/http/proxy/test.js
+++ b/packages/collector/test/tracing/protocols/http/proxy/test.js
@@ -174,31 +174,6 @@ mochaSuiteFn('http with proxy', function () {
           )
         ));
 
-    it('must trace requests to non-existing targets', () =>
-      expressProxyControls
-        .sendRequest({
-          method: 'POST',
-          path: '/callNonExistingTarget',
-          responseStatus: 503,
-          target: 'http://10.123.456.555:49162/foobar'
-        })
-        .then(() =>
-          retry(() =>
-            agentControls.getSpans().then(spans => {
-              expectAtLeastOneMatching(spans, [
-                span => expect(span.n).to.equal('node.http.server'),
-                span => expect(span.error).to.not.exist,
-                span => expect(span.ec).to.equal(1),
-                span => expect(span.f.e).to.equal(String(expressProxyControls.getPid())),
-                span => expect(span.f.h).to.equal('agent-stub-uuid'),
-                span => expect(span.async).to.not.exist,
-                span => expect(span.data.http.method).to.equal('POST'),
-                span => expect(span.data.http.url).to.equal('/callNonExistingTarget')
-              ]);
-            })
-          )
-        ));
-
     it('must not explode when asked to request a malformed url', () =>
       expressProxyControls
         .sendRequest({

--- a/packages/core/src/tracing/instrumentation/messaging/kafkaNode.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafkaNode.js
@@ -26,7 +26,10 @@ exports.init = function init() {
 };
 
 function instrument(kafka) {
-  logger.warn('kafka-node is deprecated. The support will be removed in the next major release.');
+  logger.warn(
+    // eslint-disable-next-line max-len
+    '[Deprecation Warning] The kafka-node library is deprecated and will be removed in the next major release. Please consider migrating to an appropriate package.'
+  );
 
   shimmer.wrap(Object.getPrototypeOf(kafka.Producer.prototype), 'send', shimSend);
   shimmer.wrap(kafka.Consumer.prototype, 'emit', shimEmit);

--- a/packages/core/src/tracing/instrumentation/protocols/graphql.js
+++ b/packages/core/src/tracing/instrumentation/protocols/graphql.js
@@ -343,7 +343,8 @@ function shimApolloGatewayExecuteQueryPlanFunction(originalFunction) {
 }
 function logDeprecatedWarning() {
   logger.warn(
-    'The support for @apollo-federation has been deprecated, following its official end-of-life in September 2023.'
+    // eslint-disable-next-line max-len
+    '[Deprecation Warning] The support for @apollo-federation is deprecated and will be removed in the next major release. Please consider migrating to an appropriate package.'
   );
 }
 

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -19,6 +19,11 @@ const {
 const constants = require('../../constants');
 const cls = require('../../cls');
 const url = require('url');
+const requireHook = require('../../../util/requireHook');
+let logger;
+logger = require('../../../logger').getLogger('tracing/httpClient', newLogger => {
+  logger = newLogger;
+});
 
 let extraHttpHeadersToCapture;
 let isActive = false;
@@ -26,10 +31,12 @@ let isActive = false;
 exports.init = function init(config) {
   instrument(coreHttpModule, false);
   instrument(coreHttpsModule, true);
-
   extraHttpHeadersToCapture = config.tracing.http.extraHttpHeadersToCapture;
+  requireHook.onModuleLoad('request', logDeprecatedWarning);
 };
-
+function logDeprecatedWarning() {
+  logger.warn('The support for request has been deprecated.');
+}
 exports.updateConfig = function updateConfig(config) {
   extraHttpHeadersToCapture = config.tracing.http.extraHttpHeadersToCapture;
 };

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -35,7 +35,10 @@ exports.init = function init(config) {
   requireHook.onModuleLoad('request', logDeprecatedWarning);
 };
 function logDeprecatedWarning() {
-  logger.warn('The support for request has been deprecated.');
+  logger.warn(
+    // eslint-disable-next-line max-len
+    '[Deprecation Warning] The support for request library is deprecated and will be removed in the next major release. Please consider migrating to an appropriate package.'
+  );
 }
 exports.updateConfig = function updateConfig(config) {
   extraHttpHeadersToCapture = config.tracing.http.extraHttpHeadersToCapture;

--- a/packages/core/src/util/initializedTooLateHeuristic.js
+++ b/packages/core/src/util/initializedTooLateHeuristic.js
@@ -14,6 +14,8 @@ logger = require('../logger').getLogger('util/initializedTooLateHeuristic', newL
 let firstCall = true;
 let hasBeenInitializedTooLate = false;
 
+// These patterns is used to check against the loaded modules to determine if a module has been loaded earlier or not.
+
 let patterns = [
   /\/@apollo\/gateway\/dist\//,
   /\/@aws-sdk\/smithy-client\//,
@@ -96,6 +98,7 @@ module.exports = function hasThePackageBeenInitializedTooLate() {
       );
     }
 
+    // Iterate through loaded modules and patterns to check if any module has been loaded too early.
     for (let i = 0; i < loadedModules.length; i++) {
       for (let j = 0; j < patterns.length; j++) {
         if (patterns[j].test(loadedModules[i])) {

--- a/packages/core/src/util/initializedTooLateHeuristic.js
+++ b/packages/core/src/util/initializedTooLateHeuristic.js
@@ -63,7 +63,9 @@ let patterns = [
   /\/redis\/index.js/,
   /\/sqs-consumer\/dist\//,
   /\/superagent\/lib\/node\/index.js/,
-  /\/@smithy\/smithy-client\//
+  /\/@smithy\/smithy-client\//,
+  /\/request\/index.js/,
+  /\/@apollo\/federation\/dist\//
 ];
 
 const extraPatterns = [

--- a/packages/core/test/util/initializedTooLateHeuristic_test.js
+++ b/packages/core/test/util/initializedTooLateHeuristic_test.js
@@ -73,7 +73,7 @@ describe('[UNIT] util.initializedTooLateHeurstic', function () {
       }
 
       require.cache[resolvedPath] = {};
-      const exclude = ['bluebird', 'bunyan', 'winston', 'request'];
+      const exclude = ['bluebird', 'bunyan', 'winston'];
       const excluded = exclude.filter(n => resolvedPath.indexOf(n) !== -1);
 
       if (excluded.length) {

--- a/packages/core/test/util/initializedTooLateHeuristic_test.js
+++ b/packages/core/test/util/initializedTooLateHeuristic_test.js
@@ -73,7 +73,7 @@ describe('[UNIT] util.initializedTooLateHeurstic', function () {
       }
 
       require.cache[resolvedPath] = {};
-      const exclude = ['bluebird', 'bunyan', 'winston'];
+      const exclude = ['bluebird', 'bunyan', 'winston', 'request'];
       const excluded = exclude.filter(n => resolvedPath.indexOf(n) !== -1);
 
       if (excluded.length) {


### PR DESCRIPTION
- request module deprecated and replacing request with node-fetch

The request module has been officially deprecated. Consequently, we are substituting the request module with the node-fetch module, a lightweight and widely used package. Additionally, Node.js has a native fetch module available from version 18 onwards. Therefore, once we cease support for Node.js versions 14 and 16, we can seamlessly transition to using the fetch module from node-fetch.