### PR TITLE
chore: overridden node-abi version to resolve ABI detection issue for Node.js v23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50259,6 +50259,16 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/prebuild-install/node_modules/node-abi": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
+      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "semver": "^5.4.1"
+      }
+    },
     "node_modules/prebuild-install/node_modules/npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -50297,6 +50307,16 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/prebuild-install/node_modules/string_decoder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47140,10 +47140,11 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.62.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.62.0.tgz",
-      "integrity": "sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==",
+      "version": "3.71.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.71.0.tgz",
+      "integrity": "sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -50258,16 +50259,6 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/prebuild-install/node_modules/node-abi": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "semver": "^5.4.1"
-      }
-    },
     "node_modules/prebuild-install/node_modules/npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -50306,16 +50297,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/prebuild-install/node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -251,7 +251,8 @@
     "prisma": "^5.22.0"
   },
   "overrides": {
-    "stream-shift": "1.0.2"
+    "stream-shift": "1.0.2",
+    "node-abi":"3.71.0"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -251,8 +251,7 @@
     "prisma": "^5.22.0"
   },
   "overrides": {
-    "stream-shift": "1.0.2",
-    "node-abi":"3.71.0"
+    "stream-shift": "1.0.2"
   },
   "config": {
     "commitizen": {

--- a/packages/autoprofile/CONTRIBUTING.md
+++ b/packages/autoprofile/CONTRIBUTING.md
@@ -39,3 +39,13 @@ node scripts/prebuilds.js --node=22.0.0,21.0.0                        [build spe
 ```sh
 node scripts/prebuilds.js --node=22.0.0                               [build specific node version]
 ```
+### Troubleshooting Tips
+
+If you encounter an error like the following:
+
+```
+Error: Could not detect abi for version 23.0.0 and runtime node.
+```
+Solution:
+
+Update [`node-abi`](https://www.npmjs.com/package/node-abi), a sub-dependency of `prebuildify`, to the latest version for Node.js compatibility.

--- a/packages/autoprofile/CONTRIBUTING.md
+++ b/packages/autoprofile/CONTRIBUTING.md
@@ -39,7 +39,7 @@ node scripts/prebuilds.js --node=22.0.0,21.0.0                        [build spe
 ```sh
 node scripts/prebuilds.js --node=22.0.0                               [build specific node version]
 ```
-### Troubleshooting Tips
+### Troubleshooting
 
 If you encounter an error like the following:
 


### PR DESCRIPTION
Added a section in the contributing.md  to fix the ABI detection issue while generating prebuilds for  Node.js 23. This update ensures compatibility with the latest Node.js release.

