### PR TITLE
fix(azure-container-services): gracefully shutdown if node version is unsupported

### DIFF
--- a/packages/azure-container-services/src/index.js
+++ b/packages/azure-container-services/src/index.js
@@ -16,7 +16,7 @@ if (isNodeJsTooOld()) {
     `The package @instana/azure-container-services requires at least Node.js ${minimumNodeJsVersion} but this` +
       `process is running on Node.js ${process.version}. This azure container service will not be monitored by Instana.`
   );
-  module.exports = exports = require('./noop');
+  return;
 }
 
 const { util: coreUtil } = require('@instana/core');


### PR DESCRIPTION
A return was missing. This is a bug.

Furthermore: At the moment all serverless packages **return** without a default export. Consistency change.
Its worth raising an issue to test if we have to export a default interface in case a customers is doing a manual instrumentation. We do not want to crash the customer's application.