### PR TITLE
fix: dropped support for Node.js lambda runtime v14 and v16

### DIFF
--- a/packages/aws-lambda/layer/bin/publish-layer.sh
+++ b/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -371,7 +371,7 @@ if [[ -z $SKIP_AWS_PUBLISH_LAYER ]]; then
           --license-info $LICENSE \
           --zip-file fileb://$ZIP_NAME \
           --output json \
-          --compatible-runtimes nodejs14.x nodejs16.x nodejs18.x nodejs20.x \
+          --compatible-runtimes nodejs18.x nodejs20.x \
           | jq '.Version' \
       )
 


### PR DESCRIPTION

V14 and v16 are officially reached end of support, see  https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated