### PR TITLE
fix: dropped support for disabling AWS SDK instrumentation in old syntax

### DIFF
--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -41,8 +41,8 @@ let processIdentityProvider = null;
 
 // Note: Also update initializedTooLateHeuristic.js and the accompanying test when adding instrumentations.
 let instrumentations = [
-  './instrumentation/cloud/aws-sdk/v2/index',
-  './instrumentation/cloud/aws-sdk/v3/index',
+  './instrumentation/cloud/aws-sdk/v2',
+  './instrumentation/cloud/aws-sdk/v3',
   './instrumentation/cloud/aws-sdk/v2/sdk',
   './instrumentation/cloud/aws-sdk/v2/sqs',
   './instrumentation/cloud/azure/blob',

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/index.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/index.js
@@ -27,8 +27,6 @@ awsProducts.forEach(awsProduct => {
 
 let isActive = false;
 
-exports.instrumentationName = 'aws-sdk/v2';
-
 exports.isActive = function () {
   return isActive;
 };

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/index.js
@@ -31,8 +31,6 @@ awsProducts.forEach(awsProduct => {
 
 let isActive = false;
 
-exports.instrumentationName = 'aws-sdk/v3';
-
 exports.init = function init() {
   sqsConsumer.init();
 

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -127,28 +127,17 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     expect(activateStubRdKafka).to.have.been.calledWith(extraConfigFromAgent);
   });
 
-  it('[deprecated] aws-sdk/v2/index', () => {
-    initAndActivate({ tracing: { disabledTracers: ['aws-sdk/v2/index'] } });
+  it('deactivate aws-sdk/v3 and aws-sdk/v2', () => {
+    initAndActivate({ tracing: { disabledTracers: ['aws-sdk/v3', 'aws-sdk/v2'] } });
 
-    // aws-sdk/v2 has been disabled (via aws-sdk/v2/index)
+    // aws-sdk/v2 has been disabled (via aws-sdk/v2)
     expect(initAwsSdkv2).not.to.have.been.called;
     expect(activateAwsSdkv2).not.to.have.been.called;
 
-    // aws-sdk/v3 has not been disabled
-    expect(initAwsSdkv3).to.have.been.called;
-    expect(activateAwsSdkv3).to.have.been.called;
+    // aws-sdk/v3 has been disabled (via aws-sdk/v3)
+    expect(initAwsSdkv3).not.to.have.been.called;
+    expect(activateAwsSdkv3).not.to.have.been.called;
   });
-   it('deactivate aws-sdk/v3 and aws-sdk/v2', () => {
-     initAndActivate({ tracing: { disabledTracers: ['aws-sdk/v3', 'aws-sdk/v2'] } });
-
-     // aws-sdk/v2 has been disabled (via aws-sdk/v2)
-     expect(initAwsSdkv2).not.to.have.been.called;
-     expect(activateAwsSdkv2).not.to.have.been.called;
-
-     // aws-sdk/v3 has been disabled (via aws-sdk/v3)
-     expect(initAwsSdkv3).not.to.have.been.called;
-     expect(activateAwsSdkv3).not.to.have.been.called;
-   });
 
   function initAndActivate(initConfig, extraConfigForActivate) {
     normalizeConfig(initConfig);

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -127,7 +127,18 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     expect(activateStubRdKafka).to.have.been.calledWith(extraConfigFromAgent);
   });
 
-  it('deactivate aws-sdk/v3 and aws-sdk/v2', () => {
+  it('disable aws-sdk/v3', () => {
+    initAndActivate({ tracing: { disabledTracers: ['aws-sdk/v3'] } });
+
+    // aws-sdk/v3 has been disabled (via aws-sdk/v3)
+    expect(initAwsSdkv3).not.to.have.been.called;
+    expect(activateAwsSdkv3).not.to.have.been.called;
+
+    // aws-sdk/v2 has not been disabled (via aws-sdk/v2)
+    expect(initAwsSdkv2).to.have.been.called;
+    expect(activateAwsSdkv2).to.have.been.called;
+  });
+  it('disable aws-sdk/v3 and aws-sdk/v2', () => {
     initAndActivate({ tracing: { disabledTracers: ['aws-sdk/v3', 'aws-sdk/v2'] } });
 
     // aws-sdk/v2 has been disabled (via aws-sdk/v2)

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -138,6 +138,17 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     expect(initAwsSdkv3).to.have.been.called;
     expect(activateAwsSdkv3).to.have.been.called;
   });
+   it('deactivate aws-sdk/v3 and aws-sdk/v2', () => {
+     initAndActivate({ tracing: { disabledTracers: ['aws-sdk/v3', 'aws-sdk/v2'] } });
+
+     // aws-sdk/v2 has been disabled (via aws-sdk/v2)
+     expect(initAwsSdkv2).not.to.have.been.called;
+     expect(activateAwsSdkv2).not.to.have.been.called;
+
+     // aws-sdk/v3 has been disabled (via aws-sdk/v3)
+     expect(initAwsSdkv3).not.to.have.been.called;
+     expect(activateAwsSdkv3).not.to.have.been.called;
+   });
 
   function initAndActivate(initConfig, extraConfigForActivate) {
     normalizeConfig(initConfig);


### PR DESCRIPTION
Added a test to verify that customers can disable AWS SDK v3 instrumentation using `disabledTracers: ['aws-sdk/v3']`.

This highlights a design issue in our earlier system. 
Already documented in the public [documenation](https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-configuration#disabling-individual-tracers)

As part of the updates made in https://github.com/instana/nodejs/pull/866, we've introduced an instrumentationName in our AWS SDK instrumentation. This enhancement allowed us to disable the tracer effectively using the instrumentation name rather than relying on the instrumentation syntax.

BREAKING CHANGE:
- Removed the ability to disable AWS SDK instrumentation using the old syntax disabledTracers: ['aws-sdk/v2/index'].
- Migrate to the new syntax for disabling instrumentation: disabledTracers: ['aws-sdk/v2'].