### PR TITLE
chore: avoided wrapping libraries twice

### DIFF
--- a/packages/collector/test/tracing/database/redis/test.js
+++ b/packages/collector/test/tracing/database/redis/test.js
@@ -327,6 +327,8 @@ const globalAgent = require('../../../globalAgent');
                         span => expect(span.data.http.method).to.equal('GET')
                       ]);
 
+                      expect(spans.length).to.be.eql(3);
+
                       expectAtLeastOneMatching(spans, [
                         span => expect(span.t).to.equal(writeEntrySpan.t),
                         span => expect(span.p).to.equal(writeEntrySpan.s),


### PR DESCRIPTION
We noticed that redis `wrapExec` fn is called twice:

https://github.com/instana/nodejs/blob/v3.18.2/packages/core/src/tracing/instrumentation/database/redis.js#L69
https://github.com/instana/nodejs/blob/v3.18.2/packages/core/src/tracing/instrumentation/database/redis.js#L109
https://github.com/instana/nodejs/blob/v3.18.2/packages/core/src/tracing/instrumentation/database/redis.js#L142

Client & cluster using the same help function.
But the internal client object in redis is the same. We could probably rewrite the redis instrumentation, but adding a protection against double wrapping is much easier and we need this anyway.
