### PR TITLE
test: fixed the failing testcase for w3c_trace_context

### DIFF
--- a/packages/collector/test/tracing/misc/w3c_trace_context/test.js
+++ b/packages/collector/test/tracing/misc/w3c_trace_context/test.js
@@ -996,7 +996,7 @@ function verifyHttpExit(spans, parentSpan, url) {
     span => expect(span.s).to.be.a('string'),
     span => expect(span.p).to.equal(parentSpan.s),
     span => expect(span.data.http.method).to.equal('GET'),
-    span => expect(span.data.http.url).contains(`${otherVendorAppPort}${url}`),
+    span => expect(span.data.http.url).to.match(RegExp(`^.*:${otherVendorAppPort}${url}$`)),
     span => expect(span.data.http.status).to.equal(200),
     span => expect(span.fp).to.not.exist
   ]);

--- a/packages/core/src/util/url.js
+++ b/packages/core/src/util/url.js
@@ -19,6 +19,7 @@ exports.sanitizeUrl = function sanitizeUrl(urlString) {
     const url = new URL(urlString);
 
     // If URL has no protocol, host, or path, return the original URL.
+    // TODO: This case need adjustment for complete sanitization of the URL.
     if (!url.protocol && !url.host && !url.pathname) {
       return urlString;
     }
@@ -30,10 +31,11 @@ exports.sanitizeUrl = function sanitizeUrl(urlString) {
   } catch (e) {
     // If URL parsing fails and it's a relative URL, return its path.
     // For example, if the input is "/foo?a=b", the returned value will be "/foo".
-    if (urlString.startsWith('/')) {
+    if (typeof urlString === 'string' && urlString.startsWith('/')) {
       return new URL(urlString, 'https://example.org/').pathname;
     } else {
-      return '';
+      // This case  need adjustment for complete sanitization of the URL, reference 159741
+      return urlString;
     }
   }
   return normalizedUrl;

--- a/packages/core/src/util/url.js
+++ b/packages/core/src/util/url.js
@@ -15,6 +15,9 @@ const secrets = require('../secrets');
 exports.sanitizeUrl = function sanitizeUrl(urlString) {
   let normalizedUrl;
   try {
+    if (!URL.canParse(urlString)) {
+      return urlString && urlString.replace(/\?.*/g, "$'");
+    }
     const url = new URL(urlString);
 
     if (!url.protocol && !url.host && !url.pathname) {


### PR DESCRIPTION
If an invalid URL is found, such as when simply a path is provided without a host part, this scenario is taken into consideration.
Invalid URLs, such as /start?key=value, result in an error and the same input string. Handled this in the fix
Earlier the url.parse was used, so we deprecate that and use the new base parameter of the URL constructor , Related PR https://github.com/instana/nodejs/pull/1069