### PR TITLE
ci: updated  aws cli installation in dind image

### DIFF
--- a/packages/serverless/ci/dind-nodejs-aws-jq/Dockerfile
+++ b/packages/serverless/ci/dind-nodejs-aws-jq/Dockerfile
@@ -16,11 +16,11 @@
 # Note: Needs to be run with --privileged.
 # ----------------------------------------------------------------------------
 
-FROM node:16.13.1-alpine3.14
+FROM node:18-alpine
 
 ENV DOCKER_CHANNEL=stable \
-    DOCKER_VERSION=20.10.11 \
-    GLIBC_VER=2.34-r0
+    DOCKER_VERSION=24.0.9 \
+    GLIBC_VER=2.35-r0
 
 RUN apk --update --no-cache add \
         bash \

--- a/packages/serverless/ci/dind-nodejs-aws-jq/Dockerfile
+++ b/packages/serverless/ci/dind-nodejs-aws-jq/Dockerfile
@@ -12,7 +12,6 @@
 
 FROM node:22-alpine
 
-# Environment variables for Docker 
 ENV DOCKER_CHANNEL=stable \
     DOCKER_VERSION=27.3.1
 

--- a/packages/serverless/ci/dind-nodejs-aws-jq/Dockerfile
+++ b/packages/serverless/ci/dind-nodejs-aws-jq/Dockerfile
@@ -51,14 +51,17 @@ RUN apk --update --no-cache add \
 # AWS CLI v2 is fetched directly from Amazon’s servers using a static
 # download link, which always provides the latest release of the CLI tool.
 # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#getting-started-install-instructions
+ARG ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download"
 RUN apk --no-cache add \
-        binutils \
-    && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
-    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
-    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
-    && apk add --no-cache \
-        glibc-${GLIBC_VER}.apk \
-        glibc-bin-${GLIBC_VER}.apk \
+        --virtual .build-deps curl binutils zstd gcompat \
+    && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
+    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk -o /tmp/glibc-${GLIBC_VER}.apk \
+    && apk add --force-overwrite --no-cache /tmp/glibc-${GLIBC_VER}.apk \
+    && apk del gcompat \
+    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk -o /tmp/glibc-bin-${GLIBC_VER}.apk \
+    && apk add --no-cache /tmp/glibc-bin-${GLIBC_VER}.apk \
+    && curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk -o /tmp/glibc-i18n-${GLIBC_VER}.apk \
+    && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
     && unzip awscliv2.zip \
     && aws/install \
@@ -70,8 +73,10 @@ RUN apk --no-cache add \
         /usr/local/aws-cli/v2/*/dist/awscli/examples \
     && apk --no-cache del \
         binutils \
-    && rm glibc-${GLIBC_VER}.apk \
-    && rm glibc-bin-${GLIBC_VER}.apk \
+    && rm -f \
+        /tmp/glibc-${GLIBC_VER}.apk \
+        /tmp/glibc-bin-${GLIBC_VER}.apk \
+        /tmp/glibc-i18n-${GLIBC_VER}.apk \
     && rm -rf /var/cache/apk/*
 
 COPY entrypoint.sh /bin/entrypoint.sh

--- a/packages/serverless/ci/dind-nodejs-aws-jq/Dockerfile
+++ b/packages/serverless/ci/dind-nodejs-aws-jq/Dockerfile
@@ -4,24 +4,22 @@
 # https://github.com/karlkfi/concourse-dcind/blob/477674e4a27d79fa62099a86aa032017d4292d12/Dockerfile
 #
 # Modifications:
-# - Use a Node.js base image instead of raw alpine,
-# - add glibc because the AWS cli requires that (does not work with muslc)
-# - Updated DOCKER_VERSION to the latest stable release
-# - Updated GLIBC_VER to the latest stable release
-# - removed docker-compose and some related packages (py-pip, python3-dev)
-# - removed docker squash support,
-# - added jq, and
-# - added/removed a bunch apk packages.
+# - Use a Node.js base image instead of raw alpine.
+# - Set DOCKER_VERSION=20.10.11
 #
 # Note: Needs to be run with --privileged.
+#
+# Note: Starting from Alpine 3.18, aws-cli v2 is available as a 'main' package,
+# so you can install it directly using `apk add aws-cli`.
 # ----------------------------------------------------------------------------
 
-FROM node:18-alpine
+FROM node:20-alpine
 
+# Environment variables for Docker 
 ENV DOCKER_CHANNEL=stable \
-    DOCKER_VERSION=24.0.9 \
-    GLIBC_VER=2.35-r0
+    DOCKER_VERSION=20.10.11
 
+# Install necessary packages and Docker
 RUN apk --update --no-cache add \
         bash \
         ca-certificates \
@@ -36,48 +34,15 @@ RUN apk --update --no-cache add \
         musl-dev \
         openssl-dev \
         util-linux \
-        jq \
         zip \
-        && \
-    apk upgrade && \
-    curl -fL "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" | tar zx && \
-    mv /docker/* /bin/ && chmod +x /bin/docker* && \
-    rm -rf /var/cache/apk/* && \
-    rm -rf /root/.cache
+    && apk upgrade \
+    && curl -fL "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" | tar zx \
+    && mv /docker/* /bin/ \
+    && chmod +x /bin/docker* \
+    && rm -rf /var/cache/apk/* /root/.cache
 
-# Install glibc compatibility for alpine plus AWS cli
-# ----------------------------------------------------------------------------
-# This section installs the latest version of AWS CLI (v2) and glibc.
-# AWS CLI v2 is fetched directly from Amazon’s servers using a static
-# download link, which always provides the latest release of the CLI tool.
-# https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#getting-started-install-instructions
-ARG ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download"
-RUN apk --no-cache add \
-        --virtual .build-deps curl binutils zstd gcompat \
-    && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk -o /tmp/glibc-${GLIBC_VER}.apk \
-    && apk add --force-overwrite --no-cache /tmp/glibc-${GLIBC_VER}.apk \
-    && apk del gcompat \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk -o /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk -o /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
-    && unzip awscliv2.zip \
-    && aws/install \
-    && rm -rf \
-        awscliv2.zip \
-        aws \
-        /usr/local/aws-cli/v2/*/dist/aws_completer \
-        /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index \
-        /usr/local/aws-cli/v2/*/dist/awscli/examples \
-    && apk --no-cache del \
-        binutils \
-    && rm -f \
-        /tmp/glibc-${GLIBC_VER}.apk \
-        /tmp/glibc-bin-${GLIBC_VER}.apk \
-        /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && rm -rf /var/cache/apk/*
+# Install AWS CLI
+RUN apk add --no-cache aws-cli
 
 COPY entrypoint.sh /bin/entrypoint.sh
 

--- a/packages/serverless/ci/dind-nodejs-aws-jq/Dockerfile
+++ b/packages/serverless/ci/dind-nodejs-aws-jq/Dockerfile
@@ -1,23 +1,20 @@
 # ----------------------------------------------------------------------------
-# Loosely based on
-#
-# https://github.com/karlkfi/concourse-dcind/blob/477674e4a27d79fa62099a86aa032017d4292d12/Dockerfile
-#
 # Modifications:
 # - Use a Node.js base image instead of raw alpine.
-# - Set DOCKER_VERSION=20.10.11
-#
+# - Set latest DOCKER_VERSION=27.3.1
+# https://docs.docker.com/engine/release-notes/27/
 # Note: Needs to be run with --privileged.
 #
 # Note: Starting from Alpine 3.18, aws-cli v2 is available as a 'main' package,
-# so you can install it directly using `apk add aws-cli`.
+# so we can install it directly using `apk add aws-cli`.
+# https://pkgs.alpinelinux.org/packages?name=aws-cli
 # ----------------------------------------------------------------------------
 
-FROM node:20-alpine
+FROM node:22-alpine
 
 # Environment variables for Docker 
 ENV DOCKER_CHANNEL=stable \
-    DOCKER_VERSION=20.10.11
+    DOCKER_VERSION=27.3.1
 
 # Install necessary packages and Docker
 RUN apk --update --no-cache add \
@@ -34,6 +31,7 @@ RUN apk --update --no-cache add \
         musl-dev \
         openssl-dev \
         util-linux \
+        jq \
         zip \
     && apk upgrade \
     && curl -fL "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" | tar zx \


### PR DESCRIPTION
Updates

1. Base Image: Updated from node:16.13.1-alpine3.14 to node:22-alpine.
2. Docker Version: Updated to latest 27.3.1. See https://docs.docker.com/engine/release-notes/27/
3. AWS CLI Installation: Now installed directly with apk add aws-cli, see https://pkgs.alpinelinux.org/packages?name=aws-cli.
