### PR TITLE
Revert "chore(aws-lambda): removed timeout detection"

### DIFF
--- a/packages/aws-lambda/src/wrapper.js
+++ b/packages/aws-lambda/src/wrapper.js
@@ -175,6 +175,17 @@ function shimmedHandler(originalHandler, originalThis, originalArgs, _config) {
       });
     };
 
+    /**
+     * We offer the customer to disable the timeout detection
+     * See https://github.com/instana/nodejs/pull/443
+     */
+    if (
+      !process.env.INSTANA_DISABLE_LAMBDA_TIMEOUT_DETECTION ||
+      process.env.INSTANA_DISABLE_LAMBDA_TIMEOUT_DETECTION === 'false'
+    ) {
+      registerTimeoutDetection(context, entrySpan);
+    }
+
     let handlerPromise;
     try {
       handlerPromise = originalHandler.apply(originalThis, originalArgs);
@@ -256,6 +267,50 @@ function init(event, arnInfo, _config) {
   metrics.init(config);
   metrics.activate();
   tracing.activate();
+}
+
+function registerTimeoutDetection(context, entrySpan) {
+  // We register the timeout detection directly at the start so getRemainingTimeInMillis basically gives us the
+  // configured timeout for this Lambda function, minus roughly 50 - 100 ms that is spent in bootstrapping.
+  const initialRemainingMillis = getRemainingTimeInMillis(context);
+  if (typeof initialRemainingMillis !== 'number') {
+    return;
+  }
+  if (initialRemainingMillis <= 2500) {
+    logger.debug(
+      'Heuristical timeout detection will be disabled for Lambda functions with a short timeout ' +
+        '(2 seconds and smaller).'
+    );
+    return;
+  }
+
+  let triggerTimeoutHandlingAfter;
+  if (initialRemainingMillis <= 4000) {
+    // For Lambdas configured with a timeout of 3 or 4 seconds we heuristically assume a timeout when only
+    // 10% of time is remaining.
+    triggerTimeoutHandlingAfter = initialRemainingMillis * 0.9;
+  } else {
+    // For Lambdas configured with a timeout of  5 seconds or more we heuristically assume a timeout when only 400 ms of
+    // time are remaining.
+    triggerTimeoutHandlingAfter = initialRemainingMillis - 400;
+  }
+
+  logger.debug(
+    `Registering heuristical timeout detection to be triggered in ${triggerTimeoutHandlingAfter} milliseconds.`
+  );
+
+  setTimeout(() => {
+    postHandlerForTimeout(entrySpan, getRemainingTimeInMillis(context));
+  }, triggerTimeoutHandlingAfter).unref();
+}
+
+function getRemainingTimeInMillis(context) {
+  if (context && typeof context.getRemainingTimeInMillis === 'function') {
+    return context.getRemainingTimeInMillis();
+  } else {
+    logger.warn('context.getRemainingTimeInMillis() is not available, timeout detection will be disabled.');
+    return null;
+  }
 }
 
 function shouldUseLambdaExtension() {
@@ -387,6 +442,48 @@ function postHandler(entrySpan, error, result, callback) {
     metricsPayload,
     finalLambdaRequest: true,
     callback
+  });
+}
+
+/**
+ * When the timeout heuristic detects an imminent timeout, we finish the entry span prematurely and send it to the
+ * back end.
+ */
+function postHandlerForTimeout(entrySpan, remainingMillis) {
+  /**
+   * context.getRemainingTimeInMillis(context) can return negative values
+   * That just means that the lambda was already closed.
+   * `setTimeout` is not 100% reliable
+   */
+  if (remainingMillis < 200) {
+    logger.debug('Skipping heuristical timeout detection because lambda timeout exceeded already.');
+    return;
+  }
+
+  if (entrySpan) {
+    // CASE: Timeout not needed, we already send the data to the backend successfully
+    if (entrySpan.transmitted) {
+      logger.debug('Skipping heuristical timeout detection because BE data was sent already.');
+      return;
+    }
+
+    entrySpan.ec = 1;
+    entrySpan.data.lambda.msleft = remainingMillis;
+    entrySpan.data.lambda.error = `Possible Lambda timeout with only ${remainingMillis} ms left.`;
+    entrySpan.d = Date.now() - entrySpan.ts;
+    entrySpan.transmit();
+  }
+
+  logger.debug(`Heuristical timeout detection was triggered with ${remainingMillis} milliseconds left.`);
+
+  // deliberately not gathering metrics but only sending spans.
+  const spans = spanBuffer.getAndResetSpans();
+
+  sendToBackend({
+    spans,
+    metricsPayload: {},
+    finalLambdaRequest: true,
+    callback: () => {}
   });
 }
 

--- a/packages/aws-lambda/test/timeout/lambda.js
+++ b/packages/aws-lambda/test/timeout/lambda.js
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc. and contributors 2020
+ */
+
+/* eslint-disable no-console */
+
+'use strict';
+
+const instana = require('../..');
+
+const delay = require('../../../core/test/test_util/delay');
+
+if (!process.env.DELAY) {
+  throw new Error('This Lambda requires the environment variable DELAY to be set.');
+}
+
+exports.handler = instana.wrap(async () => {
+  console.log(`Lambda handler started, now waiting ${process.env.DELAY} milliseconds.`);
+  await delay(process.env.DELAY);
+  console.log('Lambda handler finished');
+
+  return {
+    body: {
+      message: 'Stan says hi!'
+    }
+  };
+});

--- a/packages/aws-lambda/test/timeout/test.js
+++ b/packages/aws-lambda/test/timeout/test.js
@@ -1,0 +1,285 @@
+/*
+ * (c) Copyright IBM Corp. 2021
+ * (c) Copyright Instana Inc. and contributors 2021
+ */
+
+'use strict';
+
+const { expect } = require('chai');
+const path = require('path');
+const constants = require('@instana/core').tracing.constants;
+
+const Control = require('../Control');
+const config = require('../../../serverless/test/config');
+const { expectExactlyOneMatching, isCI } = require('../../../core/test/test_util');
+const retry = require('../../../serverless/test/util/retry');
+
+const { fail } = expect;
+
+const functionName = 'functionName';
+const unqualifiedArn = `arn:aws:lambda:us-east-2:410797082306:function:${functionName}`;
+const version = '$LATEST';
+const qualifiedArn = `${unqualifiedArn}:${version}`;
+
+const backendPort = 8443;
+const backendBaseUrl = `https://localhost:${backendPort}/serverless`;
+const downstreamDummyPort = 3456;
+const downstreamDummyUrl = `http://localhost:${downstreamDummyPort}/`;
+const instanaAgentKey = 'aws-lambda-dummy-key';
+
+function prelude(opts) {
+  const timeout = opts.lambdaTimeout * 2;
+  this.timeout(isCI() ? config.getTestTimeout() : timeout);
+  this.slow(timeout);
+
+  if (opts.startBackend == null) {
+    opts.startBackend = true;
+  }
+
+  // eslint-disable-next-line prefer-object-spread
+  const env = Object.assign(
+    {
+      INSTANA_ENDPOINT_URL: opts.instanaEndpointUrl,
+      INSTANA_AGENT_KEY: opts.instanaAgentKey,
+      LAMBDA_TIMEOUT: opts.lambdaTimeout
+    },
+    opts.env
+  );
+  const control = new Control({
+    faasRuntimePath: path.join(__dirname, '../runtime_mock'),
+    handlerDefinitionPath: opts.handlerDefinitionPath,
+    startBackend: opts.startBackend,
+    backendPort,
+    backendBaseUrl,
+    downstreamDummyUrl,
+    env,
+    timeout,
+    lambdaTimeout: opts.lambdaTimeout
+  });
+  control.registerTestHooks();
+  return control;
+}
+
+describe('timeout heuristic', () => {
+  const handlerDefinitionPath = path.join(__dirname, './lambda');
+
+  describe('when the Lambda has a very short timeout and times out', function () {
+    // For Lambdas with timeout configured at 1 second or lower, we disable timeout detection.
+    runTest.bind(this)({
+      lambdaTimeout: 1000,
+      delay: 1500,
+      expectEntrySpan: false,
+      expectTimeout: false,
+      expectResponseFromLambda: false
+    });
+  });
+
+  describe('when the Lambda has a short timeout and times out', function () {
+    runTest.bind(this)({
+      lambdaTimeout: 3100,
+      delay: 3500,
+      expectEntrySpan: true,
+      expectTimeout: true,
+      expectResponseFromLambda: false,
+      expectedMillisRemainingAtTimeout: 280
+    });
+  });
+
+  describe('when the Lambda has a short timeout and finishes just after the timeout detection', function () {
+    runTest.bind(this)({
+      lambdaTimeout: 3100,
+      delay: 2900, // timeout is assumed after ~ 3100 ms * 0.9 ~= 2800 ms
+      expectEntrySpan: true,
+      expectTimeout: true,
+      expectResponseFromLambda: true,
+      expectedMillisRemainingAtTimeout: 280
+    });
+  });
+
+  describe('when the Lambda has a short timeout and finishes before the timeout detection', function () {
+    runTest.bind(this)({
+      lambdaTimeout: 3100,
+      delay: 2000,
+      expectEntrySpan: true,
+      expectTimeout: false,
+      expectResponseFromLambda: true
+    });
+  });
+
+  describe('when the Lambda has a longer timeout and times out', function () {
+    runTest.bind(this)({
+      lambdaTimeout: 10000,
+      delay: 11000,
+      expectEntrySpan: true,
+      expectTimeout: true,
+      expectResponseFromLambda: false,
+      expectedMillisRemainingAtTimeout: 400
+    });
+  });
+
+  describe('when the Lambda has a longer timeout and finishes just after the timeout detection', function () {
+    runTest.bind(this)({
+      lambdaTimeout: 10000,
+      delay: 9750,
+      expectEntrySpan: true,
+      expectTimeout: true,
+      expectResponseFromLambda: true,
+      expectedMillisRemainingAtTimeout: 400
+    });
+  });
+
+  describe('when the Lambda has a longer timeout and finishes before the timeout detection', function () {
+    runTest.bind(this)({
+      lambdaTimeout: 10000,
+      delay: 8000,
+      expectEntrySpan: true,
+      expectTimeout: false,
+      expectResponseFromLambda: true
+    });
+  });
+
+  describe('when the timeout detection is disabled and a timeout occurs', function () {
+    runTest.bind(this)({
+      lambdaTimeout: 3100,
+      delay: 3500,
+      expectEntrySpan: false,
+      expectTimeout: true,
+      expectResponseFromLambda: false,
+      disableLambdaTimeoutDetection: true
+    });
+  });
+
+  describe('when the timeout detection env is set but its set to false', function () {
+    runTest.bind(this)({
+      lambdaTimeout: 3100,
+      delay: 3500,
+      expectEntrySpan: true,
+      expectTimeout: true,
+      expectResponseFromLambda: false,
+      disableLambdaTimeoutDetection: false,
+      expectedMillisRemainingAtTimeout: 300
+    });
+  });
+
+  function runTest({
+    lambdaTimeout,
+    delay,
+    expectEntrySpan,
+    expectTimeout,
+    expectResponseFromLambda,
+    expectedMillisRemainingAtTimeout,
+    disableLambdaTimeoutDetection
+  }) {
+    const envs = {
+      DELAY: delay
+    };
+
+    if (disableLambdaTimeoutDetection !== undefined) {
+      envs.INSTANA_DISABLE_LAMBDA_TIMEOUT_DETECTION = disableLambdaTimeoutDetection;
+    }
+
+    const opts = {
+      handlerDefinitionPath,
+      instanaEndpointUrl: backendBaseUrl,
+      instanaAgentKey,
+      lambdaTimeout,
+      env: envs
+    };
+
+    const control = prelude.bind(this)(opts);
+
+    let label;
+
+    if (expectTimeout && !expectResponseFromLambda) {
+      label = 'must detect the timeout';
+    } else if (expectTimeout) {
+      label = "must a assume timeout but not impact the handler's response";
+    } else {
+      label = 'must not detect a timeout';
+    }
+
+    it(label, () => {
+      const lambdaFinishedUnexpectedlyMessage = 'The Lambda was expected to time out but it actually finished.';
+      return control
+        .runHandler()
+        .then(() => {
+          if (expectResponseFromLambda) {
+            if (control.getLambdaErrors() && control.getLambdaErrors().length > 0) {
+              // eslint-disable-next-line no-console
+              console.log('Unexpected Errors:');
+              // eslint-disable-next-line no-console
+              console.log(JSON.stringify(control.getLambdaErrors()));
+            }
+            expect(control.getLambdaErrors()).to.be.empty;
+            expect(control.getLambdaResults().length).to.equal(1);
+            const result = control.getLambdaResults()[0];
+            expect(result).to.exist;
+            expect(result.body).to.deep.equal({ message: 'Stan says hi!' });
+          } else {
+            fail(lambdaFinishedUnexpectedlyMessage);
+          }
+        })
+        .catch(e => {
+          if (e.name === 'AssertionError' && e.message === lambdaFinishedUnexpectedlyMessage) {
+            throw e;
+          }
+
+          expect(e.message).to.include('but it ran only 0 time(s).');
+        })
+        .finally(async () => {
+          await retry(async () => {
+            const spans = await control.getSpans();
+
+            if (expectEntrySpan) {
+              verifyLambdaEntry(
+                spans,
+                expectTimeout,
+                expectedMillisRemainingAtTimeout - 100,
+                expectedMillisRemainingAtTimeout + 100
+              );
+            }
+          });
+        });
+    });
+  }
+
+  function verifyLambdaEntry(spans, expectTimeout, minRemaining, maxRemaining) {
+    let expectations = [
+      span => expect(span.t).to.exist,
+      span => expect(span.p).to.not.exist,
+      span => expect(span.s).to.exist,
+      span => expect(span.n).to.equal('aws.lambda.entry'),
+      span => expect(span.k).to.equal(constants.ENTRY),
+      span => expect(span.f).to.be.an('object'),
+      span => expect(span.f.hl).to.be.true,
+      span => expect(span.f.cp).to.equal('aws'),
+      span => expect(span.f.e).to.equal(qualifiedArn),
+      span => expect(span.data.lambda).to.be.an('object'),
+      span => expect(span.data.lambda.runtime).to.equal('nodejs')
+    ];
+
+    if (expectTimeout) {
+      expectations = expectations.concat([
+        span => expect(span.data.lambda.msleft).to.be.at.least(minRemaining),
+        span => expect(span.data.lambda.msleft).to.be.at.most(maxRemaining),
+        span => expect(span.ec).to.equal(1),
+        span => {
+          const regex = /Possible Lambda timeout with only (\d+) ms left./;
+
+          expect(span.data.lambda.error).to.match(regex);
+          const digitsFromErrorMessage = regex.exec(span.data.lambda.error)[1];
+          const remainingMillisFromErrorMessage = parseInt(digitsFromErrorMessage, 10);
+          expect(remainingMillisFromErrorMessage).to.equal(span.data.lambda.msleft);
+        }
+      ]);
+    } else {
+      expectations = expectations.concat([
+        span => expect(span.data.lambda.msleft).to.not.exist,
+        span => expect(span.ec).to.equal(0),
+        span => expect(span.data.lambda.error).to.not.exist
+      ]);
+    }
+
+    return expectExactlyOneMatching(spans, expectations);
+  }
+});


### PR DESCRIPTION
Reverts instana/nodejs#668

Brining this back but we make it optional.
Customer need this feature for debugging purposes.
We will also update the docs as well to make it clear