### PR TITLE
feat: added support for prisma v5

### DIFF
--- a/packages/collector/test/tracing/database/prisma/package-lock.json
+++ b/packages/collector/test/tracing/database/prisma/package-lock.json
@@ -9,22 +9,19 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@prisma/client": "^4.5.0"
+        "@prisma/client": "^5.11.0"
       },
       "devDependencies": {
-        "prisma": "^4.5.0"
+        "prisma": "^5.11.0"
       }
     },
     "node_modules/@prisma/client": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.5.0.tgz",
-      "integrity": "sha512-B2cV0OPI1smhdYUxsJoLYQLoMlLH06MUxgFUWQnHodGMX98VRVXKmQE/9OcrTNkqtke5RC+YU24Szxd04tZA2g==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.11.0.tgz",
+      "integrity": "sha512-SWshvS5FDXvgJKM/a0y9nDC1rqd7KG0Q6ZVzd+U7ZXK5soe73DJxJJgbNBt2GNXOa+ysWB4suTpdK5zfFPhwiw==",
       "hasInstallScript": true,
-      "dependencies": {
-        "@prisma/engines-version": "4.5.0-43.0362da9eebca54d94c8ef5edd3b2e90af99ba452"
-      },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.13"
       },
       "peerDependencies": {
         "prisma": "*"
@@ -35,33 +32,65 @@
         }
       }
     },
+    "node_modules/@prisma/debug": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.11.0.tgz",
+      "integrity": "sha512-N6yYr3AbQqaiUg+OgjkdPp3KPW1vMTAgtKX6+BiB/qB2i1TjLYCrweKcUjzOoRM5BriA4idrkTej9A9QqTfl3A==",
+      "devOptional": true
+    },
     "node_modules/@prisma/engines": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.5.0.tgz",
-      "integrity": "sha512-4t9ir2SbQQr/wMCNU4YpHWp5hU14J2m3wHUZnGJPpmBF8YtkisxyVyQsKd1e6FyLTaGq8LOLhm6VLYHKqKNm+g==",
-      "devOptional": true,
-      "hasInstallScript": true
-    },
-    "node_modules/@prisma/engines-version": {
-      "version": "4.5.0-43.0362da9eebca54d94c8ef5edd3b2e90af99ba452",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.5.0-43.0362da9eebca54d94c8ef5edd3b2e90af99ba452.tgz",
-      "integrity": "sha512-o7LyVx8PPJBLrEzLl6lpxxk2D5VnlM4Fwmrbq0NoT6pr5aa1OuHD9ZG+WJY6TlR/iD9bhmo2LNcxddCMr5Rv2A=="
-    },
-    "node_modules/prisma": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.5.0.tgz",
-      "integrity": "sha512-9Aeg4qiKlv9Wsjz4NO8k2CzRzlvS3A4FYVJ5+28sBBZ0eEwbiVOE/Jj7v6rZC1tFW2s4GSICQOAyuOjc6WsNew==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.11.0.tgz",
+      "integrity": "sha512-gbrpQoBTYWXDRqD+iTYMirDlF9MMlQdxskQXbhARhG6A/uFQjB7DZMYocMQLoiZXO/IskfDOZpPoZE8TBQKtEw==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.5.0"
+        "@prisma/debug": "5.11.0",
+        "@prisma/engines-version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+        "@prisma/fetch-engine": "5.11.0",
+        "@prisma/get-platform": "5.11.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102.tgz",
+      "integrity": "sha512-WXCuyoymvrS4zLz4wQagSsc3/nE6CHy8znyiMv8RKazKymOMd5o9FP5RGwGHAtgoxd+aB/BWqxuP/Ckfu7/3MA==",
+      "devOptional": true
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.11.0.tgz",
+      "integrity": "sha512-994viazmHTJ1ymzvWugXod7dZ42T2ROeFuH6zHPcUfp/69+6cl5r9u3NFb6bW8lLdNjwLYEVPeu3hWzxpZeC0w==",
+      "devOptional": true,
+      "dependencies": {
+        "@prisma/debug": "5.11.0",
+        "@prisma/engines-version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+        "@prisma/get-platform": "5.11.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.11.0.tgz",
+      "integrity": "sha512-rxtHpMLxNTHxqWuGOLzR2QOyQi79rK1u1XYAVLZxDGTLz/A+uoDnjz9veBFlicrpWjwuieM4N6jcnjj/DDoidw==",
+      "devOptional": true,
+      "dependencies": {
+        "@prisma/debug": "5.11.0"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.11.0.tgz",
+      "integrity": "sha512-KCLiug2cs0Je7kGkQBN9jDWoZ90ogE/kvZTUTgz2h94FEo8pczCkPH7fPNXkD1sGU7Yh65risGGD1HQ5DF3r3g==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines": "5.11.0"
       },
       "bin": {
-        "prisma": "build/index.js",
-        "prisma2": "build/index.js"
+        "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.13"
       }
     }
   }

--- a/packages/collector/test/tracing/database/prisma/package.json
+++ b/packages/collector/test/tracing/database/prisma/package.json
@@ -13,6 +13,6 @@
     "@prisma/client": "^4.5.0"
   },
   "devDependencies": {
-    "prisma": "^4.5.0"
+    "prisma": "^5.11.0"
   }
 }

--- a/packages/collector/test/tracing/database/prisma/package.json
+++ b/packages/collector/test/tracing/database/prisma/package.json
@@ -10,7 +10,7 @@
   "author": "Bastian Krol <bastian.krol@ibm.com>",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "^4.5.0"
+    "@prisma/client": "^5.11.0"
   },
   "devDependencies": {
     "prisma": "^5.11.0"

--- a/packages/collector/test/tracing/database/prisma/test.js
+++ b/packages/collector/test/tracing/database/prisma/test.js
@@ -176,7 +176,7 @@ mochaSuiteFn('tracing/prisma', function () {
 
   function verifyReadResponse(response, withError) {
     if (withError) {
-      expect(response).to.include('Unknown arg `email` in where.email');
+      expect(response).to.include('PrismaClientValidationError');
     } else {
       expect(response).to.be.an('array');
       expect(response).to.have.length(1);

--- a/packages/collector/test/tracing/database/prisma/test.js
+++ b/packages/collector/test/tracing/database/prisma/test.js
@@ -25,7 +25,7 @@ const schemaTargetFile = path.join(appDir, 'prisma', 'schema.prisma');
 const migrationsTargetDir = path.join(appDir, 'prisma', 'migrations');
 
 const mochaSuiteFn =
-  supportedVersion(process.versions.node) && semver.gte(process.versions.node, '14.17.0') ? describe : describe.skip;
+  supportedVersion(process.versions.node) && semver.gte(process.versions.node, '16.0.0') ? describe : describe.skip;
 
 mochaSuiteFn('tracing/prisma', function () {
   this.timeout(Math.max(config.getTestTimeout() * 3, 20000));


### PR DESCRIPTION
refs 158386

[ci all-tests]

- [ ] run both v4 and v5
- [ ] Prisma instrumentation does not support overriding the URL via the PrismaClient