### PR TITLE
build: removed usage of :latest from v3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,10 +79,10 @@ jobs:
             git --no-pager diff --cached
             git --no-pager diff
           elif [[ $FROM_PACKAGE = true ]]; then
-            npx lerna publish --yes --no-verify-access from-package
+            npx lerna publish --dist-tag v3 --yes --no-verify-access from-package
             git log -p -n1
           else
-            npx lerna publish --yes --no-verify-access
+            npx lerna publish --dist-tag v3 --yes --no-verify-access
             git log -p -n1
           fi
 

--- a/packages/aws-lambda/layer/bin/publish-layer.sh
+++ b/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -409,7 +409,7 @@ if [[ -z $SKIP_DOCKER_IMAGE ]]; then
   echo "step 7/9: building docker image for container image based Lambda layer"
   docker build . -t "$DOCKER_IMAGE_NAME:$VERSION"
 
-  # NOTE: serverless/ci/pipeline.yaml passes PACKAGE_VERSION=1 for 1.x branch
+  # NOTE: serverless/ci/pipeline.yaml passes PACKAGE_VERSION=X for e.g. 1.x or 2.x or 3.x branch
   if [[ $PACKAGE_VERSION == latest ]]; then
     docker tag $DOCKER_IMAGE_NAME:$VERSION $DOCKER_IMAGE_NAME:latest
   fi

--- a/packages/serverless/ci/pipeline.yaml
+++ b/packages/serverless/ci/pipeline.yaml
@@ -27,7 +27,8 @@ resources:
     icon: docker
     source:
       repository: gcr.io/k8s-brewery/instana/concourse-dind-nodejs-aws-jq
-      tag: latest
+      # NOTE: Deliberately omitting `tag: latest` here on the branch for 3.x so
+      # we do not accidentally tag 3.x image versions with `latest`.
       username: _json_key
       password: ((team-nodejs-gcp-service-account-json))
 
@@ -47,7 +48,8 @@ resources:
       repository: icr.io/instana/aws-fargate-nodejs
       username: ((concourse-icr-containers-public.apikey))
       password: ((concourse-icr-containers-public.password))
-      tag: latest
+      # NOTE: Deliberately omitting `tag: latest` here on the branch for 3.x so
+      # we do not accidentally tag 3.x image versions with `latest`.
 
   - name: aws-fargate-nodejs-image-containers-instana-io
     type: registry-image
@@ -61,7 +63,8 @@ resources:
       repository: delivery.instana.io/rel-docker-agent-local/agent/aws/fargate/nodejs
       username: ((delivery-instana-io-release-project-artifact-read-writer-creds.username))
       password: ((delivery-instana-io-release-project-artifact-read-writer-creds.password))
-      tag: latest
+      # NOTE: Deliberately omitting `tag: latest` here on the branch for 3.x so
+      # we do not accidentally tag 3.x image versions with `latest`.
 
   - name: instana-google-cloud-run-npm-package
     type: npm-resource
@@ -79,7 +82,8 @@ resources:
       repository: icr.io/instana/google-cloud-run-nodejs
       username: ((concourse-icr-containers-public.apikey))
       password: ((concourse-icr-containers-public.password))
-      tag: latest
+      # NOTE: Deliberately omitting `tag: latest` here on the branch for 3.x so
+      # we do not accidentally tag 3.x image versions with `latest`.
 
   - name: google-cloud-run-nodejs-image-containers-instana-io
     type: registry-image
@@ -93,7 +97,8 @@ resources:
       repository: delivery.instana.io/rel-docker-agent-local/agent/google/cloud-run/nodejs
       username: ((delivery-instana-io-release-project-artifact-read-writer-creds.username))
       password: ((delivery-instana-io-release-project-artifact-read-writer-creds.password))
-      tag: latest
+      # NOTE: Deliberately omitting `tag: latest` here on the branch for 3.x so
+      # we do not accidentally tag 3.x image versions with `latest`.
 
   - name: instana-aws-lambda-npm-package
     type: npm-resource
@@ -126,7 +131,8 @@ resources:
       repository: icr.io/instana/azure-container-services-nodejs
       username: ((concourse-icr-containers-public.apikey))
       password: ((concourse-icr-containers-public.password))
-      tag: latest
+      # NOTE: Deliberately omitting `tag: latest` here on the branch for 3.x so
+      # we do not accidentally tag 3.x image versions with `latest`.
 
 resource_types:
 
@@ -199,6 +205,7 @@ jobs:
       - put: aws-fargate-nodejs-image-icr
         params:
           image: image/image.tar
+          # In fact, on the branch for 3.x, this will be the only tag, not an _additional_ tag.
           additional_tags: instana-aws-fargate-npm-package/version
         get_params:
           skip_download: true
@@ -206,6 +213,7 @@ jobs:
       - put: aws-fargate-nodejs-image-containers-instana-io
         params:
           image: image/image.tar
+          # In fact, on the branch for 3.x, this will be the only tag, not an _additional_ tag.
           additional_tags: instana-aws-fargate-npm-package/version
         get_params:
           skip_download: true
@@ -293,6 +301,7 @@ jobs:
       - put: google-cloud-run-nodejs-image-icr
         params:
           image: image/image.tar
+          # In fact, on the branch for 3.x, this will be the only tag, not an _additional_ tag.
           additional_tags: instana-google-cloud-run-npm-package/version
         get_params:
           skip_download: true
@@ -300,6 +309,7 @@ jobs:
       - put: google-cloud-run-nodejs-image-containers-instana-io
         params:
           image: image/image.tar
+          # In fact, on the branch for 3.x, this will be the only tag, not an _additional_ tag.
           additional_tags: instana-google-cloud-run-npm-package/version
         get_params:
           skip_download: true
@@ -386,13 +396,15 @@ jobs:
           platform: linux
           inputs:
             - name: nodejs-repository
+          # Passing in PACKAGE_VERSION=3 will use the latest 3.x package and also avoid tagging the resulting
+          # container image as latest.  
           run:
             path: entrypoint.sh
             args:
             - bash
             - -ceux
             - |
-                BUILD_LAYER_WITH=npm \
+                PACKAGE_VERSION=3 \
                 NO_PROMPT=true \
                 CONTAINER_REGISTRY_USER=iamapikey \
                 CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
@@ -408,6 +420,8 @@ jobs:
         config:
           platform: linux
           inputs:
+          # Passing in PACKAGE_VERSION=3 will use the latest 3.x package and also avoid tagging the resulting
+          # container image as latest.  
             - name: nodejs-repository
           run:
             path: entrypoint.sh
@@ -415,7 +429,7 @@ jobs:
             - bash
             - -ceux
             - |
-                BUILD_LAYER_WITH=npm \
+                PACKAGE_VERSION=3 \
                 NO_PROMPT=true \
                 LAMBDA_ARCHITECTURE=arm64 \
                 CONTAINER_REGISTRY_USER=iamapikey \
@@ -488,6 +502,7 @@ jobs:
       - put: azure-container-services-nodejs-image-icr
         params:
           image: image/image.tar
+          # In fact, on the branch for 3.x, this will be the only tag, not an _additional_ tag.
           additional_tags: instana-azure-container-services-npm-package/version
         get_params:
           skip_download: true


### PR DESCRIPTION
This change prevents 3.x images as being tagged as latest.