### PR TITLE
chore: enabled updates for currencies packages

### DIFF
--- a/currencies.json
+++ b/currencies.json
@@ -30,7 +30,7 @@
     "latestVersion": "",
     "cloudNative": false,
     "isBeta": false,
-    "ignoreUpdates": true,
+    "ignoreUpdates": false,
     "note": "",
     "deprecated": true,
     "core": false
@@ -762,7 +762,7 @@
     "latestVersion": "",
     "cloudNative": false,
     "isBeta": false,
-    "ignoreUpdates": true,
+    "ignoreUpdates": false,
     "note": "",
     "deprecated": false,
     "core": false
@@ -846,7 +846,7 @@
     "latestVersion": "",
     "cloudNative": false,
     "isBeta": false,
-    "ignoreUpdates": true,
+    "ignoreUpdates": false,
     "note": "",
     "deprecated": false,
     "core": false
@@ -870,7 +870,7 @@
     "latestVersion": "",
     "cloudNative": false,
     "isBeta": false,
-    "ignoreUpdates": true,
+    "ignoreUpdates": false,
     "note": "",
     "deprecated": true,
     "core": false
@@ -882,7 +882,7 @@
     "latestVersion": "",
     "cloudNative": false,
     "isBeta": false,
-    "ignoreUpdates": true,
+    "ignoreUpdates": false,
     "note": "",
     "deprecated": true,
     "core": false


### PR DESCRIPTION
Deprecated packages should still get updates IMO

**@azure/storage-blob**
Dont know why ignoreUpdates was set to true.

**kafka-avro**
Not even deprecated yet. Comes in v4.

**@apollo/federation / request / request-promise**
Fully npm deprecated. Still, there is IMO no reason to set ignoreUpdates to true.


**Deprecation means, we will drop support in our tracer in the future.
Deprecation does not mean, we do not care about updates.**

We probably need a new flag in the future: removed/dropped support. Then these packages are getting "ignoreUpdates: true".
