### PR TITLE
docs(instana-aws-lambda-auto-wrap): added note about deprecating npm package

### DIFF
--- a/packages/aws-lambda-auto-wrap/README.md
+++ b/packages/aws-lambda-auto-wrap/README.md
@@ -5,7 +5,7 @@ This mainly exists because AWS Lambda handlers cannot be scoped packages.
 
 ## Deprecation Notice
 
-**Important:** This is an internal and private package that will soon be deprecated.  
+**Important:** This is an internal and private package that will soon be removed.  
 - We are no longer publish the package to npm.
 
 Please ensure any dependencies on this package are removed or replaced before the next major release.

--- a/packages/aws-lambda-auto-wrap/README.md
+++ b/packages/aws-lambda-auto-wrap/README.md
@@ -3,5 +3,9 @@ Instana Auto-Wrapper for Native Tracing of AWS Lambdas
 
 This mainly exists because AWS Lambda handlers cannot be scoped packages.
 
-NOTE: This is an internal package. We have deprecated the NPM package as of Nov 2022.
-      We will remove it from NPM in the next major release.
+## Deprecation Notice
+
+**Important:** This is an internal package will soon be deprecated.  
+- We will no longer publish new releases to NPM.
+
+Please ensure any dependencies on this package are removed or replaced before the next major release.

--- a/packages/aws-lambda-auto-wrap/README.md
+++ b/packages/aws-lambda-auto-wrap/README.md
@@ -5,7 +5,7 @@ This mainly exists because AWS Lambda handlers cannot be scoped packages.
 
 ## Deprecation Notice
 
-**Important:** This is an internal package will soon be deprecated.  
-- We will no longer publish new releases to NPM.
+**Important:** This is an internal and private package that will soon be deprecated.  
+- We are no longer publish the package to npm.
 
 Please ensure any dependencies on this package are removed or replaced before the next major release.


### PR DESCRIPTION
refs https://github.com/instana/nodejs/pull/1368