### PR TITLE
test: skipped Node v14 for tedious

### DIFF
--- a/packages/collector/test/tracing/opentelemetry/test.js
+++ b/packages/collector/test/tracing/opentelemetry/test.js
@@ -6,6 +6,7 @@
 
 const expect = require('chai').expect;
 const path = require('path');
+const semver = require('semver');
 const supportedVersion = require('@instana/core').tracing.supportedVersion;
 const constants = require('@instana/core').tracing.constants;
 const config = require('../../../../core/test/config');
@@ -497,14 +498,15 @@ mochaSuiteFn('opentelemetry/instrumentations', function () {
         ));
   });
 
-  describe('tedious', function () {
+  const runTedious = semver.gt(process.versions.node, '14.0.0') ? describe : describe.skip;
+  runTedious('tedious', function () {
     describe('opentelemetry is enabled', function () {
       globalAgent.setUpCleanUpHooks();
       const agentControls = globalAgent.instance;
       let controls;
 
-    // We need to increase the waiting timeout here for the initial azure connection,
-    // because it can take up to 1-2 minutes till azure replies if the db is in paused state
+      // We need to increase the waiting timeout here for the initial azure connection,
+      // because it can take up to 1-2 minutes till azure replies if the db is in paused state
       this.timeout(1000 * 60 * 2);
 
       before(async () => {


### PR DESCRIPTION
- Node v14 build was failing

https://cloud.ibm.com/devops/pipelines/tekton/c2cd6a8d-ea5a-47b0-913e-cd172d63833f/runs/825c961a-db6f-4ff3-b01b-6b82e2e9b73a/test-ci-collector-tracing-general-task/run-test-group?env_id=ibm:yp:eu-de

https://github.com/tediousjs/tedious/releases/tag/v17.0.0

They even dropped Node v16, but main was not failing. Let's see if Node v16 passes.