### PR TITLE
ci: fixed esm build name

### DIFF
--- a/.tekton/listeners/esm.yaml
+++ b/.tekton/listeners/esm.yaml
@@ -30,6 +30,8 @@ spec:
       value: "default-pipeline"
     - name: esm
       value: "true"
+    - name: context
+      value: "node-$(params.node-version)-esm"
 
 ---
 

--- a/.tekton/pipeline/default-pipeline.yaml
+++ b/.tekton/pipeline/default-pipeline.yaml
@@ -36,6 +36,8 @@ spec:
       value: $(params.esm)
     - name: coverage
       value: $(params.coverage)
+    - name: context
+      value: $(params.context)
   workspaces:
     - name: artifacts
   tasks:
@@ -100,7 +102,7 @@ spec:
         - name: revision
           value: $(params.commit-id)
         - name: context
-          value: "node-$(params.node-version)"
+          value: $(params.context)
         - name: description
           value: "test"
         - name: state
@@ -689,7 +691,7 @@ spec:
         - name: revision
           value: $(params.commit-id)
         - name: context
-          value: "node-$(params.node-version)"
+          value: $(params.context)
         - name: description
           value: "test"
         - name: state-var

--- a/.tekton/pipeline/trigger-template.yaml
+++ b/.tekton/pipeline/trigger-template.yaml
@@ -43,6 +43,9 @@ spec:
     - name: coverage
       default: "false"
       value: $(params.coverage)
+    - name: context
+      default: "node-$(params.node-version)"
+      value: $(params.context)
   resourcetemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
@@ -112,3 +115,5 @@ spec:
             value: $(params.esm)
           - name: coverage
             value: $(params.coverage)
+          - name: context
+            value: $(params.context)

--- a/.tekton/templates/default-pipeline.yaml.template
+++ b/.tekton/templates/default-pipeline.yaml.template
@@ -36,6 +36,8 @@ spec:
       value: $(params.esm)
     - name: coverage
       value: $(params.coverage)
+    - name: context
+      value: $(params.context)
   workspaces:
     - name: artifacts
   tasks:
@@ -100,7 +102,7 @@ spec:
         - name: revision
           value: $(params.commit-id)
         - name: context
-          value: "node-$(params.node-version)"
+          value: $(params.context)
         - name: description
           value: "test"
         - name: state
@@ -183,7 +185,7 @@ spec:
         - name: revision
           value: $(params.commit-id)
         - name: context
-          value: "node-$(params.node-version)"
+          value: $(params.context)
         - name: description
           value: "test"
         - name: state-var


### PR DESCRIPTION
Problem:
- default build (without ESM) has the same name than with ESM

Fixed:
- instead of node-18.18 -> node-18.18-esm