### PR TITLE
feat: added otel instrumentation for tedious

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -152,6 +152,7 @@
         "sqs-consumer-v5": "npm:sqs-consumer@^5.7.0",
         "stealthy-require": "1.1.1",
         "superagent": "^8.1.2",
+        "tedious": "^15.1.3",
         "tsoa": "^6.0.1",
         "typescript": "^5.0.4",
         "underscore": "^1.13.1",
@@ -9074,28 +9075,30 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-3.4.1.tgz",
-      "integrity": "sha512-oQ/r5MBdfZTMIUcY5Ch8G7Vv9aIXDkEYyU4Dfqjim4MQN+LY2uiQ57P1JDopMLeHCsZxM4yy8lEdne3tM9Xhzg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-2.1.0.tgz",
+      "integrity": "sha512-BPDz1sK7Ul9t0l9YKLEa8PHqWU4iCfhGJ+ELJl6c8CP3TpJt2urNCbm0ZHsthmxRsYoMPbz2Dvzj30zXZVmAFw==",
       "dev": true,
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.5.0",
+        "@azure/core-auth": "^1.3.0",
         "@azure/core-client": "^1.4.0",
         "@azure/core-rest-pipeline": "^1.1.0",
         "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.6.1",
+        "@azure/core-util": "^1.0.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^3.5.0",
-        "@azure/msal-node": "^2.5.1",
+        "@azure/msal-browser": "^2.26.0",
+        "@azure/msal-common": "^7.0.0",
+        "@azure/msal-node": "^1.10.0",
         "events": "^3.0.0",
         "jws": "^4.0.0",
         "open": "^8.0.0",
         "stoppable": "^1.1.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.2.0",
+        "uuid": "^8.3.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@azure/identity/node_modules/events": {
@@ -9105,6 +9108,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@azure/keyvault-keys": {
@@ -9142,38 +9154,58 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.6.0.tgz",
-      "integrity": "sha512-FrFBJXRJMyWXjAjg4cUNZwEKktzfzD/YD9+S1kj2ors67hKoveam4aL0bZuCZU/jTiHTn0xDQGQh2ksCMXTXtA==",
+      "version": "2.38.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.38.3.tgz",
+      "integrity": "sha512-2WuLFnWWPR1IdvhhysT18cBbkXx1z0YIchVss5AwVA95g7CU5CpT3d+5BcgVGNXDXbUU7/5p0xYHV99V5z8C/A==",
+      "deprecated": "A newer major version of this library is available. Please upgrade to the latest available version.",
       "dev": true,
       "dependencies": {
-        "@azure/msal-common": "14.5.0"
+        "@azure/msal-common": "13.3.1"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
+    "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.3.1.tgz",
+      "integrity": "sha512-Lrk1ozoAtaP/cp53May3v6HtcFSVxdFrg2Pa/1xu5oIvsIwhxW6zSPibKefCOVgd5osgykMi5jjcZHv8XkzZEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@azure/msal-common": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.5.0.tgz",
-      "integrity": "sha512-Gx5rZbiZV/HiZ2nEKfjfAF/qDdZ4/QWxMvMo2jhIFVz528dVKtaZyFAOtsX2Ak8+TQvRsGCaEfuwJFuXB6tu1A==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-7.6.0.tgz",
+      "integrity": "sha512-XqfbglUTVLdkHQ8F9UQJtKseRr3sSnr9ysboxtoswvaMVaEfvyLtMoHv9XdKUfOc0qKGzNgRFd9yRjIWVepl6Q==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.6.0.tgz",
-      "integrity": "sha512-RWAWCYYrSldIYC47oWtofIun41e6SB9TBYgGYsezq6ednagwo9ZRFyRsvl1NabmdTkdDDXRAABIdveeN2Gtd8w==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.18.4.tgz",
+      "integrity": "sha512-Kc/dRvhZ9Q4+1FSfsTFDME/v6+R2Y1fuMty/TfwqE5p9GTPw08BPbKgeWinE8JRHRp+LemjQbUZsn4Q4l6Lszg==",
+      "deprecated": "A newer major version of this library is available. Please upgrade to the latest available version.",
       "dev": true,
       "dependencies": {
-        "@azure/msal-common": "14.5.0",
+        "@azure/msal-common": "13.3.1",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "engines": {
-        "node": "16|| 18 || 20"
+        "node": "10 || 12 || 14 || 16 || 18"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.3.1.tgz",
+      "integrity": "sha512-Lrk1ozoAtaP/cp53May3v6HtcFSVxdFrg2Pa/1xu5oIvsIwhxW6zSPibKefCOVgd5osgykMi5jjcZHv8XkzZEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node/node_modules/uuid": {
@@ -18184,8 +18216,7 @@
     "node_modules/@types/node": {
       "version": "20.7.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.1.tgz",
-      "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg==",
-      "dev": true
+      "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.10",
@@ -18260,6 +18291,16 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz",
       "integrity": "sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA==",
       "dev": true
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.10.tgz",
+      "integrity": "sha512-AbUKBjcC8SHmImNi4yK2bbjogQlkFSg7shZCcicxPQapniOlajG8GCc39lvXzCWX4lLRRs7DM3VAeSlqmEVZUA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
     },
     "node_modules/@types/request": {
       "version": "2.48.12",
@@ -18377,7 +18418,6 @@
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.12.tgz",
       "integrity": "sha512-5NBYCLmidyXG3zxiBmR0beORRQcJOBoTKVL+9WaHQbX0E386UFXw6TSlY9/oxZDYqUWlBC98Funb83eJQt1aMw==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -30396,15 +30436,6 @@
         "whatwg-url": "^13.0.0"
       }
     },
-    "node_modules/mongodb/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/mongodb/node_modules/tr46": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
@@ -30903,100 +30934,79 @@
         "node": ">=10"
       }
     },
-    "node_modules/mssql-v9/node_modules/@azure/identity": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-2.1.0.tgz",
-      "integrity": "sha512-BPDz1sK7Ul9t0l9YKLEa8PHqWU4iCfhGJ+ELJl6c8CP3TpJt2urNCbm0ZHsthmxRsYoMPbz2Dvzj30zXZVmAFw==",
+    "node_modules/mssql/node_modules/@azure/identity": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-3.4.2.tgz",
+      "integrity": "sha512-0q5DL4uyR0EZ4RXQKD8MadGH6zTIcloUoS/RVbCpNpej4pwte0xpqYxk8K97Py2RiuUvI7F4GXpoT4046VfufA==",
       "dev": true,
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
+        "@azure/core-auth": "^1.5.0",
         "@azure/core-client": "^1.4.0",
         "@azure/core-rest-pipeline": "^1.1.0",
         "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^2.26.0",
-        "@azure/msal-common": "^7.0.0",
-        "@azure/msal-node": "^1.10.0",
+        "@azure/msal-browser": "^3.5.0",
+        "@azure/msal-node": "^2.5.1",
         "events": "^3.0.0",
         "jws": "^4.0.0",
         "open": "^8.0.0",
         "stoppable": "^1.1.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
+        "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/mssql-v9/node_modules/@azure/msal-browser": {
-      "version": "2.38.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.38.3.tgz",
-      "integrity": "sha512-2WuLFnWWPR1IdvhhysT18cBbkXx1z0YIchVss5AwVA95g7CU5CpT3d+5BcgVGNXDXbUU7/5p0xYHV99V5z8C/A==",
-      "deprecated": "A newer major version of this library is available. Please upgrade to the latest available version.",
+    "node_modules/mssql/node_modules/@azure/msal-browser": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.9.0.tgz",
+      "integrity": "sha512-Ts+Q3fw9u92koCkk+oZgL6lhwDrwWSyXBcKdsKJko1Ra7ZzDl0z7pod+1g+v4Qbt8l1YqSX4wXbXs5sWUv0VWw==",
       "dev": true,
       "dependencies": {
-        "@azure/msal-common": "13.3.1"
+        "@azure/msal-common": "14.7.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
-    "node_modules/mssql-v9/node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.3.1.tgz",
-      "integrity": "sha512-Lrk1ozoAtaP/cp53May3v6HtcFSVxdFrg2Pa/1xu5oIvsIwhxW6zSPibKefCOVgd5osgykMi5jjcZHv8XkzZEQ==",
+    "node_modules/mssql/node_modules/@azure/msal-common": {
+      "version": "14.7.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.7.0.tgz",
+      "integrity": "sha512-WexujW5jKWib7xtIxR7fEVyd5xcA3FNwenELy2HO4YC/ivTFdsEcDhtpKQuRUHqXRwxoqBblyZzTAhBm4v6fHA==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
     },
-    "node_modules/mssql-v9/node_modules/@azure/msal-common": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-7.6.0.tgz",
-      "integrity": "sha512-XqfbglUTVLdkHQ8F9UQJtKseRr3sSnr9ysboxtoswvaMVaEfvyLtMoHv9XdKUfOc0qKGzNgRFd9yRjIWVepl6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/mssql-v9/node_modules/@azure/msal-node": {
-      "version": "1.18.4",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.18.4.tgz",
-      "integrity": "sha512-Kc/dRvhZ9Q4+1FSfsTFDME/v6+R2Y1fuMty/TfwqE5p9GTPw08BPbKgeWinE8JRHRp+LemjQbUZsn4Q4l6Lszg==",
-      "deprecated": "A newer major version of this library is available. Please upgrade to the latest available version.",
+    "node_modules/mssql/node_modules/@azure/msal-node": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.6.3.tgz",
+      "integrity": "sha512-ojjJqUwb297T5Tcln4PbJANFEqRXfbQXcyOrtdr1HQYIo+dSuCT/o0nG6bFVihf6fcNykDwJLCQPVXzTkx/oGg==",
       "dev": true,
       "dependencies": {
-        "@azure/msal-common": "13.3.1",
+        "@azure/msal-common": "14.7.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "engines": {
-        "node": "10 || 12 || 14 || 16 || 18"
+        "node": ">=16"
       }
     },
-    "node_modules/mssql-v9/node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.3.1.tgz",
-      "integrity": "sha512-Lrk1ozoAtaP/cp53May3v6HtcFSVxdFrg2Pa/1xu5oIvsIwhxW6zSPibKefCOVgd5osgykMi5jjcZHv8XkzZEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/mssql-v9/node_modules/bl": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+    "node_modules/mssql/node_modules/bl": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.11.tgz",
+      "integrity": "sha512-Ok/NWrEA0mlEEbWzckkZVLq6Nv1m2xZ+i9Jq5hZ9Ph/YEcP5dExqls9wUzpluhQRPzdeT8oZNOXAytta6YN8pQ==",
       "dev": true,
       "dependencies": {
+        "@types/readable-stream": "^4.0.0",
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
+        "readable-stream": "^4.2.0"
       }
     },
-    "node_modules/mssql-v9/node_modules/buffer": {
+    "node_modules/mssql/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
@@ -31020,7 +31030,7 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/mssql-v9/node_modules/events": {
+    "node_modules/mssql/node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
@@ -31029,7 +31039,7 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/mssql-v9/node_modules/iconv-lite": {
+    "node_modules/mssql/node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
@@ -31041,7 +31051,7 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/mssql-v9/node_modules/ieee754": {
+    "node_modules/mssql/node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
@@ -31061,30 +31071,32 @@
         }
       ]
     },
-    "node_modules/mssql-v9/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+    "node_modules/mssql/node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "dev": true,
       "engines": {
-        "node": ">=6"
+        "node": ">= 0.6.0"
       }
     },
-    "node_modules/mssql-v9/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+    "node_modules/mssql/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
       "dev": true,
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/mssql-v9/node_modules/safe-buffer": {
+    "node_modules/mssql/node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
@@ -31104,13 +31116,13 @@
         }
       ]
     },
-    "node_modules/mssql-v9/node_modules/sprintf-js": {
+    "node_modules/mssql/node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true
     },
-    "node_modules/mssql-v9/node_modules/string_decoder": {
+    "node_modules/mssql/node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
@@ -31119,30 +31131,30 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/mssql-v9/node_modules/tedious": {
-      "version": "15.1.3",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-15.1.3.tgz",
-      "integrity": "sha512-166EpRm5qknwhEisjZqz/mF7k14fXKJYHRg6XiAXVovd/YkyHJ3SG4Ppy89caPaNFfRr7PVYe+s4dAvKaCMFvw==",
+    "node_modules/mssql/node_modules/tedious": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-16.6.1.tgz",
+      "integrity": "sha512-KKSDB1OPrPk0WbMPug9YqRbPl44zMjdL2hFyzLEidr2IkItzpV0ZbzW8VA47QIS2oyWhCU7ifIEQY12n23IRDA==",
       "dev": true,
       "dependencies": {
-        "@azure/identity": "^2.0.4",
+        "@azure/identity": "^3.4.1",
         "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.2.0",
-        "bl": "^5.0.0",
-        "es-aggregate-error": "^1.0.8",
+        "@js-joda/core": "^5.5.3",
+        "bl": "^6.0.3",
+        "es-aggregate-error": "^1.0.9",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
         "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.0.1",
-        "punycode": "^2.1.0",
+        "node-abort-controller": "^3.1.1",
+        "punycode": "^2.3.0",
         "sprintf-js": "^1.1.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
-    "node_modules/mssql-v9/node_modules/uuid": {
+    "node_modules/mssql/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
@@ -35367,6 +35379,15 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -38574,37 +38595,37 @@
       }
     },
     "node_modules/tedious": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-16.6.1.tgz",
-      "integrity": "sha512-KKSDB1OPrPk0WbMPug9YqRbPl44zMjdL2hFyzLEidr2IkItzpV0ZbzW8VA47QIS2oyWhCU7ifIEQY12n23IRDA==",
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-15.1.3.tgz",
+      "integrity": "sha512-166EpRm5qknwhEisjZqz/mF7k14fXKJYHRg6XiAXVovd/YkyHJ3SG4Ppy89caPaNFfRr7PVYe+s4dAvKaCMFvw==",
       "dev": true,
       "dependencies": {
-        "@azure/identity": "^3.4.1",
+        "@azure/identity": "^2.0.4",
         "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.5.3",
-        "bl": "^6.0.3",
-        "es-aggregate-error": "^1.0.9",
+        "@js-joda/core": "^5.2.0",
+        "bl": "^5.0.0",
+        "es-aggregate-error": "^1.0.8",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
         "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.1.1",
-        "punycode": "^2.3.0",
+        "node-abort-controller": "^3.0.1",
+        "punycode": "^2.1.0",
         "sprintf-js": "^1.1.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/tedious/node_modules/bl": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.9.tgz",
-      "integrity": "sha512-Vh+M9HMfeTST9rkkQ1utRnOeABNcBO3i0dJMFkenCv7JIp76XWx8uQOGpaXyXVyenrLDZsdAHXbf0Cz18Eb0fw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
       "dev": true,
       "dependencies": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
-        "readable-stream": "^4.2.0"
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/tedious/node_modules/buffer": {
@@ -38629,15 +38650,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/tedious/node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.x"
       }
     },
     "node_modules/tedious/node_modules/iconv-lite": {
@@ -38672,38 +38684,18 @@
         }
       ]
     },
-    "node_modules/tedious/node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/tedious/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tedious/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">= 6"
       }
     },
     "node_modules/tedious/node_modules/safe-buffer": {
@@ -39004,15 +38996,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/tough-cookie/node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tr46": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
@@ -39023,15 +39006,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/tr46/node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/traverse": {
@@ -39606,15 +39580,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uri-js/node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/url": {
@@ -40791,135 +40756,6 @@
         "@instana/autoprofile": "3.1.3"
       }
     },
-    "packages/collector/node_modules/@azure/identity": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-2.1.0.tgz",
-      "integrity": "sha512-BPDz1sK7Ul9t0l9YKLEa8PHqWU4iCfhGJ+ELJl6c8CP3TpJt2urNCbm0ZHsthmxRsYoMPbz2Dvzj30zXZVmAFw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
-        "@azure/core-client": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.1.0",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.0.0",
-        "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^2.26.0",
-        "@azure/msal-common": "^7.0.0",
-        "@azure/msal-node": "^1.10.0",
-        "events": "^3.0.0",
-        "jws": "^4.0.0",
-        "open": "^8.0.0",
-        "stoppable": "^1.1.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "packages/collector/node_modules/@azure/identity/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "packages/collector/node_modules/@azure/msal-browser": {
-      "version": "2.38.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.38.3.tgz",
-      "integrity": "sha512-2WuLFnWWPR1IdvhhysT18cBbkXx1z0YIchVss5AwVA95g7CU5CpT3d+5BcgVGNXDXbUU7/5p0xYHV99V5z8C/A==",
-      "deprecated": "A newer major version of this library is available. Please upgrade to the latest available version.",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@azure/msal-common": "13.3.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/collector/node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.3.1.tgz",
-      "integrity": "sha512-Lrk1ozoAtaP/cp53May3v6HtcFSVxdFrg2Pa/1xu5oIvsIwhxW6zSPibKefCOVgd5osgykMi5jjcZHv8XkzZEQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/collector/node_modules/@azure/msal-common": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-7.6.0.tgz",
-      "integrity": "sha512-XqfbglUTVLdkHQ8F9UQJtKseRr3sSnr9ysboxtoswvaMVaEfvyLtMoHv9XdKUfOc0qKGzNgRFd9yRjIWVepl6Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/collector/node_modules/@azure/msal-node": {
-      "version": "1.18.4",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.18.4.tgz",
-      "integrity": "sha512-Kc/dRvhZ9Q4+1FSfsTFDME/v6+R2Y1fuMty/TfwqE5p9GTPw08BPbKgeWinE8JRHRp+LemjQbUZsn4Q4l6Lszg==",
-      "deprecated": "A newer major version of this library is available. Please upgrade to the latest available version.",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@azure/msal-common": "13.3.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": "10 || 12 || 14 || 16 || 18"
-      }
-    },
-    "packages/collector/node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-13.3.1.tgz",
-      "integrity": "sha512-Lrk1ozoAtaP/cp53May3v6HtcFSVxdFrg2Pa/1xu5oIvsIwhxW6zSPibKefCOVgd5osgykMi5jjcZHv8XkzZEQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "packages/collector/node_modules/@azure/msal-node/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "packages/collector/node_modules/bl": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "packages/collector/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -40975,17 +40811,6 @@
         "node": ">=0.3.1"
       }
     },
-    "packages/collector/node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "packages/collector/node_modules/glob": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
@@ -41003,20 +40828,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/collector/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "packages/collector/node_modules/ieee754": {
@@ -41131,55 +40942,6 @@
         "node": ">=10"
       }
     },
-    "packages/collector/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/collector/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "packages/collector/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "optional": true,
-      "peer": true
-    },
     "packages/collector/node_modules/semver": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
@@ -41192,50 +40954,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "packages/collector/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "packages/collector/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "packages/collector/node_modules/tedious": {
-      "version": "15.1.3",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-15.1.3.tgz",
-      "integrity": "sha512-166EpRm5qknwhEisjZqz/mF7k14fXKJYHRg6XiAXVovd/YkyHJ3SG4Ppy89caPaNFfRr7PVYe+s4dAvKaCMFvw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@azure/identity": "^2.0.4",
-        "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.2.0",
-        "bl": "^5.0.0",
-        "es-aggregate-error": "^1.0.8",
-        "iconv-lite": "^0.6.3",
-        "js-md4": "^0.3.2",
-        "jsbi": "^4.3.0",
-        "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.0.1",
-        "punycode": "^2.1.0",
-        "sprintf-js": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "packages/collector/node_modules/ts-node": {
@@ -41399,6 +41117,7 @@
         "@opentelemetry/instrumentation-fs": "0.9.0",
         "@opentelemetry/instrumentation-restify": "0.34.0",
         "@opentelemetry/instrumentation-socket.io": "0.34.1",
+        "@opentelemetry/instrumentation-tedious": "^0.7.0",
         "@opentelemetry/sdk-trace-base": "1.19.0",
         "cls-bluebird": "^2.1.0",
         "lru-cache": "^10.1.0",
@@ -41417,6 +41136,51 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "packages/core/node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.7.0.tgz",
+      "integrity": "sha512-o/5my8ZOuxACPSzMaXdPnQiMpmOPIJoTj+DRcs4vEJxk+KwlVNucoafSMpWQEyTNNuq2JI87Ru6Di2mp5T20EQ==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.48.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@types/tedious": "^4.0.10"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "packages/core/node_modules/@opentelemetry/instrumentation-tedious/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.48.0.tgz",
+      "integrity": "sha512-sjtZQB5PStIdCw5ovVTDGwnmQC+GGYArJNgIcydrDSqUTdYBnMrN9P4pwQZgS3vTGIp+TU1L8vMXGe51NVmIKQ==",
+      "dependencies": {
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "1.7.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "packages/core/node_modules/import-in-the-middle": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
+      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
       }
     },
     "packages/core/node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -213,6 +213,7 @@
     "sqs-consumer-v5": "npm:sqs-consumer@^5.7.0",
     "stealthy-require": "1.1.1",
     "superagent": "^8.1.2",
+    "tedious": "^15.1.3",
     "tsoa": "^6.0.1",
     "typescript": "^5.0.4",
     "underscore": "^1.13.1",

--- a/packages/collector/test/tracing/opentelemetry/tedious-app.js
+++ b/packages/collector/test/tracing/opentelemetry/tedious-app.js
@@ -22,16 +22,18 @@ app.use(bodyParser.json());
 
 const azureConfig = process.env.AZURE_SQL_CONFIG ? JSON.parse(process.env.AZURE_SQL_CONFIG, 'utf-8') : null;
 const config = {
-  server: azureConfig.AZURE_SQL_SERVER ? azureConfig.AZURE_SQL_SERVER : process.env.AZURE_SQL_SERVER,
+  server: azureConfig && azureConfig.AZURE_SQL_SERVER ? azureConfig.AZURE_SQL_SERVER : process.env.AZURE_SQL_SERVER,
   authentication: {
     type: 'default',
     options: {
-      userName: azureConfig.AZURE_SQL_USERNAME ? azureConfig.AZURE_SQL_USERNAME : process.env.AZURE_SQL_USERNAME,
-      password: azureConfig.AZURE_SQL_PWD ? azureConfig.AZURE_SQL_PWD : process.env.AZURE_SQL_PWD
+      userName:
+        azureConfig && azureConfig.AZURE_SQL_USERNAME ? azureConfig.AZURE_SQL_USERNAME : process.env.AZURE_SQL_USERNAME,
+      password: azureConfig && azureConfig.AZURE_SQL_PWD ? azureConfig.AZURE_SQL_PWD : process.env.AZURE_SQL_PWD
     }
   },
   options: {
-    database: azureConfig.AZURE_SQL_DATABASE ? azureConfig.AZURE_SQL_DATABASE : process.env.AZURE_SQL_DATABASE
+    database:
+      azureConfig && azureConfig.AZURE_SQL_DATABASE ? azureConfig.AZURE_SQL_DATABASE : process.env.AZURE_SQL_DATABASE
   }
 };
 

--- a/packages/collector/test/tracing/opentelemetry/tedious-app.js
+++ b/packages/collector/test/tracing/opentelemetry/tedious-app.js
@@ -1,0 +1,82 @@
+/*
+ * (c) Copyright IBM Corp. 2024
+ */
+
+'use strict';
+
+/* eslint-disable no-console */
+require('../../..')({
+  tracing: {
+    useOpentelemetry: true
+  }
+});
+const express = require('express');
+const app = express();
+const port = require('../../test_util/app-port')();
+const Connection = require('tedious').Connection;
+const Request = require('tedious').Request;
+const bodyParser = require('body-parser');
+app.use(bodyParser.json());
+
+const config = {
+  server: process.env.AZURE_SQL_SERVER,
+  authentication: {
+    type: 'default',
+    options: {
+      userName: process.env.AZURE_SQL_USERNAME,
+      password: process.env.AZURE_SQL_PWD
+    }
+  },
+  options: {
+    database: process.env.AZURE_SQL_DATABASE
+  }
+};
+
+const executeStatement = (query, res) => {
+  const connection = new Connection(config);
+
+  connection.on('connect', err => {
+    if (err) {
+      res.status(500).send('Internal Server Error');
+      return;
+    }
+
+    const request = new Request(query, error => {
+      if (error) {
+        res.status(500).send('Internal Server Error');
+      }
+    });
+
+    const columnsData = [];
+
+    request.on('row', columns => {
+      const rowData = {};
+      columns.forEach(column => {
+        rowData[column.metadata.colName] = column.value;
+      });
+      columnsData.push(rowData);
+    });
+
+    request.on('requestCompleted', () => {
+      res.json({ columns: columnsData });
+      connection.close();
+    });
+
+    connection.execSql(request);
+  });
+
+  connection.connect();
+};
+
+app.get('/', (req, res) => {
+  res.sendStatus(200);
+});
+
+app.get('/packages', (req, res) => {
+  const query = 'SELECT * FROM packages';
+  executeStatement(query, res);
+});
+
+app.listen(port, () => {
+  console.warn(`Listening on port: ${port}`);
+});

--- a/packages/collector/test/tracing/opentelemetry/tedious-app.js
+++ b/packages/collector/test/tracing/opentelemetry/tedious-app.js
@@ -32,7 +32,7 @@ const config = {
   }
 };
 
-const executeStatement = (query, res) => {
+const executeStatement = (query, isBatch, res) => {
   const connection = new Connection(config);
 
   connection.on('connect', err => {
@@ -62,7 +62,11 @@ const executeStatement = (query, res) => {
       connection.close();
     });
 
-    connection.execSql(request);
+    if (isBatch) {
+      connection.execSqlBatch(request);
+    } else {
+      connection.execSql(request);
+    }
   });
 
   connection.connect();
@@ -74,9 +78,22 @@ app.get('/', (req, res) => {
 
 app.get('/packages', (req, res) => {
   const query = 'SELECT * FROM packages';
-  executeStatement(query, res);
+  executeStatement(query, false, res);
 });
 
+app.delete('/packages', (req, res) => {
+  const id = 11;
+  const query = `DELETE FROM packages WHERE id = ${id}`;
+  executeStatement(query, false, res);
+});
+
+app.post('/packages/batch', (req, res) => {
+  const batchQuery = `
+  INSERT INTO packages (id, name, version) VALUES (11, 'BatchPackage1', 1);
+  INSERT INTO packages (id, name, version) VALUES (11, 'BatchPackage2', 2);
+`;
+  executeStatement(batchQuery, true, res);
+});
 app.listen(port, () => {
   console.warn(`Listening on port: ${port}`);
 });

--- a/packages/collector/test/tracing/opentelemetry/tedious-app.js
+++ b/packages/collector/test/tracing/opentelemetry/tedious-app.js
@@ -16,24 +16,29 @@ const Connection = require('tedious').Connection;
 const Request = require('tedious').Request;
 const bodyParser = require('body-parser');
 app.use(bodyParser.json());
-
+let config;
 // To obtain the credentials for the Azure SQL Database, you can find them in 1password. Search for
 // "Team Node.js: Azure SQL credentials". The credentials are stored in the
-// "nodejs-tracer-azure-sql-cred.json" file.
+// "nodejs-tracer-azure-sql-cred.txt" file. Set the content to AZURE_SQL_CONFIG.
 
-const config = {
-  server: process.env.AZURE_SQL_SERVER,
-  authentication: {
-    type: 'default',
+const azureConfig = process.env.AZURE_SQL_CONFIG ? JSON.parse(process.env.AZURE_SQL_CONFIG) : null;
+if (azureConfig) {
+  config = azureConfig;
+} else {
+  config = {
+    server: process.env.AZURE_SQL_SERVER,
+    authentication: {
+      type: 'default',
+      options: {
+        userName: process.env.AZURE_SQL_USERNAME,
+        password: process.env.AZURE_SQL_PWD
+      }
+    },
     options: {
-      userName: process.env.AZURE_SQL_USERNAME,
-      password: process.env.AZURE_SQL_PWD
+      database: process.env.AZURE_SQL_DATABASE
     }
-  },
-  options: {
-    database: process.env.AZURE_SQL_DATABASE
-  }
-};
+  };
+}
 
 const executeStatement = (query, isBatch, res) => {
   const connection = new Connection(config);

--- a/packages/collector/test/tracing/opentelemetry/tedious-app.js
+++ b/packages/collector/test/tracing/opentelemetry/tedious-app.js
@@ -16,29 +16,24 @@ const Connection = require('tedious').Connection;
 const Request = require('tedious').Request;
 const bodyParser = require('body-parser');
 app.use(bodyParser.json());
-let config;
 // To obtain the credentials for the Azure SQL Database, you can find them in 1password. Search for
 // "Team Node.js: Azure SQL credentials". The credentials are stored in the
-// "nodejs-tracer-azure-sql-cred.txt" file. Set the content to AZURE_SQL_CONFIG.
+// "nodejs-tracer-azure-sql-cred.json" file. Set the content to AZURE_SQL_CONFIG.
 
-const azureConfig = process.env.AZURE_SQL_CONFIG ? JSON.parse(process.env.AZURE_SQL_CONFIG) : null;
-if (azureConfig) {
-  config = azureConfig;
-} else {
-  config = {
-    server: process.env.AZURE_SQL_SERVER,
-    authentication: {
-      type: 'default',
-      options: {
-        userName: process.env.AZURE_SQL_USERNAME,
-        password: process.env.AZURE_SQL_PWD
-      }
-    },
+const azureConfig = process.env.AZURE_SQL_CONFIG ? JSON.parse(process.env.AZURE_SQL_CONFIG, 'utf-8') : null;
+const config = {
+  server: azureConfig.AZURE_SQL_SERVER ? azureConfig.AZURE_SQL_SERVER : process.env.AZURE_SQL_SERVER,
+  authentication: {
+    type: 'default',
     options: {
-      database: process.env.AZURE_SQL_DATABASE
+      userName: azureConfig.AZURE_SQL_USERNAME ? azureConfig.AZURE_SQL_USERNAME : process.env.AZURE_SQL_USERNAME,
+      password: azureConfig.AZURE_SQL_PWD ? azureConfig.AZURE_SQL_PWD : process.env.AZURE_SQL_PWD
     }
-  };
-}
+  },
+  options: {
+    database: azureConfig.AZURE_SQL_DATABASE ? azureConfig.AZURE_SQL_DATABASE : process.env.AZURE_SQL_DATABASE
+  }
+};
 
 const executeStatement = (query, isBatch, res) => {
   const connection = new Connection(config);

--- a/packages/collector/test/tracing/opentelemetry/tedious-app.js
+++ b/packages/collector/test/tracing/opentelemetry/tedious-app.js
@@ -4,7 +4,6 @@
 
 'use strict';
 
-/* eslint-disable no-console */
 require('../../..')({
   tracing: {
     useOpentelemetry: true
@@ -17,6 +16,10 @@ const Connection = require('tedious').Connection;
 const Request = require('tedious').Request;
 const bodyParser = require('body-parser');
 app.use(bodyParser.json());
+
+// To obtain the credentials for the Azure SQL Database, you can find them in 1password. Search for
+// "Team Node.js: Azure SQL credentials". The credentials are stored in the
+// "nodejs-tracer-azure-sql-cred.json" file.
 
 const config = {
   server: process.env.AZURE_SQL_SERVER,
@@ -47,18 +50,8 @@ const executeStatement = (query, isBatch, res) => {
       }
     });
 
-    const columnsData = [];
-
-    request.on('row', columns => {
-      const rowData = {};
-      columns.forEach(column => {
-        rowData[column.metadata.colName] = column.value;
-      });
-      columnsData.push(rowData);
-    });
-
     request.on('requestCompleted', () => {
-      res.json({ columns: columnsData });
+      res.send('OK');
       connection.close();
     });
 
@@ -95,5 +88,6 @@ app.post('/packages/batch', (req, res) => {
   executeStatement(batchQuery, true, res);
 });
 app.listen(port, () => {
+  // eslint-disable-next-line no-console
   console.warn(`Listening on port: ${port}`);
 });

--- a/packages/collector/test/tracing/opentelemetry/tedious-app.js
+++ b/packages/collector/test/tracing/opentelemetry/tedious-app.js
@@ -6,7 +6,7 @@
 
 require('../../..')({
   tracing: {
-    useOpentelemetry: true
+    useOpentelemetry: process.env.OTEL_ENABLED
   }
 });
 const express = require('express');

--- a/packages/collector/test/tracing/opentelemetry/test.js
+++ b/packages/collector/test/tracing/opentelemetry/test.js
@@ -491,12 +491,20 @@ mochaSuiteFn('opentelemetry/instrumentations', function () {
     describe('opentelemetry is enabled', function () {
       globalAgent.setUpCleanUpHooks();
       const agentControls = globalAgent.instance;
-      const controls = new ProcessControls({
-        appPath: path.join(__dirname, './tedious-app'),
-        useGlobalAgent: true
+      let controls;
+
+      before(async () => {
+        controls = new ProcessControls({
+          appPath: path.join(__dirname, './tedious-app'),
+          useGlobalAgent: true
+        });
+
+        await controls.startAndWaitForAgentConnection();
       });
 
-      ProcessControls.setUpHooks(controls);
+      after(async () => {
+        await controls.stop();
+      });
 
       const sendRequestAndVerifySpans = (method, endpoint, expectedStatement) =>
         controls

--- a/packages/collector/test/tracing/opentelemetry/test.js
+++ b/packages/collector/test/tracing/opentelemetry/test.js
@@ -477,7 +477,7 @@ mochaSuiteFn('opentelemetry/instrumentations', function () {
           path: '/io-emit',
           suppressTracing: true
         })
-        .then(() => delay(1000))
+        .then(() => delay(DELAY_TIMEOUT_IN_MS))
         .then(() =>
           retry(() =>
             agentControls.getSpans().then(spans => {
@@ -542,8 +542,8 @@ mochaSuiteFn('opentelemetry/instrumentations', function () {
         sendRequestAndVerifySpans(
           'POST',
           '/packages/batch',
-          // eslint-disable-next-line max-len
-          "\n  INSERT INTO packages (id, name, version) VALUES (11, 'BatchPackage1', 1);\n  INSERT INTO packages (id, name, version) VALUES (11, 'BatchPackage2', 2);\n"
+          "\n  INSERT INTO packages (id, name, version) VALUES (11, 'BatchPackage1', 1);\n  " +
+            "INSERT INTO packages (id, name, version) VALUES (11, 'BatchPackage2', 2);\n"
         )
           .then(() => {
             done();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,6 +61,7 @@
     "@opentelemetry/instrumentation-fs": "0.9.0",
     "@opentelemetry/instrumentation-restify": "0.34.0",
     "@opentelemetry/instrumentation-socket.io": "0.34.1",
+    "@opentelemetry/instrumentation-tedious": "^0.7.0",
     "@opentelemetry/sdk-trace-base": "1.19.0",
     "cls-bluebird": "^2.1.0",
     "lru-cache": "^10.1.0",

--- a/packages/core/src/tracing/opentelemetry-instrumentations/tedious.js
+++ b/packages/core/src/tracing/opentelemetry-instrumentations/tedious.js
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright IBM Corp. 2024
+ */
+
+'use strict';
+
+const constants = require('../constants');
+
+module.exports.init = () => {
+  const { TediousInstrumentation } = require('@opentelemetry/instrumentation-tedious');
+
+  const instrumentation = new TediousInstrumentation();
+
+  if (!instrumentation.getConfig().enabled) {
+    instrumentation.enable();
+  }
+};
+exports.transform = otelSpan => {
+  // NOTE: This assignment is necessary to display the database name in the UI.
+  // In the backend, for OpenTelemetry, the service name is based on the OpenTelemetry span attribute service.name.
+  if (otelSpan.attributes && 'db.name' in otelSpan.attributes) {
+    otelSpan.resource._attributes['service.name'] = otelSpan.attributes['db.name'];
+  }
+  return otelSpan;
+};
+
+module.exports.getKind = () => {
+  const kind = constants.EXIT;
+  return kind;
+};

--- a/packages/core/src/tracing/opentelemetry-instrumentations/tedious.js
+++ b/packages/core/src/tracing/opentelemetry-instrumentations/tedious.js
@@ -5,8 +5,16 @@
 'use strict';
 
 const constants = require('../constants');
+const semver = require('semver');
 
 module.exports.init = () => {
+  // Opentelemetry only supports tedious version >=1.11.0 and <=15, please refer the following link
+  // for more details: https://www.npmjs.com/package/@opentelemetry/instrumentation-tedious#supported-versions
+  // eslint-disable-next-line instana/no-unsafe-require, import/no-extraneous-dependencies
+  const tediousVersion = require('tedious/package.json').version;
+  if (semver.gte(tediousVersion, '16.0.0')) {
+    return;
+  }
   const { TediousInstrumentation } = require('@opentelemetry/instrumentation-tedious');
 
   const instrumentation = new TediousInstrumentation();

--- a/packages/core/src/tracing/opentelemetry-instrumentations/tedious.js
+++ b/packages/core/src/tracing/opentelemetry-instrumentations/tedious.js
@@ -5,16 +5,11 @@
 'use strict';
 
 const constants = require('../constants');
-const semver = require('semver');
 
 module.exports.init = () => {
   // Opentelemetry only supports tedious version >=1.11.0 and <=15, please refer the following link
   // for more details: https://www.npmjs.com/package/@opentelemetry/instrumentation-tedious#supported-versions
-  // eslint-disable-next-line instana/no-unsafe-require, import/no-extraneous-dependencies
-  const tediousVersion = require('tedious/package.json').version;
-  if (semver.gte(tediousVersion, '16.0.0')) {
-    return;
-  }
+
   const { TediousInstrumentation } = require('@opentelemetry/instrumentation-tedious');
 
   const instrumentation = new TediousInstrumentation();

--- a/packages/core/src/tracing/opentelemetry-instrumentations/wrap.js
+++ b/packages/core/src/tracing/opentelemetry-instrumentations/wrap.js
@@ -19,7 +19,8 @@ const constants = require('../constants');
 const instrumentations = {
   '@opentelemetry/instrumentation-fs': { name: 'fs' },
   '@opentelemetry/instrumentation-restify': { name: 'restify' },
-  '@opentelemetry/instrumentation-socket.io': { name: 'socket.io' }
+  '@opentelemetry/instrumentation-socket.io': { name: 'socket.io' },
+  '@opentelemetry/instrumentation-tedious': { name: 'tedious' }
 };
 
 module.exports.minimumNodeJsVersion = '14.0.0';


### PR DESCRIPTION
As part of Azure SQL integration, we've chosen to improve support for the tedious library through the implementation of [opentelemetry-tedious](https://www.npmjs.com/package/@opentelemetry/instrumentation-tedious). We've also conducted tests to verify its compatibility with Azure Database.

Currently, our support extends to tedious version 15.1.3, due to limitations with the otel instrumentation.