### PR TITLE
fix: resolved logging issue for the  dependency distance calculator

### DIFF
--- a/packages/shared-metrics/src/index.js
+++ b/packages/shared-metrics/src/index.js
@@ -13,7 +13,6 @@ const allMetrics = [
   require('./dependencies'),
   require('./directDependencies'),
   require('./description'),
-  require('./directDependencies'),
   require('./execArgs'),
   require('./gc'),
   require('./healthchecks'),

--- a/packages/shared-metrics/src/util/DependencyDistanceCalculator.js
+++ b/packages/shared-metrics/src/util/DependencyDistanceCalculator.js
@@ -16,7 +16,7 @@ let logger = Logger.getLogger('metrics');
 /**
  * @param {import('@instana/core/src/logger').GenericLogger} _logger
  */
-exports.setLogger = function setLogger(_logger) {
+const setLogger = function (_logger) {
   logger = _logger;
 };
 
@@ -277,5 +277,6 @@ function searchInParentDir(dir, onParentDir, callback) {
 module.exports = {
   DependencyDistanceCalculator,
   MAX_DEPTH: 15,
-  __moduleRefExportedForTest: module
+  __moduleRefExportedForTest: module,
+  setLogger
 };

--- a/packages/shared-metrics/src/util/index.js
+++ b/packages/shared-metrics/src/util/index.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const nativeModuleRetry = require('./nativeModuleRetry');
+const { setLogger: setLoggerForDependencyDistanceCalculator } = require('./DependencyDistanceCalculator');
 module.exports = {
   nativeModuleRetry,
   /**
@@ -13,5 +14,6 @@ module.exports = {
    */
   setLogger: function setLogger(logger) {
     nativeModuleRetry.setLogger(logger);
+    setLoggerForDependencyDistanceCalculator(logger);
   }
 };


### PR DESCRIPTION
The resolution to the [github issue](https://github.com/instana/nodejs/issues/1019) addressed the logging inaccuracies. Specifically:

- The custom logging functionality was not functioning as expected, consistently outputting logs in plain text format.

- Despite not explicitly setting the log level to debug, debug logs were still being exhibited.