### PR TITLE
test: updated couchbase tests to run on node.js v18 and above

### DIFF
--- a/packages/collector/test/tracing/database/couchbase/test.js
+++ b/packages/collector/test/tracing/database/couchbase/test.js
@@ -71,8 +71,11 @@ const verifySpans = (agentControls, controls, options = {}) =>
     expectExactlyOneMatching(spans, verifyCouchbaseSpan(controls, entrySpan, options));
   });
 
+// The Couchbase Node.js client is compatible with supported LTS versions of Node.js.
+// The supported LTS versions start from v18, as support for Node.js v16.x is no longer maintained.
+// see: https://github.com/nodejs/node-addon-api/releases/tag/v8.0.0
 const mochaSuiteFn =
-  supportedVersion(process.versions.node) && semver.gte(process.versions.node, '16.0.0') ? describe : describe.skip;
+  supportedVersion(process.versions.node) && semver.gte(process.versions.node, '18.0.0') ? describe : describe.skip;
 
 let tries = 0;
 const maxTries = 100;
@@ -152,7 +155,7 @@ async function configureCouchbase() {
 }
 
 // NOTE: it takes 1-2 minutes till the couchbase server can be reached via docker
-mochaSuiteFn('tracing/couchbase', function () {
+mochaSuiteFn.only('tracing/couchbase', function () {
   this.timeout(config.getTestTimeout() * 4);
 
   globalAgent.setUpCleanUpHooks();


### PR DESCRIPTION
Discovered that the latest Couchbase silently dropped support for v16. Their official documentation states:

> The Couchbase Node.js Client will run on any [supported LTS version of Node.js](https://github.com/nodejs/Release).

They are using [node-addon-api](https://github.com/nodejs/node-addon-api ) as a dependency, and in couchbase version 4.4.0, it was updated to [8.0.0](https://github.com/nodejs/node-addon-api/releases/tag/v8.0.0), which dropped support for v16. This change causes our v16 tests to fail.