### PR TITLE
fix: deprecated request-promise-native

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -140,7 +140,6 @@
         "redis": "^4.3.1",
         "redis-v3": "npm:redis@^3.1.2",
         "request-promise": "^4.2.2",
-        "request-promise-native": "^1.0.5",
         "restify": "^8.6.1",
         "rimraf": "^3.0.2",
         "semver": "^7.5.4",
@@ -36135,24 +36134,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "dev": true,
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
       },
       "peerDependencies": {
         "request": "^2.34"

--- a/package.json
+++ b/package.json
@@ -182,7 +182,6 @@
     "redis": "^4.3.1",
     "redis-v3": "npm:redis@^3.1.2",
     "request-promise": "^4.2.2",
-    "request-promise-native": "^1.0.5",
     "restify": "^8.6.1",
     "rimraf": "^3.0.2",
     "semver": "^7.5.4",

--- a/packages/collector/test/tracing/database/couchbase/app.js
+++ b/packages/collector/test/tracing/database/couchbase/app.js
@@ -12,7 +12,7 @@ const express = require('express');
 const uuid = require('uuid');
 const morgan = require('morgan');
 const requestPromise = require('request-promise');
-const request = require('request-promise-native');
+const fetch = require('node-fetch');
 const port = require('../../../test_util/app-port')();
 const { delay } = require('../../../../../core/test/test_util');
 const agentPort = process.env.INSTANA_AGENT_PORT;
@@ -195,7 +195,7 @@ app.get('/get-callback', (req, res) => {
   collection1.get('get-key-2', (err, result) => {
     if (err) return res.status(500).send({ err: err.message });
 
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json({ result: result.value });
     });
   });

--- a/packages/collector/test/tracing/database/couchbase/app.mjs
+++ b/packages/collector/test/tracing/database/couchbase/app.mjs
@@ -10,7 +10,7 @@ import express from 'express';
 import { v1 } from 'uuid';
 import morgan from 'morgan';
 import requestPromise from 'request-promise';
-const fetch = require('node-fetch');
+import fetch from 'node-fetch';
 import portFactory from '../../../test_util/app-port.js';
 import testUtil from '../../../../../core/test/test_util/index.js';
 

--- a/packages/collector/test/tracing/database/couchbase/app.mjs
+++ b/packages/collector/test/tracing/database/couchbase/app.mjs
@@ -10,7 +10,7 @@ import express from 'express';
 import { v1 } from 'uuid';
 import morgan from 'morgan';
 import requestPromise from 'request-promise';
-import request from 'request-promise-native';
+const fetch = require('node-fetch');
 import portFactory from '../../../test_util/app-port.js';
 import testUtil from '../../../../../core/test/test_util/index.js';
 
@@ -197,7 +197,7 @@ app.get('/get-callback', (req, res) => {
   collection1.get('get-key-2', (err, result) => {
     if (err) return res.status(500).send({ err: err.message });
 
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json({ result: result.value });
     });
   });

--- a/packages/collector/test/tracing/database/elasticsearch/app.js
+++ b/packages/collector/test/tracing/database/elasticsearch/app.js
@@ -15,7 +15,7 @@ require('../../../..')();
 const bodyParser = require('body-parser');
 const express = require('express');
 const morgan = require('morgan');
-const request = require('request-promise-native');
+const fetch = require('node-fetch');
 const { Client } = require('@elastic/elasticsearch');
 const port = require('../../../test_util/app-port')();
 
@@ -58,12 +58,12 @@ app.get('/get', (req, res) => {
         id: req.query.id
       })
       .then(response => {
-        request(`http://127.0.0.1:${agentPort}`).then(() => {
+        fetch(`http://127.0.0.1:${agentPort}`).then(() => {
           res.json({ response: commonReturnValue(response) });
         });
       })
       .catch(err => {
-        request(`http://127.0.0.1:${agentPort}`).then(() => {
+        fetch(`http://127.0.0.1:${agentPort}`).then(() => {
           res.json({ error: err });
         });
       });
@@ -76,7 +76,7 @@ app.get('/get', (req, res) => {
       {},
       (error, response) => {
         // Execute another traced call to verify that we keep the tracing context.
-        request(`http://127.0.0.1:${agentPort}`).then(() => {
+        fetch(`http://127.0.0.1:${agentPort}`).then(() => {
           res.json({ error, response: commonReturnValue(response) });
         });
       }
@@ -94,7 +94,7 @@ app.get('/search', (req, res) => {
     .then(response => {
       searchResponse = response;
       // Execute another traced call to verify that we keep the tracing context.
-      return request(`http://127.0.0.1:${agentPort}`);
+      return fetch(`http://127.0.0.1:${agentPort}`);
     })
     .then(() => {
       res.json({ response: commonReturnValue(searchResponse) });

--- a/packages/collector/test/tracing/database/pg/app.js
+++ b/packages/collector/test/tracing/database/pg/app.js
@@ -16,7 +16,7 @@ const Pool = _pg.Pool;
 const Client = _pg.Client;
 const express = require('express');
 const morgan = require('morgan');
-const request = require('request-promise-native');
+const fetch = require('node-fetch');
 const bodyParser = require('body-parser');
 const port = require('../../../test_util/app-port')();
 
@@ -62,7 +62,7 @@ app.get('/select-now-pool', (req, res) => {
       return res.sendStatus(500);
     }
     // Execute another traced call to verify that we keep the tracing context.
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -74,7 +74,7 @@ app.get('/select-now-no-pool-callback', (req, res) => {
       log('Failed to execute select now query', err);
       return res.sendStatus(500);
     }
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -84,7 +84,7 @@ app.get('/select-now-no-pool-promise', (req, res) => {
   client
     .query('SELECT NOW()')
     .then(results => {
-      request(`http://127.0.0.1:${agentPort}`).then(() => {
+      fetch(`http://127.0.0.1:${agentPort}`).then(() => {
         res.json(results);
       });
     })
@@ -110,7 +110,7 @@ app.get('/pool-string-insert', (req, res) => {
       log('Failed to execute pool insert', err);
       return res.sendStatus(500);
     }
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -126,7 +126,7 @@ app.get('/pool-config-select', (req, res) => {
       log('Failed to execute pool config insert', err);
       return res.sendStatus(500);
     }
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -141,7 +141,7 @@ app.get('/pool-config-select-promise', (req, res) => {
   pool
     .query(query)
     .then(results => {
-      request(`http://127.0.0.1:${agentPort}`).then(() => {
+      fetch(`http://127.0.0.1:${agentPort}`).then(() => {
         res.json(results);
       });
     })
@@ -160,7 +160,7 @@ app.get('/client-string-insert', (req, res) => {
       log('Failed to execute client insert', err);
       return res.sendStatus(500);
     }
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -176,7 +176,7 @@ app.get('/client-config-select', (req, res) => {
       log('Failed to execute client select', err);
       return res.sendStatus(500);
     }
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -187,7 +187,7 @@ app.get('/table-doesnt-exist', (req, res) => {
     .query('SELECT name, email FROM nonexistanttable')
     .then(r => res.json(r))
     .catch(e => {
-      request(`http://127.0.0.1:${agentPort}`).then(() => {
+      fetch(`http://127.0.0.1:${agentPort}`).then(() => {
         res.status(500).json(e);
       });
     });
@@ -217,7 +217,7 @@ app.get('/transaction', (req, res) => {
             log('Failed to execute client transaction', err4);
             return res.status(500).json(err4);
           }
-          request(`http://127.0.0.1:${agentPort}`).then(() => res.json(result3));
+          fetch(`http://127.0.0.1:${agentPort}`).then(() => res.json(result3));
         });
       });
     });
@@ -262,7 +262,7 @@ app.get('/asynchronous-query', async (req, res) => {
       secondQuery: secondQueryResults,
       thirdQuery: thirdQueryResults
     };
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(combinedResults);
     });
   } catch (err) {

--- a/packages/collector/test/tracing/database/pg/app.mjs
+++ b/packages/collector/test/tracing/database/pg/app.mjs
@@ -14,7 +14,7 @@ const Pool = _pg.Pool;
 const Client = _pg.Client;
 import express from 'express';
 import morgan from 'morgan';
-const fetch = require('node-fetch');
+import fetch from 'node-fetch';
 import bodyParser from 'body-parser';
 import getAppPort from '../../../test_util/app-port.js';
 const port = getAppPort();

--- a/packages/collector/test/tracing/database/pg/app.mjs
+++ b/packages/collector/test/tracing/database/pg/app.mjs
@@ -14,7 +14,7 @@ const Pool = _pg.Pool;
 const Client = _pg.Client;
 import express from 'express';
 import morgan from 'morgan';
-import request from 'request-promise-native';
+const fetch = require('node-fetch');
 import bodyParser from 'body-parser';
 import getAppPort from '../../../test_util/app-port.js';
 const port = getAppPort();
@@ -61,7 +61,7 @@ app.get('/select-now-pool', (req, res) => {
       return res.sendStatus(500);
     }
     // Execute another traced call to verify that we keep the tracing context.
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -73,7 +73,7 @@ app.get('/select-now-no-pool-callback', (req, res) => {
       log('Failed to execute select now query', err);
       return res.sendStatus(500);
     }
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -83,7 +83,7 @@ app.get('/select-now-no-pool-promise', (req, res) => {
   client
     .query('SELECT NOW()')
     .then(results => {
-      request(`http://127.0.0.1:${agentPort}`).then(() => {
+      fetch(`http://127.0.0.1:${agentPort}`).then(() => {
         res.json(results);
       });
     })
@@ -109,7 +109,7 @@ app.get('/pool-string-insert', (req, res) => {
       log('Failed to execute pool insert', err);
       return res.sendStatus(500);
     }
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -125,7 +125,7 @@ app.get('/pool-config-select', (req, res) => {
       log('Failed to execute pool config insert', err);
       return res.sendStatus(500);
     }
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -140,7 +140,7 @@ app.get('/pool-config-select-promise', (req, res) => {
   pool
     .query(query)
     .then(results => {
-      request(`http://127.0.0.1:${agentPort}`).then(() => {
+      fetch(`http://127.0.0.1:${agentPort}`).then(() => {
         res.json(results);
       });
     })
@@ -159,7 +159,7 @@ app.get('/client-string-insert', (req, res) => {
       log('Failed to execute client insert', err);
       return res.sendStatus(500);
     }
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -175,7 +175,7 @@ app.get('/client-config-select', (req, res) => {
       log('Failed to execute client select', err);
       return res.sendStatus(500);
     }
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -186,7 +186,7 @@ app.get('/table-doesnt-exist', (req, res) => {
     .query('SELECT name, email FROM nonexistanttable')
     .then(r => res.json(r))
     .catch(e => {
-      request(`http://127.0.0.1:${agentPort}`).then(() => {
+      fetch(`http://127.0.0.1:${agentPort}`).then(() => {
         res.status(500).json(e);
       });
     });
@@ -216,7 +216,7 @@ app.get('/transaction', (req, res) => {
             log('Failed to execute client transaction', err4);
             return res.status(500).json(err4);
           }
-          request(`http://127.0.0.1:${agentPort}`).then(() => res.json(result3));
+          fetch(`http://127.0.0.1:${agentPort}`).then(() => res.json(result3));
         });
       });
     });
@@ -261,7 +261,7 @@ app.get('/asynchronous-query', async (req, res) => {
       secondQuery: secondQueryResults,
       thirdQuery: thirdQueryResults
     };
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(combinedResults);
     });
   } catch (err) {

--- a/packages/collector/test/tracing/database/pg_native/app.mjs
+++ b/packages/collector/test/tracing/database/pg_native/app.mjs
@@ -10,7 +10,7 @@ const agentPort = process.env.INSTANA_AGENT_PORT;
 import Client from 'pg-native';
 import express from 'express';
 import morgan from 'morgan';
-const fetch = require('node-fetch');
+import fetch from 'node-fetch';
 import bodyParser from 'body-parser';
 import getAppPort from '../../../test_util/app-port.js';
 const port = getAppPort();

--- a/packages/collector/test/tracing/database/pg_native/app.mjs
+++ b/packages/collector/test/tracing/database/pg_native/app.mjs
@@ -10,7 +10,7 @@ const agentPort = process.env.INSTANA_AGENT_PORT;
 import Client from 'pg-native';
 import express from 'express';
 import morgan from 'morgan';
-import request from 'request-promise-native';
+const fetch = require('node-fetch');
 import bodyParser from 'body-parser';
 import getAppPort from '../../../test_util/app-port.js';
 const port = getAppPort();
@@ -61,7 +61,7 @@ app.post('/select', (req, res) => {
       return res.sendStatus(500);
     }
     // Execute another traced call to verify that we keep the tracing context.
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -69,7 +69,7 @@ app.post('/select', (req, res) => {
 
 app.post('/select-sync', (req, res) => {
   const results = client.querySync('SELECT NOW()');
-  request(`http://127.0.0.1:${agentPort}`).then(() => {
+  fetch(`http://127.0.0.1:${agentPort}`).then(() => {
     res.json(results);
   });
 });
@@ -83,7 +83,7 @@ app.post('/insert', (req, res) => {
       log('Failed to execute client insert', err);
       return res.sendStatus(500);
     }
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.json(results);
     });
   });
@@ -92,7 +92,7 @@ app.post('/insert', (req, res) => {
 app.post('/error', (req, res) => {
   client.query('SELECT name, email FROM nonexistanttable', (err, results) => {
     if (err) {
-      request(`http://127.0.0.1:${agentPort}`).then(() => res.status(500).json({ error: err.toString() }));
+      fetch(`http://127.0.0.1:${agentPort}`).then(() => res.status(500).json({ error: err.toString() }));
     } else {
       res.json(results);
     }
@@ -104,7 +104,7 @@ app.post('/error-sync', (req, res) => {
     const results = client.querySync('SELECT name, email FROM nonexistanttable');
     return res.json(results);
   } catch (err) {
-    request(`http://127.0.0.1:${agentPort}`).then(() => res.status(500).json({ error: err.toString() }));
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => res.status(500).json({ error: err.toString() }));
   }
 });
 
@@ -119,7 +119,7 @@ app.post('/prepared-statement', (req, res) => {
         log('Failed to execute prepared statement', e2);
         return res.sendStatus(500);
       }
-      request(`http://127.0.0.1:${agentPort}`).then(() => {
+      fetch(`http://127.0.0.1:${agentPort}`).then(() => {
         res.json(results);
       });
     });
@@ -129,7 +129,7 @@ app.post('/prepared-statement', (req, res) => {
 app.post('/prepared-statement-sync', (req, res) => {
   client.prepareSync('prepared-statement-2', 'INSERT INTO users(name, email) VALUES($1, $2) RETURNING *', 2);
   const results = client.executeSync('prepared-statement-2', ['scooter', 'scooter@muppets.com']);
-  request(`http://127.0.0.1:${agentPort}`).then(() => {
+  fetch(`http://127.0.0.1:${agentPort}`).then(() => {
     res.json(results);
   });
 });
@@ -162,7 +162,7 @@ app.post('/transaction', (req, res) => {
                 log('Failed to COMMIT transaction', err4);
                 return res.status(500).json(err4);
               }
-              request(`http://127.0.0.1:${agentPort}`).then(() => res.json(result3));
+              fetch(`http://127.0.0.1:${agentPort}`).then(() => res.json(result3));
             });
           }
         );
@@ -188,13 +188,13 @@ app.post('/cancel', (req, res) => {
       // is called. So we wait a few milliseconds more and only then send the response - by then, the cancel callback
       // will have been called, too, and hasBeenCancelled has the correct value.
       setTimeout(() => {
-        request(`http://127.0.0.1:${agentPort}`).then(() => res.json({ results, hasBeenCancelled }));
+        fetch(`http://127.0.0.1:${agentPort}`).then(() => res.json({ results, hasBeenCancelled }));
       }, 100);
     } else if (err2) {
       log('Failed to execute query', err2);
       return res.sendStatus(500);
     } else {
-      request(`http://127.0.0.1:${agentPort}`).then(() => res.json({ results, hasBeenCancelled }));
+      fetch(`http://127.0.0.1:${agentPort}`).then(() => res.json({ results, hasBeenCancelled }));
     }
   });
 });

--- a/packages/collector/test/tracing/database/redis/legacyApp.js
+++ b/packages/collector/test/tracing/database/redis/legacyApp.js
@@ -13,7 +13,7 @@ const bodyParser = require('body-parser');
 const express = require('express');
 const morgan = require('morgan');
 const redis = require('redis');
-const request = require('request-promise-native');
+const fetch = require('node-fetch');
 const port = require('../../../test_util/app-port')();
 
 const cls = require('../../../../../core/src/tracing/cls');
@@ -72,7 +72,7 @@ app.post('/values', (req, res) => {
       log('Set with key %s, value %s failed', key, value, err);
       res.sendStatus(500);
     } else {
-      request(`http://127.0.0.1:${agentPort}`).then(() => {
+      fetch(`http://127.0.0.1:${agentPort}`).then(() => {
         res.sendStatus(200);
       });
     }
@@ -91,7 +91,7 @@ app.get('/hset-hget', (req, res) => {
           return res.sendStatus(500);
         }
 
-        request(`http://127.0.0.1:${agentPort}`).then(() => {
+        fetch(`http://127.0.0.1:${agentPort}`).then(() => {
           res.status(200).send(val);
         });
       });
@@ -103,7 +103,7 @@ app.get('/hset-hget', (req, res) => {
 app.get('/get-without-waiting', (req, res) => {
   const key = req.query.key;
   client.get(key);
-  request(`http://127.0.0.1:${agentPort}`).then(() => {
+  fetch(`http://127.0.0.1:${agentPort}`).then(() => {
     res.sendStatus(200);
   });
 });
@@ -114,7 +114,7 @@ app.get('/set-without-waiting', (req, res) => {
 
   client.set(key, value);
 
-  request(`http://127.0.0.1:${agentPort}`).then(() => {
+  fetch(`http://127.0.0.1:${agentPort}`).then(() => {
     res.sendStatus(200);
   });
 });
@@ -126,7 +126,7 @@ app.get('/values', (req, res) => {
       log('Get with key %s failed', key, err);
       res.sendStatus(500);
     } else {
-      request(`http://127.0.0.1:${agentPort}`).then(() => {
+      fetch(`http://127.0.0.1:${agentPort}`).then(() => {
         res.send(redisRes);
       });
     }
@@ -137,7 +137,7 @@ app.get('/failure', (req, res) => {
   // simulating wrong get usage
   client.get('someCollection', 'someKey', 'someValue', (err, redisRes) => {
     if (err) {
-      request(`http://127.0.0.1:${agentPort}`).then(() => {
+      fetch(`http://127.0.0.1:${agentPort}`).then(() => {
         res.sendStatus(500);
       });
     } else {
@@ -156,7 +156,7 @@ app.get('/multi', (req, res) => {
         log('Multi failed', err);
         res.sendStatus(500);
       } else {
-        request(`http://127.0.0.1:${agentPort}`).then(() => {
+        fetch(`http://127.0.0.1:${agentPort}`).then(() => {
           res.sendStatus(200);
         });
       }
@@ -174,7 +174,7 @@ app.get('/multi-sub-cb', (req, res) => {
       if (err) {
         log('Multi failed', err);
 
-        request(`http://127.0.0.1:${agentPort}`).then(() => {
+        fetch(`http://127.0.0.1:${agentPort}`).then(() => {
           res.sendStatus(200);
         });
       } else {
@@ -186,7 +186,7 @@ app.get('/multi-sub-cb', (req, res) => {
 app.get('/multi-no-waiting', (req, res) => {
   client.multi().hset('someCollection', 'key', 'value').hget('someCollection', 'key').exec();
 
-  request(`http://127.0.0.1:${agentPort}`).then(() => {
+  fetch(`http://127.0.0.1:${agentPort}`).then(() => {
     res.sendStatus(200);
   });
 });
@@ -200,7 +200,7 @@ app.get('/multiFailure', (req, res) => {
     .exec(err => {
       if (err) {
         log('Multi failed', err);
-        request(`http://127.0.0.1:${agentPort}`).then(() => {
+        fetch(`http://127.0.0.1:${agentPort}`).then(() => {
           res.sendStatus(200);
         });
       } else {
@@ -220,7 +220,7 @@ app.get('/batchSuccess', (req, res) => {
         log('batch should not fail', err);
         res.sendStatus(500);
       } else {
-        request(`http://127.0.0.1:${agentPort}`).then(() => {
+        fetch(`http://127.0.0.1:${agentPort}`).then(() => {
           res.sendStatus(200);
         });
       }
@@ -238,7 +238,7 @@ app.get('/batchFailure', (req, res) => {
         log('batch should not fail', err);
         res.sendStatus(500);
       } else {
-        request(`http://127.0.0.1:${agentPort}`).then(() => {
+        fetch(`http://127.0.0.1:${agentPort}`).then(() => {
           res.sendStatus(200);
         });
       }
@@ -262,7 +262,7 @@ app.get('/callSequence', (req, res) => {
         return;
       }
 
-      request(`http://127.0.0.1:${agentPort}`).then(() => {
+      fetch(`http://127.0.0.1:${agentPort}`).then(() => {
         res.send(result);
       });
     });

--- a/packages/collector/test/tracing/misc/span-batching-with-redis/app.js
+++ b/packages/collector/test/tracing/misc/span-batching-with-redis/app.js
@@ -14,7 +14,7 @@ const bodyParser = require('body-parser');
 const express = require('express');
 const morgan = require('morgan');
 const redis = require('redis');
-const request = require('request-promise-native');
+const fetch = require('node-fetch');
 const port = require('../../../test_util/app-port')();
 const app = express();
 const logPrefix = `Redis Batching App (${process.pid}):\t`;
@@ -66,7 +66,7 @@ app.post('/quick-successive-calls', (req, res) => {
           log(`Consecutive read access returned different results: ${redisGetResponse1} != ${redisRes2}`);
           return res.sendStatus(500);
         }
-        request(`http://127.0.0.1:${agentPort}`).then(() => {
+        fetch(`http://127.0.0.1:${agentPort}`).then(() => {
           res.send(redisGetResponse1);
         });
       });
@@ -90,7 +90,7 @@ app.post('/quick-successive-calls-with-errors', (req, res) => {
           log('Get unexpectedly succeeded');
           return res.sendStatus(500);
         }
-        request(`http://127.0.0.1:${agentPort}`).then(() => {
+        fetch(`http://127.0.0.1:${agentPort}`).then(() => {
           res.send('done');
         });
       });

--- a/packages/collector/test/tracing/opentelemetry/restify-app.js
+++ b/packages/collector/test/tracing/opentelemetry/restify-app.js
@@ -16,7 +16,7 @@ require('../../../src')({
 });
 
 const restify = require('restify');
-const request = require('request-promise-native');
+const fetch = require('node-fetch');
 const _pg = require('pg');
 const Pool = _pg.Pool;
 const Client = _pg.Client;
@@ -60,7 +60,7 @@ server.get('/test', function (req, res, next) {
       return res.sendStatus(500);
     }
     // Execute another traced call to verify that we keep the tracing context.
-    request(`http://127.0.0.1:${agentPort}`).then(() => {
+    fetch(`http://127.0.0.1:${agentPort}`).then(() => {
       res.send(results);
       next();
     });


### PR DESCRIPTION
The `request-promise-native` module is now deprecated as it relies on the deprecated `request` package. Please refer to the following link for more information: https://github.com/request/request/issues/3142

In light of this deprecation, we are discontinuing the use of the `request-promise-native` module and adopting the `node-fetch` module as an alternative. `node-fetch` is a lightweight and widely utilized package. It is important to note that Node.js has introduced a native fetch module starting from version 18. Consequently, once support for Node.js versions 14 and 16 is discontinued, we will seamlessly transition to utilizing the fetch module from `node-fetch`.

What's pending?

- [x] [PR](https://github.com/instana/nodejs/pull/1004)  needs to be merged first.
