### PR TITLE
test: skipped rdkafka on v23

### DIFF
--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -52,13 +52,11 @@ const SINGLE_TEST_PROPS = {
 const retryTime = 1000;
 const topic = 'rdkafka-topic';
 
-let mochaSuiteFn;
-
-if (!supportedVersion(process.versions.node) || semver.lte(process.versions.node, '16.0.0')) {
-  mochaSuiteFn = describe.skip;
-} else {
-  mochaSuiteFn = describe;
-}
+// TODO: investigate as part of https://jsw.ibm.com/browse/INSTA-17132
+const mochaSuiteFn =
+  supportedVersion(process.versions.node) && semver.satisfies(process.versions.node, '<=22.x')
+    ? describe
+    : describe.skip;
 
 mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
   this.timeout(config.getTestTimeout() * 4);


### PR DESCRIPTION
As node-rdkafka relies heavily on librdkafka and C++ bindings, compatibility with newer Node.js versions typically depends on updates...
Skipping test for now and will investigate as part of https://jsw.ibm.com/browse/INSTA-17132