### PR TITLE
test: upgraded the mysql docker image for M1 compatibility

### DIFF
--- a/.tekton/assets/sidecars.json
+++ b/.tekton/assets/sidecars.json
@@ -10,7 +10,7 @@
         { "name": "MYSQL_PASSWORD", "value": "nodepw" },
         { "name": "MYSQL_ROOT_HOST", "value": "0.0.0.0" }
       ],
-      "command": ["/bin/sh", "-c", "--default-authentication-plugin=mysql_native_password"],
+      "command": ["mysqld", "--default-authentication-plugin=mysql_native_password"],
       "readinessProbe": {
         "exec": {
           "command": ["sh", "-c", "mysql -h 0.0.0.0 -u node -p'nodepw' -e 'SELECT 1'"]

--- a/.tekton/assets/sidecars.json
+++ b/.tekton/assets/sidecars.json
@@ -10,7 +10,7 @@
         { "name": "MYSQL_PASSWORD", "value": "nodepw" },
         { "name": "MYSQL_ROOT_HOST", "value": "0.0.0.0" }
       ],
-      "command": "--default-authentication-plugin=mysql_native_password",
+      "command": ["/bin/sh", "-c", "--default-authentication-plugin=mysql_native_password"],
       "readinessProbe": {
         "exec": {
           "command": ["sh", "-c", "mysql -h 0.0.0.0 -u node -p'nodepw' -e 'SELECT 1'"]

--- a/.tekton/assets/sidecars.json
+++ b/.tekton/assets/sidecars.json
@@ -2,7 +2,7 @@
   "sidecars": [
     {
       "name": "mysql",
-      "image": "mysql:8.0.1",
+      "image": "mysql:8.0.26",
       "env": [
         { "name": "MYSQL_ROOT_PASSWORD", "value": "nodepw" },
         { "name": "MYSQL_DATABASE", "value": "nodedb" },
@@ -10,6 +10,7 @@
         { "name": "MYSQL_PASSWORD", "value": "nodepw" },
         { "name": "MYSQL_ROOT_HOST", "value": "0.0.0.0" }
       ],
+      "command": "--default-authentication-plugin=mysql_native_password",
       "readinessProbe": {
         "exec": {
           "command": ["sh", "-c", "mysql -h 0.0.0.0 -u node -p'nodepw' -e 'SELECT 1'"]

--- a/.tekton/tasks/test-groups/test-ci-collector-general-task.yaml
+++ b/.tekton/tasks/test-groups/test-ci-collector-general-task.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   sidecars:
     - name: mysql
-      image: mysql:8.0.1
+      image: mysql:8.0.26
       env:
           - name: "MYSQL_ROOT_PASSWORD"
             value: "nodepw"

--- a/.tekton/tasks/test-groups/test-ci-collector-tracing-database-task.yaml
+++ b/.tekton/tasks/test-groups/test-ci-collector-tracing-database-task.yaml
@@ -29,7 +29,7 @@ spec:
           periodSeconds: 2
           timeoutSeconds: 60
     - name: mysql
-      image: mysql:8.0.1
+      image: mysql:8.0.26
       env:
           - name: "MYSQL_ROOT_PASSWORD"
             value: "nodepw"

--- a/docker-compose-base.yaml
+++ b/docker-compose-base.yaml
@@ -119,10 +119,11 @@ services:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
 
   mysql:
-    image: mysql:8.0.1
+    image: mysql:8.0.26
     platform: linux/amd64
     ports:
       - 3306:3306
+    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: nodepw
       MYSQL_DATABASE: nodedb


### PR DESCRIPTION
- Upgraded MySQL image version to 8.0.26 to support M1. https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-26.html
- Included `--default-authentication-plugin=mysql_native_password` to ensure compatibility with older MySQL clients.

REF INSTA-796