### PR TITLE
chore: fixed sendRequest function in ProcessControls

### DIFF
--- a/packages/collector/test/tracing/database/mongodb/app.js
+++ b/packages/collector/test/tracing/database/mongodb/app.js
@@ -236,7 +236,7 @@ app.post('/long-find', (req, res) => {
       // Execute another traced call to verify that we keep the tracing context.
       return fetch(`http://127.0.0.1:${agentPort}?call=${call}`);
     })
-    .then(() => res.json(mongoResponse))
+    .then(() => res.json(mongoResponse || {}))
     .catch(e => {
       log('Failed to find document', e);
       res.sendStatus(500);

--- a/packages/collector/test/tracing/database/pg/app.js
+++ b/packages/collector/test/tracing/database/pg/app.js
@@ -98,7 +98,7 @@ app.get('/select-now-no-pool-promise', (req, res) => {
 
 app.get('/parameterized-query', async (req, res) => {
   await client.query('SELECT * FROM users WHERE name = $1', ['parapeter']);
-  res.json();
+  res.json({});
 });
 
 app.get('/pool-string-insert', (req, res) => {

--- a/packages/collector/test/tracing/database/pg/app.mjs
+++ b/packages/collector/test/tracing/database/pg/app.mjs
@@ -97,7 +97,7 @@ app.get('/select-now-no-pool-promise', (req, res) => {
 
 app.get('/parameterized-query', async (req, res) => {
   await client.query('SELECT * FROM users WHERE name = $1', ['parapeter']);
-  res.json();
+  res.json({});
 });
 
 app.get('/pool-string-insert', (req, res) => {

--- a/packages/collector/test/tracing/frameworks/fastify/test.js
+++ b/packages/collector/test/tracing/frameworks/fastify/test.js
@@ -70,8 +70,7 @@ const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : descri
             .sendRequest({
               method: 'GET',
               path: actualPath,
-              simple: false,
-              resolveWithFullResponse: true
+              simple: false
             })
             .then(response => {
               expect(response).to.deep.equal(expectedResponse);

--- a/packages/collector/test/tracing/frameworks/got/app.js
+++ b/packages/collector/test/tracing/frameworks/got/app.js
@@ -41,7 +41,7 @@ app.get('/', async (req, res) => {
 app.get('/request', async (req, res) => {
   await got.get(`http://127.0.0.1:${agentPort}`);
 
-  res.json();
+  res.json({});
 });
 
 app.listen(port, () => {

--- a/packages/collector/test/tracing/frameworks/got/app.mjs
+++ b/packages/collector/test/tracing/frameworks/got/app.mjs
@@ -41,7 +41,7 @@ app.get('/', async (req, res) => {
 app.get('/request', async (req, res) => {
   await got.get(`http://127.0.0.1:${agentPort}`);
 
-  res.json();
+  res.json({});
 });
 
 app.listen(port, () => {

--- a/packages/collector/test/tracing/frameworks/hapi/test.js
+++ b/packages/collector/test/tracing/frameworks/hapi/test.js
@@ -56,8 +56,7 @@ mochaSuiteFn('tracing/hapi', function () {
           .sendRequest({
             method: 'GET',
             path: actualPath,
-            simple: false,
-            resolveWithFullResponse: true
+            simple: false
           })
           .then(response => {
             expect(response).to.equal(expectedTemplate);

--- a/packages/collector/test/tracing/frameworks/koa/test.js
+++ b/packages/collector/test/tracing/frameworks/koa/test.js
@@ -58,8 +58,7 @@ mochaSuiteFn('tracing/koa', function () {
           .sendRequest({
             method: 'GET',
             path: actualPath,
-            simple: false,
-            resolveWithFullResponse: true
+            simple: false
           })
           .then(response => {
             expect(response.indexOf(actualPath)).to.equal(

--- a/packages/collector/test/tracing/frameworks/sequelize/app.js
+++ b/packages/collector/test/tracing/frameworks/sequelize/app.js
@@ -71,7 +71,7 @@ app.get('/find-one', async (req, res) => {
     attributes: ['name']
   });
 
-  res.json();
+  res.json({});
 });
 
 app.get('/raw', async (req, res) => {
@@ -81,7 +81,7 @@ app.get('/raw', async (req, res) => {
     bind: ['parapeter']
   });
 
-  res.json();
+  res.json({});
 });
 
 app.get('/insert', async (req, res) => {
@@ -92,7 +92,7 @@ app.get('/insert', async (req, res) => {
     { fields: ['name'] }
   );
 
-  res.json();
+  res.json({});
 });
 
 app.listen(port, () => {

--- a/packages/collector/test/tracing/frameworks/sequelize/app.mjs
+++ b/packages/collector/test/tracing/frameworks/sequelize/app.mjs
@@ -66,7 +66,7 @@ app.get('/find-one', async (req, res) => {
     attributes: ['name']
   });
 
-  res.json();
+  res.json({});
 });
 
 app.get('/raw', async (req, res) => {
@@ -76,7 +76,7 @@ app.get('/raw', async (req, res) => {
     bind: ['parapeter']
   });
 
-  res.json();
+  res.json({});
 });
 
 app.get('/insert', async (req, res) => {
@@ -87,7 +87,7 @@ app.get('/insert', async (req, res) => {
     { fields: ['name'] }
   );
 
-  res.json();
+  res.json({});
 });
 
 app.listen(port, () => {

--- a/packages/collector/test/tracing/frameworks/typeorm/app.js
+++ b/packages/collector/test/tracing/frameworks/typeorm/app.js
@@ -84,7 +84,7 @@ app.get('/find-one', async (req, res) => {
   const repo = AppDataSource.getRepository(UserTypeOrm);
   await repo.findOne({ where: { name: 'parapeter' } });
 
-  res.json();
+  res.json({});
 });
 
 app.listen(port, () => {

--- a/packages/collector/test/tracing/frameworks/typeorm/app.mjs
+++ b/packages/collector/test/tracing/frameworks/typeorm/app.mjs
@@ -84,7 +84,7 @@ app.get('/find-one', async (req, res) => {
   const repo = AppDataSource.getRepository(UserTypeOrm);
   await repo.findOne({ where: { name: 'parapeter' } });
 
-  res.json();
+  res.json({});
 });
 
 app.listen(port, () => {

--- a/packages/collector/test/tracing/messaging/bull/sender.js
+++ b/packages/collector/test/tracing/messaging/bull/sender.js
@@ -6,6 +6,7 @@
 'use strict';
 
 require('../../../..')();
+
 const logPrefix = `Bull (${process.pid}):\t`;
 const Queue = require('bull');
 const redisServer = process.env.REDIS_SERVER || 'redis://127.0.0.1:6379';
@@ -15,7 +16,6 @@ const port = require('../../../test_util/app-port')();
 const bullJobName = process.env.BULL_JOB_NAME || 'steve';
 
 const app = express();
-
 const sender = new Queue(queueName, redisServer);
 
 function getJobData(testId, bulkIndex, withError) {
@@ -86,7 +86,7 @@ app.post('/send', (request, response) => {
 
   sender[addFunction].apply(sender, functionParams);
 
-  response.send({
+  response.json({
     status: `Job${repeat || bulk ? 's' : ''} sent`
   });
 });

--- a/packages/collector/test/tracing/messaging/bull/test.js
+++ b/packages/collector/test/tracing/messaging/bull/test.js
@@ -452,6 +452,7 @@ mochaSuiteFn('tracing/messaging/bull', function () {
 
 async function verifyResponseAndJobProcessing({ response, testId, isRepeatable, isBulk }) {
   expect(response).to.be.an('object');
+
   if (isRepeatable || isBulk) {
     expect(response.status).to.equal('Jobs sent');
   } else {

--- a/packages/collector/test/tracing/misc/specification_compliance/test.js
+++ b/packages/collector/test/tracing/misc/specification_compliance/test.js
@@ -150,11 +150,14 @@ describe('spec compliance', function () {
             headers,
             resolveWithFullResponse: true
           };
+
           const response = await appControls.sendRequest(request);
+
           const expectedServerTimingValue = testDefinition['Server-Timing'];
           const actualServerTimingValue = http2
             ? response.headers['server-timing']
             : response.headers.get('server-timing');
+
           if (expectedServerTimingValue && expectedServerTimingValue.includes('$')) {
             expect(actualServerTimingValue).to.exist;
             parseForPlaceholders(valuesForPlaceholders, expectedServerTimingValue, actualServerTimingValue);

--- a/packages/collector/test/tracing/misc/w3c_trace_context/test.js
+++ b/packages/collector/test/tracing/misc/w3c_trace_context/test.js
@@ -851,6 +851,8 @@ function startRequest({ app, depth = 2, withSpecHeaders = null, otherMode = 'par
   } else if (withInstanaHeaders != null) {
     throw new Error(`Invalid withInstanaHeaders value: ${withInstanaHeaders}.`);
   }
+
+  request.resolveWithFullResponse = true;
   return app.sendRequest(request);
 }
 

--- a/packages/collector/test/tracing/protocols/http/server/test.js
+++ b/packages/collector/test/tracing/protocols/http/server/test.js
@@ -652,8 +652,7 @@ function registerTests(agentControls, useHttps, useHttp2CompatApi) {
       .sendRequest({
         method: 'GET',
         path: '/inject-instana-trace-id',
-        responseStatus: 200,
-        resolveWithFullResponse: true
+        responseStatus: 200
       })
       .then(response => {
         expect(response).to.match(/^Instana Trace ID: [a-f0-9]{16}$/);

--- a/packages/collector/test/tracing/protocols/http/server/test.js
+++ b/packages/collector/test/tracing/protocols/http/server/test.js
@@ -656,8 +656,9 @@ function registerTests(agentControls, useHttps, useHttp2CompatApi) {
         resolveWithFullResponse: true
       })
       .then(response => {
-        expect(response.body).to.match(/^Instana Trace ID: [a-f0-9]{16}$/);
-        const traceId = /^Instana Trace ID: ([a-f0-9]{16})$/.exec(response.body)[1];
+        expect(response).to.match(/^Instana Trace ID: [a-f0-9]{16}$/);
+
+        const traceId = /^Instana Trace ID: ([a-f0-9]{16})$/.exec(response)[1];
         return retry(() =>
           agentControls.getSpans().then(spans => {
             const span = verifyThereIsExactlyOneHttpEntry(

--- a/packages/collector/test/tracing/protocols/http2/test.js
+++ b/packages/collector/test/tracing/protocols/http2/test.js
@@ -312,8 +312,9 @@ mochaSuiteFn('tracing/http2', function () {
         resolveWithFullResponse: true
       })
       .then(response => {
-        expect(response.body).to.match(/^Instana Trace ID: [a-f0-9]{16}$/);
-        const traceId = /^Instana Trace ID: ([a-f0-9]{16})$/.exec(response.body)[1];
+        expect(response).to.match(/^Instana Trace ID: [a-f0-9]{16}$/);
+
+        const traceId = /^Instana Trace ID: ([a-f0-9]{16})$/.exec(response)[1];
         return retry(() =>
           agentControls.getSpans().then(spans => {
             const span = verifyRootHttpEntry(spans, `localhost:${serverControls.getPort()}`, '/inject-trace-id');

--- a/packages/collector/test/tracing/protocols/http2/test.js
+++ b/packages/collector/test/tracing/protocols/http2/test.js
@@ -308,8 +308,7 @@ mochaSuiteFn('tracing/http2', function () {
     serverControls
       .sendRequest({
         method: 'GET',
-        path: '/inject-trace-id',
-        resolveWithFullResponse: true
+        path: '/inject-trace-id'
       })
       .then(response => {
         expect(response).to.match(/^Instana Trace ID: [a-f0-9]{16}$/);

--- a/packages/collector/test/tracing/sdk/test.js
+++ b/packages/collector/test/tracing/sdk/test.js
@@ -250,7 +250,7 @@ mochaSuiteFn('tracing/sdk', function () {
               path: `/${apiType}/create-overlapping-intermediates`
             })
             .then(response => {
-              expect(response.body).to.be.eq('');
+              expect(response).to.be.eq('');
 
               return retry(() =>
                 agentControls.getSpans().then(spans => {

--- a/packages/collector/test/uncaught/unhandled_promise_rejections_test.js
+++ b/packages/collector/test/uncaught/unhandled_promise_rejections_test.js
@@ -57,7 +57,8 @@ mochaSuiteFn('unhandled promise rejections', function () {
         resolveWithFullResponse: true
       })
       .then(response => {
-        expect(response.body).to.equal('Rejected.');
+        expect(response).to.equal('Rejected.');
+
         return testUtils.retry(() =>
           agentControls.getSpans().then(spans => {
             testUtils.expectAtLeastOneMatching(spans, [
@@ -81,7 +82,8 @@ mochaSuiteFn('unhandled promise rejections', function () {
         resolveWithFullResponse: true
       })
       .then(response => {
-        expect(response.body).to.equal('Rejected.');
+        expect(response).to.equal('Rejected.');
+
         return testUtils.retry(() =>
           agentControls.getEvents().then(events => {
             testUtils.expectAtLeastOneMatching(events, [
@@ -111,7 +113,8 @@ mochaSuiteFn('unhandled promise rejections', function () {
           resolveWithFullResponse: true
         })
         .then(response => {
-          expect(response.body).to.equal('Rejected.');
+          expect(response).to.equal('Rejected.');
+
           return testUtils.retry(() =>
             agentControls.getEvents().then(events => {
               testUtils.expectAtLeastOneMatching(events, [
@@ -140,7 +143,8 @@ mochaSuiteFn('unhandled promise rejections', function () {
         resolveWithFullResponse: true
       })
       .then(response => {
-        expect(response.body).to.equal('Rejected.');
+        expect(response).to.equal('Rejected.');
+
         return testUtils.retry(() =>
           agentControls.getEvents().then(events => {
             testUtils.expectAtLeastOneMatching(events, [

--- a/packages/collector/test/uncaught/unhandled_promise_rejections_test.js
+++ b/packages/collector/test/uncaught/unhandled_promise_rejections_test.js
@@ -53,8 +53,7 @@ mochaSuiteFn('unhandled promise rejections', function () {
       .sendRequest({
         method: 'GET',
         path: '/reject-with-error-reason',
-        simple: false,
-        resolveWithFullResponse: true
+        simple: false
       })
       .then(response => {
         expect(response).to.equal('Rejected.');
@@ -78,8 +77,7 @@ mochaSuiteFn('unhandled promise rejections', function () {
       .sendRequest({
         method: 'GET',
         path: '/reject-with-error-reason',
-        simple: false,
-        resolveWithFullResponse: true
+        simple: false
       })
       .then(response => {
         expect(response).to.equal('Rejected.');
@@ -109,8 +107,7 @@ mochaSuiteFn('unhandled promise rejections', function () {
         .sendRequest({
           method: 'GET',
           path: '/reject-with-string-reason',
-          simple: false,
-          resolveWithFullResponse: true
+          simple: false
         })
         .then(response => {
           expect(response).to.equal('Rejected.');
@@ -139,8 +136,7 @@ mochaSuiteFn('unhandled promise rejections', function () {
       .sendRequest({
         method: 'GET',
         path: '/reject-with-null-reason',
-        simple: false,
-        resolveWithFullResponse: true
+        simple: false
       })
       .then(response => {
         expect(response).to.equal('Rejected.');


### PR DESCRIPTION
refs https://github.com/instana/nodejs/pull/1017

We saw so many random failures on CircleCI and Tekton because `waitUntilServerIsUp` no longer waited for the app to be ready. The function `sendRequest` was refactored wrong.