### PR TITLE
test: enabled test for bull in node v23 and greater

### DIFF
--- a/packages/collector/test/tracing/messaging/bull/test.js
+++ b/packages/collector/test/tracing/messaging/bull/test.js
@@ -35,11 +35,8 @@ if (process.env.BULL_QUEUE_NAME) {
   queueName = `${process.env.BULL_QUEUE_NAME}${semver.major(process.versions.node)}`;
 }
 
-// TODO: bull is broken in v23. Investigate currency as part of https://jsw.ibm.com/browse/INSTA-17032
 const mochaSuiteFn =
-  supportedVersion(process.versions.node) && semver.satisfies(process.versions.node, '<=22.x')
-    ? describe
-    : describe.skip;
+  supportedVersion(process.versions.node) ? describe : describe.skip;
 
 const retryTime = 1000;
 


### PR DESCRIPTION
refs INSTA-17032


Bull was failing for node version 23,

It was failing due to a dependency that bull uses 'msgpackr'. See existing issue [here](https://github.com/kriszyp/msgpackr/pull/151)


It was fixed in the [latest version of bull](https://github.com/OptimalBits/bull/releases/tag/v4.16.4)