### PR TITLE
fix: added missing destruction of request after receiving the response and removing all listeners

### DIFF
--- a/packages/serverless/src/backend_connector.js
+++ b/packages/serverless/src/backend_connector.js
@@ -308,6 +308,9 @@ function send(resourcePath, payload, finalLambdaRequest, callback) {
       if (finalLambdaRequest) {
         req.removeAllListeners();
         req.on('error', () => {});
+        // At this point we already received a response from the server, but since we removed all listeners we have to
+        // manually clean up the request.
+        req.destroy();
       }
 
       handleCallback();

--- a/packages/serverless/test/backend_connector_test.js
+++ b/packages/serverless/test/backend_connector_test.js
@@ -43,7 +43,8 @@ describe('[UNIT] backend connector', () => {
         on: onStub,
         setTimeout: sinon.stub(),
         end: sinon.stub(),
-        removeAllListeners: sinon.stub()
+        removeAllListeners: sinon.stub(),
+        destroy: sinon.stub()
       });
     });
 

--- a/packages/serverless/test/backend_connector_test.js
+++ b/packages/serverless/test/backend_connector_test.js
@@ -32,19 +32,21 @@ describe('[UNIT] backend connector', () => {
     this.timeout(config.getTestTimeout());
 
     let onStub;
+    let destroyStub;
 
     beforeEach(() => {
       sinon.spy(global, 'setInterval');
       sinon.spy(global, 'clearInterval');
 
       onStub = sinon.stub();
+      destroyStub = sinon.stub();
 
       sinon.stub(uninstrumentedHttp.http, 'request').returns({
         on: onStub,
         setTimeout: sinon.stub(),
         end: sinon.stub(),
         removeAllListeners: sinon.stub(),
-        destroy: sinon.stub()
+        destroy: destroyStub
       });
     });
 
@@ -98,6 +100,8 @@ describe('[UNIT] backend connector', () => {
 
         setTimeout(onEnd, 200);
         await prom;
+
+        expect(destroyStub.called).to.be.true;
       });
     });
 
@@ -123,6 +127,8 @@ describe('[UNIT] backend connector', () => {
 
         setTimeout(onEnd, 200);
         await prom;
+
+        expect(destroyStub.called).to.be.true;
       });
     });
 
@@ -164,6 +170,8 @@ describe('[UNIT] backend connector', () => {
 
         // 1 bundle req, 2 heartbeats
         expect(uninstrumentedHttp.http.request.callCount).to.eql(3);
+
+        expect(destroyStub.called).to.be.true;
       });
     });
 
@@ -225,6 +233,8 @@ describe('[UNIT] backend connector', () => {
         await delay(250);
 
         expect(uninstrumentedHttp.http.request.callCount).to.eql(2);
+
+        expect(destroyStub.called).to.be.true;
       });
     });
   });


### PR DESCRIPTION
Previously this resulted in a high file descriptor usage in Lambda until the function reached the hard limit

This is a fix for the IBM customer support ticket: TS016453828
More details about the detection of the problem and steps to reproduce are documented in the ticket.

**A short summary of the problem:** 
Old requests were not correctly cleaned up which was mainly a problem for Lambda functions with a lot of reuse (warm Lambdas), since the number of file descriptors continued increasing over time until the Lambda hard limit was reached and the function crashed.

While this fixes the problem described above, I have the feeling the root rause which led to this problem becoming visible might be related to failing heartbeat checks and the actual extension binary which I couldn't check further.

**Testing**
| Node version of the Lambda     | File descriptor problem resolved      |  Traces received in Instana
| ------------- | ------------- | ------- |
| Node 16.x | ✅  | ✅
| Node 18.x | ✅  |✅
| Node 20.x | ✅  |✅

Successor of #1208 (using - instead of / in the branch name)