### PR TITLE
fix(lambda): changed memory warning when using the lambda extension

### DIFF
--- a/packages/aws-lambda/src/wrapper.js
+++ b/packages/aws-lambda/src/wrapper.js
@@ -345,7 +345,7 @@ function shouldUseLambdaExtension() {
       return false;
     }
     if (memorySize < 256) {
-      if (process.env.LAMBDA_HANDLER.includes('instana-aws-lambda-auto-wrap')) {
+      if (process.env.LAMBDA_HANDLER?.includes('instana-aws-lambda-auto-wrap')) {
         logger.warn(
           'The Lambda function is configured with less than 256 MB of memory according to the value of ' +
             `AWS_LAMBDA_FUNCTION_MEMORY_SIZE: ${memorySetting}. The Lambda extension does ` +

--- a/packages/aws-lambda/src/wrapper.js
+++ b/packages/aws-lambda/src/wrapper.js
@@ -345,13 +345,20 @@ function shouldUseLambdaExtension() {
       return false;
     }
     if (memorySize < 256) {
-      logger.debug(
-        'The Lambda function is configured with less than 256 MB of memory according to the value of ' +
-          `AWS_LAMBDA_FUNCTION_MEMORY_SIZE: ${memorySetting}. Offloading data via a Lambda extension does currently ` +
-          'not work reliably with low memory settings, therefore not using the Lambda extension.'
-      );
+      if (process.env.LAMBDA_HANDLER.includes('instana-aws-lambda-auto-wrap')) {
+        logger.warn(
+          'The Lambda function is configured with less than 256 MB of memory according to the value of ' +
+            `AWS_LAMBDA_FUNCTION_MEMORY_SIZE: ${memorySetting}. The Lambda extension does ` +
+            'not work with 256mb reliably with low memory settings. ' +
+            'As the extension is already running, it might ' +
+            'block the lambda execution which can result in larger execution times. Please configure at least ' +
+            '256 MB of memory for your Lambda function.'
+        );
+      }
+
       return false;
     }
+
     return true;
   }
 }

--- a/packages/aws-lambda/src/wrapper.js
+++ b/packages/aws-lambda/src/wrapper.js
@@ -345,7 +345,7 @@ function shouldUseLambdaExtension() {
       return false;
     }
     if (memorySize < 256) {
-      if (process.env.LAMBDA_HANDLER?.includes('instana-aws-lambda-auto-wrap')) {
+      if (process.env._HANDLER?.includes('instana-aws-lambda-auto-wrap')) {
         logger.warn(
           'The Lambda function is configured with less than 256 MB of memory according to the value of ' +
             `AWS_LAMBDA_FUNCTION_MEMORY_SIZE: ${memorySetting}. The Lambda extension does ` +

--- a/packages/aws-lambda/src/wrapper.js
+++ b/packages/aws-lambda/src/wrapper.js
@@ -345,16 +345,24 @@ function shouldUseLambdaExtension() {
       return false;
     }
     if (memorySize < 256) {
+      let logFn = logger.debug;
+
+      // CASE: We try to determine if the customer has the extension installed. We need to put a warning
+      //       because the extension is **not** working and might block the lambda extension when
+      //       its not used correctly e.g. slow startup of extension or waiting for invokes or incoming spans
+      //       from the tracer.
       if (process.env._HANDLER?.includes('instana-aws-lambda-auto-wrap')) {
-        logger.warn(
-          'The Lambda function is configured with less than 256 MB of memory according to the value of ' +
-            `AWS_LAMBDA_FUNCTION_MEMORY_SIZE: ${memorySetting}. The Lambda extension does ` +
-            'not work with 256mb reliably with low memory settings. ' +
-            'As the extension is already running, it might ' +
-            'block the lambda execution which can result in larger execution times. Please configure at least ' +
-            '256 MB of memory for your Lambda function.'
-        );
+        logFn = logger.warn;
       }
+
+      logFn(
+        'The Lambda function is configured with less than 256 MB of memory according to the value of ' +
+          `AWS_LAMBDA_FUNCTION_MEMORY_SIZE: ${memorySetting}. The Lambda extension does ` +
+          'not work with 256mb reliably with low memory settings. ' +
+          'As the extension is already running, it might ' +
+          'block the lambda execution which can result in larger execution times. Please configure at least ' +
+          '256 MB of memory for your Lambda function.'
+      );
 
       return false;
     }


### PR DESCRIPTION
Background:
We assume that when installing the lambda layer, but mis-configuring the memory, the extension is still started and running.
There could be significant latency especially during cold starts. That could be caused by:

- waiting for AWS events (invokes, shutdowns), incoming tracer requests or go channels
- slow startup because of low memory

As soon as we increase the memory, the latency problem is gone.

We should discuss if we want to change this behavior e.g. we disable tracing completely. Because **as soon as the extension is installed**, it should be configured correctly.
