### PR TITLE
build: bumped node-rdkafka from 3.1.1 to 3.2.0

### DIFF
--- a/.tekton/assets/sidecars.json
+++ b/.tekton/assets/sidecars.json
@@ -46,7 +46,7 @@
     },
     {
       "name": "kafka",
-      "image": "wurstmeister/kafka:2.12-2.2.1",
+      "image": "wurstmeister/kafka:2.13-2.8.1",
       "env": [
         { "name": "KAFKA_LISTENERS", "value": "EXTERNAL://:9092,PLAINTEXT://:29092" },
         { "name": "KAFKA_ADVERTISED_LISTENERS", "value": "PLAINTEXT://127.0.0.1:29092,EXTERNAL://localhost:9092" },

--- a/.tekton/tasks/test-groups/test-ci-collector-tracing-messaging-task.yaml
+++ b/.tekton/tasks/test-groups/test-ci-collector-tracing-messaging-task.yaml
@@ -13,7 +13,7 @@ spec:
           periodSeconds: 2
           timeoutSeconds: 30
     - name: kafka
-      image: wurstmeister/kafka:2.12-2.2.1
+      image: wurstmeister/kafka:2.13-2.8.1
       env:
           - name: "KAFKA_LISTENERS"
             value: "EXTERNAL://:9092,PLAINTEXT://:29092"

--- a/docker-compose-base.yaml
+++ b/docker-compose-base.yaml
@@ -80,7 +80,7 @@ services:
       - 2181:2181
 
   kafka:
-    image: wurstmeister/kafka:2.12-2.2.1
+    image: wurstmeister/kafka:2.13-2.8.1
     platform: linux/amd64
     ports:
       - 9092:9092

--- a/package-lock.json
+++ b/package-lock.json
@@ -188,7 +188,7 @@
         "couchbase": "^4.4.3",
         "ibm_db": "^3.2.5",
         "kafka-avro": "^3.2.0",
-        "node-rdkafka": "^3.1.1",
+        "node-rdkafka": "^3.2.0",
         "pg-native": "^3.2.0",
         "prisma": "^5.22.0"
       }
@@ -47844,9 +47844,9 @@
       }
     },
     "node_modules/node-rdkafka": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-3.1.1.tgz",
-      "integrity": "sha512-3rY24KlFvkQ0Pfqo5HP/fXa1GA+8R7hFLP+rm2htT7XJluH2lJ1fcEM5KDWKpkq1Nf4otHYvnBdY5eRH6ecYjg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-3.2.0.tgz",
+      "integrity": "sha512-Xt30tiwTKv6LXLtelNDXYETb1VnrzPU5s5OAeyY6fz20Bpqy5ARDoWKim4zsKugGlaztsmzPauqMYcQrLdk8HQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "couchbase": "^4.4.3",
     "ibm_db": "^3.2.5",
     "kafka-avro": "^3.2.0",
-    "node-rdkafka": "^3.1.1",
+    "node-rdkafka": "^3.2.0",
     "pg-native": "^3.2.0",
     "prisma": "^5.22.0"
   },

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -184,14 +184,20 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
   });
 
   function verify(_producerControls, _consumerControls, response, apiPath, withError, objectMode, producerMethod) {
-    return retry(() => {
+    return retry(async () => {
       verifyResponseAndMessage(response, _producerControls, withError, objectMode, producerMethod);
 
-      return agentControls
-        .getSpans()
-        .then(spans =>
-          verifySpans(_producerControls, _consumerControls, spans, apiPath, null, withError, objectMode, producerMethod)
-        );
+      const spans = await agentControls.getSpans();
+      return verifySpans(
+        _producerControls,
+        _consumerControls,
+        spans,
+        apiPath,
+        null,
+        withError,
+        objectMode,
+        producerMethod
+      );
     }, retryTime);
   }
 


### PR DESCRIPTION
The tests were failing after upgrading node-rdkafka from v3.1.1 to v3.2.0 due to an underlying [issue](https://github.com/confluentinc/librdkafka/issues/4870) with librdkafka v2.6.0, which causes an error for Kafka versions earlier than 2.7.
 I have raised an issue regarding this [here](https://github.com/Blizzard/node-rdkafka/issues/1105). In the meantime, as we are using an older Kafka image version, I have updated the image to a version greater than 2.7 to work around the issue.