### PR TITLE
fix: included the matrix parameters in url

### DIFF
--- a/packages/collector/test/tracing/misc/w3c_trace_context/test.js
+++ b/packages/collector/test/tracing/misc/w3c_trace_context/test.js
@@ -994,7 +994,7 @@ function verifyHttpExit(spans, parentSpan, url) {
     span => expect(span.s).to.be.a('string'),
     span => expect(span.p).to.equal(parentSpan.s),
     span => expect(span.data.http.method).to.equal('GET'),
-    span => expect(span.data.http.url).to.match(RegExp(`^.*:${otherVendorAppPort}${url}$`)),
+    span => expect(span.data.http.url).contains(`${otherVendorAppPort}${url}`),
     span => expect(span.data.http.status).to.equal(200),
     span => expect(span.fp).to.not.exist
   ]);

--- a/packages/collector/test/tracing/protocols/http/client/clientApp.js
+++ b/packages/collector/test/tracing/protocols/http/client/clientApp.js
@@ -287,6 +287,13 @@ app.post('/upload-s3', (req, res) => {
     }
   });
 });
+app.get('/matrix-params/:params', (req, res) => {
+  try {
+    res.sendStatus(200);
+  } catch (error) {
+    res.sendStatus(500);
+  }
+});
 
 function createUrl(req, urlPath) {
   const pathWithQuery = req.query.withQuery ? `${urlPath}?q1=some&pass=verysecret&q2=value` : urlPath;

--- a/packages/collector/test/tracing/protocols/http/client/clientApp.js
+++ b/packages/collector/test/tracing/protocols/http/client/clientApp.js
@@ -288,11 +288,7 @@ app.post('/upload-s3', (req, res) => {
   });
 });
 app.get('/matrix-params/:params', (req, res) => {
-  try {
-    res.sendStatus(200);
-  } catch (error) {
-    res.sendStatus(500);
-  }
+  res.sendStatus(200);
 });
 
 function createUrl(req, urlPath) {

--- a/packages/collector/test/tracing/protocols/http/client/test.js
+++ b/packages/collector/test/tracing/protocols/http/client/test.js
@@ -494,6 +494,21 @@ function registerTests(useHttps) {
         expect(response.key).to.exist;
         expect(response.Key).to.exist;
       }));
+  it('must capture complete request path even if it contain `;`', () =>
+    clientControls
+      .sendRequest({ method: 'GET', path: '/matrix-params/ACDKey=1:00000:00000;ANI=00000111;DN=00000111' })
+      .then(() =>
+        retry(() =>
+          globalAgent.instance.getSpans().then(spans => {
+            expectExactlyOneMatching(spans, [
+              span => expect(span.n).to.equal('node.http.server'),
+              span => expect(span.k).to.equal(constants.ENTRY),
+              span => expect(span.data.http.url).to.eq('/matrix-params/ACDKey=1:00000:00000;ANI=00000111;DN=00000111'),
+              span => expect(span.data.http.status).to.eq(200)
+            ]);
+          })
+        )
+      ));
 }
 
 function registerConnectionRefusalTest(useHttps) {

--- a/packages/core/src/util/url.js
+++ b/packages/core/src/util/url.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const url = require('url');
+const { URL } = require('url');
 const secrets = require('../secrets');
 
 /**
@@ -15,23 +15,19 @@ const secrets = require('../secrets');
 exports.sanitizeUrl = function sanitizeUrl(urlString) {
   let normalizedUrl;
   try {
-    // This currently uses the legacy URL API. As soon as we drop support for Node.js 6 we should move to the
-    // WHATWG URL API (https://nodejs.org/api/url.html#url_the_whatwg_url_api).
-    const p = url.parse(urlString);
-    if (p.protocol == null && p.host == null && p.pathname == null) {
+    const url = new URL(urlString);
+
+    if (!url.protocol && !url.host && !url.pathname) {
       return urlString;
     }
 
-    normalizedUrl = `${nullToEmptyString(p.protocol)}${p.protocol != null || p.host != null ? '//' : ''}${
-      p.auth != null ? '<redacted>:<redacted>@' : ''
-    }${nullToEmptyString(p.host)}${nullToEmptyString(p.pathname)}`;
+    normalizedUrl = `${nullToEmptyString(url.protocol)}${url.protocol || url.host ? '//' : ''}${
+      url.username || url.password ? '<redacted>:<redacted>@' : ''
+    }${nullToEmptyString(url.host)}${nullToEmptyString(url.pathname)}`;
   } catch (e) {
     return urlString;
   }
-
-  // url.parse does not take care of matrix params starting with ";", so we have to remove those manually.
-  const indexOfSemicolon = getCharCountUntilOccurenceOfChar(normalizedUrl, ';');
-  return normalizedUrl.substring(0, indexOfSemicolon);
+  return normalizedUrl;
 };
 
 /**
@@ -41,17 +37,6 @@ exports.sanitizeUrl = function sanitizeUrl(urlString) {
  */
 function nullToEmptyString(string) {
   return string == null ? '' : string;
-}
-
-/**
- * @param {string} haystack the string in which to search for the needle
- * @param {string} needle the character to search for
- * @returns {number} the number of characters in haystack until the first occurence of needle or the length of haystack,
- * if haystack does not contain needle
- */
-function getCharCountUntilOccurenceOfChar(haystack, needle) {
-  const index = haystack.indexOf(needle);
-  return index === -1 ? haystack.length : index;
 }
 
 /**

--- a/packages/core/test/util/url_test.js
+++ b/packages/core/test/util/url_test.js
@@ -19,8 +19,8 @@ describe('util/url', () => {
       expect(sanitizeUrl('https://google.com/search?foo=bar')).to.equal('https://google.com/search');
     });
 
-    it('must strip matrix parameters', () => {
-      expect(sanitizeUrl('https://google.com/search;foo=bar')).to.equal('https://google.com/search');
+    it('must not strip matrix parameters', () => {
+      expect(sanitizeUrl('https://google.com/search;foo=bar')).to.equal('https://google.com/search;foo=bar');
     });
 
     it('must keep the URL intact when no parameters exist', () => {
@@ -28,7 +28,9 @@ describe('util/url', () => {
     });
 
     it('must discard of mix of various parameter types', () => {
-      expect(sanitizeUrl('https://google.com/search/;foo=bar?query=true#blub')).to.equal('https://google.com/search/');
+      expect(sanitizeUrl('https://google.com/search/;foo=bar?query=true#blub')).to.equal(
+        'https://google.com/search/;foo=bar'
+      );
     });
 
     it('must redact embedded credentials', () => {
@@ -39,7 +41,7 @@ describe('util/url', () => {
 
     it('must redact embedded credentials and remove params', () => {
       expect(sanitizeUrl('http://user:password@example.org/route;matrix=value?query=true#anchor')).to.equal(
-        'http://<redacted>:<redacted>@example.org/route'
+        'http://<redacted>:<redacted>@example.org/route;matrix=value'
       );
     });
 
@@ -54,6 +56,11 @@ describe('util/url', () => {
     it('must not mistakenly interprete paths with : and @ as credentials', () => {
       expect(sanitizeUrl('http://example.org/colon:/param=email@domain.tld')).to.equal(
         'http://example.org/colon:/param=email@domain.tld'
+      );
+    });
+    it('must keep URL with matrix parameters and query string', () => {
+      expect(sanitizeUrl('http://example.org/ACDKey=1:00000:00000;ANI=00000111;DN=00000111')).to.equal(
+        'http://example.org/ACDKey=1:00000:00000;ANI=00000111;DN=00000111'
       );
     });
   });


### PR DESCRIPTION
The truncation of variables after the semicolon (;) was made a few years ago in response to a reported [issue](https://github.com/instana/nodejs/issues/327). The purpose of this truncation is to address cases where credential  are present in the URL. So as per the request from the customer we are about to add the matrix parameters back in the url.

