### PR TITLE
feat: added support for couchbase v4.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -187,6 +187,7 @@
       },
       "optionalDependencies": {
         "couchbase": "^4.4.4",
+        "couchbase-v443": "npm:couchbase@4.4.3",
         "ibm_db": "^3.2.5",
         "kafka-avro": "^3.2.0",
         "node-rdkafka": "^3.2.1",
@@ -35589,6 +35590,135 @@
         "@couchbase/couchbase-linuxmusl-arm64-napi": "4.4.4",
         "@couchbase/couchbase-linuxmusl-x64-napi": "4.4.4",
         "@couchbase/couchbase-win32-x64-napi": "4.4.4"
+      }
+    },
+    "node_modules/couchbase-v443": {
+      "name": "couchbase",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/couchbase/-/couchbase-4.4.3.tgz",
+      "integrity": "sha512-J8lhlueKPmQGY51znMDEOBdVkfbOjZpArP8qW2VjktbV4AQWpeH81KwQvQqbso6BA1RKnxxUeiMyEt7PN6x+Wg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "cmake-js": "^7.3.0",
+        "node-addon-api": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@couchbase/couchbase-darwin-arm64-napi": "4.4.3",
+        "@couchbase/couchbase-darwin-x64-napi": "4.4.3",
+        "@couchbase/couchbase-linux-arm64-napi": "4.4.3",
+        "@couchbase/couchbase-linux-x64-napi": "4.4.3",
+        "@couchbase/couchbase-linuxmusl-arm64-napi": "4.4.3",
+        "@couchbase/couchbase-linuxmusl-x64-napi": "4.4.3",
+        "@couchbase/couchbase-win32-x64-napi": "4.4.3"
+      }
+    },
+    "node_modules/couchbase-v443/node_modules/@couchbase/couchbase-darwin-arm64-napi": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-arm64-napi/-/couchbase-darwin-arm64-napi-4.4.3.tgz",
+      "integrity": "sha512-nH5282Pql5400P1zCOh70FVX4Yoaah2HMfA7ka3ZWB6M1h1C8VJ97gfUD/lsU5Pja8PekrLbZip3OARuieSeiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/couchbase-v443/node_modules/@couchbase/couchbase-darwin-x64-napi": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-x64-napi/-/couchbase-darwin-x64-napi-4.4.3.tgz",
+      "integrity": "sha512-W9+x1CYkHG2jIdEeHZXo6D2IK8jq4JKVfo53D9AnqETFnO1W2Tf5+k2fuDz/NCHMfn4S9wXvAquwbhftE4DLEA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/couchbase-v443/node_modules/@couchbase/couchbase-linux-arm64-napi": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-arm64-napi/-/couchbase-linux-arm64-napi-4.4.3.tgz",
+      "integrity": "sha512-meeLqhhT+/6tZk5wjp/6EitYbJ5yn7WniINvYV+dFy6lNas3ev/XVlT/w+toZ+Smo/+sBnR4EJhXFcvYj39+MQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/couchbase-v443/node_modules/@couchbase/couchbase-linux-x64-napi": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-x64-napi/-/couchbase-linux-x64-napi-4.4.3.tgz",
+      "integrity": "sha512-++Q/dOrywzJ2Rb4hWFfHxAuZZU70EGf1OSkhhl+yiFRyg3/9eeuhTkDZNaVCpjEFr8mZKY2nz9JKs8f8yjd9AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/couchbase-v443/node_modules/@couchbase/couchbase-linuxmusl-arm64-napi": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linuxmusl-arm64-napi/-/couchbase-linuxmusl-arm64-napi-4.4.3.tgz",
+      "integrity": "sha512-H4Y6SADDHQMdUwJ5AXbQN3YCBnbhs4S7jAYSVBlS8blVNqrpNH+ZCLoyiwgLSjHEt5qs4U1ODd/S9zYUrYYxww==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/couchbase-v443/node_modules/@couchbase/couchbase-linuxmusl-x64-napi": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linuxmusl-x64-napi/-/couchbase-linuxmusl-x64-napi-4.4.3.tgz",
+      "integrity": "sha512-NP4+puEW1nakxfXBhAL6I+hcj9iSSDF5NQ+W9sacnGEUQsPqqgqH293piAPEYj0WQrmtqPv4a3cVgSP7bWfEXw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/couchbase-v443/node_modules/@couchbase/couchbase-win32-x64-napi": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-win32-x64-napi/-/couchbase-win32-x64-napi-4.4.3.tgz",
+      "integrity": "sha512-Pt66jVf6nNyN6DvY7PvzDFDA0pLyOyh4b63CSHFDcLVruF2Z9xwPpjvCiGSfk3N1zdod66ndLXMBo36Xo5UT0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/create-ecdh": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,7 +186,7 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "couchbase": "^4.4.3",
+        "couchbase": "^4.4.4",
         "ibm_db": "^3.2.5",
         "kafka-avro": "^3.2.0",
         "node-rdkafka": "^3.2.1",
@@ -21871,13 +21871,12 @@
       }
     },
     "node_modules/@couchbase/couchbase-darwin-arm64-napi": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-arm64-napi/-/couchbase-darwin-arm64-napi-4.4.3.tgz",
-      "integrity": "sha512-nH5282Pql5400P1zCOh70FVX4Yoaah2HMfA7ka3ZWB6M1h1C8VJ97gfUD/lsU5Pja8PekrLbZip3OARuieSeiw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-arm64-napi/-/couchbase-darwin-arm64-napi-4.4.4.tgz",
+      "integrity": "sha512-JVBLeckWZpZIPMJCoOCFgVxLNMDAsK1rZsQRBTN6/dp4NYDOaLpy+521ica9QLN0Uqk8UNI6oLPaABwolQFRaA==",
       "cpu": [
         "arm64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -21887,13 +21886,12 @@
       }
     },
     "node_modules/@couchbase/couchbase-darwin-x64-napi": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-x64-napi/-/couchbase-darwin-x64-napi-4.4.3.tgz",
-      "integrity": "sha512-W9+x1CYkHG2jIdEeHZXo6D2IK8jq4JKVfo53D9AnqETFnO1W2Tf5+k2fuDz/NCHMfn4S9wXvAquwbhftE4DLEA==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-darwin-x64-napi/-/couchbase-darwin-x64-napi-4.4.4.tgz",
+      "integrity": "sha512-XjM+WK8AdCnCdiOwM+zFeg4/TKCj3wyF9rcuM6MRcYxusNoyGpZjyWYU5fYT8iLyrFwoBts7p9M8BKUaUMB0EQ==",
       "cpu": [
         "x64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -21903,13 +21901,12 @@
       }
     },
     "node_modules/@couchbase/couchbase-linux-arm64-napi": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-arm64-napi/-/couchbase-linux-arm64-napi-4.4.3.tgz",
-      "integrity": "sha512-meeLqhhT+/6tZk5wjp/6EitYbJ5yn7WniINvYV+dFy6lNas3ev/XVlT/w+toZ+Smo/+sBnR4EJhXFcvYj39+MQ==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-arm64-napi/-/couchbase-linux-arm64-napi-4.4.4.tgz",
+      "integrity": "sha512-hNiK/yjWUB1oygAlRufg5bVccucHKZifEXbn0cYduUKYjsob7Q61IT8/k9X+hIcCQIShA2NvE60VYKHvzyd5Yg==",
       "cpu": [
         "arm64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -21919,13 +21916,12 @@
       }
     },
     "node_modules/@couchbase/couchbase-linux-x64-napi": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-x64-napi/-/couchbase-linux-x64-napi-4.4.3.tgz",
-      "integrity": "sha512-++Q/dOrywzJ2Rb4hWFfHxAuZZU70EGf1OSkhhl+yiFRyg3/9eeuhTkDZNaVCpjEFr8mZKY2nz9JKs8f8yjd9AQ==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linux-x64-napi/-/couchbase-linux-x64-napi-4.4.4.tgz",
+      "integrity": "sha512-xVo3ARZDxH9XHJpO8JIDv92i9yEuoMk6yvHxh9XNvSOHN4Ymju3KEFwPPFmfNezLGFWbDRZi6+z5JPdB1IPoGQ==",
       "cpu": [
         "x64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -21935,13 +21931,12 @@
       }
     },
     "node_modules/@couchbase/couchbase-linuxmusl-arm64-napi": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linuxmusl-arm64-napi/-/couchbase-linuxmusl-arm64-napi-4.4.3.tgz",
-      "integrity": "sha512-H4Y6SADDHQMdUwJ5AXbQN3YCBnbhs4S7jAYSVBlS8blVNqrpNH+ZCLoyiwgLSjHEt5qs4U1ODd/S9zYUrYYxww==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linuxmusl-arm64-napi/-/couchbase-linuxmusl-arm64-napi-4.4.4.tgz",
+      "integrity": "sha512-s2MDllkq0XubGqUKbXB9B1U9+flYTeBIRMwQYXhO40UEBRDxsYOtrtVMAfgogDE4y/oA14OQNIHePyIR78D32g==",
       "cpu": [
         "arm64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -21951,13 +21946,12 @@
       }
     },
     "node_modules/@couchbase/couchbase-linuxmusl-x64-napi": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linuxmusl-x64-napi/-/couchbase-linuxmusl-x64-napi-4.4.3.tgz",
-      "integrity": "sha512-NP4+puEW1nakxfXBhAL6I+hcj9iSSDF5NQ+W9sacnGEUQsPqqgqH293piAPEYj0WQrmtqPv4a3cVgSP7bWfEXw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-linuxmusl-x64-napi/-/couchbase-linuxmusl-x64-napi-4.4.4.tgz",
+      "integrity": "sha512-I/yzOHY5Yxq7rtsNPJlc/d3E2Y4Nj85BIK3LM1SRvBe57kJBOJDckDg9xeMf9rB4YOfprFXYCWu2R4fPmNLBcg==",
       "cpu": [
         "x64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -21967,13 +21961,12 @@
       }
     },
     "node_modules/@couchbase/couchbase-win32-x64-napi": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-win32-x64-napi/-/couchbase-win32-x64-napi-4.4.3.tgz",
-      "integrity": "sha512-Pt66jVf6nNyN6DvY7PvzDFDA0pLyOyh4b63CSHFDcLVruF2Z9xwPpjvCiGSfk3N1zdod66ndLXMBo36Xo5UT0Q==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@couchbase/couchbase-win32-x64-napi/-/couchbase-win32-x64-napi-4.4.4.tgz",
+      "integrity": "sha512-DkOeEQzCE/SaKkKqe+hfN8PLc8b/UzhPn7ORsG03Xxisyme6KTd/U9DYRkNiENwT9PPx00/HdPnSgZmpXVkb0g==",
       "cpu": [
         "x64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -35576,11 +35569,10 @@
       }
     },
     "node_modules/couchbase": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/couchbase/-/couchbase-4.4.3.tgz",
-      "integrity": "sha512-J8lhlueKPmQGY51znMDEOBdVkfbOjZpArP8qW2VjktbV4AQWpeH81KwQvQqbso6BA1RKnxxUeiMyEt7PN6x+Wg==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/couchbase/-/couchbase-4.4.4.tgz",
+      "integrity": "sha512-4xBMNOvrD62lJCatzM9zhpKBbJ07MsRXx7zGEMcQYVNWX4bLNxI1jOYaOJnAvqG6gpo6sqFESrZbKzvkPBoUow==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "cmake-js": "^7.3.0",
@@ -35590,13 +35582,13 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@couchbase/couchbase-darwin-arm64-napi": "4.4.3",
-        "@couchbase/couchbase-darwin-x64-napi": "4.4.3",
-        "@couchbase/couchbase-linux-arm64-napi": "4.4.3",
-        "@couchbase/couchbase-linux-x64-napi": "4.4.3",
-        "@couchbase/couchbase-linuxmusl-arm64-napi": "4.4.3",
-        "@couchbase/couchbase-linuxmusl-x64-napi": "4.4.3",
-        "@couchbase/couchbase-win32-x64-napi": "4.4.3"
+        "@couchbase/couchbase-darwin-arm64-napi": "4.4.4",
+        "@couchbase/couchbase-darwin-x64-napi": "4.4.4",
+        "@couchbase/couchbase-linux-arm64-napi": "4.4.4",
+        "@couchbase/couchbase-linux-x64-napi": "4.4.4",
+        "@couchbase/couchbase-linuxmusl-arm64-napi": "4.4.4",
+        "@couchbase/couchbase-linuxmusl-x64-napi": "4.4.4",
+        "@couchbase/couchbase-win32-x64-napi": "4.4.4"
       }
     },
     "node_modules/create-ecdh": {

--- a/package.json
+++ b/package.json
@@ -246,6 +246,7 @@
   },
   "optionalDependencies": {
     "couchbase": "^4.4.4",
+    "couchbase-v443": "npm:couchbase@4.4.3",
     "ibm_db": "^3.2.5",
     "kafka-avro": "^3.2.0",
     "node-rdkafka": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "yargs": "^17.5.1"
   },
   "optionalDependencies": {
-    "couchbase": "^4.4.3",
+    "couchbase": "^4.4.4",
     "ibm_db": "^3.2.5",
     "kafka-avro": "^3.2.0",
     "node-rdkafka": "^3.2.1",

--- a/packages/collector/test/tracing/database/couchbase/app.js
+++ b/packages/collector/test/tracing/database/couchbase/app.js
@@ -686,7 +686,7 @@ app.post('/queryindexes-callback', (req, res) => {
         scope2.query(qs1, err3 => {
           if (err3) return res.status(500).json({ err: err3.message });
 
-          // Forcing the error handling due to an issue in the package.
+          // Added a temporarily promise catch handler due to an issue in the package.
           // see https://github.com/couchbase/couchnode/issues/123
           scope2
             .query(qs2)

--- a/packages/collector/test/tracing/database/couchbase/app.js
+++ b/packages/collector/test/tracing/database/couchbase/app.js
@@ -10,6 +10,8 @@ process.on('SIGTERM', () => {
   process.exit(0);
 });
 
+require('./mockVersion');
+
 require('../../../..')();
 
 const couchbase = require('couchbase');

--- a/packages/collector/test/tracing/database/couchbase/app.js
+++ b/packages/collector/test/tracing/database/couchbase/app.js
@@ -686,6 +686,8 @@ app.post('/queryindexes-callback', (req, res) => {
         scope2.query(qs1, err3 => {
           if (err3) return res.status(500).json({ err: err3.message });
 
+          // Forcing the error handling due to an issue in the package.
+          // see https://github.com/couchbase/couchnode/issues/123
           scope2
             .query(qs2)
             .catch(() => {

--- a/packages/collector/test/tracing/database/couchbase/app.js
+++ b/packages/collector/test/tracing/database/couchbase/app.js
@@ -686,7 +686,7 @@ app.post('/queryindexes-callback', (req, res) => {
         scope2.query(qs1, err3 => {
           if (err3) return res.status(500).json({ err: err3.message });
 
-          // Added a temporarily promise catch handler due to an issue in the package.
+          // Added a temporary promise catch handler due to an issue in the package.
           // see https://github.com/couchbase/couchnode/issues/123
           scope2
             .query(qs2)

--- a/packages/collector/test/tracing/database/couchbase/app.mjs
+++ b/packages/collector/test/tracing/database/couchbase/app.mjs
@@ -566,7 +566,7 @@ app.post('/queryindexes-callback', (req, res) => {
     cluster.queryIndexes().createIndex(bucket2.name, idx2, ['name'], () => {
       cluster.query(qs, () => {
         scope2.query(qs1, () => {
-          // Added a temporarily promise catch handler due to an issue in the package.
+          // Added a temporary promise catch handler due to an issue in the package.
           // see https://github.com/couchbase/couchnode/issues/123
           scope2
             .query(qs2)

--- a/packages/collector/test/tracing/database/couchbase/app.mjs
+++ b/packages/collector/test/tracing/database/couchbase/app.mjs
@@ -15,7 +15,6 @@ import bodyParser from 'body-parser';
 import express from 'express';
 import { v1 } from 'uuid';
 import morgan from 'morgan';
-import fetch from 'node-fetch';
 import portFactory from '../../../test_util/app-port.js';
 import testUtil from '../../../../../core/test/test_util/index.js';
 
@@ -567,15 +566,20 @@ app.post('/queryindexes-callback', (req, res) => {
     cluster.queryIndexes().createIndex(bucket2.name, idx2, ['name'], () => {
       cluster.query(qs, () => {
         scope2.query(qs1, () => {
-          scope2.query(qs2, () => {
-            cluster.queryIndexes().dropIndex(bucket1.name, idx1, () => {
-              cluster.queryIndexes().dropPrimaryIndex(bucket2.name, { name: idx2 }, () => {
-                cluster.queryIndexes().getAllIndexes(bucket2.name, () => {
-                  res.json({ success: true });
+          scope2
+            .query(qs2)
+            .catch(() => {
+              // Ignore this error because we expect it to fail
+            })
+            .finally(() => {
+              cluster.queryIndexes().dropIndex(bucket1.name, idx1, () => {
+                cluster.queryIndexes().dropPrimaryIndex(bucket2.name, { name: idx2 }, () => {
+                  cluster.queryIndexes().getAllIndexes(bucket2.name, () => {
+                    res.json({ success: true });
+                  });
                 });
               });
             });
-          });
         });
       });
     });

--- a/packages/collector/test/tracing/database/couchbase/app.mjs
+++ b/packages/collector/test/tracing/database/couchbase/app.mjs
@@ -566,7 +566,7 @@ app.post('/queryindexes-callback', (req, res) => {
     cluster.queryIndexes().createIndex(bucket2.name, idx2, ['name'], () => {
       cluster.query(qs, () => {
         scope2.query(qs1, () => {
-          // Forcing the error handling due to an issue in the package.
+          // Added a temporarily promise catch handler due to an issue in the package.
           // see https://github.com/couchbase/couchnode/issues/123
           scope2
             .query(qs2)

--- a/packages/collector/test/tracing/database/couchbase/app.mjs
+++ b/packages/collector/test/tracing/database/couchbase/app.mjs
@@ -566,6 +566,8 @@ app.post('/queryindexes-callback', (req, res) => {
     cluster.queryIndexes().createIndex(bucket2.name, idx2, ['name'], () => {
       cluster.query(qs, () => {
         scope2.query(qs1, () => {
+          // Forcing the error handling due to an issue in the package.
+          // see https://github.com/couchbase/couchnode/issues/123
           scope2
             .query(qs2)
             .catch(() => {

--- a/packages/collector/test/tracing/database/couchbase/mockVersion.js
+++ b/packages/collector/test/tracing/database/couchbase/mockVersion.js
@@ -1,0 +1,13 @@
+/*
+ * (c) Copyright IBM Corp. 2024
+ */
+
+'use strict';
+
+const mock = require('mock-require');
+const COUCHBASE_VERSION = process.env.COUCHBASE_VERSION;
+const COUCHBASE_REQUIRE = process.env.COUCHBASE_VERSION === 'latest' ? 'couchbase' : `couchbase-${COUCHBASE_VERSION}`;
+
+if (COUCHBASE_REQUIRE !== 'couchbase') {
+  mock('couchbase', COUCHBASE_REQUIRE);
+}

--- a/packages/collector/test/tracing/database/couchbase/test.js
+++ b/packages/collector/test/tracing/database/couchbase/test.js
@@ -438,7 +438,7 @@ mochaSuiteFn('tracing/couchbase', function () {
             );
           }));
 
-      it('[analyticsindexes] must trace', () =>
+      it.skip('[analyticsindexes] must trace', () =>
         controls
           .sendRequest({
             method: 'post',

--- a/packages/collector/test/tracing/database/couchbase/test.js
+++ b/packages/collector/test/tracing/database/couchbase/test.js
@@ -438,7 +438,7 @@ mochaSuiteFn('tracing/couchbase', function () {
             );
           }));
 
-      it.skip('[analyticsindexes] must trace', () =>
+      it('[analyticsindexes] must trace', () =>
         controls
           .sendRequest({
             method: 'post',
@@ -455,14 +455,14 @@ mochaSuiteFn('tracing/couchbase', function () {
               verifySpans(agentControls, controls, {
                 spanLength: 9,
                 verifyCustom: (entrySpan, spans) => {
-                  expectExactlyOneMatching(
-                    spans,
-                    verifyCouchbaseSpan(controls, entrySpan, {
-                      bucket: 'projects',
-                      type: 'membase',
-                      sql: 'SELECT '
-                    })
-                  );
+                  // expectExactlyOneMatching(
+                  //   spans,
+                  //   verifyCouchbaseSpan(controls, entrySpan, {
+                  //     bucket: 'projects',
+                  //     type: 'membase',
+                  //     sql: 'NOW SELECT '
+                  //   })
+                  // );
                   expectExactlyNMatching(
                     spans,
                     1,
@@ -490,15 +490,15 @@ mochaSuiteFn('tracing/couchbase', function () {
                       sql: 'CREATE INDEX '
                     })
                   );
-                  expectExactlyNMatching(
-                    spans,
-                    1,
-                    verifyCouchbaseSpan(controls, entrySpan, {
-                      bucket: '',
-                      type: '',
-                      sql: 'SELECT'
-                    })
-                  );
+                  // expectExactlyNMatching(
+                  //   spans,
+                  //   1,
+                  //   verifyCouchbaseSpan(controls, entrySpan, {
+                  //     bucket: '',
+                  //     type: '',
+                  //     sql: 'SELECT'
+                  //   })
+                  // );
                   expectExactlyNMatching(
                     spans,
                     1,

--- a/packages/collector/test/tracing/database/couchbase/test.js
+++ b/packages/collector/test/tracing/database/couchbase/test.js
@@ -271,7 +271,7 @@ couchbaseVersions.forEach(version => {
               }
 
               expect(resp.success).to.eql(true);
-              return retry(() => verifySpans(agentControls, controls, { sql: 'GETANDTOUCH' }));
+              return retry(() => verifySpans(agentControls, controls, { sql: 'GET AND TOUCH' }));
             }));
 
         it('[crud] must trace replace', () =>
@@ -344,7 +344,7 @@ couchbaseVersions.forEach(version => {
               }
 
               expect(resp.success).to.eql(true);
-              return retry(() => verifySpans(agentControls, controls, { sql: 'MUTATEIN' }));
+              return retry(() => verifySpans(agentControls, controls, { sql: 'MUTATE IN' }));
             }));
 
         it('[crud] must trace lookupIn', () =>
@@ -359,7 +359,7 @@ couchbaseVersions.forEach(version => {
               }
 
               expect(resp.result).to.eql(2);
-              return retry(() => verifySpans(agentControls, controls, { sql: 'LOOKUPIN' }));
+              return retry(() => verifySpans(agentControls, controls, { sql: 'LOOKUP IN' }));
             }));
 
         it('[crud] must trace exists', () =>
@@ -414,7 +414,7 @@ couchbaseVersions.forEach(version => {
                       verifyCouchbaseSpan(controls, entrySpan, {
                         bucket: 'projects',
                         type: 'membase',
-                        sql: 'UPSERTINDEX'
+                        sql: 'UPSERT INDEX'
                       })
                     );
                     expectExactlyOneMatching(
@@ -422,7 +422,7 @@ couchbaseVersions.forEach(version => {
                       verifyCouchbaseSpan(controls, entrySpan, {
                         bucket: 'projects',
                         type: 'membase',
-                        sql: 'GETINDEX'
+                        sql: 'GET INDEX'
                       })
                     );
                     expectExactlyOneMatching(
@@ -430,7 +430,7 @@ couchbaseVersions.forEach(version => {
                       verifyCouchbaseSpan(controls, entrySpan, {
                         bucket: 'projects',
                         type: 'membase',
-                        sql: 'GETALLINDEXES'
+                        sql: 'GET ALL INDEXES'
                       })
                     );
                     expectExactlyOneMatching(
@@ -438,7 +438,7 @@ couchbaseVersions.forEach(version => {
                       verifyCouchbaseSpan(controls, entrySpan, {
                         bucket: '',
                         type: '',
-                        sql: 'DROPINDEX'
+                        sql: 'DROP INDEX'
                       })
                     );
                   }
@@ -565,7 +565,7 @@ couchbaseVersions.forEach(version => {
                       verifyCouchbaseSpan(controls, entrySpan, {
                         bucket: '',
                         type: '',
-                        sql: 'SEARCHQUERY'
+                        sql: 'SEARCH QUERY'
                       })
                     );
                   }
@@ -687,7 +687,7 @@ couchbaseVersions.forEach(version => {
                     expectExactlyOneMatching(
                       spans,
                       verifyCouchbaseSpan(controls, entrySpan, {
-                        sql: 'CREATEINDEX'
+                        sql: 'CREATE INDEX'
                       })
                     );
                     expectExactlyOneMatching(
@@ -695,7 +695,7 @@ couchbaseVersions.forEach(version => {
                       verifyCouchbaseSpan(controls, entrySpan, {
                         bucket: 'companies',
                         type: 'ephemeral',
-                        sql: 'CREATEINDEX'
+                        sql: 'CREATE INDEX'
                       })
                     );
 
@@ -737,7 +737,7 @@ couchbaseVersions.forEach(version => {
                     expectExactlyOneMatching(
                       spans,
                       verifyCouchbaseSpan(controls, entrySpan, {
-                        sql: 'DROPINDEX'
+                        sql: 'DROP INDEX'
                       })
                     );
                     expectExactlyOneMatching(
@@ -745,7 +745,7 @@ couchbaseVersions.forEach(version => {
                       verifyCouchbaseSpan(controls, entrySpan, {
                         bucket: 'companies',
                         type: 'ephemeral',
-                        sql: 'DROPINDEX'
+                        sql: 'DROP INDEX'
                       })
                     );
                     expectExactlyOneMatching(
@@ -753,7 +753,7 @@ couchbaseVersions.forEach(version => {
                       verifyCouchbaseSpan(controls, entrySpan, {
                         bucket: 'companies',
                         type: 'ephemeral',
-                        sql: 'GETALLINDEXES'
+                        sql: 'GET ALL INDEXES'
                       })
                     );
                   }
@@ -824,14 +824,14 @@ couchbaseVersions.forEach(version => {
                         spans,
                         3,
                         verifyCouchbaseSpan(controls, entrySpan, {
-                          sql: 'MUTATEIN'
+                          sql: 'MUTATE IN'
                         })
                       );
                       expectExactlyNMatching(
                         spans,
                         2,
                         verifyCouchbaseSpan(controls, entrySpan, {
-                          sql: 'LOOKUPIN'
+                          sql: 'LOOKUP IN'
                         })
                       );
                       expectExactlyNMatching(
@@ -867,14 +867,14 @@ couchbaseVersions.forEach(version => {
                         spans,
                         3,
                         verifyCouchbaseSpan(controls, entrySpan, {
-                          sql: 'MUTATEIN'
+                          sql: 'MUTATE IN'
                         })
                       );
                       expectExactlyNMatching(
                         spans,
                         3,
                         verifyCouchbaseSpan(controls, entrySpan, {
-                          sql: 'LOOKUPIN'
+                          sql: 'LOOKUP IN'
                         })
                       );
                       expectExactlyNMatching(

--- a/packages/collector/test/tracing/database/couchbase/test.js
+++ b/packages/collector/test/tracing/database/couchbase/test.js
@@ -455,14 +455,6 @@ mochaSuiteFn('tracing/couchbase', function () {
               verifySpans(agentControls, controls, {
                 spanLength: 9,
                 verifyCustom: (entrySpan, spans) => {
-                  // expectExactlyOneMatching(
-                  //   spans,
-                  //   verifyCouchbaseSpan(controls, entrySpan, {
-                  //     bucket: 'projects',
-                  //     type: 'membase',
-                  //     sql: 'NOW SELECT '
-                  //   })
-                  // );
                   expectExactlyNMatching(
                     spans,
                     1,
@@ -490,15 +482,6 @@ mochaSuiteFn('tracing/couchbase', function () {
                       sql: 'CREATE INDEX '
                     })
                   );
-                  // expectExactlyNMatching(
-                  //   spans,
-                  //   1,
-                  //   verifyCouchbaseSpan(controls, entrySpan, {
-                  //     bucket: '',
-                  //     type: '',
-                  //     sql: 'SELECT'
-                  //   })
-                  // );
                   expectExactlyNMatching(
                     spans,
                     1,

--- a/packages/collector/test/tracing/database/couchbase/test.js
+++ b/packages/collector/test/tracing/database/couchbase/test.js
@@ -519,26 +519,25 @@ couchbaseVersions.forEach(version => {
                     );
 
                     // It is difficult to get exact query from couchbase after v4.4.4 release
-                    // as they are not generating queries from JS anymore
-                    if (version !== 'latest') {
-                      expectExactlyNMatching(
-                        spans,
-                        1,
-                        verifyCouchbaseSpan(controls, entrySpan, {
-                          bucket: '',
-                          type: '',
-                          sql: 'SELECT'
-                        })
-                      );
-                      expectExactlyOneMatching(
-                        spans,
-                        verifyCouchbaseSpan(controls, entrySpan, {
-                          bucket: 'projects',
-                          type: 'membase',
-                          sql: 'SELECT '
-                        })
-                      );
-                    }
+                    // as they are not generating queries from JS anymore, so we use the function name instead
+                    // for v443, we use partial query statement
+                    expectExactlyNMatching(
+                      spans,
+                      1,
+                      verifyCouchbaseSpan(controls, entrySpan, {
+                        bucket: '',
+                        type: '',
+                        sql: version === 'v443' ? 'SELECT ' : 'GET ALL INDEXES'
+                      })
+                    );
+                    expectExactlyOneMatching(
+                      spans,
+                      verifyCouchbaseSpan(controls, entrySpan, {
+                        bucket: 'projects',
+                        type: 'membase',
+                        sql: version === 'v443' ? 'SELECT ' : 'GET ALL DATASETS '
+                      })
+                    );
                   }
                 })
               );

--- a/packages/core/src/tracing/instrumentation/database/couchbase.js
+++ b/packages/core/src/tracing/instrumentation/database/couchbase.js
@@ -94,7 +94,7 @@ function instrumentCluster(cluster, connectionStr) {
   // #### FTS SERVICE (.searchIndexes().)
   instrumentSearchIndexes(cluster, connectionStr);
 
-  // #### ANALYTICS SERVICES (.analyticsIndexes().) version >= 4.4.4
+  // #### ANALYTICS SERVICES (.analyticsIndexes().)
   instrumentAnalyticsIndexes(cluster, connectionStr);
 
   // #### N1QL SERVICE (.queryIndexes().)
@@ -114,29 +114,6 @@ function instrumentCluster(cluster, connectionStr) {
         {
           connectionStr,
           sql: tracingUtil.shortenDatabaseStatement(sqlStatement)
-        },
-        original
-      ).apply(originalThis, originalArgs);
-    };
-  });
-
-  // #### ANALYTICS SERVICE (.analyticsIndexes().) v <= 4.4.3
-  shimmer.wrap(cluster, 'analyticsQuery', function instanaClusterAnalyticsQuery(original) {
-    return function instanaClusterAnalyticsQueryWrapped() {
-      const originalThis = this;
-      const originalArgs = arguments;
-      const sqlStatement = originalArgs[0] || '';
-
-      return instrumentOperation(
-        {
-          connectionStr,
-          sql: tracingUtil.shortenDatabaseStatement(sqlStatement),
-          resultHandler: (span, result) => {
-            if (result && result.rows && result.rows.length > 0 && result.rows[0].BucketName) {
-              span.data.couchbase.bucket = result.rows[0].BucketName;
-              span.data.couchbase.type = bucketLookup[span.data.couchbase.bucket];
-            }
-          }
         },
         original
       ).apply(originalThis, originalArgs);

--- a/packages/core/src/tracing/instrumentation/database/couchbase.js
+++ b/packages/core/src/tracing/instrumentation/database/couchbase.js
@@ -92,7 +92,11 @@ function instrumentCluster(cluster, connectionStr) {
   if (!cluster) return;
 
   // #### SEARCH QUERY
-  shimmer.wrap(cluster, 'searchQuery', instrumentOperation.bind(null, { connectionStr, sql: 'SEARCHQUERY' }));
+  shimmer.wrap(
+    cluster,
+    'searchQuery',
+    instrumentOperation.bind(null, { connectionStr, sql: camelCaseToUpperWords('searchQuery') })
+  );
 
   // #### CRUD
   instrumentCollection(cluster, connectionStr);
@@ -188,7 +192,7 @@ function instrumentCollection(cluster, connectionStr) {
                     connectionStr,
                     bucketName,
                     getBucketTypeFn,
-                    sql: op.toUpperCase()
+                    sql: camelCaseToUpperWords(op)
                   },
                   original
                 ).apply(this, arguments);
@@ -253,7 +257,7 @@ function instrumentSearchIndexes(cluster, connectionStr) {
           return instrumentOperation(
             {
               connectionStr,
-              sql: fnName.toUpperCase(),
+              sql: camelCaseToUpperWords(fnName),
               bucketName,
               getBucketTypeFn,
               resultHandler: (span, result) => {
@@ -298,7 +302,7 @@ function instrumentQueryIndexes(cluster, connectionStr) {
           return instrumentOperation(
             {
               connectionStr,
-              sql: fnName.toUpperCase(),
+              sql: camelCaseToUpperWords(fnName),
               bucketName,
               getBucketTypeFn
             },
@@ -392,7 +396,7 @@ function instrumentTransactions(cluster, connectionStr) {
                     connectionStr,
                     bucketName,
                     getBucketTypeFn,
-                    sql: op.toUpperCase()
+                    sql: camelCaseToUpperWords(op)
                   },
                   original
                 ).apply(originalThis1, originalArgs1);

--- a/packages/core/src/tracing/instrumentation/database/couchbase.js
+++ b/packages/core/src/tracing/instrumentation/database/couchbase.js
@@ -129,7 +129,7 @@ function instrumentCluster(cluster, connectionStr) {
 
   // v4.4.4 introduced a breaking code change.
   // We are no longer able to extract the SQL statements for "analyticsindexes".
-  // see chnages: https://github.com/couchbase/couchnode/compare/v4.4.3...v4.4.4?diff=split&w=
+  // see changes: https://github.com/couchbase/couchnode/commit/b8118b8dd05c710e0f0d898ba8e16372028ea294
   if (instrumentLatest) {
     // #### ANALYTICS SERVICES (.analyticsIndexes().) v >= 4.4.4
     instrumentAnalyticsIndexes(cluster, connectionStr);

--- a/packages/core/src/tracing/instrumentation/database/couchbase.js
+++ b/packages/core/src/tracing/instrumentation/database/couchbase.js
@@ -48,8 +48,8 @@ exports.init = function init() {
 // CRUD operations:
 // https://github.com/couchbase/couchnode/blob/e855b094cd1b0140ffefc40f32a828b9134d181c/src/connection_autogen.cpp#L210
 function instrument(cb) {
-  // cb.RawBinaryTranscoder is added in v4.4.4,
-  // so inorder to distinguish version with v4.4.3 and lesser, we can rely on this
+  // RawBinaryTranscoder function is added in v4.4.4,
+  // so inorder to check version, we can rely on this logic
   instrumentV444 = typeof cb.RawBinaryTranscoder === 'function';
 
   // NOTE: we could instrument `cb.Collection.prototype` here, but we want to instrument each cluster connection.
@@ -124,7 +124,7 @@ function instrumentCluster(cluster, connectionStr) {
   });
 
   if (instrumentV444) {
-    // #### ANALYTICS SERVICES (.analyticsIndexes().)
+    // #### ANALYTICS SERVICES (.analyticsIndexes().) v >= 4.4.4
     instrumentAnalyticsIndexes(cluster, connectionStr);
   } else {
     // #### ANALYTICS SERVICE (.analyticsIndexes().) v <= 4.4.3


### PR DESCRIPTION
refs [INSTA-20554](https://jsw.ibm.com/browse/INSTA-20554)

couchnode changelog: https://github.com/couchbase/couchnode/compare/v4.4.3...v4.4.4

In this update, there is code changes that affects our instrumentation.

We have instrumented `cluster.analyticsQuery` for analyticsServices,

 `await this._cluster.analyticsQuery` :
  https://github.com/couchbase/couchnode/blob/e855b094cd1b0140ffefc40f32a828b9134d181c/lib/analyticsindexmanager.ts#L1039

 now the core implementation changed and we have to instrument all functions separately like
`conn.managementAnalyticsDataverseDrop `: 
https://github.com/couchbase/couchnode/blob/9e3e1f1174d5e3aa29f6499c08fafd2ccbf8dbdf/lib/analyticsindexmanager.ts#L1202C21-L1202C58
