### PR TITLE
fix: made the latest version of instana-aws-lambda-auto-wrap available on npm

### DIFF
--- a/packages/aws-lambda-auto-wrap/package.json
+++ b/packages/aws-lambda-auto-wrap/package.json
@@ -2,7 +2,6 @@
   "name": "instana-aws-lambda-auto-wrap",
   "version": "4.0.1",
   "description": "Automatically wrap AWS Lambdas for Instana tracing and monitoring without code modification.",
-  "private": true,
   "author": {
     "name": "Bastian Krol",
     "email": "bastian.krol@instana.com"


### PR DESCRIPTION
The `instana-aws-lambda-auto-wrap` package was deprecated in version 4 because we believed we were using locally built versions of the package, and no new versions were published to npm. However, during the layer's publishing process, the npm package was being directly [downloaded](https://github.com/instana/nodejs/blob/main/packages/aws-lambda/layer/bin/publish-layer.sh#L287) from `instana-aws-lambda-auto-wrap`. This caused a version mismatch where the original handler was wrapped with version 3.21.0, while the Lambda code from the layer was using version 4.0.1.  

We have now published the latest version of `instana-aws-lambda-auto-wrap`, which resolves this issue.

related issue `https://github.com/instana/nodejs/issues/1451`