### PR TITLE
ci: removed deprecated column from the currency report

### DIFF
--- a/bin/currency/generate-currency-report.js
+++ b/bin/currency/generate-currency-report.js
@@ -115,7 +115,7 @@ function jsonToMarkdown(data) {
     '# Node.js supported core & third party packages' +
     '\n\n' +
     // eslint-disable-next-line max-len
-    '| Package name | Last Supported Version | Latest Version | Latest Version Published At | Support Policy | Days behind | Up-to-date | Note | Depri-cated | Cloud Native | Beta version |\n';
+    '| Package name | Last Supported Version | Latest Version | Latest Version Published At | Support Policy | Days behind | Up-to-date | Note | Cloud Native | Beta version |\n';
 
   markdown +=
     // eslint-disable-next-line max-len
@@ -124,7 +124,7 @@ function jsonToMarkdown(data) {
   // eslint-disable-next-line no-restricted-syntax
   for (const entry of data) {
     // eslint-disable-next-line max-len
-    markdown += `| ${entry.name} | ${entry.lastSupportedVersion} | ${entry.latestVersion} | ${entry.publishedAt} | ${entry.policy} | ${entry.daysBehind} day/s | ${entry.upToDate} | ${entry.note} | ${entry.deprecated} | ${entry.cloudNative} | ${entry.isBeta} |\n`;
+    markdown += `| ${entry.name} | ${entry.lastSupportedVersion} | ${entry.latestVersion} | ${entry.publishedAt} | ${entry.policy} | ${entry.daysBehind} day/s | ${entry.upToDate} | ${entry.note} | ${entry.cloudNative} | ${entry.isBeta} |\n`;
   }
 
   return markdown;

--- a/currencies.json
+++ b/currencies.json
@@ -8,7 +8,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -20,7 +19,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -32,7 +30,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": true,
     "core": false
   },
   {
@@ -44,7 +41,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -56,7 +52,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -68,7 +63,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -80,7 +74,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -92,7 +85,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -104,7 +96,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -116,7 +107,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -128,7 +118,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -140,7 +129,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -152,7 +140,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -164,7 +151,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -176,7 +162,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -188,7 +173,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -200,7 +184,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -212,7 +195,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -224,7 +206,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -236,7 +217,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -248,7 +228,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -260,7 +239,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -272,7 +250,6 @@
     "isBeta": false,
     "ignoreUpdates": true,
     "note": "",
-    "deprecated": false,
     "core": true
   },
   {
@@ -284,7 +261,6 @@
     "isBeta": false,
     "ignoreUpdates": true,
     "note": "",
-    "deprecated": false,
     "core": true
   },
   {
@@ -296,7 +272,6 @@
     "isBeta": false,
     "ignoreUpdates": true,
     "note": "",
-    "deprecated": false,
     "core": true
   },
   {
@@ -308,7 +283,6 @@
     "isBeta": false,
     "ignoreUpdates": true,
     "note": "",
-    "deprecated": false,
     "core": true
   },
   {
@@ -320,7 +294,6 @@
     "isBeta": false,
     "ignoreUpdates": true,
     "note": "",
-    "deprecated": false,
     "core": true
   },
   {
@@ -332,7 +305,6 @@
     "isBeta": false,
     "ignoreUpdates": true,
     "note": "",
-    "deprecated": false,
     "core": true
   },
   {
@@ -344,7 +316,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -356,7 +327,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -368,7 +338,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -380,7 +349,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -392,7 +360,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -404,7 +371,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -416,7 +382,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -428,7 +393,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": true,
     "core": false
   },
   {
@@ -440,7 +404,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -452,7 +415,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -464,7 +426,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -476,7 +437,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -488,7 +448,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -500,7 +459,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -512,7 +470,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -524,7 +481,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -536,7 +492,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -548,7 +503,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -560,7 +514,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -572,7 +525,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -584,7 +536,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -596,7 +547,6 @@
     "isBeta": false,
     "ignoreUpdates": true,
     "note": "",
-    "deprecated": false,
     "core": true
   },
   {
@@ -608,7 +558,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -620,7 +569,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -632,7 +580,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -644,7 +591,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -656,7 +602,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -668,7 +613,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -680,7 +624,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -692,7 +635,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -704,7 +646,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -716,7 +657,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -728,7 +668,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -740,7 +679,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -752,7 +690,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -764,7 +701,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": true,
     "core": false
   },
   {
@@ -776,7 +712,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": true,
     "core": false
   },
   {
@@ -788,7 +723,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -800,7 +734,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -812,7 +745,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -824,7 +756,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -836,7 +767,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -848,7 +778,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   },
   {
@@ -860,7 +789,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": true,
     "core": false
   },
   {
@@ -872,7 +800,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": true,
     "core": false
   },
   {
@@ -884,7 +811,6 @@
     "isBeta": false,
     "ignoreUpdates": false,
     "note": "",
-    "deprecated": false,
     "core": false
   }
 ]


### PR DESCRIPTION
As we  are using "Deprecated" value in support policy column, the "deprecated" column is not relevant in currency report, so removed the column from currency report. 
ref https://github.com/instana/nodejs/pull/1435#discussion_r1832384400