### PR TITLE
test: enhanced test cases with stringent span assertions

### DIFF
--- a/packages/collector/test/tracing/cloud/aws-sdk/v2/dynamodb/test.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v2/dynamodb/test.js
@@ -151,6 +151,7 @@ mochaSuiteFn('tracing/cloud/aws-sdk/v2/dynamodb', function () {
       });
 
       if (!withError) {
+        expect(spans.length).to.equal(3);
         verifyHttpExit({ spans, parent: httpEntry, pid: String(controls.getPid()) });
       }
     }

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/test_definition.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/dynamodb/test_definition.js
@@ -388,6 +388,7 @@ function start(version, requestMethod, reducedTestSuite = false) {
       });
 
       if (!withError) {
+        expect(spans.length).to.equal(3);
         verifyHttpExit({ spans, parent: httpEntry, pid: String(controls.getPid()) });
       }
     }

--- a/packages/collector/test/tracing/database/ioredis/test.js
+++ b/packages/collector/test/tracing/database/ioredis/test.js
@@ -80,7 +80,7 @@ mochaSuiteFn('tracing/ioredis', function () {
               span => expect(span.n).to.equal('node.http.server'),
               span => expect(span.data.http.method).to.equal('POST')
             ]);
-
+            expect(spans).to.have.lengthOf(4);
             expectAtLeastOneMatching(spans, [
               span => expect(span.t).to.equal(writeEntrySpan.t),
               span => expect(span.p).to.equal(writeEntrySpan.s),
@@ -145,7 +145,7 @@ mochaSuiteFn('tracing/ioredis', function () {
               span => expect(span.n).to.equal('node.http.server'),
               span => expect(span.data.http.method).to.equal('POST')
             ]);
-
+            expect(spans).to.have.lengthOf(5);
             expectAtLeastOneMatching(spans, [
               span => expect(span.t).to.equal(writeEntrySpan.t),
               span => expect(span.p).to.equal(writeEntrySpan.s),
@@ -225,7 +225,7 @@ mochaSuiteFn('tracing/ioredis', function () {
               span => expect(span.n).to.equal('node.http.server'),
               span => expect(span.data.http.method).to.equal('POST')
             ]);
-
+            expect(spans).to.have.lengthOf(5);
             expectAtLeastOneMatching(spans, [
               span => expect(span.t).to.equal(writeEntrySpan.t),
               span => expect(span.p).to.equal(writeEntrySpan.s),
@@ -362,7 +362,7 @@ mochaSuiteFn('tracing/ioredis', function () {
               span => expect(span.n).to.equal('node.http.server'),
               span => expect(span.data.http.method).to.equal('GET')
             ]);
-
+            expect(spans).to.have.lengthOf(5);
             expectAtLeastOneMatching(spans, [
               span => expect(span.t).to.equal(writeEntrySpan.t),
               span => expect(span.p).to.equal(writeEntrySpan.s),
@@ -397,7 +397,7 @@ mochaSuiteFn('tracing/ioredis', function () {
               span => expect(span.n).to.equal('node.http.server'),
               span => expect(span.data.http.method).to.equal('POST')
             ]);
-
+            expect(spans).to.have.lengthOf(6);
             expectAtLeastOneMatching(spans, [
               span => expect(span.t).to.equal(entrySpan.t),
               span => expect(span.p).to.equal(entrySpan.s),
@@ -476,6 +476,7 @@ mochaSuiteFn('tracing/ioredis', function () {
       .then(() =>
         retry(() =>
           agentControls.getSpans().then(spans => {
+            expect(spans).to.have.lengthOf(5);
             const writeEntrySpan = expectAtLeastOneMatching(spans, [
               span => expect(span.n).to.equal('node.http.server'),
               span => expect(span.data.http.method).to.equal('GET')
@@ -515,7 +516,7 @@ mochaSuiteFn('tracing/ioredis', function () {
               span => expect(span.n).to.equal('node.http.server'),
               span => expect(span.data.http.method).to.equal('POST')
             ]);
-
+            expect(spans).to.have.lengthOf(5);
             expectAtLeastOneMatching(spans, [
               span => expect(span.t).to.equal(entrySpan.t),
               span => expect(span.p).to.equal(entrySpan.s),

--- a/packages/collector/test/tracing/database/mongodb/test.js
+++ b/packages/collector/test/tracing/database/mongodb/test.js
@@ -90,6 +90,7 @@ const USE_ATLAS = process.env.USE_ATLAS === 'true';
               expect(res).to.be.a('number');
               return retry(() =>
                 agentControls.getSpans().then(spans => {
+                  expect(spans).to.have.lengthOf(2);
                   const entrySpan = expectHttpEntry(controls, spans, '/count');
                   expectMongoExit(
                     controls,
@@ -119,6 +120,7 @@ const USE_ATLAS = process.env.USE_ATLAS === 'true';
             .then(() =>
               retry(() =>
                 agentControls.getSpans().then(spans => {
+                  expect(spans).to.have.lengthOf(3);
                   const entrySpan = expectHttpEntry(controls, spans, '/insert-one');
                   expectMongoExit(controls, spans, entrySpan, 'insert');
                   expectHttpExit(controls, spans, entrySpan);
@@ -154,6 +156,7 @@ const USE_ATLAS = process.env.USE_ATLAS === 'true';
 
               return retry(() =>
                 agentControls.getSpans().then(spans => {
+                  expect(spans).to.have.lengthOf(9);
                   const entrySpanUpdate = expectHttpEntry(controls, spans, '/update-one');
 
                   expectMongoExit(
@@ -210,6 +213,7 @@ const USE_ATLAS = process.env.USE_ATLAS === 'true';
 
               return retry(() =>
                 agentControls.getSpans().then(spans => {
+                  expect(spans).to.have.lengthOf(9);
                   const entrySpanUpdate = expectHttpEntry(controls, spans, '/replace-one');
                   expectMongoExit(
                     controls,
@@ -256,6 +260,7 @@ const USE_ATLAS = process.env.USE_ATLAS === 'true';
               expect(response).to.not.exist;
               return retry(() =>
                 agentControls.getSpans().then(spans => {
+                  expect(spans).to.have.lengthOf(9);
                   const entrySpanUpdate = expectHttpEntry(controls, spans, '/delete-one');
                   expectMongoExit(
                     controls,
@@ -294,6 +299,7 @@ const USE_ATLAS = process.env.USE_ATLAS === 'true';
             .then(() =>
               retry(() =>
                 agentControls.getSpans().then(spans => {
+                  expect(spans).to.have.lengthOf(3);
                   const entrySpan = expectHttpEntry(controls, spans, '/find-one');
                   expectMongoExit(
                     controls,

--- a/packages/collector/test/tracing/database/mongoose/test.js
+++ b/packages/collector/test/tracing/database/mongoose/test.js
@@ -83,6 +83,7 @@ const USE_ATLAS = process.env.USE_ATLAS === 'true';
         .then(() =>
           retry(() =>
             agentControls.getSpans().then(spans => {
+              expect(spans).to.have.lengthOf(2);
               const entrySpan = expectEntry(controls, spans, '/insert');
               expectMongoExit(controls, spans, entrySpan, 'insert');
             })
@@ -119,6 +120,7 @@ const USE_ATLAS = process.env.USE_ATLAS === 'true';
         .then(() =>
           retry(() =>
             agentControls.getSpans().then(spans => {
+              expect(spans).to.have.lengthOf(4);
               const entrySpan = expectEntry(controls, spans, '/find');
               const mongoExit = expectMongoExit(controls, spans, entrySpan, 'find');
               expect(mongoExit.data.mongo.filter).to.contain('"age":42');

--- a/packages/collector/test/tracing/misc/stack_trace/test.js
+++ b/packages/collector/test/tracing/misc/stack_trace/test.js
@@ -52,6 +52,7 @@ mochaSuiteFn('tracing/stackTraces', function () {
         .then(() =>
           testUtils.retry(() =>
             agentControls.getSpans().then(spans => {
+              expect(spans.length).to.equal(3);
               testUtils.expectAtLeastOneMatching(spans, [
                 span => expect(span.n).to.equal('node.http.server'),
                 span => expect(span.stack).to.have.lengthOf(0)
@@ -90,6 +91,7 @@ mochaSuiteFn('tracing/stackTraces', function () {
         .then(() =>
           testUtils.retry(() =>
             agentControls.getSpans().then(spans => {
+              expect(spans.length).to.equal(6);
               testUtils.expectAtLeastOneMatching(spans, [
                 span => expect(span.n).to.equal('node.http.server'),
                 span => expect(span.stack).to.have.lengthOf(0)
@@ -108,6 +110,7 @@ mochaSuiteFn('tracing/stackTraces', function () {
         .then(() =>
           testUtils.retry(() =>
             agentControls.getSpans().then(spans => {
+              expect(spans.length).to.equal(9);
               testUtils.expectAtLeastOneMatching(spans, [
                 span => expect(span.n).to.equal('node.http.client'),
                 span => expect(span.k).to.equal(constants.EXIT),

--- a/packages/collector/test/tracing/misc/too_late/test.js
+++ b/packages/collector/test/tracing/misc/too_late/test.js
@@ -62,6 +62,7 @@ mochaSuiteFn('tracing/too late', function () {
               agentControls.getMonitoringEvents(),
               agentControls.getAllMetrics(controls.getPid())
             ]).then(([spans, monitoringEvents, metrics]) => {
+              expect(spans.length).to.equal(1);
               // expect HTTP entry to be captured
               testUtils.expectAtLeastOneMatching(spans, [
                 span => expect(span.n).to.equal('node.http.server'),
@@ -146,6 +147,7 @@ mochaSuiteFn('tracing/too late', function () {
               agentControls.getMonitoringEvents(),
               agentControls.getAllMetrics(controls.getPid())
             ]).then(([spans, monitoringEvents, metrics]) => {
+              expect(spans.length).to.equal(2);
               const httpEntry = testUtils.expectAtLeastOneMatching(spans, [
                 span => expect(span.n).to.equal('node.http.server'),
                 span => expect(span.k).to.equal(constants.ENTRY),

--- a/packages/collector/test/tracing/misc/tracing_metrics/test.js
+++ b/packages/collector/test/tracing/misc/tracing_metrics/test.js
@@ -53,6 +53,7 @@ mochaSuiteFn('tracing/tracing metrics', function () {
       expect(response).to.equal('OK');
       await testUtils.retry(async () => {
         const spans = await agentControls.getSpans();
+        expect(spans.length).to.equal(4);
         const httpEntry = expectHttpEntry(spans, '/create-spans');
         expectExit(spans, httpEntry, 'exit-1');
         expectExit(spans, httpEntry, 'exit-2');
@@ -74,6 +75,7 @@ mochaSuiteFn('tracing/tracing metrics', function () {
       expect(response).to.equal('OK');
       await testUtils.retry(async () => {
         const spans = await agentControls.getSpans();
+        expect(spans.length).to.equal(2);
         const httpEntry = expectHttpEntry(spans, '/create-unfinished-spans');
         expectExit(spans, httpEntry, 'exit-1');
       });
@@ -116,6 +118,7 @@ mochaSuiteFn('tracing/tracing metrics', function () {
       expect(response).to.equal('OK');
       await testUtils.retry(async () => {
         const spans = await agentControls.getSpans();
+        expect(spans.length).to.equal(4);
         const httpEntry = expectHttpEntry(spans, '/create-spans');
         expectExit(spans, httpEntry, 'exit-1');
         expectExit(spans, httpEntry, 'exit-2');

--- a/packages/collector/test/tracing/protocols/apollo_subgraph/test.js
+++ b/packages/collector/test/tracing/protocols/apollo_subgraph/test.js
@@ -101,6 +101,11 @@ mochaSuiteFn('tracing gateway with apollo-subgraph', function () {
 
             return testUtils.retry(() => {
               return agentControls.getSpans().then(spans => {
+                if (withError) {
+                  expect(spans.length).to.equal(5);
+                } else {
+                  expect(spans.length).to.equal(11);
+                }
                 return verifySpansForQuery(
                   {
                     gatewayControls,

--- a/packages/collector/test/tracing/sdk/test.js
+++ b/packages/collector/test/tracing/sdk/test.js
@@ -74,6 +74,7 @@ mochaSuiteFn('tracing/sdk', function () {
             expect(ipcMessages.length).to.equal(1);
             expect(ipcMessages[0]).to.equal('done: start-entry');
             return agentControls.getSpans().then(spans => {
+              expect(spans.length).to.equal(2);
               const customEntry = expectCustomEntry({
                 spans,
                 pid: controls.getPid(),
@@ -100,6 +101,7 @@ mochaSuiteFn('tracing/sdk', function () {
             expect(ipcMessages.length).to.equal(1);
             expect(ipcMessages[0]).to.equal('done: start-entry');
             return agentControls.getSpans().then(spans => {
+              expect(spans.length).to.equal(2);
               const customEntry = expectCustomEntry({
                 spans,
                 pid: controls.getPid(),
@@ -126,6 +128,7 @@ mochaSuiteFn('tracing/sdk', function () {
             expect(ipcMessages.length).to.equal(1);
             expect(ipcMessages[0]).to.equal('done: start-entry');
             return agentControls.getSpans().then(spans => {
+              expect(spans.length).to.equal(2);
               const customEntry = expectCustomEntry({
                 spans,
                 pid: controls.getPid(),
@@ -152,6 +155,7 @@ mochaSuiteFn('tracing/sdk', function () {
             expect(ipcMessages.length).to.equal(1);
             expect(ipcMessages[0]).to.equal('done: start-entry');
             return agentControls.getSpans().then(spans => {
+              expect(spans.length).to.equal(2);
               const customEntry = expectCustomEntry({
                 spans,
                 pid: controls.getPid(),
@@ -172,6 +176,7 @@ mochaSuiteFn('tracing/sdk', function () {
             expect(ipcMessages.length).to.equal(1);
             expect(ipcMessages[0]).to.equal('done: start-entry');
             return agentControls.getSpans().then(spans => {
+              expect(spans.length).to.equal(2);
               const customEntry = expectCustomEntry({
                 spans,
                 pid: controls.getPid(),
@@ -202,6 +207,7 @@ mochaSuiteFn('tracing/sdk', function () {
             expect(ipcMessages.length).to.equal(1);
             expect(ipcMessages[0]).to.equal('done: start-entry');
             return agentControls.getSpans().then(spans => {
+              expect(spans.length).to.equal(2);
               const customEntry = expectCustomEntry({
                 spans,
                 pid: controls.getPid(),
@@ -230,6 +236,7 @@ mochaSuiteFn('tracing/sdk', function () {
               expect(response.indexOf('The MIT License')).to.equal(0);
               return retry(() =>
                 agentControls.getSpans().then(spans => {
+                  expect(spans.length).to.equal(4);
                   const httpEntry = expectHttpEntry({
                     spans,
                     path: `/${apiType}/create-intermediate`,
@@ -258,6 +265,7 @@ mochaSuiteFn('tracing/sdk', function () {
 
               return retry(() =>
                 agentControls.getSpans().then(spans => {
+                  expect(spans.length).to.equal(3);
                   const httpEntry = expectHttpEntry({
                     spans,
                     path: `/${apiType}/create-overlapping-intermediates`
@@ -294,6 +302,7 @@ mochaSuiteFn('tracing/sdk', function () {
               expect(response.indexOf('The MIT License')).to.equal(0);
               return retry(() =>
                 agentControls.getSpans().then(spans => {
+                  expect(spans.length).to.equal(3);
                   const httpEntry = expectHttpEntry({
                     spans,
                     path: `/${apiType}/create-exit`,
@@ -319,6 +328,7 @@ mochaSuiteFn('tracing/sdk', function () {
               expect(response).to.equal('Not Found');
               return retry(() =>
                 agentControls.getSpans().then(spans => {
+                  expect(spans.length).to.equal(3);
                   const httpEntry = expectHttpEntry({
                     spans,
                     path: `/${apiType}/create-exit`,
@@ -345,6 +355,7 @@ mochaSuiteFn('tracing/sdk', function () {
             expect(ipcMessages.length).to.equal(1);
             expect(ipcMessages[0]).to.equal('done: event-emitter');
             return agentControls.getSpans().then(spans => {
+              expect(spans.length).to.equal(2);
               const customEntry = expectCustomEntry({
                 spans,
                 pid: controls.getPid(),
@@ -364,6 +375,7 @@ mochaSuiteFn('tracing/sdk', function () {
             expect(ipcMessages.length).to.equal(1);
             expect(ipcMessages[0]).to.equal('done: nest-entry-exit');
             return agentControls.getSpans().then(spans => {
+              expect(spans.length).to.equal(2);
               const customEntry = expectCustomEntry({
                 spans,
                 pid: controls.getPid(),
@@ -389,6 +401,7 @@ mochaSuiteFn('tracing/sdk', function () {
             expect(ipcMessages.length).to.equal(1);
             expect(ipcMessages[0]).to.equal('done: nest-intermediates');
             return agentControls.getSpans().then(spans => {
+              expect(spans.length).to.equal(4);
               const customEntry = expectCustomEntry({
                 spans,
                 pid: controls.getPid(),
@@ -434,6 +447,7 @@ mochaSuiteFn('tracing/sdk', function () {
           expect(response.result).to.equal(42);
           return retry(() =>
             agentControls.getSpans().then(spans => {
+              expect(spans.length).to.equal(3);
               const httpEntry = expectHttpEntry({
                 spans,
                 path: '/callback/create-exit-synchronous-result',
@@ -463,6 +477,7 @@ mochaSuiteFn('tracing/sdk', function () {
         expect(ipcMessages[0]).to.equal('done: 4711');
         return retry(() =>
           agentControls.getSpans().then(spans => {
+            expect(spans.length).to.equal(3);
             const customEntry = expectExactlyOneMatching(spans, [
               span => expect(span.t).to.exist,
               span => expect(span.p).to.not.exist,


### PR DESCRIPTION
We've noticed that some of our tests lack strict assertions regarding the span lengths. To address this, we've added a few assertions to ensure everything functions smoothly. By doing so, we can also uncover any potential bugs when we merge these changes in the future. While we haven't added strict assertions to all test cases at this point, we've incorporated them into a few to enhance our test coverage.
reference https://github.com/instana/nodejs/pull/1159#discussion_r1638122556