### PR TITLE
fix(kafka): enforced 'string' format for Kafka trace headers and removed 'binary' support

### DIFF
--- a/packages/aws-fargate/test/using_api/test.js
+++ b/packages/aws-fargate/test/using_api/test.js
@@ -106,20 +106,10 @@ describe('Using the API', function () {
     return retry(async () => {
       expect(response).to.be.an('object');
       expect(response.message).to.equal('Hello Fargate!');
-
-      // During phase 1 of the Kafka header migration (October 2022 - October 2023) there will be a debug log about
-      // ignoring the option 'both' for rdkafka. We do not care about that log message in this test.
-      const debug = response.logs.debug.filter(msg => !msg.includes('Ignoring configuration or default value'));
-
-      // As part of the Kafka header migration phase 2, we have added warning logs regarding the removal of the option
-      // to configure Kafka header formats. This test skips the warning message, and the warning itself will be removed
-      // in the next major release.
-      const warn = response.logs.warn.filter(msg => !msg.includes('Kafka header format'));
-      expect(debug).to.contain('Sending data to Instana (/serverless/metrics).');
-      expect(debug).to.contain('Sent data to Instana (/serverless/metrics).');
-
+      expect(response.logs.debug).to.contain('Sending data to Instana (/serverless/metrics).');
+      expect(response.logs.debug).to.contain('Sent data to Instana (/serverless/metrics).');
       expect(response.logs.info).to.be.empty;
-      expect(warn).to.deep.equal([
+      expect(response.logs.warn).to.deep.equal([
         'INSTANA_DISABLE_CA_CHECK is set, which means that the server certificate will not be verified against the ' +
           'list of known CAs. This makes your service vulnerable to MITM attacks when connecting to Instana. This ' +
           'setting should never be used in production, unless you use our on-premises product and are unable to ' +

--- a/packages/collector/src/announceCycle/unannounced.js
+++ b/packages/collector/src/announceCycle/unannounced.js
@@ -192,11 +192,7 @@ function applyKafkaTracingConfiguration(agentResponse) {
       traceCorrelation:
         kafkaTracingConfigFromAgent['trace-correlation'] != null
           ? kafkaTracingConfigFromAgent['trace-correlation']
-          : tracingConstants.kafkaTraceCorrelationDefault,
-      headerFormat:
-        kafkaTracingConfigFromAgent['header-format'] != null
-          ? kafkaTracingConfigFromAgent['header-format']
-          : tracingConstants.kafkaHeaderFormatDefault
+          : tracingConstants.kafkaTraceCorrelationDefault
     };
     ensureNestedObjectExists(agentOpts.config, ['tracing', 'kafka']);
     agentOpts.config.tracing.kafka = kafkaTracingConfig;

--- a/packages/collector/src/announceCycle/unannounced.js
+++ b/packages/collector/src/announceCycle/unannounced.js
@@ -49,7 +49,6 @@ const maxRetryDelay = 60 * 1000; // one minute
 /**
  * @typedef {Object} KafkaTracingConfig
  * @property {boolean} [trace-correlation]
- * @property {string} [header-format]
  */
 
 module.exports = {

--- a/packages/collector/test/announceCycle/unannounced_test.js
+++ b/packages/collector/test/announceCycle/unannounced_test.js
@@ -166,8 +166,7 @@ describe('unannounced state', () => {
       prepareAnnounceResponse({
         tracing: {
           kafka: {
-            'trace-correlation': false,
-            'header-format': 'string'
+            'trace-correlation': false
           }
         }
       });

--- a/packages/collector/test/announceCycle/unannounced_test.js
+++ b/packages/collector/test/announceCycle/unannounced_test.js
@@ -153,8 +153,7 @@ describe('unannounced state', () => {
           expect(agentOptsStub.config).to.deep.equal({
             tracing: {
               kafka: {
-                traceCorrelation: constants.kafkaTraceCorrelationDefault,
-                headerFormat: constants.kafkaHeaderFormatDefault
+                traceCorrelation: constants.kafkaTraceCorrelationDefault
               }
             }
           });
@@ -177,8 +176,7 @@ describe('unannounced state', () => {
           expect(agentOptsStub.config).to.deep.equal({
             tracing: {
               kafka: {
-                traceCorrelation: false,
-                headerFormat: 'string'
+                traceCorrelation: false
               }
             }
           });

--- a/packages/collector/test/apps/agentStub.js
+++ b/packages/collector/test/apps/agentStub.js
@@ -38,7 +38,6 @@ const enableSpanBatching = process.env.ENABLE_SPANBATCHING === 'true';
 const kafkaTraceCorrelation = process.env.KAFKA_TRACE_CORRELATION
   ? process.env.KAFKA_TRACE_CORRELATION === 'true'
   : null;
-const kafkaHeaderFormat = process.env.KAFKA_HEADER_FORMAT;
 
 let discoveries = {};
 let rejectAnnounceAttempts = 0;
@@ -87,20 +86,17 @@ app.put('/com.instana.plugin.nodejs.discovery', (req, res) => {
     }
   };
 
-  if (kafkaTraceCorrelation != null || kafkaHeaderFormat || extraHeaders.length > 0 || enableSpanBatching) {
+  if (kafkaTraceCorrelation != null || extraHeaders.length > 0 || enableSpanBatching) {
     response.tracing = {};
 
     if (extraHeaders.length > 0) {
       response.tracing['extra-http-headers'] = extraHeaders;
     }
 
-    if (kafkaTraceCorrelation != null || kafkaHeaderFormat) {
+    if (kafkaTraceCorrelation != null) {
       response.tracing.kafka = {};
       if (kafkaTraceCorrelation != null) {
         response.tracing.kafka['trace-correlation'] = kafkaTraceCorrelation;
-      }
-      if (kafkaHeaderFormat) {
-        response.tracing.kafka['header-format'] = kafkaHeaderFormat;
       }
     }
 

--- a/packages/collector/test/apps/agentStubControls.js
+++ b/packages/collector/test/apps/agentStubControls.js
@@ -42,9 +42,6 @@ class AgentStubControls {
       if (opts.kafkaConfig.traceCorrelation != null) {
         env.KAFKA_TRACE_CORRELATION = opts.kafkaConfig.traceCorrelation.toString();
       }
-      if (opts.kafkaConfig.headerFormat) {
-        env.KAFKA_HEADER_FORMAT = opts.kafkaConfig.headerFormat;
-      }
     }
 
     this.agentStub = spawn('node', [path.join(__dirname, 'agentStub.js')], {

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -309,10 +309,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
     before(async () => {
       producerControls = new ProcessControls({
         appPath: path.join(__dirname, 'producer'),
-        useGlobalAgent: true,
-        env: {
-          INSTANA_KAFKA_HEADER_FORMAT: 'string'
-        }
+        useGlobalAgent: true
       });
       consumerControls = new ProcessControls({
         appPath: path.join(__dirname, 'consumer'),
@@ -364,9 +361,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
     let consumerControls;
 
     before(async () => {
-      await customAgentControls.startAgent({
-        kafkaConfig: { headerFormat: 'string' }
-      });
+      await customAgentControls.startAgent();
 
       producerControls = new ProcessControls({
         appPath: path.join(__dirname, 'producer'),

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -283,8 +283,7 @@ function startSpan(spanName, kind, traceId, parentSpanId, w3cTraceContext) {
 
   // If the client code has specified a trace ID/parent ID, use the provided IDs.
   if (traceId) {
-    // The incoming trace ID/span ID from an upstream tracer could be shorter than the standard length. Some of our code
-    // (in particular, the binary Kafka trace correlation header X_INSTANA_C) assumes the standard length. We normalize
+    // The incoming trace ID/span ID from an upstream tracer could be shorter than the standard length. We normalize
     // both IDs here by left-padding with 0 characters.
 
     // Maintenance note (128-bit-trace-ids): When we switch to 128 bit trace IDs, we need to left-pad the trace ID to 32

--- a/packages/core/src/tracing/constants.js
+++ b/packages/core/src/tracing/constants.js
@@ -17,9 +17,10 @@ exports.traceLevelHeaderNameLowerCase = exports.traceLevelHeaderName.toLowerCase
 exports.syntheticHeaderName = 'X-INSTANA-SYNTHETIC';
 exports.syntheticHeaderNameLowerCase = exports.syntheticHeaderName.toLowerCase();
 
-// New kafka trace correlation (string values). Available as opt-in since 2021-10, and send out together with the legacy
-// binary headers by default starting in 2022-10. We will switch over to these headers completely (omitting the legacy
-// headers approximately in 2023-10.
+// New Kafka trace correlation (string values) was introduced as an opt-in feature in 2021-10. Initially, it was sent
+// out along with the legacy binary headers by default starting in 2022-10. However, as of 2024-10, only string headers
+// are supported, and the legacy binary headers are no longer supported.
+
 exports.kafkaTraceIdHeaderName = 'X_INSTANA_T';
 exports.kafkaSpanIdHeaderName = 'X_INSTANA_S';
 exports.kafkaTraceLevelHeaderName = 'X_INSTANA_L_S';

--- a/packages/core/src/tracing/constants.js
+++ b/packages/core/src/tracing/constants.js
@@ -17,12 +17,6 @@ exports.traceLevelHeaderNameLowerCase = exports.traceLevelHeaderName.toLowerCase
 exports.syntheticHeaderName = 'X-INSTANA-SYNTHETIC';
 exports.syntheticHeaderNameLowerCase = exports.syntheticHeaderName.toLowerCase();
 
-// legacy kafka trace correlation (binary values)
-exports.kafkaLegacyTraceContextHeaderName = 'X_INSTANA_C';
-exports.kafkaLegacyTraceLevelHeaderName = 'X_INSTANA_L';
-exports.kafkaLegacyTraceLevelValueSuppressed = Buffer.from([0]);
-exports.kafkaLegacyTraceLevelValueInherit = Buffer.from([1]);
-
 // New kafka trace correlation (string values). Available as opt-in since 2021-10, and send out together with the legacy
 // binary headers by default starting in 2022-10. We will switch over to these headers completely (omitting the legacy
 // headers approximately in 2023-10.
@@ -30,22 +24,12 @@ exports.kafkaTraceIdHeaderName = 'X_INSTANA_T';
 exports.kafkaSpanIdHeaderName = 'X_INSTANA_S';
 exports.kafkaTraceLevelHeaderName = 'X_INSTANA_L_S';
 
-/**
- * @typedef {'binary' | 'string' | 'both'} KafkaTraceCorrelationFormat
- */
-
-// With the current phase 1 of the Kafka header format migration, 'both', is the default.
-// With phase 2 (starting approximately October 2023) it will no longer be configurable and will always use 'string'.
-/** @type {KafkaTraceCorrelationFormat} */
-exports.kafkaHeaderFormatDefault = 'both';
 exports.kafkaTraceCorrelationDefault = true;
 
 exports.allInstanaKafkaHeaders = [
   exports.kafkaTraceIdHeaderName,
   exports.kafkaSpanIdHeaderName,
-  exports.kafkaTraceLevelHeaderName,
-  exports.kafkaLegacyTraceContextHeaderName,
-  exports.kafkaLegacyTraceLevelHeaderName
+  exports.kafkaTraceLevelHeaderName
 ];
 
 exports.w3cTraceParent = 'traceparent';

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -123,7 +123,6 @@ if (customInstrumentations.length > 0) {
 /**
  * @typedef {Object} KafkaTracingConfig
  * @property {boolean} [traceCorrelation]
- * @property {string} [headerFormat]
  */
 
 /** @type {Array.<InstanaInstrumentedModule>} */

--- a/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
@@ -375,7 +375,8 @@ function addTraceContextHeaderToAllMessages(messages, span) {
   if (!traceCorrelationEnabled) {
     return;
   }
-
+  // Add trace ID and span ID headers to all Kafka messages for trace correlation.
+  // 'string' headers are used by default starting from v4.
   addTraceIdSpanIdToAllMessages(messages, span);
 }
 
@@ -402,6 +403,7 @@ function addTraceLevelSuppressionToAllMessages(messages) {
   if (!traceCorrelationEnabled) {
     return;
   }
+  // Since v4, only 'string' format is supported by default.
   addTraceLevelSuppressionToAllMessagesString(messages);
 }
 
@@ -426,14 +428,4 @@ function removeInstanaHeadersFromMessage(message) {
       delete message.headers[name];
     });
   }
-}
-
-// Note: This function can be removed as soon as we finish the Kafka header migration phase2.
-// Might happen in major release v4.
-function logWarningForKafkaHeaderFormat() {
-  logger.warn(
-    '[Deprecation Warning] The configuration option for specifying the Kafka header format will be removed in the ' +
-      'next major release as the format will no longer be configurable and Instana tracers will only send string ' +
-      'headers. More details see: https://ibm.biz/kafka-trace-correlation-header.'
-  );
 }

--- a/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
@@ -24,7 +24,6 @@ let isActive = false;
 exports.init = function init(config) {
   hook.onFileLoad(/\/kafkajs\/src\/producer\/messageProducer\.js/, instrumentProducer);
   hook.onFileLoad(/\/kafkajs\/src\/consumer\/runner\.js/, instrumentConsumer);
-  hook.onModuleLoad('kafkajs', logWarningForKafkaHeaderFormat);
   traceCorrelationEnabled = config.tracing.kafka.traceCorrelation;
 };
 

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -14,18 +14,12 @@ const shimmer = require('../../shimmer');
 const { getFunctionArguments } = require('../../../util/function_arguments');
 let traceCorrelationEnabled = constants.kafkaTraceCorrelationDefault;
 
-let logger;
-logger = require('../../../logger').getLogger('tracing/rdkafka', newLogger => {
-  logger = newLogger;
-});
-
 let isActive = false;
 
 exports.init = function init(config) {
   hook.onFileLoad(/\/node-rdkafka\/lib\/producer\.js/, instrumentProducer);
   hook.onFileLoad(/\/node-rdkafka\/lib\/kafka-consumer-stream\.js/, instrumentConsumerAsStream);
   hook.onModuleLoad('node-rdkafka', instrumentConsumer);
-  hook.onModuleLoad('node-rdkafka', logWarningForKafkaHeaderFormat);
 
   traceCorrelationEnabled = config.tracing.kafka.traceCorrelation;
 };
@@ -40,24 +34,12 @@ exports.activate = function activate(extraConfig) {
       traceCorrelationEnabled = extraConfig.tracing.kafka.traceCorrelation;
     }
   }
-
   isActive = true;
 };
 
 exports.deactivate = function deactivate() {
   isActive = false;
 };
-
-// Note: This function can be removed as soon as we finish the Kafka header migration phase 2 and remove the ability to
-// configure the header format.  Might happen in major release v4.
-function logWarningForKafkaHeaderFormat() {
-  logger.warn(
-    '[Deprecation Warning] The Kafka header format configuration will be removed in the next major release. ' +
-      'Instana tracers will only support string headers, as binary headers are not compatible with node-rdkafka. ' +
-      'For more information, see the GitHub issue: https://github.com/Blizzard/node-rdkafka/pull/968, and review our ' +
-      'official documentation on Kafka header configuration: https://ibm.biz/kafka-trace-correlation-header.'
-  );
-}
 
 function instrumentProducer(ProducerClass) {
   shimmer.wrap(ProducerClass.prototype, 'produce', shimProduce);
@@ -312,16 +294,6 @@ function instrumentedConsumerEmit(ctx, originalEmit, originalArgs) {
   });
 }
 
-function readTraceLevelBinary(instanaHeadersAsObject) {
-  if (instanaHeadersAsObject[constants.kafkaLegacyTraceLevelHeaderName]) {
-    const traceLevelBuffer = instanaHeadersAsObject[constants.kafkaLegacyTraceLevelHeaderName];
-    if (Buffer.isBuffer(traceLevelBuffer) && traceLevelBuffer.length >= 1) {
-      return String(traceLevelBuffer.readInt8());
-    }
-  }
-  return '1';
-}
-
 function addTraceContextHeader(headers, span) {
   if (!traceCorrelationEnabled) {
     return headers;
@@ -383,22 +355,6 @@ function findInstanaHeaderValues(instanaHeadersAsObject) {
   }
   if (instanaHeadersAsObject[constants.kafkaTraceLevelHeaderName]) {
     level = String(instanaHeadersAsObject[constants.kafkaTraceLevelHeaderName]);
-  }
-
-  // CASE: Only fall back to legacy binary trace correlation headers if no new header is present.
-  if (traceId == null && parentSpanId == null && level == null) {
-    // The newer string header format has not been found, fall back to legacy binary headers.
-    if (instanaHeadersAsObject[constants.kafkaLegacyTraceContextHeaderName]) {
-      const traceContextBuffer = instanaHeadersAsObject[constants.kafkaLegacyTraceContextHeaderName];
-
-      if (Buffer.isBuffer(traceContextBuffer) && traceContextBuffer.length === 24) {
-        const traceContext = tracingUtil.readTraceContextFromBuffer(traceContextBuffer);
-        traceId = traceContext.t;
-        parentSpanId = traceContext.s;
-      }
-    }
-
-    level = readTraceLevelBinary(instanaHeadersAsObject);
   }
 
   return { level, traceId, longTraceId, parentSpanId };

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -341,7 +341,7 @@ function findInstanaHeaderValues(instanaHeadersAsObject) {
   let parentSpanId;
   let level;
 
-  // CASE: Look for the the newer string header format first.
+  // Since v4, only 'string' format is supported.
   if (instanaHeadersAsObject[constants.kafkaTraceIdHeaderName]) {
     traceId = String(instanaHeadersAsObject[constants.kafkaTraceIdHeaderName]);
     if (traceId) {

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -36,7 +36,6 @@ const constants = require('../tracing/constants');
 /**
  * @typedef {Object} KafkaTracingOptions
  * @property {boolean} [traceCorrelation]
- * @property {import('../tracing/constants').KafkaTraceCorrelationFormat} [headerFormat]
  */
 
 /**
@@ -81,7 +80,6 @@ const constants = require('../tracing/constants');
 /**
  * @typedef {Object} AgentTracingKafkaConfig
  * @property {boolean} [traceCorrelation]
- * @property {string} [headerFormat]
  */
 
 /** @type {import('../logger').GenericLogger} */
@@ -116,8 +114,7 @@ const defaults = {
     spanBatchingEnabled: false,
     disableW3cTraceCorrelation: false,
     kafka: {
-      traceCorrelation: true,
-      headerFormat: constants.kafkaHeaderFormatDefault
+      traceCorrelation: true
     }
   },
   secrets: {
@@ -125,8 +122,6 @@ const defaults = {
     keywords: ['key', 'pass', 'secret']
   }
 };
-
-const validKafkaHeaderFormats = ['binary', 'string', 'both'];
 
 const validSecretsMatcherModes = ['equals-ignore-case', 'equals', 'contains-ignore-case', 'contains', 'regex', 'none'];
 
@@ -547,33 +542,6 @@ function normalizeTracingKafka(config) {
     config.tracing.kafka.traceCorrelation = false;
   } else {
     config.tracing.kafka.traceCorrelation = defaults.tracing.kafka.traceCorrelation;
-  }
-
-  // @ts-ignore
-  config.tracing.kafka.headerFormat =
-    config.tracing.kafka.headerFormat || process.env.INSTANA_KAFKA_HEADER_FORMAT || defaults.tracing.kafka.headerFormat;
-  if (typeof config.tracing.kafka.headerFormat !== 'string') {
-    logger.warn(
-      `The value of config.tracing.kafka.headerFormat ("${config.tracing.kafka.headerFormat}") is not a string. ` +
-        `Assuming the default value "${defaults.tracing.kafka.headerFormat}".`
-    );
-    config.tracing.kafka.headerFormat = defaults.tracing.kafka.headerFormat;
-    return;
-  }
-  // @ts-ignore
-  config.tracing.kafka.headerFormat = config.tracing.kafka.headerFormat.toLowerCase();
-  if (validKafkaHeaderFormats.indexOf(config.tracing.kafka.headerFormat) < 0) {
-    logger.warn(
-      'The value of config.tracing.kafka.headerFormat (or the value of INSTANA_KAFKA_HEADER_FORMAT) ' +
-        `("${config.tracing.kafka.headerFormat}") is not a supported header format. Assuming the default ` +
-        `value "${defaults.tracing.kafka.headerFormat}".`
-    );
-    config.tracing.kafka.headerFormat = defaults.tracing.kafka.headerFormat;
-    return;
-  }
-
-  if (config.tracing.kafka.headerFormat !== defaults.tracing.kafka.headerFormat) {
-    logger.info(`Kafka trace correlation header format has been set to "${config.tracing.kafka.headerFormat}".`);
   }
 }
 

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -118,8 +118,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     const extraConfigFromAgent = {
       tracing: {
         kafka: {
-          traceCorrelation: false,
-          headerFormat: 'string'
+          traceCorrelation: false
         }
       }
     };

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -29,7 +29,6 @@ describe('util.normalizeConfig', () => {
     delete process.env.INSTANA_DISABLE_SPANBATCHING;
     delete process.env.INSTANA_DISABLE_W3C_TRACE_CORRELATION;
     delete process.env.INSTANA_KAFKA_TRACE_CORRELATION;
-    delete process.env.INSTANA_KAFKA_HEADER_FORMAT;
     delete process.env.INSTANA_PACKAGE_JSON_PATH;
   }
 
@@ -337,47 +336,6 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.kafka.traceCorrelation).to.be.false;
   });
 
-  it('should set Kafka header format to binary', () => {
-    const config = normalizeConfig({ tracing: { kafka: { headerFormat: 'binary' } } });
-    expect(config.tracing.kafka.headerFormat).to.equal('binary');
-  });
-
-  it('should set Kafka header format to string', () => {
-    const config = normalizeConfig({ tracing: { kafka: { headerFormat: 'string' } } });
-    expect(config.tracing.kafka.headerFormat).to.equal('string');
-  });
-
-  it('should set Kafka header format to both', () => {
-    const config = normalizeConfig({ tracing: { kafka: { headerFormat: 'both' } } });
-    expect(config.tracing.kafka.headerFormat).to.equal('both');
-  });
-
-  it('should ignore non-string Kafka header format', () => {
-    const config = normalizeConfig({ tracing: { kafka: { headerFormat: 13 } } });
-    // During phase 1 of the migration, 'both' will be the default value. In phase 2, the ability to configure the
-    // format will be removed and we will only use the 'string' format.
-    expect(config.tracing.kafka.headerFormat).to.equal('both');
-  });
-
-  it('should ignore invalid Kafka header format', () => {
-    const config = normalizeConfig({ tracing: { kafka: { headerFormat: 'whatever' } } });
-    // During phase 1 of the migration, 'both' will be the default value. In phase 2, the ability to configure the
-    // format will be removed and we will only use the 'string' format.
-    expect(config.tracing.kafka.headerFormat).to.equal('both');
-  });
-
-  it('should set Kafka header format to binary via INSTANA_KAFKA_HEADER_FORMAT', () => {
-    process.env.INSTANA_KAFKA_HEADER_FORMAT = 'binary';
-    const config = normalizeConfig();
-    expect(config.tracing.kafka.headerFormat).to.equal('binary');
-  });
-
-  it('should set Kafka header format to string via INSTANA_KAFKA_HEADER_FORMAT', () => {
-    process.env.INSTANA_KAFKA_HEADER_FORMAT = 'string';
-    const config = normalizeConfig();
-    expect(config.tracing.kafka.headerFormat).to.equal('string');
-  });
-
   it('should disable opentelemetry if config is set', () => {
     const config = normalizeConfig({
       tracing: { useOpentelemetry: false }
@@ -402,20 +360,6 @@ describe('util.normalizeConfig', () => {
     process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'false';
     const config = normalizeConfig();
     expect(config.tracing.useOpentelemetry).to.equal(true);
-  });
-
-  it('should set Kafka header format to both via INSTANA_KAFKA_HEADER_FORMAT', () => {
-    process.env.INSTANA_KAFKA_HEADER_FORMAT = 'both';
-    const config = normalizeConfig();
-    expect(config.tracing.kafka.headerFormat).to.equal('both');
-  });
-
-  it('should ignore invalid Kafka header format in INSTANA_KAFKA_HEADER_FORMAT', () => {
-    process.env.INSTANA_KAFKA_HEADER_FORMAT = 'whatever';
-    const config = normalizeConfig();
-    // During phase 1 of the migration, 'both' will be the default value. In phase 2, the ability to configure the
-    // format will be removed and we will only use the 'string' format.
-    expect(config.tracing.kafka.headerFormat).to.equal('both');
   });
 
   it('should accept custom secrets config', () => {
@@ -528,7 +472,6 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.spanBatchingEnabled).to.be.false;
     expect(config.tracing.disableW3cTraceCorrelation).to.be.false;
     expect(config.tracing.kafka.traceCorrelation).to.be.true;
-    expect(config.tracing.kafka.headerFormat).to.equal('both');
     expect(config.tracing.useOpentelemetry).to.equal(true);
 
     expect(config.secrets).to.be.an('object');

--- a/packages/google-cloud-run/test/using_api/test.js
+++ b/packages/google-cloud-run/test/using_api/test.js
@@ -101,22 +101,10 @@ describe('Using the API', function () {
   function verify(control, response) {
     expect(response).to.be.an('object');
     expect(response.message).to.equal('Hello Cloud Run!');
-
-    // During phase 1 of the Kafka header migration (October 2022 - October 2023) there will be a debug log about
-    // ignoring the option 'both' for rdkafka. We do not care about that log message in this test.
-
-    const debug = response.logs.debug.filter(msg => !msg.includes('Ignoring configuration or default value'));
-
-    // As part of the Kafka header migration phase 2, we have added warning logs regarding the removal of the option to
-    // configure Kafka header formats. This test skips the warning message, and the warning itself will be removed
-    // in the next major release.
-    const warn = response.logs.warn.filter(msg => !msg.includes('Kafka header format'));
-
-    expect(debug).to.contain('Sending data to Instana (/serverless/metrics).');
-    expect(debug).to.contain('Sent data to Instana (/serverless/metrics).');
-
+    expect(response.logs.debug).to.contain('Sending data to Instana (/serverless/metrics).');
+    expect(response.logs.debug).to.contain('Sent data to Instana (/serverless/metrics).');
     expect(response.logs.info).to.be.empty;
-    expect(warn).to.deep.equal([
+    expect(response.logs.warn).to.deep.equal([
       'INSTANA_DISABLE_CA_CHECK is set, which means that the server certificate will not be verified against the ' +
         'list of known CAs. This makes your service vulnerable to MITM attacks when connecting to Instana. This ' +
         'setting should never be used in production, unless you use our on-premises product and are unable to ' +


### PR DESCRIPTION
Kafka header migration [phase-2](https://www.ibm.com/docs/en/instana-observability/current?topic=references-kafka-header-migration#phase-2)

- Always send Kafka trace correlation headers in  format 'string' 

- Remove the ability to configure the header format

- Remove the code associated with sending headers in format 'binary' or sending 'both' formats.

Tasks

- [x] Remove ability to configure the header format
- [x] Remove unwanted tests
- [x] PR for updating test suite https://github.ibm.com/instana/tracer-test-suite/pull/96
- [x] Create a PR to add a deprecation warning https://github.com/instana/nodejs/pull/1311
- [x]  Manual testing

Post Release

- [ ] Update migration table in public doc see [kafka-migration phase-2](https://www.ibm.com/docs/en/instana-observability/current?topic=references-kafka-header-migration#tracer-versions)
- [ ] Merge test suite [PR](https://github.ibm.com/instana/tracer-test-suite/pull/96)

refs https://jsw.ibm.com/browse/INSTA-809

This PR should merge against V4 branch.