### PR TITLE
fix(shared-metrics): removed fs-extra dependency from production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25591,16 +25591,6 @@
         "@types/send": "*"
       }
     },
-    "node_modules/@types/fs-extra": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
-      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/glob": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
@@ -25784,15 +25774,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
-    },
-    "node_modules/@types/jsonfile": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
-      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/keygrip": {
       "version": "1.0.3",
@@ -35611,7 +35592,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "devOptional": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -37769,6 +37751,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "devOptional": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -50111,6 +50094,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "devOptional": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -55123,12 +55107,10 @@
         "@instana/core": "3.20.1",
         "detect-libc": "^2.0.2",
         "event-loop-lag": "^1.4.0",
-        "fs-extra": "^11.2.0",
         "semver": "^7.5.4",
         "tar": "^6.2.1"
       },
       "devDependencies": {
-        "@types/fs-extra": "^11.0.4",
         "@types/tar": "^6.1.6",
         "event-loop-stats": "1.4.1",
         "gcstats.js": "1.0.0"
@@ -55144,19 +55126,6 @@
       "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "packages/shared-metrics/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     }
   }

--- a/packages/collector/test/tracing/database/db2/test.js
+++ b/packages/collector/test/tracing/database/db2/test.js
@@ -877,10 +877,10 @@ mochaSuiteFn('tracing/db2', function () {
         .then(() =>
           testUtils.retry(() =>
             verifySpans(agentControls, controls, {
-              numberOfSpans: 14,
+              numberOfSpans: 15,
               // Spans:
               // 10 queries splitted from the file
-              // 4 fs operations on top (ours + from db2 internally fs-extra)
+              // 5 fs operations on top (ours + from db2 internally fs-extra)
               // https://github.com/ibmdb/node-ibm_db/blob/fb25937524d74d25917e9aa67fb4737971317986/lib/odbc.js#L916
               // If the Otel integration is disabled, we expect 11 spans.
               verifyCustom: (entrySpan, spans) => {

--- a/packages/shared-metrics/package.json
+++ b/packages/shared-metrics/package.json
@@ -62,12 +62,10 @@
     "@instana/core": "3.20.1",
     "detect-libc": "^2.0.2",
     "event-loop-lag": "^1.4.0",
-    "fs-extra": "^11.2.0",
     "semver": "^7.5.4",
     "tar": "^6.2.1"
   },
   "devDependencies": {
-    "@types/fs-extra": "^11.0.4",
     "@types/tar": "^6.1.6",
     "event-loop-stats": "1.4.1",
     "gcstats.js": "1.0.0"

--- a/packages/shared-metrics/src/util/nativeModuleRetry.js
+++ b/packages/shared-metrics/src/util/nativeModuleRetry.js
@@ -13,7 +13,6 @@ const os = require('os');
 const tar = require('tar');
 const path = require('path');
 const detectLibc = require('detect-libc');
-const fse = require('fs-extra');
 
 /**
  * @typedef {Object} InstanaSharedMetricsOptions
@@ -188,8 +187,8 @@ function copyPrecompiled(opts, loaderEmitter, callback) {
           `Copying the precompiled build for ${opts.nativeModuleName} ${label} from ${sourceDir} to ${targetDir}.`
         );
 
-        fse
-          .copy(sourceDir, targetDir)
+        fs.promises
+          .cp(sourceDir, targetDir, { recursive: true })
           .then(() => {
             // We have unpacked and copied the correct precompiled native addon. The next attempt to require the
             // dependency should work.


### PR DESCRIPTION
The external dependency `fs-extra` has been removed from the production dependencies. Previously, we couldn't use the native `fs.cp` module due to its unavailability in earlier versions of Node.js 16. Now that we're deprecating support for versions below 18, we're switching to the native fs module See https://nodejs.org/api/fs.html#fspromisescpsrc-dest-options
refs https://github.com/instana/nodejs/pull/1265