### PR TITLE
test: added proof test for parallel intermediates

### DIFF
--- a/packages/collector/test/tracing/sdk/app.js
+++ b/packages/collector/test/tracing/sdk/app.js
@@ -199,6 +199,17 @@ app.post('/async/create-intermediate', async function createIntermediateAsync(re
   afterCreateIntermediate(instana.sdk.async, file, encoding, res);
 });
 
+app.post('/async/parallel-intermediates', async (req, res) => {
+  const execute = async name => {
+    const s = await instana.sdk.async.startIntermediateSpan(name);
+    await delay(200);
+    await instana.sdk.async.completeIntermediateSpan(null, null, s);
+  };
+
+  await Promise.all([execute('eins'), execute('zwei')]);
+  res.sendStatus(200);
+});
+
 function afterCreateIntermediate(instanaSdk, file, encoding, res) {
   fs.readFile(file, encoding, (err, content) => {
     if (err) {


### PR DESCRIPTION
refs https://bigblue.aha.io/ideas/ideas/INSTANA-I-2600

We could possibly change the SDK interface to support `startIntermediateSpan(...parentSpan (optional)...)`