### PR TITLE
chore(instana-aws-lambda-auto-wrap): marked package as private to prevent publishing to npm

### DIFF
--- a/packages/aws-lambda-auto-wrap/package.json
+++ b/packages/aws-lambda-auto-wrap/package.json
@@ -2,6 +2,7 @@
   "name": "instana-aws-lambda-auto-wrap",
   "version": "3.20.1",
   "description": "Automatically wrap AWS Lambdas for Instana tracing and monitoring without code modification.",
+  "private": true,
   "author": {
     "name": "Bastian Krol",
     "email": "bastian.krol@instana.com"


### PR DESCRIPTION
The `instana-aws-lambda-auto-wrap` package is an internal package created for AWS Lambda handlers. We are currently using locally built versions of this package, as referenced in [this script](https://github.com/instana/nodejs/blob/main/packages/aws-lambda/layer/bin/publish-layer.sh#L276).
 We are in the process of removing this package from NPM publishing. A deprecation warning will be added to NPM, which can be done through either the command line or the NPM UI. As part of this process, we are excluding it from future publishing. 
Reference: 
https://lerna.js.org/docs/features/version-and-publish
https://docs.npmjs.com/cli/v10/commands/npm-deprecate

TODO:

- [x] Add the deprecation warning after the v4 release

`npm deprecate instana-aws-lambda-auto-wrap "This package is deprecated, and its support will be removed soon. Consider using an alternative."`

