### PR TITLE
docs(tekton): extended the tekton readme file to add multi configuration

### DIFF
--- a/.tekton/README.md
+++ b/.tekton/README.md
@@ -10,23 +10,34 @@
 npm run tekton:lint
 ```
 
-## Local testing
+## Local Testing
 
-https://github.com/tektoncd/dashboard/blob/97700646be7728e36f01120131da8620ee69122f/docs/tutorial.md#prerequisites
+Follow the instructions provided in the [Tekton Dashboard tutorial](https://github.com/tektoncd/dashboard/blob/97700646be7728e36f01120131da8620ee69122f/docs/tutorial.md#prerequisites).
 
-## Generate files
+## Generate Files
+
+To generate/update the required Tekton pipeline files, run the following commands:
 
 ```
 cd .tekton
-node generate-test-files.yaml
-node generate-test-coverage.yaml
-node generate-pipeline.yaml
+node generate-default-pipeline.js
+node generate-test-files.js
 ```
 
-## Migrate to a new cluster
+## Migrate to a New Cluster
 
-- You need to add sub paths for the tekton files in Settings - Definitions
-  - main .tekton/listeners
-  - main .tekton/tasks
-  - main .tekton/pipeline
-  - main .tekton/tasks/test-groups
+- You will need to add subpaths for the Tekton files under **Settings** > **Definitions**:
+  - `main .tekton/listeners`
+  - `main .tekton/tasks`
+  - `main .tekton/pipeline`
+  - `main .tekton/tasks/test-groups`
+
+### Multi-Configuration Strategy:
+
+If your target branch is not `main`, you can add new definitions in **Settings** for that branch. For example:
+  - `v4 .tekton/listeners`
+  - `v4 .tekton/tasks`
+  - `v4 .tekton/pipeline`
+  - `v4 .tekton/tasks/test-groups`
+
+Here, `v4` represents the branch. Once these settings are added, any listeners or test tasks associated with that branch will be available for use in triggers.


### PR DESCRIPTION
Multi-Configuration Strategy: We can add subpaths for the Tekton files under Settings > Definitions on a per-branch basis. When a specific branch is selected, it retrieves the corresponding Tekton configuration from the designated path, making any listeners or test tasks linked to that branch available for use in triggers.