### PR TITLE
chore: excluded misc folder from sonar cube report

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,4 +29,4 @@ sonar.eslint.reportPaths=eslint-report.json
 # Code analysis parameters  
 sonar.inclusions=**/src/**,**/lib/**
 sonar.exclusions=**/test/**,**/dummy-app/**,**/precompile/**,**lcov-report**,node_modules
-sonar.coverage.exclusions=**/test/**,**/dummy-app/**,**/precompile/**
+sonar.coverage.exclusions=**/test/**,**/dummy-app/**,**/precompile/**,misc/**


### PR DESCRIPTION
I saw this file in our report, which reduces our test coverage:

> misc/eslint-plugin/lib/rules/no-unsafe-require.js

I don't know what the difference is between:

> sonar.exclusions=...
> sonar.coverage.exclusions=...

I was too lazy to investigate. Feel free to do it!