### PR TITLE
build: resolved the failing unit test case for google-cloud/storage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,13 @@ Troubleshooting `pg_config: command not found`: The tests in this package depend
 
 Install the [`aws-cli`](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) to publish AWS layers from local.
 
+### Upgrade npm for Node.js v14
+
+If you are using Node.js v14 and would like to take advantage of the "overrides" feature in package.json, you need to upgrade npm manually since Node.js v14 ships with npm v6, and "overrides" were introduced in npm v8.3. Upgrade npm manually to the latest version using the following command:
+```
+npm install npm@latest
+```
+
 ## Executing Tests Locally
 
 Some of the tests require infrastructure components (databases etc.) to run locally. The easiest way to run all required components locally is to use Docker and on top of this [Docker Compose](https://docs.docker.com/compose/). Start the script `bin/start-test-containers.sh` to set up all the necessary infrastructure. Once this is up, leave it running and, in second shell, start `bin/run-tests.sh`. This will set the necessary environment variables and kick off the tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Install the [`aws-cli`](https://docs.aws.amazon.com/cli/latest/userguide/getting
 
 If you are using Node.js v14 and would like to take advantage of the "overrides" feature in package.json, you need to upgrade npm manually since Node.js v14 ships with npm v6, and `overrides` were introduced in npm v8.3. Upgrade npm manually to the latest version using the following command:
 ```
-npm install npm@latest
+npm install -g npm@latest
 ```
 
 ## Executing Tests Locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Install the [`aws-cli`](https://docs.aws.amazon.com/cli/latest/userguide/getting
 
 ### Upgrade npm for Node.js v14
 
-If you are using Node.js v14 and would like to take advantage of the "overrides" feature in package.json, you need to upgrade npm manually since Node.js v14 ships with npm v6, and "overrides" were introduced in npm v8.3. Upgrade npm manually to the latest version using the following command:
+If you are using Node.js v14 and would like to take advantage of the "overrides" feature in package.json, you need to upgrade npm manually since Node.js v14 ships with npm v6, and `overrides` were introduced in npm v8.3. Upgrade npm manually to the latest version using the following command:
 ```
 npm install npm@latest
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -37817,9 +37817,9 @@
       }
     },
     "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.2.tgz",
+      "integrity": "sha512-rV4Bovi9xx0BFzOb/X0B2GqoIjvqPCttZdu0Wgtx2Dxkj7ETyWl9gmqJ4EutWRLvtZWm8dxE+InQZX1IryZn/w==",
       "dev": true
     },
     "node_modules/stream-transform": {

--- a/package.json
+++ b/package.json
@@ -209,7 +209,8 @@
     "pg-native": "^3.0.1"
   },
   "overrides": {
-    "nx": "15.8.9"
+    "nx": "15.8.9",
+    "stream-shift": "1.0.2"
   },
   "config": {
     "commitizen": {

--- a/packages/collector/test/tracing/cloud/gcp/storage/test.js
+++ b/packages/collector/test/tracing/cloud/gcp/storage/test.js
@@ -7,7 +7,6 @@
 
 const { expect } = require('chai');
 const { fail } = expect;
-const semver = require('semver');
 
 const constants = require('@instana/core').tracing.constants;
 const supportedVersion = require('@instana/core').tracing.supportedVersion;
@@ -50,14 +49,8 @@ if (
   });
 } else {
   let mochaSuiteFn;
-  // There is bug in node 21.2.0, more details please see
-  // https://github.com/googleapis/nodejs-storage/issues/2368
 
-  if (
-    !supportedVersion(process.versions.node) ||
-    !process.env.GCP_PROJECT ||
-    semver.gte(process.versions.node, '21.2.0')
-  ) {
+  if (!supportedVersion(process.versions.node) || !process.env.GCP_PROJECT) {
     mochaSuiteFn = describe.skip;
   } else {
     mochaSuiteFn = describe;


### PR DESCRIPTION
It appears that the issue with the google-cloud/storage test failing for node versions 21.2.0 and above has been rectified.(https://github.com/googleapis/nodejs-storage/issues/2368). 


