### PR TITLE
feat(couchbase): added support for raw sql queries

### DIFF
--- a/packages/collector/test/tracing/database/couchbase/test.js
+++ b/packages/collector/test/tracing/database/couchbase/test.js
@@ -401,6 +401,7 @@ mochaSuiteFn('tracing/couchbase', function () {
           })
           .then(resp => {
             expect(resp.success).to.eql(true);
+
             return retry(() =>
               verifySpans(agentControls, controls, {
                 spanLength: 9,
@@ -410,16 +411,70 @@ mochaSuiteFn('tracing/couchbase', function () {
                     verifyCouchbaseSpan(controls, entrySpan, {
                       bucket: 'projects',
                       type: 'membase',
-                      sql: 'ANALYTICSQUERY'
+                      sql: 'SELECT '
                     })
                   );
                   expectExactlyNMatching(
                     spans,
-                    7,
+                    1,
                     verifyCouchbaseSpan(controls, entrySpan, {
                       bucket: '',
                       type: '',
-                      sql: 'ANALYTICSQUERY'
+                      sql: 'CREATE DATAVERSE '
+                    })
+                  );
+                  expectExactlyNMatching(
+                    spans,
+                    1,
+                    verifyCouchbaseSpan(controls, entrySpan, {
+                      bucket: '',
+                      type: '',
+                      sql: 'CREATE DATASET '
+                    })
+                  );
+                  expectExactlyNMatching(
+                    spans,
+                    1,
+                    verifyCouchbaseSpan(controls, entrySpan, {
+                      bucket: '',
+                      type: '',
+                      sql: 'CREATE INDEX '
+                    })
+                  );
+                  expectExactlyNMatching(
+                    spans,
+                    1,
+                    verifyCouchbaseSpan(controls, entrySpan, {
+                      bucket: '',
+                      type: '',
+                      sql: 'SELECT'
+                    })
+                  );
+                  expectExactlyNMatching(
+                    spans,
+                    1,
+                    verifyCouchbaseSpan(controls, entrySpan, {
+                      bucket: '',
+                      type: '',
+                      sql: 'DROP INDEX '
+                    })
+                  );
+                  expectExactlyNMatching(
+                    spans,
+                    1,
+                    verifyCouchbaseSpan(controls, entrySpan, {
+                      bucket: '',
+                      type: '',
+                      sql: 'DROP DATASET '
+                    })
+                  );
+                  expectExactlyNMatching(
+                    spans,
+                    1,
+                    verifyCouchbaseSpan(controls, entrySpan, {
+                      bucket: '',
+                      type: '',
+                      sql: 'DROP DATAVERSE '
                     })
                   );
                 }

--- a/packages/collector/test/tracing/database/couchbase/test.js
+++ b/packages/collector/test/tracing/database/couchbase/test.js
@@ -43,7 +43,7 @@ const verifyCouchbaseSpan = (controls, entrySpan, options = {}) => [
       // eslint-disable-next-line no-nested-ternary
       'type' in options ? (options.type === '' ? undefined : options.type) : 'membase'
     ),
-  span => expect(span.data.couchbase.sql).to.equal(options.sql || 'GET'),
+  span => expect(span.data.couchbase.sql).to.contain(options.sql || 'GET'),
   span =>
     options.error
       ? expect(span.data.couchbase.error).to.equal(options.error)
@@ -393,8 +393,7 @@ mochaSuiteFn('tracing/couchbase', function () {
             );
           }));
 
-      // flaky on CI
-      it.skip('[analyticsindexes] must trace', () =>
+      it('[analyticsindexes] must trace', () =>
         controls
           .sendRequest({
             method: 'post',
@@ -428,8 +427,7 @@ mochaSuiteFn('tracing/couchbase', function () {
             );
           }));
 
-      // flaky on CI
-      it.skip('[searchquery] must trace', () =>
+      it('[searchquery] must trace', () =>
         controls
           .sendRequest({
             method: 'get',
@@ -575,7 +573,7 @@ mochaSuiteFn('tracing/couchbase', function () {
                     verifyCouchbaseSpan(controls, entrySpan, {
                       bucket: '',
                       type: '',
-                      sql: 'QUERY'
+                      sql: 'SELECT * FROM projects WHERE name='
                     })
                   );
 
@@ -586,7 +584,7 @@ mochaSuiteFn('tracing/couchbase', function () {
                     verifyCouchbaseSpan(controls, entrySpan, {
                       bucket: 'companies',
                       type: 'ephemeral',
-                      sql: 'QUERY'
+                      sql: 'SELECT * FROM _default WHERE name='
                     })
                   );
 
@@ -599,7 +597,7 @@ mochaSuiteFn('tracing/couchbase', function () {
                       // FYI: this error msg does not come from us.
                       error: 'bucket not found',
                       type: 'ephemeral',
-                      sql: 'QUERY'
+                      sql: 'SELECT * FROM TABLE_DOES_NOT_EXIST WHERE name'
                     })
                   );
 
@@ -649,7 +647,7 @@ mochaSuiteFn('tracing/couchbase', function () {
                       verifyCouchbaseSpan(controls, entrySpan, {
                         bucket: '',
                         type: '',
-                        sql: 'QUERY'
+                        sql: 'SELECT * FROM'
                       })
                     );
                     expectExactlyOneMatching(
@@ -658,7 +656,7 @@ mochaSuiteFn('tracing/couchbase', function () {
                         bucket: '',
                         hostname: connStr2,
                         type: '',
-                        sql: 'QUERY'
+                        sql: 'SELECT * FROM'
                       })
                     );
                   }

--- a/packages/core/src/tracing/instrumentation/database/couchbase.js
+++ b/packages/core/src/tracing/instrumentation/database/couchbase.js
@@ -101,8 +101,8 @@ function instrumentCluster(cluster, connectionStr) {
   instrumentTransactions(cluster, connectionStr);
 
   // cluster.query
-  shimmer.wrap(cluster, 'query', function instrumentClusterQuery(original) {
-    return function instrumentClusterQueryWrapped() {
+  shimmer.wrap(cluster, 'query', function insatanClusterQuery(original) {
+    return function instanaClusterQueryWrapped() {
       const originalThis = this;
       const originalArgs = arguments;
       const sqlStatement = originalArgs[0] || '';


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-5903

- extract full query for cluster.query & scope.query and analyticsQuery
- for all other ORM operations we cannot extract the raw sql queries, because the core library is [written in c++](https://github.com/couchbase/couchnode/tree/master/src)