### PR TITLE
chore: logged Kafka header deprecation warning only if Kafka module was used

### DIFF
--- a/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
@@ -25,6 +25,7 @@ let isActive = false;
 exports.init = function init(config) {
   hook.onFileLoad(/\/kafkajs\/src\/producer\/messageProducer\.js/, instrumentProducer);
   hook.onFileLoad(/\/kafkajs\/src\/consumer\/runner\.js/, instrumentConsumer);
+  hook.onModuleLoad('kafkajs', logWarningForKafkaHeaderFormat);
   traceCorrelationEnabled = config.tracing.kafka.traceCorrelation;
   headerFormat = config.tracing.kafka.headerFormat;
 };
@@ -42,9 +43,6 @@ exports.activate = function activate(extraConfig) {
     if (typeof extraConfig.tracing.kafka.headerFormat === 'string') {
       headerFormat = extraConfig.tracing.kafka.headerFormat;
     }
-  }
-  if (headerFormat) {
-    logWarningForKafkaHeaderFormat();
   }
   isActive = true;
 };


### PR DESCRIPTION
Now the kafka warning is logged always, instead it should log only if the module is required. 