### PR TITLE
chore: fix version of sonarqube-scanner to v3.5 

### DIFF
--- a/.tekton/tasks/tasks-results.yaml
+++ b/.tekton/tasks/tasks-results.yaml
@@ -26,16 +26,6 @@ spec:
             secretKeyRef:
               name: $(params.continuous-delivery-context-secret)
               key: "SONAR_TOKEN"          
-        - name: SONAR_PWD
-          valueFrom:
-            secretKeyRef:
-              name: $(params.continuous-delivery-context-secret)
-              key: "SONAR_PWD"          
-        - name: SONAR_LOGIN
-          valueFrom:
-            secretKeyRef:
-              name: $(params.continuous-delivery-context-secret)
-              key: "SONAR_LOGIN"          
       script: |
         #!/bin/bash
         
@@ -55,7 +45,7 @@ spec:
           npx eslint packages/ -f json > eslint-report.json || true
 
           echo "Install sonarcube scanner..."
-          npm install -g sonarqube-scanner
+          npm install -g sonarqube-scanner@3.5
 
           echo "Run sonarqube..."
           sonar-scanner


### PR DESCRIPTION
fix version of sonarqube-scanner to v3.5  as they introduced br…aking changes in v4
 - they removed support for node v16 in sonarqube-scanner v4
 - our test pipeline was failing with some authentication error

refs I[NSTA-12663](https://jsw.ibm.com/browse/INSTA-12663)