### PR TITLE
chore: esm support for < 18.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -919,7 +919,7 @@ jobs:
     environment:
       CIRCLE_COMPARE_URL: << pipeline.project.git_url >>/compare/<< pipeline.git.base_revision >>..<<pipeline.git.revision>>
     docker:
-      - image: cimg/node:18.19
+      - image: cimg/node:18.18
       - <<: *zookeeper
       - <<: *elasticsearch
       - <<: *mongo
@@ -994,7 +994,7 @@ jobs:
       CIRCLE_COMPARE_URL: << pipeline.project.git_url >>/compare/<< pipeline.git.base_revision >>..<<pipeline.git.revision>>
       RUN_ALL_TESTS: true
     docker:
-      - image: cimg/node:18.19
+      - image: cimg/node:18.18
       - <<: *zookeeper
       - <<: *elasticsearch
       - <<: *mongo
@@ -1046,7 +1046,7 @@ jobs:
       CIRCLE_COMPARE_URL: << pipeline.project.git_url >>/compare/<< pipeline.git.base_revision >>..<<pipeline.git.revision>>
       RUN_ALL_TESTS: true
     docker:
-      - image: cimg/node:18.19
+      - image: cimg/node:18.18
       - <<: *zookeeper
       - <<: *elasticsearch
       - <<: *mongo

--- a/packages/core/src/tracing/esmSupportedVersion.js
+++ b/packages/core/src/tracing/esmSupportedVersion.js
@@ -8,5 +8,6 @@ const semver = require('semver');
 
 /** @type {(version: string) => boolean} */
 module.exports = exports = function esmSupportedVersion(version) {
-  return semver.satisfies(version, '>=14.0.0 <20.0.0');
+  // https://github.com/nodejs/node/pull/44710
+  return semver.satisfies(version, '>=14.0.0 <18.19');
 };


### PR DESCRIPTION
[ci all-tests]

https://github.com/nodejs/node/pull/44710

- pin 18.18
- add link
- update esm support library
