### PR TITLE
Fixed workspaces issues

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+install-strategy="nested"


### PR DESCRIPTION
An alternative approach for https://jsw.ibm.com/browse/INSTA-7722 is to workaround the problems:

- try a different installation strategy to workaround the missing feature `nohoist` 
- add a script which protects running a wrong library version in tests e.g. you have pino v8 and v9 installed and you run the pino test against both major versions, we need to ensure `npm` is loading the correct dependency