### PR TITLE
feat: extended typescript support

### DIFF
--- a/packages/collector/.eslintignore
+++ b/packages/collector/.eslintignore
@@ -3,3 +3,4 @@ test/apps/babel-typescript/
 test/metrics/app/node_modules/
 test/metrics/npmInstalledApp/node_modules/
 test/tracing/frameworks/tsoa/build/
+test/tracing/misc/esm-typescript/

--- a/packages/collector/package.json
+++ b/packages/collector/package.json
@@ -9,6 +9,7 @@
   "homepage": "https://github.com/instana/nodejs/blob/main/packages/collector/README.md",
   "license": "MIT",
   "main": "src/index.js",
+  "types": "src/types/index.d.ts",
   "bin": {
     "instana-instrument-edgemicro-cli": "src/bin/instrument-edgemicro-cli.js"
   },

--- a/packages/collector/src/actions/source.js
+++ b/packages/collector/src/actions/source.js
@@ -7,7 +7,7 @@
 
 const { uninstrumentedFs: fs } = require('@instana/core');
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('actions/source', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/agent/opts.js
+++ b/packages/collector/src/agent/opts.js
@@ -20,7 +20,7 @@ exports.autoProfile = false;
 exports.config = {};
 
 /**
- * @param {import('../util/normalizeConfig').CollectorConfig} config
+ * @param {import('../types/collector').CollectorConfig} config
  */
 exports.init = function init(config) {
   // @ts-ignore - Cannot redeclare exported variable

--- a/packages/collector/src/agent/requestHandler.js
+++ b/packages/collector/src/agent/requestHandler.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 
 logger = require('../logger').getLogger('agent/requestHandler', newLogger => {

--- a/packages/collector/src/agentConnection.js
+++ b/packages/collector/src/agentConnection.js
@@ -10,9 +10,9 @@ const http = uninstrumentedHttp.http;
 
 const pathUtil = require('path');
 
-/** @typedef {import('@instana/core/src/tracing/cls').InstanaBaseSpan} InstanaBaseSpan */
+/** @typedef {import('@instana/core/src/core').InstanaBaseSpan} InstanaBaseSpan */
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('./logger').getLogger('agentConnection', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/announceCycle/agentHostLookup.js
+++ b/packages/collector/src/announceCycle/agentHostLookup.js
@@ -13,7 +13,7 @@ const agentOpts = require('../agent/opts');
 const defaultGatewayParser = require('./defaultGatewayParser');
 const readDefaultGateway = callbackify(defaultGatewayParser.parseProcSelfNetRouteFile);
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('announceCycle/agentHostLookup', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/announceCycle/agentready.js
+++ b/packages/collector/src/announceCycle/agentready.js
@@ -37,7 +37,7 @@ let autoprofile;
 /** @type {*} */
 let profiler;
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('announceCycle/agentready', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/announceCycle/announced.js
+++ b/packages/collector/src/announceCycle/announced.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('announceCycle/announced', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/announceCycle/defaultGatewayParser.js
+++ b/packages/collector/src/announceCycle/defaultGatewayParser.js
@@ -6,7 +6,7 @@
 
 const fs = require('fs').promises;
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('announceCycle/defaultGatewayParser', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/announceCycle/index.js
+++ b/packages/collector/src/announceCycle/index.js
@@ -16,7 +16,7 @@
  * @property {(ctx?: AnnounceCycleContext) => void} leave
  */
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('announceCycle', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/announceCycle/unannounced.js
+++ b/packages/collector/src/announceCycle/unannounced.js
@@ -12,7 +12,7 @@ const {
 } = require('@instana/core');
 const { constants: tracingConstants } = tracing;
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('announceCycle/unannounced', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/cmdline.js
+++ b/packages/collector/src/cmdline.js
@@ -7,7 +7,7 @@
 
 const { uninstrumentedFs: fs } = require('@instana/core');
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('./logger').getLogger('cmdline', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/index.js
+++ b/packages/collector/src/index.js
@@ -12,6 +12,10 @@ if (!isProcessAvailable()) {
   // eslint-disable-next-line no-console
   console.error('The Node.js core module process is not available. This process will not be monitored by Instana.');
   module.exports = function noOp() {};
+
+  // ESM default exports for TS
+  module.exports.default = function noOp() {};
+
   // @ts-ignore TS1108 (return can only be used within a function body)
   return;
 }
@@ -22,7 +26,10 @@ if (isNodeJsTooOld()) {
     `The package @instana/collector requires at least Node.js ${minimumNodeJsVersion} but this process is ` +
       `running on Node.js ${process.version}. This process will not be monitored by Instana.`
   );
-  module.exports = function noOp() {};
+
+  // ESM default exports for TS
+  module.exports.default = function noOp() {};
+
   // @ts-ignore TS1108 (return can only be used within a function body)
   return;
 }
@@ -40,17 +47,18 @@ const instanaSharedMetrics = require('@instana/shared-metrics');
 
 require('./tracing'); // load additional instrumentations
 const log = require('./logger');
+
 const normalizeConfig = require('./util/normalizeConfig');
 const experimental = require('./experimental');
 
 /** @type {import('./agentConnection')} */
 let agentConnection;
 
-/** @type {import('./util/normalizeConfig').CollectorConfig} */
+/** @type {import('./types/collector').CollectorConfig} */
 let config;
 
 /**
- * @param {import('./util/normalizeConfig').CollectorConfig} [_config]
+ * @param {import('./types/collector').CollectorConfig} [_config]
  */
 function init(_config) {
   // @ts-ignore: Property '__INSTANA_INITIALIZED' does not exist on type global
@@ -129,7 +137,7 @@ init.isConnected = function isConnected() {
 };
 
 /**
- * @param {import('@instana/core/src/logger').GenericLogger} logger
+ * @param {import('@instana/core/src/core').GenericLogger} logger
  */
 init.setLogger = function setLogger(logger) {
   // NOTE: Override our default logger with customer's logger
@@ -153,3 +161,4 @@ if (process.env.INSTANA_IMMEDIATE_INIT != null && process.env.INSTANA_IMMEDIATE_
 }
 
 module.exports = init;
+module.exports.default = init;

--- a/packages/collector/src/logger.js
+++ b/packages/collector/src/logger.js
@@ -21,13 +21,13 @@ const { logger } = require('@instana/core');
 
 const bunyanToAgentStream = require('./agent/bunyanToAgentStream');
 
-/** @type {bunyan | import('@instana/core/src/logger').GenericLogger} */
+/** @type {bunyan | import('@instana/core/src/core').GenericLogger} */
 let parentLogger = null;
-/** @type {Object.<string, (logger: import('@instana/core/src/logger').GenericLogger) => *>} */
+/** @type {Object.<string, (logger: import('@instana/core/src/core').GenericLogger) => *>} */
 const registry = {};
 
 /**
- * @param {import('./util/normalizeConfig').CollectorConfig} config
+ * @param {import('./types/collector').CollectorConfig} config
  * @param {boolean} [isReInit]
  */
 exports.init = function init(config, isReInit) {
@@ -80,14 +80,13 @@ exports.init = function init(config, isReInit) {
 
 /**
  * @param {string} loggerName
- * @param {(logger: import('@instana/core/src/logger').GenericLogger) => *} [reInitFn]
- * @returns {import('@instana/core/src/logger').GenericLogger}
+ * @param {(logger: import('@instana/core/src/core').GenericLogger) => *} [reInitFn]
+ * @returns {import('@instana/core/src/core').GenericLogger}
  */
 exports.getLogger = function getLogger(loggerName, reInitFn) {
   if (!parentLogger) {
     exports.init({});
   }
-
   let _logger;
 
   if (typeof parentLogger.child === 'function') {
@@ -106,7 +105,8 @@ exports.getLogger = function getLogger(loggerName, reInitFn) {
     }
     registry[loggerName] = reInitFn;
   }
-  return _logger;
+
+  return /** @type {import('@instana/core/src/core').GenericLogger} */ (_logger);
 };
 
 /**
@@ -118,7 +118,7 @@ function isBunyan(_logger) {
 }
 
 /**
- * @param {import('@instana/core/src/logger').GenericLogger | *} _logger
+ * @param {import('@instana/core/src/core').GenericLogger | *} _logger
  * @returns {boolean}
  */
 function hasLoggingFunctions(_logger) {

--- a/packages/collector/src/metrics/index.js
+++ b/packages/collector/src/metrics/index.js
@@ -13,7 +13,7 @@ coreMetrics.registerAdditionalMetrics(sharedMetrics.allMetrics);
 const additionalCollectorMetrics = coreMetrics.findAndRequire(__dirname);
 coreMetrics.registerAdditionalMetrics(additionalCollectorMetrics);
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 const logger = require('../logger').getLogger('metrics', newLogger => {
   coreMetrics.setLogger(newLogger);
 });

--- a/packages/collector/src/metrics/transmissionCycle.js
+++ b/packages/collector/src/metrics/transmissionCycle.js
@@ -7,7 +7,7 @@
 
 const { clone, compression } = require('@instana/core').util;
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('metrics/sender', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/pidStore/index.js
+++ b/packages/collector/src/pidStore/index.js
@@ -11,7 +11,7 @@ const { uninstrumentedFs: fs } = require('@instana/core');
 const internalPidStore = require('./internalPidStore');
 const agentOpts = require('../agent/opts');
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('pidStore', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/tracing/instrumentation/process/childProcess.js
+++ b/packages/collector/src/tracing/instrumentation/process/childProcess.js
@@ -15,7 +15,7 @@ const getCls = tracing.getCls;
 
 const selfPath = require('./selfPath');
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../../../logger').getLogger('tracing/child_process', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/tracing/instrumentation/process/edgemicro.js
+++ b/packages/collector/src/tracing/instrumentation/process/edgemicro.js
@@ -10,7 +10,7 @@ const cluster = require('cluster');
 const hook = require('@instana/core').util.hook;
 const selfPath = require('./selfPath');
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../../../logger').getLogger('tracing/edgemicro', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/tracing/instrumentation/process/selfPath.js
+++ b/packages/collector/src/tracing/instrumentation/process/selfPath.js
@@ -8,7 +8,7 @@
 const { uninstrumentedFs: fs } = require('@instana/core');
 const path = require('path');
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../../../logger').getLogger('tracing/selfPath', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/types/collector.d.ts
+++ b/packages/collector/src/types/collector.d.ts
@@ -1,0 +1,14 @@
+import { GenericLogger } from '@instana/core/src/core';
+
+export interface CollectorConfig {
+  agentPort?: number;
+  agentHost?: string;
+  tracing?: {
+    stackTraceLength?: number;
+    [key: string]: any;
+  };
+  autoProfile?: boolean | string;
+  reportUnhandledPromiseRejections?: boolean;
+  logger?: GenericLogger;
+  level?: string | number;
+}

--- a/packages/collector/src/types/index.d.ts
+++ b/packages/collector/src/types/index.d.ts
@@ -1,0 +1,3 @@
+import { InitFunction } from './shared';
+declare const init: InitFunction;
+export = init;

--- a/packages/collector/src/types/shared.d.ts
+++ b/packages/collector/src/types/shared.d.ts
@@ -1,0 +1,23 @@
+import { CollectorConfig } from './collector';
+import { GenericLogger, InstanaBaseSpan } from '@instana/core/src/core';
+
+export interface Init {
+  currentSpan(): InstanaBaseSpan;
+  isTracing(): boolean;
+  isConnected(): boolean;
+  setLogger(logger: GenericLogger): void;
+  core: any;
+  sharedMetrics: any;
+  experimental: any;
+  opentracing: any;
+  sdk: any;
+}
+
+export type InitFunction = {
+  (config?: CollectorConfig): Init;
+  sdk: any;
+  core: any;
+  sharedMetrics: any;
+  experimental: any;
+  opentracing: any;
+};

--- a/packages/collector/src/uncaught/index.js
+++ b/packages/collector/src/uncaught/index.js
@@ -11,7 +11,7 @@
 
 const serializeError = require('serialize-error');
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('util/uncaughtExceptionHandler', newLogger => {
   logger = newLogger;
@@ -24,7 +24,7 @@ let processIdentityProvider = null;
 const unhandledRejectionEventName = 'unhandledRejection';
 let unhandledRejectionDeprecationWarningHasBeenEmitted = false;
 
-/** @type {import('../util/normalizeConfig').CollectorConfig} */
+/** @type {import('../types/collector').CollectorConfig} */
 let config;
 
 // see
@@ -40,7 +40,7 @@ for (let i = 0; i < process.execArgv.length; i++) {
 }
 
 /**
- * @param {import('../util/normalizeConfig').CollectorConfig} _config
+ * @param {import('../types/collector').CollectorConfig} _config
  * @param {import('../agentConnection')} _downstreamConnection
  * @param {import('../pidStore')} _processIdentityProvider
  */

--- a/packages/collector/src/util/initializedTooLate.js
+++ b/packages/collector/src/util/initializedTooLate.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-/** @type {import('@instana/core/src/logger').GenericLogger} */
+/** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('util/initializedTooLate', newLogger => {
   logger = newLogger;

--- a/packages/collector/src/util/normalizeConfig.js
+++ b/packages/collector/src/util/normalizeConfig.js
@@ -17,20 +17,9 @@ const defaults = {
 };
 
 /**
- * @typedef {Object} CollectorConfig
- * @property {number} [agentPort]
- * @property {string} [agentHost]
- * @property {Object.<string, *>} [tracing]
- * @property {boolean | string} [autoProfile]
- * @property {boolean} [reportUnhandledPromiseRejections]
- * @property {import('@instana/core/src/logger').GenericLogger} [logger]
- * @property {string | number} [level]
- */
-
-/**
  * Merges the config that was passed to the init function with environment variables and default values.
- * @param {CollectorConfig} config
- * @returns {CollectorConfig}
+ * @param {import('../types/collector').CollectorConfig} config
+ * @returns {import('../types/collector').CollectorConfig}
  */
 module.exports = function normalizeConfig(config = {}) {
   config.agentHost = config.agentHost || process.env.INSTANA_AGENT_HOST || defaults.agentHost;

--- a/packages/collector/test/tracing/misc/esm-typescript/dist/app.js
+++ b/packages/collector/test/tracing/misc/esm-typescript/dist/app.js
@@ -1,0 +1,11 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const collector_1 = __importDefault(require("@instana/collector"));
+if (!collector_1.default.sdk) {
+    throw new Error('instana.sdk does not exist.');
+}
+exports.default = collector_1.default;
+//# sourceMappingURL=app.js.map

--- a/packages/collector/test/tracing/misc/esm-typescript/dist/app.js.map
+++ b/packages/collector/test/tracing/misc/esm-typescript/dist/app.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"app.js","sourceRoot":"","sources":["../src/app.ts"],"names":[],"mappings":";;;;;AAAA,mEAAyC;AAEzC,IAAI,CAAC,mBAAO,CAAC,GAAG,EAAE,CAAC;IACjB,MAAM,IAAI,KAAK,CAAC,6BAA6B,CAAC,CAAC;AACjD,CAAC;AAED,kBAAe,mBAAO,CAAC"}

--- a/packages/collector/test/tracing/misc/esm-typescript/dist/app_1.js
+++ b/packages/collector/test/tracing/misc/esm-typescript/dist/app_1.js
@@ -1,0 +1,11 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const collector_1 = __importDefault(require("@instana/collector"));
+if (!collector_1.default.sdk) {
+    throw new Error('instana.sdk does not exist.');
+}
+exports.default = collector_1.default;
+//# sourceMappingURL=app_1.js.map

--- a/packages/collector/test/tracing/misc/esm-typescript/dist/app_1.js.map
+++ b/packages/collector/test/tracing/misc/esm-typescript/dist/app_1.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"app_1.js","sourceRoot":"","sources":["../src/app_1.ts"],"names":[],"mappings":";;;;;AAAA,mEAAyC;AAEzC,IAAI,CAAC,mBAAO,CAAC,GAAG,EAAE,CAAC;IACjB,MAAM,IAAI,KAAK,CAAC,6BAA6B,CAAC,CAAC;AACjD,CAAC;AAED,kBAAe,mBAAO,CAAC"}

--- a/packages/collector/test/tracing/misc/esm-typescript/dist/app_2.js
+++ b/packages/collector/test/tracing/misc/esm-typescript/dist/app_2.js
@@ -1,0 +1,31 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const instana = __importStar(require("@instana/collector"));
+if (!instana.sdk) {
+    throw new Error('instana.sdk does not exist.');
+}
+exports.default = instana;
+//# sourceMappingURL=app_2.js.map

--- a/packages/collector/test/tracing/misc/esm-typescript/dist/app_2.js.map
+++ b/packages/collector/test/tracing/misc/esm-typescript/dist/app_2.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"app_2.js","sourceRoot":"","sources":["../src/app_2.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;;;;;;;;;AAAA,4DAA8C;AAE9C,IAAI,CAAC,OAAO,CAAC,GAAG,EAAE,CAAC;IACjB,MAAM,IAAI,KAAK,CAAC,6BAA6B,CAAC,CAAC;AACjD,CAAC;AAED,kBAAe,OAAO,CAAC"}

--- a/packages/collector/test/tracing/misc/esm-typescript/esm_ts_test.js
+++ b/packages/collector/test/tracing/misc/esm-typescript/esm_ts_test.js
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright IBM Corp. 2024
+ */
+
+'use strict';
+
+const expect = require('chai').expect;
+const { execSync } = require('child_process');
+const config = require('@instana/core/test/config');
+
+describe('ESM Typescript App', function () {
+  this.timeout(config.getTestTimeout() * 2);
+
+  before(() => {
+    execSync('npm run build', { cwd: __dirname, stdio: 'inherit' });
+  });
+
+  it('[app_1] should be able to load Instana SDK', () => {
+    const exported = require('./dist/app_1');
+    expect(exported).to.be.an('object');
+
+    // This is `.default` because we transform it back into CJS. Its correct in the esm app.
+    expect(exported.default.sdk).to.exist;
+  });
+
+  it('[app_2] should be able to load Instana SDK', () => {
+    const exported = require('./dist/app_2');
+    expect(exported).to.be.an('object');
+
+    // This is `.default` because we transform it back into CJS. Its correct in the esm app.
+    expect(exported.default.sdk).to.exist;
+  });
+});

--- a/packages/collector/test/tracing/misc/esm-typescript/package-lock.json
+++ b/packages/collector/test/tracing/misc/esm-typescript/package-lock.json
@@ -1,0 +1,986 @@
+{
+  "name": "esm-typescript",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "esm-typescript",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@instana/collector": "^3.19.0",
+        "typescript": "^5.6.2"
+      }
+    },
+    "node_modules/@instana/autoprofile": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@instana/autoprofile/-/autoprofile-3.19.0.tgz",
+      "integrity": "sha512-qWHo6bvx+8cJA0jixoPzbl16M0Fm94cS5Vl11fiz/Pj1ecvh8FyReRayE7qnXvwXuAK6vRGvNUdbcMvtyCxA9g==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "@instana/core": "3.19.0",
+        "detect-libc": "^2.0.2",
+        "nan": "^2.14.2",
+        "node-gyp-build": "^4.7.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@instana/collector": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@instana/collector/-/collector-3.19.0.tgz",
+      "integrity": "sha512-ex4YgvB8mDWiELArkiU4JXw5d2S2NXBZ3Mm4nCWBB3hOGuAbucoXGSFwWMtVkHTud7oIwcT/bTuNmAWRFCLUyA==",
+      "dependencies": {
+        "@instana/core": "3.19.0",
+        "@instana/shared-metrics": "3.19.0",
+        "bunyan": "^1.8.15",
+        "semver": "^7.5.4",
+        "serialize-error": "^8.1.0"
+      },
+      "bin": {
+        "instana-instrument-edgemicro-cli": "src/bin/instrument-edgemicro-cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@instana/autoprofile": "3.19.0"
+      }
+    },
+    "node_modules/@instana/core": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@instana/core/-/core-3.19.0.tgz",
+      "integrity": "sha512-75M8pkWY0Vo+64hhlgPfxALu7C20AmZQfsb6fqK5EMOdROaoWj2IgbmyPeBdAW+6M+hLBvuetXUTdVCNVsAIcg==",
+      "dependencies": {
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/instrumentation-fs": "0.12.0",
+        "@opentelemetry/instrumentation-restify": "0.38.0",
+        "@opentelemetry/instrumentation-socket.io": "0.39.0",
+        "@opentelemetry/instrumentation-tedious": "0.13.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "cls-bluebird": "^2.1.0",
+        "import-in-the-middle": "1.9.0",
+        "lru-cache": "^10.1.0",
+        "methods": "^1.1.2",
+        "opentracing": "^0.14.5",
+        "semver": "^7.5.4",
+        "shimmer": "^1.2.1"
+      }
+    },
+    "node_modules/@instana/shared-metrics": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@instana/shared-metrics/-/shared-metrics-3.19.0.tgz",
+      "integrity": "sha512-bx/wR5Eo4nXUK3HfukjYzUDKObSyjZYEHqrgGdZHSd41yOAu0Z5Eyho/Qop+yGKR7pRJScTLCo55AaCd5AltQg==",
+      "dependencies": {
+        "@instana/core": "3.19.0",
+        "detect-libc": "^2.0.2",
+        "event-loop-lag": "^1.4.0",
+        "fs-extra": "^11.2.0",
+        "semver": "^7.5.4",
+        "tar": "^6.2.1"
+      },
+      "optionalDependencies": {
+        "event-loop-stats": "1.4.1",
+        "gcstats.js": "1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
+      "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.0.tgz",
+      "integrity": "sha512-sBW313mnMyFg0cp/40BRzrZBWG+581s2j5gIsa5fgGadswyILk4mNFATsqrCOpAx945RDuZ2B7ThQLgor9OpfA==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
+      "integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.51.1.tgz",
+      "integrity": "sha512-JIrvhpgqY6437QIqToyozrUG1h5UhwHkaGK/WAX+fkrpyPtc+RO5FkRtUd9BH0MibabHHvqsnBGKfKVijbmp8w==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.51.1",
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "1.7.4",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.12.0.tgz",
+      "integrity": "sha512-Waf+2hekJRxIwq1PmivxOWLdMOtYbY22hKr34gEtfbv2CArSv8FBJH4BmQxB9o5ZcwkdKu589qs009dbuSfNmQ==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.51.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-restify": {
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.38.0.tgz",
+      "integrity": "sha512-VYK47Z9GBaZX5MQLL7kZDdzQDdyUtHRD4J/GSr6kdwmIpdpUQXLsV3EnboeB8P+BlpucF57FyJKE8yWTOEMfnA==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-socket.io": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.39.0.tgz",
+      "integrity": "sha512-4J2ehk5mJyDT6j2yJCOuPxAjit5QB1Fwzhx0LID5jjvhI9LxzZIGDNAPTTHyghSiaRDeNMzceXKkkEQJkg2MNw==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.51.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.13.0.tgz",
+      "integrity": "sha512-Pob0+0R62AqXH50pjazTeGBy/1+SK4CYpFUBV5t7xpbpeuQezkkgVGvLca84QqjBqQizcXedjpUJLgHQDixPQg==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious/node_modules/@opentelemetry/api-logs": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz",
+      "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.1.tgz",
+      "integrity": "sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.52.1",
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation/node_modules/import-in-the-middle": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.4.tgz",
+      "integrity": "sha512-Lk+qzWmiQuRPPulGQeK5qq0v32k2bHnWrRPFgqyvhw7Kkov5L6MOLOIU3pcWeujc9W4q54Cp3Q2WV16eQkc7Bg==",
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.0.tgz",
+      "integrity": "sha512-iHjydPMYJ+Li1auveJCq2rp5U2h6Mhq8BidiyE0jfVlDTFyR1ny8AfJHfmFzJ/RAM8vT8L7T21kcmGybxZC7lQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.0.tgz",
+      "integrity": "sha512-n0B3s8rrqGrasTgNkXLKXzN0fXo+6IYP7M5b7AMsrZM33f/y6DS6kJ0Btd7SespASWq8bgL3taLo0oe0vB52IQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
+      "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.0.tgz",
+      "integrity": "sha512-6+g2fiRQUG39guCsKVeY8ToeuUf3YUnPkN6DXRA1qDmFLprlLvZm9cS6+chgbW70cZJ406FTtSCDnJwxDC5sGQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.0.tgz",
+      "integrity": "sha512-n0B3s8rrqGrasTgNkXLKXzN0fXo+6IYP7M5b7AMsrZM33f/y6DS6kJ0Btd7SespASWq8bgL3taLo0oe0vB52IQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
+      "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "optional": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/bunyan": {
+      "version": "1.8.15",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
+      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
+      "engines": [
+        "node >=0.10.0"
+      ],
+      "bin": {
+        "bunyan": "bin/bunyan"
+      },
+      "optionalDependencies": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.19.3",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
+      "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA=="
+    },
+    "node_modules/cls-bluebird": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
+      "integrity": "sha512-XVb0RPmHQyy35Tz9z34gvtUcBKUK8A/1xkGCyeFc9B0C7Zr5SysgFaswRVdwI5NEMcO+3JKlIDGIOgERSn9NdA==",
+      "dependencies": {
+        "is-bluebird": "^1.0.2",
+        "shimmer": "^1.1.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "optional": true
+    },
+    "node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dtrace-provider": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.14.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/event-loop-lag": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/event-loop-lag/-/event-loop-lag-1.4.0.tgz",
+      "integrity": "sha512-uNAYTAexGyPI7rms2jSES20nhUoCtjkmxgaOcAfaoaOQ6h3q1+fw6d5MfyfV0zMJpR//+GUYPVXrh2Wbv+E0sQ==",
+      "dependencies": {
+        "debug": "^3.1.0"
+      }
+    },
+    "node_modules/event-loop-stats": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/event-loop-stats/-/event-loop-stats-1.4.1.tgz",
+      "integrity": "sha512-Wzohoz1JrQOBjt/shh5Z3/8Ti6SVoGl5nyX952Vcp5N56QVOtjPuJsQa+dEhsDJHu4QAFz45ePXRFq01skb9xA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.14.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gcstats.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gcstats.js/-/gcstats.js-1.0.0.tgz",
+      "integrity": "sha512-gY4x4gWpZtXwIot2js62z4xNNZd+skNzfr4zpK5lVvDqZcqWKP/LhMKKi1Q/VFszJgqPz8ZQpO/OG4SHRgiTng==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.0.5"
+      }
+    },
+    "node_modules/glob": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "optional": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.9.0.tgz",
+      "integrity": "sha512-Ng1SJINJDBzyUEkx9Mj32XD8G0TQCUb5TMoL9V91CTn6F3wYZLygLuhNFrv0cNMBZaeptnL1zecV6XrIdHJ+xQ==",
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "optional": true
+    },
+    "node_modules/is-bluebird": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
+      "integrity": "sha512-PDRu1vVip5dGQg5tfn2qVCCyxbBYu5MhYUJwSfL/RoGBI97n1fxvilVazxzptZW0gcmsMH17H4EVZZI5E/RSeA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "optional": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
+      "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
+      "optional": true
+    },
+    "node_modules/ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
+      "optional": true,
+      "bin": {
+        "ncp": "bin/ncp"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
+      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/opentracing": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
+      "integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.4.0.tgz",
+      "integrity": "sha512-X34iHADNbNDfr6OTStIAHWSAvvKQRYgLO6duASaVf7J2VA3lvmNYboAHOuLC2huav1IwgZJtyEcJCKVzFxOSMQ==",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+      "integrity": "sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "optional": true,
+      "dependencies": {
+        "glob": "^6.0.1"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "optional": true
+    },
+    "node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "optional": true
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
+}

--- a/packages/collector/test/tracing/misc/esm-typescript/package.json
+++ b/packages/collector/test/tracing/misc/esm-typescript/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "esm-typescript",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc -p ./tsconfig.json",
+    "install": "npm install --prefix ./"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@instana/collector": "^3.19.0",
+    "typescript": "^5.6.2"
+  }
+}

--- a/packages/collector/test/tracing/misc/esm-typescript/src/app_1.ts
+++ b/packages/collector/test/tracing/misc/esm-typescript/src/app_1.ts
@@ -1,0 +1,7 @@
+import instana from '@instana/collector';
+
+if (!instana.sdk) {
+  throw new Error('instana.sdk does not exist.');
+}
+
+export default instana;

--- a/packages/collector/test/tracing/misc/esm-typescript/src/app_2.ts
+++ b/packages/collector/test/tracing/misc/esm-typescript/src/app_2.ts
@@ -1,0 +1,7 @@
+import * as instana from '@instana/collector';
+
+if (!instana.sdk) {
+  throw new Error('instana.sdk does not exist.');
+}
+
+export default instana;

--- a/packages/collector/test/tracing/misc/esm-typescript/tsconfig.json
+++ b/packages/collector/test/tracing/misc/esm-typescript/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "target": "es6",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "lib": ["es2020"]
+}

--- a/packages/core/src/core.d.ts
+++ b/packages/core/src/core.d.ts
@@ -1,0 +1,81 @@
+export interface GenericLogger {
+  log?: (...args: any[]) => void;
+  error: (...args: any[]) => void;
+  warn: (...args: any[]) => void;
+  info: (...args: any[]) => void;
+  [key: string]: any;
+  child?: (fields: Record<string, any>) => GenericLogger;
+}
+
+export interface InstanaBaseSpan {
+  /** trace ID */
+  t?: string;
+  /** parent span ID */
+  p?: string;
+  /** span ID */
+  s?: string;
+  /** type/name */
+  n?: string;
+  /** kind */
+  k?: number;
+  /** error count */
+  ec?: number;
+  /** internal property for error count */
+  _ec?: number;
+  /** whether the error count has been set manually via the SDK */
+  ecHasBeenSetManually?: boolean;
+  /** timestamp */
+  ts?: number;
+  /** duration */
+  d?: number;
+  /** from section */
+  f?: {
+    e?: string;
+    h?: string;
+    hl?: boolean;
+    cp?: string;
+  };
+  /** trace ID is from traceparent header */
+  tp?: boolean;
+  /** long trace ID */
+  lt?: string;
+  /** closest Instana ancestor span */
+  ia?: object;
+  /** correlation type */
+  crtp?: string;
+  /** correlation ID */
+  crid?: string;
+  /** synthetic marker */
+  sy?: boolean;
+  /** pathTplFrozen */
+  pathTplFrozen?: boolean;
+  /** transmitted */
+  transmitted?: boolean;
+  /** manualEndMode */
+  manualEndMode?: boolean;
+  /** stack trace */
+  stack?: any;
+  /** additional data */
+  data?: Record<string, any>;
+  /** batching information */
+  b?: {
+    s?: number;
+    d?: number;
+  };
+  /** GraphQL destination */
+  gqd?: any;
+  /** function to transmit logs */
+  transmit?: () => void;
+  /** function to freeze path template */
+  freezePathTemplate?: () => void;
+  /** function to disable auto end */
+  disableAutoEnd?: () => void;
+  /** function for manual transmission */
+  transmitManual?: () => void;
+  /** function to cancel the logger */
+  cancel?: () => void;
+  /** function to add cleanup operations */
+  addCleanup?: (callback: () => void) => void;
+  /** function to perform cleanup */
+  cleanup?: () => void;
+}

--- a/packages/core/src/logger.js
+++ b/packages/core/src/logger.js
@@ -10,17 +10,7 @@ let parentLogger = null;
 /** @type {*} */
 const registry = {};
 
-/**
- * @typedef {Object} GenericLogger
- * @property {(...args: *) => void} [trace]
- * @property {(...args: *) => void} debug
- * @property {(...args: *) => void} info
- * @property {(...args: *) => void} warn
- * @property {(...args: *) => void} error
- * @property {*} [child]
- */
-
-/** @type {GenericLogger} */
+/** @type {import('./core').GenericLogger} */
 const consoleLogger = {
   /* eslint-disable no-console */
   debug: console.log,
@@ -72,7 +62,7 @@ exports.init = function init(config = {}) {
 /**
  * @param {string} loggerName
  * @param {(arg: *) => *} [reInitFn]
- * @returns {GenericLogger}
+ * @returns {import('./core').GenericLogger}
  */
 exports.getLogger = function getLogger(loggerName, reInitFn) {
   if (!parentLogger) {
@@ -102,7 +92,7 @@ exports.getLogger = function getLogger(loggerName, reInitFn) {
 };
 
 /**
- * @param {GenericLogger} logger
+ * @param {import('./core').GenericLogger} logger
  * @returns {boolean}
  */
 function hasLoggingFunctions(logger) {

--- a/packages/core/src/metrics/index.js
+++ b/packages/core/src/metrics/index.js
@@ -32,7 +32,7 @@ exports.init = _config => {
  * @property {SnapshotOrMetricsPayload} currentPayload
  * @property {(config?: InstanaConfig) => void} [activate]
  * @property {() => void} [deactivate]
- * @property {(logger: import('../logger').GenericLogger) => void} [setLogger]
+ * @property {(logger: import('../core').GenericLogger) => void} [setLogger]
  */
 
 /**
@@ -95,7 +95,7 @@ exports.gatherData = function gatherData() {
 };
 
 /**
- * @param {import('../logger').GenericLogger} logger
+ * @param {import('../core').GenericLogger} logger
  */
 exports.setLogger = function setLogger(logger) {
   metricsModules.forEach(metricModule => {

--- a/packages/core/src/secrets.js
+++ b/packages/core/src/secrets.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-/** @type {import('./logger').GenericLogger} */
+/** @type {import('./core').GenericLogger} */
 let logger;
 logger = require('./logger').getLogger('secrets', newLogger => {
   logger = newLogger;

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -11,7 +11,7 @@ const tracingUtil = require('./tracingUtil');
 const { ENTRY, EXIT, INTERMEDIATE, isExitSpan } = require('./constants');
 const hooked = require('./clsHooked');
 const tracingMetrics = require('./metrics');
-/** @type {import('../logger').GenericLogger} */
+/** @type {import('../core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('tracing/cls', newLogger => {
   logger = newLogger;
@@ -49,46 +49,6 @@ function init(config, _processIdentityProvider) {
   }
   processIdentityProvider = _processIdentityProvider;
 }
-
-/**
- * This type is to be used across the code base, as we don't have a public explicit type for a span.
- * Also, it is often that we simply create a literal object and gradually throw few properties on it and
- * handle them as spans. This type has all span properties, but they are all optional, so we can safely
- * type these literal objects.
- * TODO: move InstanaSpan and InstanaPseudoSpan to their own file and make them publicly accessible?
- * @typedef {Object} InstanaBaseSpan
- * @property {string} [t] trace ID
- * @property {string} [p] parent span ID
- * @property {string} [s] span ID
- * @property {string} [n] type/name
- * @property {number} [k] kind
- * @property {number} [ec] error count
- * @property {number} [_ec] internal property for error count
- * @property {boolean} [ecHasBeenSetManually] whether the error count has been set manually via the SDK
- * @property {number} [ts] timestamp
- * @property {number} [d] duration
- * @property {{e?: string, h?: string, hl?: boolean, cp?: string}} [f] from section
- * @property {boolean} [tp] trace ID is from traceparent header
- * @property {string} [lt] long trace ID
- * @property {object} [ia] closest Instana ancestor span
- * @property {string} [crtp] correlation type
- * @property {string} [crid] correlation ID
- * @property {boolean} [sy] synthetic marker
- * @property {boolean} [pathTplFrozen] pathTplFrozen
- * @property {boolean} [transmitted] transmitted
- * @property {boolean} [manualEndMode] manualEndMode
- * @property {*} [stack] stack trace
- * @property {Object.<string, *>} [data]
- * @property {{s?: number, d?: number}} [b] batching information
- * @property {*} [gqd] GraphQL destination
- * @property {Function} [transmit]
- * @property {Function} [freezePathTemplate]
- * @property {Function} [disableAutoEnd]
- * @property {Function} [transmitManual]
- * @property {Function} [cancel]
- * @property {Function} [addCleanup]
- * @property {Function} [cleanup]
- */
 
 class InstanaSpan {
   /**
@@ -390,7 +350,7 @@ function setCurrentSpan(span) {
 /**
  * Get the currently active span.
  * @param {boolean} [fallbackToSharedContext=false]
- * @returns {InstanaBaseSpan}
+ * @returns {import('../core').InstanaBaseSpan}
  */
 function getCurrentSpan(fallbackToSharedContext = false) {
   return ns.get(currentSpanKey, fallbackToSharedContext);

--- a/packages/core/src/tracing/clsHooked/unset.js
+++ b/packages/core/src/tracing/clsHooked/unset.js
@@ -26,7 +26,7 @@ module.exports = function unset(context, key, value) {
  * like data, stackTrace, etc. are not stored.
  * @param {import('./context').InstanaCLSContext} context
  * @param {string} key
- * @param {import('../cls').InstanaBaseSpan} span
+ * @param {import('../../core').InstanaBaseSpan} span
  */
 function storeReducedSpan(context, key, span) {
   // We keep a reduced record of spans after having sent them to the agent. This serves two purposes:

--- a/packages/core/src/tracing/constants.js
+++ b/packages/core/src/tracing/constants.js
@@ -76,7 +76,7 @@ exports.snsSqsInstanaHeaderPrefixRegex = /"X_INSTANA_/i;
 
 /**
  * Determine if <span> is an entry span (server span).
- * @param {import('./cls').InstanaBaseSpan} span
+ * @param {import('../core').InstanaBaseSpan} span
  * @returns {boolean}
  */
 exports.isEntrySpan = function isEntrySpan(span) {
@@ -85,7 +85,7 @@ exports.isEntrySpan = function isEntrySpan(span) {
 
 /**
  * Determine if <span> is an exit span (client span).
- * @param {import('./cls').InstanaBaseSpan} span
+ * @param {import('../core').InstanaBaseSpan} span
  * @returns {boolean}
  */
 exports.isExitSpan = function isExitSpan(span) {
@@ -94,7 +94,7 @@ exports.isExitSpan = function isExitSpan(span) {
 
 /**
  * Determine if <span> is an intermediate span (local span).
- * @param {import('./cls').InstanaBaseSpan} span
+ * @param {import('../core').InstanaBaseSpan} span
  * @returns {boolean}
  */
 exports.isIntermediateSpan = function isIntermediateSpan(span) {

--- a/packages/core/src/tracing/instrumentation/protocols/superagent.js
+++ b/packages/core/src/tracing/instrumentation/protocols/superagent.js
@@ -7,7 +7,7 @@
 
 const shimmer = require('../../shimmer');
 
-/** @type {import('../../../logger').GenericLogger} */
+/** @type {import('../../../core').GenericLogger} */
 let logger;
 logger = require('../../../logger').getLogger('tracing/superagent', newLogger => {
   logger = newLogger;

--- a/packages/core/src/tracing/sdk/sdk.js
+++ b/packages/core/src/tracing/sdk/sdk.js
@@ -9,9 +9,9 @@ const deepMerge = require('../../util/deepMerge');
 const tracingUtil = require('../tracingUtil');
 const constants = require('../constants');
 
-/** @typedef {import('../cls').InstanaBaseSpan} InstanaBaseSpan */
+/** @typedef {import('../../core').InstanaBaseSpan} InstanaBaseSpan */
 
-/** @type {import('../../logger').GenericLogger} */
+/** @type {import('../../core').GenericLogger} */
 let logger;
 logger = require('../../logger').getLogger('tracing/sdk', newLogger => {
   logger = newLogger;
@@ -295,7 +295,7 @@ module.exports = function (isCallbackApi) {
 
   /**
    * @param {Error} error
-   * @param {import('../cls').InstanaBaseSpan} span
+   * @param {import('../../core').InstanaBaseSpan} span
    * @param {Object.<string, *>} tags
    */
   function completeSpan(error, span, tags) {

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -7,7 +7,7 @@
 
 const tracingMetrics = require('./metrics');
 
-/** @type {import('../logger').GenericLogger} */
+/** @type {import('../core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('tracing/spanBuffer', newLogger => {
   logger = newLogger;
@@ -47,7 +47,7 @@ let isFaaS;
 /** @type {boolean} */
 let transmitImmediate;
 
-/** @type {Array.<import('./cls').InstanaBaseSpan>} */
+/** @type {Array.<import('../core').InstanaBaseSpan>} */
 let spans = [];
 
 let batchThreshold = 10;
@@ -79,7 +79,7 @@ const batchBucketWidth = 18;
 // The batchingBuckets are cleared once the span buffer is flushed downstream.
 
 /**
- * @typedef {Map.<number, Array.<import('./cls').InstanaBaseSpan>>} BatchingBucket
+ * @typedef {Map.<number, Array.<import('../core').InstanaBaseSpan>>} BatchingBucket
  */
 /**
  * @typedef {Map.<string, BatchingBucket>} BatchingBucketMap
@@ -172,7 +172,7 @@ exports.addBatchableSpanName = function (spanName) {
 };
 
 /**
- * @param {import('./cls').InstanaBaseSpan} span
+ * @param {import('../core').InstanaBaseSpan} span
  */
 exports.addSpan = function (span) {
   if (!isActive) {
@@ -209,7 +209,7 @@ exports.addSpan = function (span) {
 };
 
 /**
- * @param {import('./cls').InstanaBaseSpan} span
+ * @param {import('../core').InstanaBaseSpan} span
  * @returns {boolean}
  */
 function addToBatch(span) {
@@ -234,7 +234,7 @@ function addToBatch(span) {
 
 /**
  *
- * @param {import('./cls').InstanaBaseSpan} newSpan
+ * @param {import('../core').InstanaBaseSpan} newSpan
  * @param {BatchingBucket} bucketsForTrace
  * @param {number} bucketKey
  * @returns
@@ -271,9 +271,9 @@ function findBatchPartnerAndMerge(newSpan, bucketsForTrace, bucketKey) {
 }
 
 /**
- * @param {import('./cls').InstanaBaseSpan} oldSpan
- * @param {import('./cls').InstanaBaseSpan} newSpan
- * @param {Array.<import('./cls').InstanaBaseSpan>} bucket
+ * @param {import('../core').InstanaBaseSpan} oldSpan
+ * @param {import('../core').InstanaBaseSpan} newSpan
+ * @param {Array.<import('../core').InstanaBaseSpan>} bucket
  * @param {number} bucketKey
  * @param {number} indexInBucket
  */
@@ -310,8 +310,8 @@ function mergeSpansAsBatch(oldSpan, newSpan, bucket, bucketKey, indexInBucket) {
 /**
  * Merges the source span into the target span. Assumes that target is already in the spanBuffer and source can be
  * discarded afterwards.
- * @param {import('./cls').InstanaBaseSpan} target
- * @param {import('./cls').InstanaBaseSpan} source
+ * @param {import('../core').InstanaBaseSpan} target
+ * @param {import('../core').InstanaBaseSpan} source
  * @param {number} originalBucketKey
  */
 function mergeIntoTargetSpan(target, source, originalBucketKey) {
@@ -351,8 +351,8 @@ function mergeIntoTargetSpan(target, source, originalBucketKey) {
 }
 
 /**
- * @param {import('./cls').InstanaBaseSpan} target
- * @param {import('./cls').InstanaBaseSpan} source
+ * @param {import('../core').InstanaBaseSpan} target
+ * @param {import('../core').InstanaBaseSpan} source
  */
 function setBatchSize(target, source) {
   if (target.b && target.b.s && source.b && source.b.s) {
@@ -376,7 +376,7 @@ function setBatchSize(target, source) {
 }
 
 /**
- * @param {import('./cls').InstanaBaseSpan} span
+ * @param {import('../core').InstanaBaseSpan} span
  * @param {number} [preComputedBucketKey]
  */
 function addToBucket(span, preComputedBucketKey) {
@@ -393,7 +393,7 @@ function addToBucket(span, preComputedBucketKey) {
 }
 
 /**
- * @param {import('./cls').InstanaBaseSpan} span
+ * @param {import('../core').InstanaBaseSpan} span
  * @returns {number}
  */
 function batchingBucketKey(span) {
@@ -402,7 +402,7 @@ function batchingBucketKey(span) {
 }
 
 /**
- * @param {import('./cls').InstanaBaseSpan} span
+ * @param {import('../core').InstanaBaseSpan} span
  * @returns {boolean}
  */
 function isBatchable(span) {

--- a/packages/core/src/tracing/spanHandle.js
+++ b/packages/core/src/tracing/spanHandle.js
@@ -7,7 +7,7 @@
 
 const constants = require('./constants');
 
-/** @type {import('../logger').GenericLogger} */
+/** @type {import('../core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('tracing/spanHandle', newLogger => {
   logger = newLogger;
@@ -15,7 +15,7 @@ logger = require('../logger').getLogger('tracing/spanHandle', newLogger => {
 
 /**
  * Provides very limited access from client code to the current active span.
- * @param {import('./cls').InstanaBaseSpan} _span
+ * @param {import('../core').InstanaBaseSpan} _span
  */
 function SpanHandle(_span) {
   this.span = _span;
@@ -261,7 +261,7 @@ SpanHandle.prototype._annotateErrorMessage = function _annotateErrorMessage(erro
 };
 
 /**
- * @param {import('./cls').InstanaBaseSpan} span
+ * @param {import('../core').InstanaBaseSpan} span
  * @param {string|Array.<string>} message
  */
 function findAndAnnotateErrorMessage(span, message) {

--- a/packages/core/src/tracing/tracingHeaders.js
+++ b/packages/core/src/tracing/tracingHeaders.js
@@ -372,7 +372,7 @@ exports.limitTraceId = function limitTraceId(result) {
 
 /**
  * Takes the result of fromHttpReques/fromHeaders and sets the required attributes on the span.
- * @param {import('./cls').InstanaBaseSpan} span
+ * @param {import('../core').InstanaBaseSpan} span
  * @param {TracingHeaders} tracingHeaders
  */
 exports.setSpanAttributes = function (span, tracingHeaders) {

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -11,7 +11,7 @@ const StringDecoder = require('string_decoder').StringDecoder;
 
 const stackTrace = require('../util/stackTrace');
 
-/** @type {import('../logger').GenericLogger} */
+/** @type {import('../core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('tracing/tracingUtil', newLogger => {
   logger = newLogger;
@@ -156,7 +156,7 @@ function writeHexToBuffer(hexString, buffer, offset) {
 }
 
 /**
- * @param {import('./cls').InstanaBaseSpan} span
+ * @param {import('../core').InstanaBaseSpan} span
  * @returns {Buffer}
  */
 exports.renderTraceContextToBuffer = function renderTraceContextToBuffer(span) {

--- a/packages/core/src/tracing/w3c_trace_context/parse.js
+++ b/packages/core/src/tracing/w3c_trace_context/parse.js
@@ -10,7 +10,7 @@ const leftPad = require('../leftPad');
 
 const W3cTraceContext = require('./W3cTraceContext');
 
-/** @type {import('../../logger').GenericLogger} */
+/** @type {import('../../core').GenericLogger} */
 let logger;
 logger = require('../../logger').getLogger('tracing/W3C trace context parser', newLogger => {
   logger = newLogger;

--- a/packages/core/src/util/applicationUnderMonitoring.js
+++ b/packages/core/src/util/applicationUnderMonitoring.js
@@ -9,7 +9,7 @@ const fs = require('../uninstrumentedFs');
 const path = require('path');
 const isESMApp = require('./esm').isESMApp;
 
-/** @type {import('../logger').GenericLogger} */
+/** @type {import('../core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('util/applicationUnderMonitoring', newLogger => {
   logger = newLogger;

--- a/packages/core/src/util/atMostOnce.js
+++ b/packages/core/src/util/atMostOnce.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-/** @type {import('../logger').GenericLogger} */
+/** @type {import('../core').GenericLogger} */
 let logger;
 
 logger = require('../logger').getLogger('util/atMostOnce', newLogger => {

--- a/packages/core/src/util/getPreloadFlags.js
+++ b/packages/core/src/util/getPreloadFlags.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-/** @type {import('../logger').GenericLogger} */
+/** @type {import('../core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('util/getPreloadFlags', newLogger => {
   logger = newLogger;

--- a/packages/core/src/util/iitmHook.js
+++ b/packages/core/src/util/iitmHook.js
@@ -6,7 +6,7 @@
 
 const iitmHook = require('import-in-the-middle');
 
-/** @type {import('../logger').GenericLogger} */
+/** @type {import('../core').GenericLogger} */
 let logger = require('../logger').getLogger('util/iitmHook', newLogger => {
   logger = newLogger;
 });

--- a/packages/core/src/util/initializedTooLateHeuristic.js
+++ b/packages/core/src/util/initializedTooLateHeuristic.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-/** @type {import('../logger').GenericLogger} */
+/** @type {import('../core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('util/initializedTooLateHeuristic', newLogger => {
   logger = newLogger;

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -84,7 +84,7 @@ const constants = require('../tracing/constants');
  * @property {string} [headerFormat]
  */
 
-/** @type {import('../logger').GenericLogger} */
+/** @type {import('../core').GenericLogger} */
 let logger;
 logger = require('../logger').getLogger('configuration', newLogger => {
   logger = newLogger;

--- a/packages/core/src/util/requireHook.js
+++ b/packages/core/src/util/requireHook.js
@@ -35,7 +35,7 @@ let byModuleNameTransformers = {};
 let byFileNamePatternTransformers = [];
 const origLoad = /** @type {*} */ (Module)._load;
 
-/** @type {import('../logger').GenericLogger} */
+/** @type {import('../core').GenericLogger} */
 let logger;
 
 logger = require('../logger').getLogger('util/requireHook', newLogger => {

--- a/packages/opentelemetry-exporter/src/index.js
+++ b/packages/opentelemetry-exporter/src/index.js
@@ -12,7 +12,7 @@ const instanaEndpointUrlEnvVar = 'INSTANA_ENDPOINT_URL';
 const instanaAgentKeyEnvVar = 'INSTANA_AGENT_KEY';
 
 /** @typedef {import('@opentelemetry/sdk-trace-base').ReadableSpan} ReadableSpan */
-/** @typedef {import('@instana/core/src/tracing/cls').InstanaBaseSpan} InstanaBaseSpan */
+/** @typedef {import('@instana/core/src/core').InstanaBaseSpan} InstanaBaseSpan */
 
 /** Span Kind
   Default value. Indicates that the span is used internally.
@@ -152,7 +152,7 @@ class InstanaExporter {
    * @returns {InstanaBaseSpan}
    */
   _transform(span) {
-    /** @type {import('@instana/core/src/tracing/cls').InstanaBaseSpan} */
+    /** @type {import('@instana/core/src/core').InstanaBaseSpan} */
     const result = {
       n: 'otel',
       f: {

--- a/packages/shared-metrics/src/dependencies.js
+++ b/packages/shared-metrics/src/dependencies.js
@@ -14,7 +14,7 @@ const CountDownLatch = require('./util/CountDownLatch');
 const { DependencyDistanceCalculator, MAX_DEPTH } = require('./util/DependencyDistanceCalculator');
 
 /**
- * @param {import('@instana/core/src/logger').GenericLogger} _logger
+ * @param {import('@instana/core/src/core').GenericLogger} _logger
  */
 exports.setLogger = function setLogger(_logger) {
   logger = _logger;

--- a/packages/shared-metrics/src/description.js
+++ b/packages/shared-metrics/src/description.js
@@ -10,7 +10,7 @@ const { applicationUnderMonitoring } = require('@instana/core').util;
 let logger = require('@instana/core').logger.getLogger('metrics');
 
 /**
- * @param {import('@instana/core/src/logger').GenericLogger} _logger
+ * @param {import('@instana/core/src/core').GenericLogger} _logger
  */
 exports.setLogger = _logger => {
   logger = _logger;

--- a/packages/shared-metrics/src/directDependencies.js
+++ b/packages/shared-metrics/src/directDependencies.js
@@ -10,7 +10,7 @@ const { util, uninstrumentedFs: fs } = require('@instana/core');
 let logger = require('@instana/core').logger.getLogger('metrics');
 
 /**
- * @param {import('@instana/core/src/logger').GenericLogger} _logger
+ * @param {import('@instana/core/src/core').GenericLogger} _logger
  */
 exports.setLogger = function setLogger(_logger) {
   logger = _logger;

--- a/packages/shared-metrics/src/healthchecks.js
+++ b/packages/shared-metrics/src/healthchecks.js
@@ -10,7 +10,7 @@ const { hook } = require('@instana/core').util;
 let logger = require('@instana/core').logger.getLogger('metrics');
 
 /**
- * @param {import('@instana/core/src/logger').GenericLogger} _logger
+ * @param {import('@instana/core/src/core').GenericLogger} _logger
  */
 exports.setLogger = function setLogger(_logger) {
   logger = _logger;

--- a/packages/shared-metrics/src/index.js
+++ b/packages/shared-metrics/src/index.js
@@ -28,7 +28,7 @@ const allMetrics = [
 const util = require('./util');
 
 /**
- * @param {import('@instana/core/src/logger').GenericLogger} logger
+ * @param {import('@instana/core/src/core').GenericLogger} logger
  */
 const setLogger = function (logger) {
   util.setLogger(logger);
@@ -38,7 +38,7 @@ const setLogger = function (logger) {
  * @typedef {Object} InstanaSharedMetrics
  * @property {Array.<import('@instana/core/src/metrics').InstanaMetricsModule>} allMetrics
  * @property {import('./util')} util
- * @property {(logger: import('@instana/core/src/logger').GenericLogger) => void} setLogger
+ * @property {(logger: import('@instana/core/src/core').GenericLogger) => void} setLogger
  */
 
 /** @type {InstanaSharedMetrics} */

--- a/packages/shared-metrics/src/keywords.js
+++ b/packages/shared-metrics/src/keywords.js
@@ -9,7 +9,7 @@ const { applicationUnderMonitoring } = require('@instana/core').util;
 
 let logger = require('@instana/core').logger.getLogger('metrics');
 /**
- * @param {import('@instana/core/src/logger').GenericLogger} _logger
+ * @param {import('@instana/core/src/core').GenericLogger} _logger
  */
 exports.setLogger = function setLogger(_logger) {
   logger = _logger;

--- a/packages/shared-metrics/src/name.js
+++ b/packages/shared-metrics/src/name.js
@@ -10,7 +10,7 @@ const { applicationUnderMonitoring } = require('@instana/core').util;
 let logger = require('@instana/core').logger.getLogger('metrics');
 
 /**
- * @param {import('@instana/core/src/logger').GenericLogger} _logger
+ * @param {import('@instana/core/src/core').GenericLogger} _logger
  */
 exports.setLogger = function setLogger(_logger) {
   logger = _logger;

--- a/packages/shared-metrics/src/util/DependencyDistanceCalculator.js
+++ b/packages/shared-metrics/src/util/DependencyDistanceCalculator.js
@@ -14,7 +14,7 @@ const CountDownLatch = require('./CountDownLatch');
 let logger = Logger.getLogger('metrics');
 
 /**
- * @param {import('@instana/core/src/logger').GenericLogger} _logger
+ * @param {import('@instana/core/src/core').GenericLogger} _logger
  */
 const setLogger = function (_logger) {
   logger = _logger;

--- a/packages/shared-metrics/src/util/index.js
+++ b/packages/shared-metrics/src/util/index.js
@@ -10,7 +10,7 @@ const { setLogger: setLoggerForDependencyDistanceCalculator } = require('./Depen
 module.exports = {
   nativeModuleRetry,
   /**
-   * @param {import('@instana/core/src/logger').GenericLogger} logger
+   * @param {import('@instana/core/src/core').GenericLogger} logger
    */
   setLogger: function setLogger(logger) {
     nativeModuleRetry.setLogger(logger);

--- a/packages/shared-metrics/src/util/nativeModuleRetry.js
+++ b/packages/shared-metrics/src/util/nativeModuleRetry.js
@@ -283,7 +283,7 @@ loadNativeAddOn.setLogger = setLogger;
 loadNativeAddOn.selfNodeModulesPath = '';
 
 /**
- * @param {import('@instana/core/src/logger').GenericLogger} _logger
+ * @param {import('@instana/core/src/core').GenericLogger} _logger
  */
 function setLogger(_logger) {
   logger = _logger;

--- a/packages/shared-metrics/src/version.js
+++ b/packages/shared-metrics/src/version.js
@@ -9,7 +9,7 @@ const { applicationUnderMonitoring } = require('@instana/core').util;
 
 let logger = require('@instana/core').logger.getLogger('metrics');
 /**
- * @param {import('@instana/core/src/logger').GenericLogger} _logger
+ * @param {import('@instana/core/src/core').GenericLogger} _logger
  */
 exports.setLogger = function setLogger(_logger) {
   logger = _logger;


### PR DESCRIPTION
## Problems:

> import instana from '@instana/collector';
> console.log('instana', instana);
> instana: undefined

> No declaration file was found for the module "@instana/collector." "node_modules/@instana/collector/src/index.js" implicitly has an "any" type.


## Explanations

Typescript could not load our in-code typedefs. We had to provide types files.
We had no definitions for exported functions. 

The PR is a beginning. We need to do much more. Raised a new ticket.

## Works

```js
import * as instana from '@instana/collector'
```

```js
import instana from '@instana/collector'
```

## Raised

https://jsw.ibm.com/browse/INSTA-15926
https://jsw.ibm.com/browse/INSTA-15926

## Tasks
- [x] fix tests
- [x] add test