### PR TITLE
chore: support policy updated for timers in currencies.json

### DIFF
--- a/currencies.json
+++ b/currencies.json
@@ -325,7 +325,7 @@
   },
   {
     "name": "timers",
-    "policy": "45-days",
+    "policy": "0-days",
     "lastSupportedVersion": "",
     "latestVersion": "",
     "cloudNative": false,


### PR DESCRIPTION
Timers is a core module, update the support policy to 0 day. 