### PR TITLE
docs: update contributing.md to add commit message constraint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,8 @@ For any change that is customer-facing and should appear in the changelog file, 
 
 When composing commit messages, it's important to use past tense. Additionally, if there is a corresponding ticket or issue associated with the change, please put the ticket link in the commit message and pull request.
 
+The commit message length is limited. Read through our commitlint rules [here](https://github.com/instana/nodejs/blob/v3.14.4/commitlint.config.js#L14).
+
 For instance, you can refer to this example commit message: https://github.com/instana/nodejs/commit/bd3e7554fe21188c3ad10d442e4d72546d5c2267
 
 ## Creating a development branch


### PR DESCRIPTION
Our current CI pipeline enforces a commit message length restriction using commit-lint, which only accepts messages under 100 characters. Messages exceeding this limit will cause the commit to fail. For more details, see [commitlint documentation](https://github.com/conventional-changelog/commitlint/#what-is-commitlint) and [commitlint configuration](https://github.com/conventional-changelog/commitlint/blob/a2f27fa19b789471928889ddfca98d0c662e9b71/%40commitlint/config-conventional/README.md?plain=1#L119).