### PR TITLE
chore: readme update for esm support to aws lambda

### DIFF
--- a/packages/aws-lambda-auto-wrap/esm/README.md
+++ b/packages/aws-lambda-auto-wrap/esm/README.md
@@ -9,7 +9,7 @@ AWS Lambda began supporting ES modules with Node v14. Learn more on the [AWS Lam
   - We utilize the handler as a CommonJS module with dynamic imports.
   - Transitioning the handler to pure ES modules does not provide immediate benefits, but we are monitoring AWS updates closely.
 
-- **Roadmap for Improvement**:
-  - We've initiated an AWS support ticket (172069954500883) and engaged with the AWS SDK community to advocate for ES module support in Lambda layers.
-  - Future plans for version 4.x include removing the `aws-lambda-auto-wrap` npm package and enhancing our deployment process by manually integrating necessary files during the layer publishing script.
-  - Considering discontinuing support for Node.js version 14, which have reached the end of their LTS (Long-Term Support) lifecycle.
+- **Roadmap for Improvements**:
+  - We've initiated an AWS support ticket (172069954500883) and engaged with the AWS SDK community to advocate for ES module support in Lambda layers. For more details, see the [GitHub discussion](https://github.com/aws/aws-sdk-js/discussions/4651).
+  - In 4.x we will remove the `aws-lambda-auto-wrap` npm package, because this is an internal package. It got published by mistake. We copy the necessary files during the layer publishing script into the layer.
+  - Considering discontinuing support for Node.js version 14, which has reached the end of their LTS (Long-Term Support) lifecycle.

--- a/packages/aws-lambda-auto-wrap/esm/README.md
+++ b/packages/aws-lambda-auto-wrap/esm/README.md
@@ -1,4 +1,4 @@
-## ES Module Support for AWS Lambda
+## ES Module Support for AWS Lambda Layer
 
 AWS Lambda began supporting ES modules with Node v14. Learn more on the [AWS Lambda ES modules and top-level await with Node.js 14](https://aws.amazon.com/about-aws/whats-new/2022/01/aws-lambda-es-modules-top-level-await-node-js-14/) page.
 

--- a/packages/aws-lambda-auto-wrap/esm/README.md
+++ b/packages/aws-lambda-auto-wrap/esm/README.md
@@ -10,6 +10,9 @@ But AWS forgot to add support for layers. There are currently two known bugs:
 
 We are affected by the second bug. When AWS fixes the underlying problem in their AWS runtime, we are able to transform the new esm handler into a real ES module.
 
-For now: We ship the ES handler as commonjs module with the help of dynamic imports.
+For the time being, we are shipping the ES handler as a CommonJS module using dynamic imports as a workaround for Node.js 14 and 16, as AWS has yet to resolve the issue for these versions, which are no longer LTS.
+see the comment https://github.com/aws/aws-sdk-js-v3/issues/3230#issuecomment-1561973247
 
-In 4.x: We remove the aws-lambda-auto-wrap npm package and manually copy over the files in the publish layer script.
+The Node.js 18.x runtime introduces support for ES module resolution using NODE_PATH. For more information, refer to [Node.js 18.x runtime now available in AWS Lambda](https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/). This is the recommended workaround.
+
+In version 4.x, we will remove the aws-lambda-auto-wrap npm package and manually copy over the files in the publish layer script. Additionally, we can drop support for Node.js 14 and 16, as the issue will be resolved with version 18.

--- a/packages/aws-lambda-auto-wrap/esm/README.md
+++ b/packages/aws-lambda-auto-wrap/esm/README.md
@@ -1,15 +1,15 @@
-# ES Module support for AWS Lambda
+## ES Module Support for AWS Lambda
 
-The support for ES modules was added in Node v14.
-See https://aws.amazon.com/about-aws/whats-new/2022/01/aws-lambda-es-modules-top-level-await-node-js-14/
+AWS Lambda began supporting ES modules with Node v14. Learn more on the [AWS Lambda ES modules and top-level await with Node.js 14](https://aws.amazon.com/about-aws/whats-new/2022/01/aws-lambda-es-modules-top-level-await-node-js-14/) page.
 
-But AWS forgot to add support for layers. There are currently two known bugs:
+- **Current Issues (July 2024)**:
+  - Defining an ES module as a handler in a Lambda layer is not supported at present. For updates, refer to AWS support case ID 172069954500883.
 
-1. You cannot import an ES module, which is located in a layer. See https://github.com/vibe/aws-esm-modules-layer-support
-2. You cannot define an ES module as handler, which is located in a layer. See AWS support case ID 11226031451.
+- **Current Workaround**:
+  - We utilize the handler as a CommonJS module with dynamic imports.
+  - Transitioning the handler to pure ES modules does not provide immediate benefits, but we are monitoring AWS updates closely.
 
-We are affected by the second bug. When AWS fixes the underlying problem in their AWS runtime, we are able to transform the new esm handler into a real ES module.
-
-For now: We ship the ES handler as commonjs module with the help of dynamic imports.
-
-In version 4.x, we will remove the aws-lambda-auto-wrap npm package and manually copy over the files in the publish layer script. Additionally, we can drop support for Node.js 14 and 16, which are no longer LTS.
+- **Roadmap for Improvement**:
+  - We've initiated an AWS support ticket (172069954500883) and engaged with the AWS SDK community to advocate for ES module support in Lambda layers.
+  - Future plans for version 4.x include removing the `aws-lambda-auto-wrap` npm package and enhancing our deployment process by manually integrating necessary files during the layer publishing script.
+  - Considering discontinuing support for Node.js version 14, which have reached the end of their LTS (Long-Term Support) lifecycle.

--- a/packages/aws-lambda-auto-wrap/esm/README.md
+++ b/packages/aws-lambda-auto-wrap/esm/README.md
@@ -10,9 +10,6 @@ But AWS forgot to add support for layers. There are currently two known bugs:
 
 We are affected by the second bug. When AWS fixes the underlying problem in their AWS runtime, we are able to transform the new esm handler into a real ES module.
 
-For the time being, we are shipping the ES handler as a CommonJS module using dynamic imports as a workaround for Node.js 14 and 16, as AWS has yet to resolve the issue for these versions, which are no longer LTS.
-see the comment https://github.com/aws/aws-sdk-js-v3/issues/3230#issuecomment-1561973247
+For now: We ship the ES handler as commonjs module with the help of dynamic imports.
 
-The Node.js 18.x runtime introduces support for ES module resolution using NODE_PATH. For more information, refer to [Node.js 18.x runtime now available in AWS Lambda](https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/). This is the recommended workaround.
-
-In version 4.x, we will remove the aws-lambda-auto-wrap npm package and manually copy over the files in the publish layer script. Additionally, we can drop support for Node.js 14 and 16, as the issue will be resolved with version 18.
+In version 4.x, we will remove the aws-lambda-auto-wrap npm package and manually copy over the files in the publish layer script. Additionally, we can drop support for Node.js 14 and 16, which are no longer LTS.


### PR DESCRIPTION
Currently, defining an ES module as a handler in Lambda layers is not supported (AWS support case ID 172069954500883). As a workaround, we use the handler as a CommonJS module with dynamic imports. Transitioning to pure ES modules offers no immediate benefits, but we closely monitor AWS updates.
Also started a discussion  here https://github.com/aws/aws-sdk-js/discussions/4651
