### PR TITLE
test: updated rdkafka test minimum node version to above 16

### DIFF
--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -54,7 +54,9 @@ const topic = 'rdkafka-topic';
 
 // TODO: investigate as part of https://jsw.ibm.com/browse/INSTA-17132
 const mochaSuiteFn =
-  supportedVersion(process.versions.node) && semver.satisfies(process.versions.node, '<=22.x')
+  supportedVersion(process.versions.node) &&
+  semver.gt(process.versions.node, '16.0.0') &&
+  semver.satisfies(process.versions.node, '<=22.x')
     ? describe
     : describe.skip;
 


### PR DESCRIPTION
Remove test from node v14 and v16 (this was existing condition before prerelease)