### PR TITLE
chore: updated the currency-update ignore list to include packages

### DIFF
--- a/currencies.json
+++ b/currencies.json
@@ -420,7 +420,7 @@
     "latestVersion": "",
     "cloudNative": false,
     "isBeta": false,
-    "ignoreUpdates": false
+    "ignoreUpdates": true
   },
   {
     "name": "node-nats-streaming",
@@ -465,7 +465,7 @@
     "latestVersion": "",
     "cloudNative": false,
     "isBeta": false,
-    "ignoreUpdates": false
+    "ignoreUpdates": true
   },
   {
     "name": "sequelize",
@@ -510,7 +510,7 @@
     "latestVersion": "",
     "cloudNative": false,
     "isBeta": false,
-    "ignoreUpdates": false
+    "ignoreUpdates": true
   },
   {
     "name": "winston",


### PR DESCRIPTION
Ignoring currency updates for got and node-fetch for now, as these packages are pure esm in their latest versions. 
Refs for track this issue
INSTA-1838
INSTA-1841
