### PR TITLE
ci: fixed gcstats & event-loop-stats not being installed

### DIFF
--- a/.tekton/tasks/install-npm-dependencies.yaml
+++ b/.tekton/tasks/install-npm-dependencies.yaml
@@ -45,12 +45,8 @@ spec:
           echo "Installing npm dependencies..."
           npm install --loglevel verbose
 
-          echo "Forcing the installation of optional dependencies for the test env..."
-
           # Force non optional dependency installation
           npm install gcstats.js event-loop-stats -w packages/shared-metrics --save-dev
-
-          echo "Installed npm dependencies..."
         else
           echo "Restoring node_modules cache..."
           curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
@@ -101,12 +97,10 @@ spec:
             echo "npm install: $npmInstall"
 
             if [ "$npmInstall" == true ]; then
-              echo "Download from main was not successful. Installing node_modules..."
               npm install --loglevel verbose
 
-              echo "Forcing the installation of optional dependencies for the test env..."
+              # Force non optional dependency installation
               npm install gcstats.js event-loop-stats -w packages/shared-metrics --save-dev
-              echo "Installed npm dependencies..."
 
               rm -rf node-modules.tar.zst
               rm -rf node-modules.tar
@@ -152,23 +146,18 @@ spec:
               rm -rf node-modules.tar
 
               if [ "$npmInstall" == true ]; then
-                echo "Download from main was not successful. Installing node_modules..."
                 npm install --loglevel verbose
 
-                echo "Forcing the installation of optional dependencies for the test env..."
+                # Force non optional dependency installation
                 npm install gcstats.js event-loop-stats -w packages/shared-metrics --save-dev
-
-                echo "Installed npm dependencies..."
               fi
 
               echo "Restored node_modules cache..."
             else
               echo "Download from main was not successful. Installing node_modules..."
               npm install --loglevel verbose
-
-              echo "Forcing the installation of optional dependencies for the test env..."
+              # Force non optional dependency installation
               npm install gcstats.js event-loop-stats -w packages/shared-metrics --save-dev
-              echo "Installed npm dependencies..."
             fi
           fi
         fi

--- a/.tekton/tasks/install-npm-dependencies.yaml
+++ b/.tekton/tasks/install-npm-dependencies.yaml
@@ -44,9 +44,6 @@ spec:
           echo "Skipping npm cache..."
           echo "Installing npm dependencies..."
           npm install --loglevel verbose
-
-          # Force non optional dependency installation
-          npm install gcstats.js event-loop-stats -w packages/shared-metrics --save-dev
         else
           echo "Restoring node_modules cache..."
           curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
@@ -99,9 +96,6 @@ spec:
             if [ "$npmInstall" == true ]; then
               npm install --loglevel verbose
 
-              # Force non optional dependency installation
-              npm install gcstats.js event-loop-stats -w packages/shared-metrics --save-dev
-
               rm -rf node-modules.tar.zst
               rm -rf node-modules.tar
             fi
@@ -147,17 +141,12 @@ spec:
 
               if [ "$npmInstall" == true ]; then
                 npm install --loglevel verbose
-
-                # Force non optional dependency installation
-                npm install gcstats.js event-loop-stats -w packages/shared-metrics --save-dev
               fi
 
               echo "Restored node_modules cache..."
             else
               echo "Download from main was not successful. Installing node_modules..."
               npm install --loglevel verbose
-              # Force non optional dependency installation
-              npm install gcstats.js event-loop-stats -w packages/shared-metrics --save-dev
             fi
           fi
         fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -32861,9 +32861,9 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/event-loop-stats/-/event-loop-stats-1.4.1.tgz",
       "integrity": "sha512-Wzohoz1JrQOBjt/shh5Z3/8Ti6SVoGl5nyX952Vcp5N56QVOtjPuJsQa+dEhsDJHu4QAFz45ePXRFq01skb9xA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "nan": "^2.14.0"
       },
@@ -34724,9 +34724,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gcstats.js/-/gcstats.js-1.0.0.tgz",
       "integrity": "sha512-gY4x4gWpZtXwIot2js62z4xNNZd+skNzfr4zpK5lVvDqZcqWKP/LhMKKi1Q/VFszJgqPz8ZQpO/OG4SHRgiTng==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "nan": "^2.0.5"
       }
@@ -55126,7 +55126,9 @@
       },
       "devDependencies": {
         "@types/fs-extra": "^11.0.4",
-        "@types/tar": "^6.1.6"
+        "@types/tar": "^6.1.6",
+        "event-loop-stats": "1.4.1",
+        "gcstats.js": "1.0.0"
       },
       "optionalDependencies": {
         "event-loop-stats": "1.4.1",

--- a/packages/shared-metrics/package.json
+++ b/packages/shared-metrics/package.json
@@ -68,7 +68,9 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
-    "@types/tar": "^6.1.6"
+    "@types/tar": "^6.1.6",
+    "event-loop-stats": "1.4.1",
+    "gcstats.js": "1.0.0"
   },
   "optionalDependencies": {
     "event-loop-stats": "1.4.1",


### PR DESCRIPTION
> npm verbose reify failed optional dependency /artifacts/node_modules/gcstats.js

We tried solving it differently via Tekton see https://github.com/instana/nodejs/commit/a2fcb0ffe17a468ace5150f97a3839b507b2348f.
But that does not work for the currency-bot. Because the currency-bot pushes a PR
including the change of the forced dev installation.

a2fcb0ffe17a468ace5150f97a3839b507b2348f was anyway too hard to maintain.

I moved the dependencies to the dev dependencies as well. I hope that does the same trick.
At least, I want the install step to fail if something can't be installed.