### PR TITLE
fix: dropped support for x-instana-service header

### DIFF
--- a/packages/collector/test/tracing/common/test.js
+++ b/packages/collector/test/tracing/common/test.js
@@ -168,23 +168,6 @@ mochaSuiteFn('tracing/common', function () {
       );
     });
 
-    describe('with header when agent is configured to capture the header', function () {
-      const agentControls = new AgentStubControls();
-      const agentConfig = { extraHeaders: ['x-iNsTanA-sErViCe'] };
-
-      before(async () => {
-        await agentControls.startAgent(agentConfig);
-      });
-      after(async () => {
-        await agentControls.stopAgent();
-      });
-
-      registerServiceNameTest.call(this, agentControls, {
-        configMethod: 'X-Instana-Service header',
-        expectServiceNameOnSpans: 'on-entry-span'
-      });
-    });
-
     describe('with header when agent is _not_ configured to capture the header', function () {
       const agentControls = new AgentStubControls();
 
@@ -196,7 +179,6 @@ mochaSuiteFn('tracing/common', function () {
       });
 
       registerServiceNameTest.call(this, agentControls, {
-        configMethod: 'X-Instana-Service header',
         expectServiceNameOnSpans: 'no'
       });
     });
@@ -236,11 +218,6 @@ mochaSuiteFn('tracing/common', function () {
         const req = {
           path: '/with-intermediate-and-exit-spans'
         };
-        if (configMethod === 'X-Instana-Service header') {
-          req.headers = {
-            'x-InsTana-sErvice': 'much-custom-very-wow service'
-          };
-        }
         return controls.sendRequest(req).then(() => verifyServiceName(agentControls, expectServiceNameOnSpans));
       });
     }

--- a/packages/collector/test/tracing/protocols/http2/test.js
+++ b/packages/collector/test/tracing/protocols/http2/test.js
@@ -30,8 +30,7 @@ mochaSuiteFn('tracing/http2', function () {
       extraHeaders: [
         //
         'X-My-Request-Header',
-        'X-My-Response-Header',
-        'x-iNsTanA-sErViCe'
+        'X-My-Response-Header'
       ],
       secretsList: ['remove']
     });
@@ -206,24 +205,6 @@ mochaSuiteFn('tracing/http2', function () {
         retry(() =>
           agentControls.getSpans().then(spans => {
             verifyRootHttpEntry(spans, `localhost:${serverControls.getPort()}`, '/request', 'GET', 200, false, true);
-          })
-        )
-      ));
-
-  it('must use x-service-service', () =>
-    serverControls
-      .sendRequest({
-        method: 'GET',
-        path: '/request',
-        headers: {
-          'x-instanA-SERVICE': 'Custom Service'
-        }
-      })
-      .then(() =>
-        retry(() =>
-          agentControls.getSpans().then(spans => {
-            const entry = verifyRootHttpEntry(spans, `localhost:${serverControls.getPort()}`, '/request');
-            expect(entry.data.service).to.equal('Custom Service');
           })
         )
       ));

--- a/packages/core/src/tracing/constants.js
+++ b/packages/core/src/tracing/constants.js
@@ -38,9 +38,6 @@ exports.w3cTraceState = 'tracestate';
 exports.w3cInstana = 'in';
 exports.w3cInstanaEquals = `${exports.w3cInstana}=`;
 
-exports.serviceNameHeaderName = 'X-Instana-Service';
-exports.serviceNameHeaderNameLowerCase = exports.serviceNameHeaderName.toLowerCase();
-
 exports.ENTRY = 1;
 exports.EXIT = 2;
 exports.INTERMEDIATE = 3;

--- a/packages/core/src/tracing/instrumentation/protocols/http2Server.js
+++ b/packages/core/src/tracing/instrumentation/protocols/http2Server.js
@@ -131,12 +131,6 @@ function shimEmit(realEmit) {
         header: getExtraHeadersFromNormalizedObjectLiteral(headers, extraHttpHeadersToCapture)
       };
 
-      const incomingServiceName =
-        span.data.http.header && span.data.http.header[constants.serviceNameHeaderNameLowerCase];
-      if (incomingServiceName != null) {
-        span.data.service = incomingServiceName;
-      }
-
       if (!headers['x-instana-t']) {
         // In cases where we have started a fresh trace (that is, there is no X-INSTANA-T in the incoming request
         // headers, we add the new trace ID to the incoming request so a customer's app can render it reliably into the

--- a/packages/core/src/tracing/instrumentation/protocols/httpServer.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpServer.js
@@ -104,12 +104,6 @@ function shimEmit(realEmit) {
         header: getExtraHeadersFromMessage(req, extraHttpHeadersToCapture)
       };
 
-      const incomingServiceName =
-        span.data.http.header && span.data.http.header[constants.serviceNameHeaderNameLowerCase];
-      if (incomingServiceName != null) {
-        span.data.service = incomingServiceName;
-      }
-
       if (!req.headers['x-instana-t']) {
         // In cases where we have started a fresh trace (that is, there is no X-INSTANA-T in the incoming request
         // headers, we add the new trace ID to the incoming request so a customer's app can render it reliably into the


### PR DESCRIPTION
The capture of the `X-Instana-Service` header value as `span.data.service` has been removed from the tracer. According to the public documentation [here](https://www.ibm.com/docs/en/instana-observability/current?topic=applications-services#specify-the-x-instana-service-http-header):

> By setting the `X-Instana-Service` HTTP header on a call, the destination service (the one receiving the HTTP request) is tagged with the value provided in the header.
> 
> Note: The `X-Instana-Service` HTTP header is not collected automatically. To use it, the Instana agent must be configured, as explained in ["Capturing custom HTTP headers"](https://www.ibm.com/docs/en/instana-observability/current?topic=cha-configuring-host-agents-by-using-agent-configuration-file#capturing-custom-http-headers).

By default, Instana does not capture HTTP headers during tracing. However, you can configure HTTP header capture by modifying the agent's configuration file (<instana-agent-dir>/etc/instana/configuration.yaml) as follows:

```yaml
com.instana.tracing:
  extra-http-headers:
    - 'X-Instana-Service'
```

The backend extracting the service name from the captured header. 
Therefore, implementing this directly within our tracer by inspecting the `X-Instana-Service` header and adding the annotation is redundant. For this reason, the Instana tracer community has chosen not to capture the X-Instana-Service header within the tracer.