### PR TITLE
ci: temporarily skip publishing to the newly added region ap-southeast-5

### DIFF
--- a/packages/aws-lambda/layer/bin/publish-layer.sh
+++ b/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -127,7 +127,8 @@ fi
 
 # The us-gov-* regions are only available to US government agencies, U.S. government etc. The regions have not been (and
 # maybe cannot be) enabled for our AWS account. We currently do not publish Lambda layers to these regions.
-SKIPPED_REGIONS=$'us-gov-east-1\nus-gov-west-1'
+# Currently skipping the newly added region, ap-southeast-5; it will need to be added later. Ref: INSTA-13582.
+SKIPPED_REGIONS=$'us-gov-east-1\nus-gov-west-1\nap-southeast-5'
 
 # AWS China is completely separated from the rest of AWS. You cannot enable the Chinese regions in a global AWS account.
 # Instead, we have a separate account for AWS China.


### PR DESCRIPTION
A new region, ap-southeast-5, has been introduced, temporarily skip publishing to the newly added region ap-southeast-5.

https://aws.amazon.com/blogs/aws/now-open-aws-asia-pacific-malaysia-region/