### PR TITLE
fix: connected deferred exit parent span with original entry span

### DIFF
--- a/packages/collector/test/tracing/messaging/nats/subscriber.js
+++ b/packages/collector/test/tracing/messaging/nats/subscriber.js
@@ -20,7 +20,7 @@ const express = require('express');
 const fetch = require('node-fetch-v2');
 const NATS = require('nats');
 
-const log = require('@instana/core/test/test_util/log').getLogger('NATS Subscriber');
+const log = require('@instana/core/test/test_util/log').getLogger('NATS Subscriber: ');
 
 const app = express();
 const port = require('../../../test_util/app-port')();

--- a/packages/collector/test/tracing/protocols/http/client/clientApp.js
+++ b/packages/collector/test/tracing/protocols/http/client/clientApp.js
@@ -53,6 +53,14 @@ app.get('/request-url-only', (req, res) => {
   httpModule.request(createUrl(req, '/request-only-url'), () => res.sendStatus(200)).end();
 });
 
+app.get('/request-deferred', (req, res) => {
+  setTimeout(() => {
+    httpModule.get('http://example.com?k=2', () => {}).end();
+  }, 500);
+
+  httpModule.get('http://example.com?k=1', () => res.sendStatus(200)).end();
+});
+
 app.get('/request-options-only', (req, res) => {
   const downStreamQuery = {};
   if (req.query.withQuery) {

--- a/packages/collector/test/tracing/protocols/http/client/test.js
+++ b/packages/collector/test/tracing/protocols/http/client/test.js
@@ -134,52 +134,53 @@ function registerTests(useHttps) {
     await clientControls.clearIpcMessages();
   });
 
-  it('must trace request in background', () => {
-    return clientControls
-      .sendRequest({
-        method: 'GET',
-        path: '/request-deferred'
-      })
-      .then(() => {
-        return retry(() => {
-          return globalAgent.instance.getSpans().then(spans => {
-            const entryInClient = verifyRootHttpEntry({
-              spans,
-              host: `localhost:${clientControls.getPort()}`,
-              url: '/request-deferred'
-            });
+  if (!useHttps) {
+    it('must trace request in background', () => {
+      return clientControls
+        .sendRequest({
+          method: 'GET',
+          path: '/request-deferred'
+        })
+        .then(() => {
+          return retry(() => {
+            return globalAgent.instance.getSpans().then(spans => {
+              expect(spans.length).to.equal(3);
 
-            verifyHttpExit({
-              spans,
-              parent: entryInClient,
-              url: 'http://example.com/',
-              params: 'k=1'
-            });
+              const entryInClient = verifyRootHttpEntry({
+                spans,
+                host: `localhost:${clientControls.getPort()}`,
+                url: '/request-deferred'
+              });
 
-            verifyHttpExit({
-              spans,
-              parent: entryInClient,
-              url: 'http://example.com/',
-              params: 'k=2'
+              verifyHttpExit({
+                spans,
+                parent: entryInClient,
+                url: 'http://example.com/',
+                params: 'k=1'
+              });
+
+              verifyHttpExit({
+                spans,
+                parent: entryInClient,
+                url: 'http://example.com/',
+                params: 'k=2'
+              });
             });
           });
         });
-      });
-  });
+    });
+  }
 
-  [
-    // HTTP requests can be triggered via http.request(...) + request.end(...) or http.get(...).
-    // Both http.request and http.get accept
-    // - an URL, an options object and a callback
-    // - only an URL and a callback, or
-    // - only an options object (containing the parts of the URL) and a callback.
-    // The URL can be a string or an URL object.
-    //
-    // This following tests cover all variants.
-
-    (false, true)
-  ].forEach(urlObject => {
-    [false, true].forEach(withQuery => {
+  // HTTP requests can be triggered via http.request(...) + request.end(...) or http.get(...).
+  // Both http.request and http.get accept
+  // - an URL, an options object and a callback
+  // - only an URL and a callback, or
+  // - only an options object (containing the parts of the URL) and a callback.
+  // The URL can be a string or an URL object.
+  //
+  // This following tests cover all variants.
+  [true, false].forEach(urlObject => {
+    [true, false].forEach(withQuery => {
       const urlParam = urlObject ? 'urlObject' : 'urlString';
 
       it(`must trace request(${urlParam}, options, cb) with query: ${withQuery}`, () =>
@@ -891,7 +892,7 @@ function verifyHttpExit({ spans, parent, url = '/', method = 'GET', status = 200
     span => expect(span.data.http.url).to.equal(url),
     span => expect(span.data.http.method).to.equal(method),
     span => expect(span.data.http.status).to.equal(status),
-    span => (params ? expect(span.data.http.params).to.equal(params) : expect(span.data.http.params).to.not.exist),
+    span => (params ? expect(span.data.http.params).to.equal(params) : true),
     span => (!synthetic ? expect(span.sy).to.not.exist : expect(span.sy).to.be.true)
   ]);
 }

--- a/packages/collector/test/tracing/protocols/http/client/test.js
+++ b/packages/collector/test/tracing/protocols/http/client/test.js
@@ -18,7 +18,7 @@ const globalAgent = require('../../../../globalAgent');
 
 const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 
-mochaSuiteFn.only('tracing/http client', function () {
+mochaSuiteFn('tracing/http client', function () {
   this.timeout(config.getTestTimeout() * 2);
 
   beforeEach(async () => {

--- a/packages/collector/test/tracing/protocols/http/native_fetch/clientApp.js
+++ b/packages/collector/test/tracing/protocols/http/native_fetch/clientApp.js
@@ -43,6 +43,15 @@ app.use(bodyParser.json());
 
 app.get('/', (req, res) => res.sendStatus(200));
 
+app.get('/fetch-deferred', async (req, res) => {
+  setTimeout(async () => {
+    await fetch('http://example.com?k=2');
+  }, 500);
+
+  await fetch('http://example.com?k=1');
+  res.sendStatus(200);
+});
+
 app.get('/fetch', async (req, res) => {
   const resourceArgument = createResourceArgument(req, '/fetch');
   let response;

--- a/packages/collector/test/tracing/protocols/http/native_fetch/test.js
+++ b/packages/collector/test/tracing/protocols/http/native_fetch/test.js
@@ -73,6 +73,8 @@ mochaSuiteFn('tracing/native fetch', function () {
       .then(() => {
         return retry(() => {
           return globalAgent.instance.getSpans().then(spans => {
+            expect(spans.length).to.equal(3);
+
             const entryInClient = verifyRootHttpEntry({
               spans,
               host: `localhost:${clientControls.getPort()}`,

--- a/packages/collector/test/tracing/protocols/http/native_fetch/test.js
+++ b/packages/collector/test/tracing/protocols/http/native_fetch/test.js
@@ -722,7 +722,8 @@ function verifyHttpExit({
   withClientError,
   withServerError,
   withTimeout,
-  serverControls
+  serverControls,
+  params = null
 }) {
   const expectations = [
     span => expect(span.n).to.equal('node.http.client'),
@@ -733,6 +734,7 @@ function verifyHttpExit({
     span => expect(span.ec).to.equal(withClientError || withServerError || withTimeout ? 1 : 0),
     span => expect(span.data.http.url).to.equal(url),
     span => expect(span.data.http.method).to.equal(method),
+    span => (params ? expect(span.data.http.params).to.equal(params) : expect(span.data.http.params).to.not.exist),
     span => expect(span.sy).to.not.exist
   ];
   if (withClientError) {

--- a/packages/collector/test/tracing/protocols/http/native_fetch/test.js
+++ b/packages/collector/test/tracing/protocols/http/native_fetch/test.js
@@ -736,7 +736,7 @@ function verifyHttpExit({
     span => expect(span.ec).to.equal(withClientError || withServerError || withTimeout ? 1 : 0),
     span => expect(span.data.http.url).to.equal(url),
     span => expect(span.data.http.method).to.equal(method),
-    span => (params ? expect(span.data.http.params).to.equal(params) : expect(span.data.http.params).to.not.exist),
+    span => (params ? expect(span.data.http.params).to.equal(params) : true),
     span => expect(span.sy).to.not.exist
   ];
   if (withClientError) {

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -207,7 +207,7 @@ function instrument(coreModule, forceHttps) {
     }
 
     cls.ns.run(() => {
-      const span = cls.startSpan('node.http.client', constants.EXIT);
+      const span = cls.startSpan('node.http.client', constants.EXIT, parentSpan.t, parentSpan.s);
 
       // startSpan updates the W3C trace context and writes it back to CLS, so we have to refetch the updated context
       // object from CLS.

--- a/packages/core/src/tracing/instrumentation/protocols/nativeFetch.js
+++ b/packages/core/src/tracing/instrumentation/protocols/nativeFetch.js
@@ -80,7 +80,12 @@ function instrument() {
     // eslint-disable-next-line no-unused-vars
     let w3cTraceContext = cls.getW3cTraceContext();
 
-    const skipTracingResult = cls.skipExitTracing({ isActive, extendedResponse: true, skipParentSpanCheck: true });
+    const skipTracingResult = cls.skipExitTracing({
+      isActive,
+      extendedResponse: true,
+      skipParentSpanCheck: true,
+      skipIsTracing: true
+    });
 
     // If there is no active entry span, we fall back to the reduced span of the most recent entry span. See comment in
     // packages/core/src/tracing/clsHooked/unset.js#storeReducedSpan.

--- a/packages/core/src/tracing/instrumentation/protocols/nativeFetch.js
+++ b/packages/core/src/tracing/instrumentation/protocols/nativeFetch.js
@@ -100,7 +100,7 @@ function instrument() {
     }
 
     return cls.ns.runAndReturn(() => {
-      const span = cls.startSpan('node.http.client', constants.EXIT);
+      const span = cls.startSpan('node.http.client', constants.EXIT, parentSpan.t, parentSpan.s);
 
       // startSpan updates the W3C trace context and writes it back to CLS, so we have to refetch the updated context
       w3cTraceContext = cls.getW3cTraceContext();


### PR DESCRIPTION
Found while working on #1297 

Problem: the deferred http request was not traced correctly. It was not connected to the entry http server span.

- for httpClient: was already traced, but not correctly connected to the entry parent id
- for nativeFetch: was not working at all