### PR TITLE
ci: updated node image to alpine in dind-nodejs-aws-jq dockerfile

### DIFF
--- a/packages/serverless/ci/dind-nodejs-aws-jq/Dockerfile
+++ b/packages/serverless/ci/dind-nodejs-aws-jq/Dockerfile
@@ -15,7 +15,7 @@
 # Note: Needs to be run with --privileged.
 # ----------------------------------------------------------------------------
 
-FROM node:22
+FROM node:22-alpine
 
 ENV DOCKER_CHANNEL=stable \
     DOCKER_VERSION=20.10.11 \


### PR DESCRIPTION
Encountering following error while building dind-nodejs-aws-jq image
> apk: not found

The base image (node:22) does not include the apk. So updating to `node:22-alpine`