### PR TITLE
chore: fixed the linting issue for tsoa files

### DIFF
--- a/packages/collector/.prettierignore
+++ b/packages/collector/.prettierignore
@@ -1,0 +1,1 @@
+test/tracing/frameworks/tsoa/build/


### PR DESCRIPTION
Linting appears to be broken on main