### PR TITLE
Revert "ci: skipped publishing AWS layer to the newly added region ap-southeast-5

### DIFF
--- a/packages/aws-lambda/layer/bin/publish-layer.sh
+++ b/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -127,8 +127,7 @@ fi
 
 # The us-gov-* regions are only available to US government agencies, U.S. government etc. The regions have not been (and
 # maybe cannot be) enabled for our AWS account. We currently do not publish Lambda layers to these regions.
-# Currently skipping the newly added region, ap-southeast-5; it will need to be added later. Ref: INSTA-13582.
-SKIPPED_REGIONS=$'us-gov-east-1\nus-gov-west-1\nap-southeast-5'
+SKIPPED_REGIONS=$'us-gov-east-1\nus-gov-west-1'
 
 # AWS China is completely separated from the rest of AWS. You cannot enable the Chinese regions in a global AWS account.
 # Instead, we have a separate account for AWS China.


### PR DESCRIPTION
Added the new region in our AWS account.