### PR TITLE
chore: updated comments to reflect targeting of the next major release

### DIFF
--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -181,7 +181,7 @@ exports.init = function init(_config, downstreamConnection, _processIdentityProv
     console.debug(`The App is using the following preload flags: ${preloadFlags}`);
   }
 
-  // Consider removing this in the next major release(v4.x) of the @instana package.
+  // Consider removing this in the next major release(v5.x) of the @instana package.
   if (hasExperimentalLoaderFlag()) {
     // eslint-disable-next-line no-console
     console.warn(

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -181,7 +181,7 @@ exports.init = function init(_config, downstreamConnection, _processIdentityProv
     console.debug(`The App is using the following preload flags: ${preloadFlags}`);
   }
 
-  // Consider removing this in the next major release(v5.x) of the @instana package.
+  // Consider removing this in the next major release of the @instana package.
   if (hasExperimentalLoaderFlag()) {
     // eslint-disable-next-line no-console
     console.warn(

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
@@ -84,12 +84,11 @@ function shimSmithySend(originalSend) {
     if (awsProduct && awsProduct.supportsOperation(command.constructor.name)) {
       return awsProduct.instrumentedSmithySend(self, isActive, originalSend, smithySendArgs);
     } else {
-      // This code can be removed once all AWS SDK v3 instrumentations have been refactored to use the new approach
-      // introduced in https://github.com/instana/nodejs/pull/838 for kinesis. That is: Do not use an explicit
-      // operationsInfo/operationsMap map that restricts the traced operations to a subset of possible operations, but
-      // instead allow _all_ operations to be traced, using the operation name from `command.constructor.name` for
-      // span.data.$spanName.op. We plan to finish this refactoring before or with the next major release (4.x) of the
-      // @instana packages.
+      // This logic should not be used in AWS SDK v4. All AWS SDK v4 instrumentations must use the new approach
+      // introduced in https://github.com/instana/nodejs/pull/838 for Kinesis. That is: Do not use an explicit
+      // operationsInfo/operationsMap that restricts the traced operations to a subset of possible operations.
+      // Instead, allow all operations to be traced using the operation name from `command.constructor.name`
+      // for span.data.$spanName.op.
       awsProduct = operationMap[smithySendArgs[0].constructor.name];
       if (awsProduct) {
         return awsProduct.instrumentedSmithySend(self, isActive, originalSend, smithySendArgs);

--- a/packages/core/src/util/hook.js
+++ b/packages/core/src/util/hook.js
@@ -19,7 +19,7 @@ const isESMApp = require('./esm').isESMApp;
  * Offers support for all native ECMAScript Modules within ESM applications.
  * However, it does not provide support for modules loaded from CJS applications.
  *
- * Note: In the next major release (4.x), we plan to transition all CJS modules in ESM applications to be
+ * Note: In the next major release (5.x), we plan to transition all CJS modules in ESM applications to be
  * supported with iitmHook. For now, this approach is chosen to minimize risk.
  */
 

--- a/packages/core/src/util/hook.js
+++ b/packages/core/src/util/hook.js
@@ -19,7 +19,7 @@ const isESMApp = require('./esm').isESMApp;
  * Offers support for all native ECMAScript Modules within ESM applications.
  * However, it does not provide support for modules loaded from CJS applications.
  *
- * Note: In the next major release (5.x), we plan to transition all CJS modules in ESM applications to be
+ * Note: In the next major release, we might transition all CJS modules in ESM applications to be
  * supported with iitmHook. For now, this approach is chosen to minimize risk.
  */
 


### PR DESCRIPTION
I updated some comments in the repository to reflect that the updates are targeting next major release instead of v4.