### PR TITLE
chore: updated ignore endpoints configuration format

### DIFF
--- a/packages/collector/src/announceCycle/unannounced.js
+++ b/packages/collector/src/announceCycle/unannounced.js
@@ -224,7 +224,7 @@ function applySpanBatchingConfiguration(agentResponse) {
 }
 
 /**
- * The agent configuration currently follows the `string[]` format.
+ * The agent configuration returns the `string[]` format.
  * For more information, see the related design discussion:
  * https://github.ibm.com/instana/requests-for-discussion/pull/84
  *

--- a/packages/collector/src/announceCycle/unannounced.js
+++ b/packages/collector/src/announceCycle/unannounced.js
@@ -224,11 +224,9 @@ function applySpanBatchingConfiguration(agentResponse) {
 }
 
 /**
- * - The agent configuration currently uses a pipe ('|') as a separator for endpoints.
- * - This function supports both ('|') and comma (',') to ensure future compatibility.
- * - Additionally, it supports the `string[]` format for backward compatibility,
- *   as this was the previously used standard. The final design decision is not yet completed.
- *   https://github.ibm.com/instana/requests-for-discussion/pull/84
+ * The agent configuration currently follows the `string[]` format.
+ * For more information, see the related design discussion:
+ * https://github.ibm.com/instana/requests-for-discussion/pull/84
  *
  * @param {AgentAnnounceResponse} agentResponse
  */
@@ -239,9 +237,7 @@ function applyIgnoreEndpointsConfiguration(agentResponse) {
     const endpointTracingConfig = Object.fromEntries(
       Object.entries(endpointTracingConfigFromAgent).map(([service, endpoints]) => {
         let normalizedEndpoints = null;
-        if (typeof endpoints === 'string') {
-          normalizedEndpoints = endpoints.split(/[|,]/).map(endpoint => endpoint?.trim()?.toLowerCase());
-        } else if (Array.isArray(endpoints)) {
+        if (Array.isArray(endpoints)) {
           normalizedEndpoints = endpoints.map(endpoint => endpoint?.toLowerCase());
         }
 

--- a/packages/collector/test/announceCycle/unannounced_test.js
+++ b/packages/collector/test/announceCycle/unannounced_test.js
@@ -217,7 +217,7 @@ describe('unannounced state', () => {
       prepareAnnounceResponse({
         tracing: {
           'ignore-endpoints': {
-            redis: 'get'
+            redis: ['get']
           }
         }
       });
@@ -239,7 +239,7 @@ describe('unannounced state', () => {
       prepareAnnounceResponse({
         tracing: {
           'ignore-endpoints': {
-            redis: 'SET|GET'
+            redis: ['SET', 'GET']
           }
         }
       });
@@ -261,8 +261,8 @@ describe('unannounced state', () => {
       prepareAnnounceResponse({
         tracing: {
           'ignore-endpoints': {
-            REDIS: 'get|set',
-            dynamodb: 'query'
+            REDIS: ['GET', 'SET'],
+            dynamodb: ['query']
           }
         }
       });
@@ -281,11 +281,11 @@ describe('unannounced state', () => {
       });
     });
 
-    it('should apply tracing configuration to ignore endpoints when specified using array format', done => {
+    it('should set ignoreEndpoints to null when the format is invalid', done => {
       prepareAnnounceResponse({
         tracing: {
           'ignore-endpoints': {
-            REDIS: ['get', 'type'],
+            REDIS: 'get|set',
             dynamodb: 'query'
           }
         }
@@ -295,8 +295,8 @@ describe('unannounced state', () => {
           expect(agentOptsStub.config).to.deep.equal({
             tracing: {
               ignoreEndpoints: {
-                redis: ['get', 'type'],
-                dynamodb: ['query']
+                redis: null,
+                dynamodb: null
               }
             }
           });

--- a/packages/collector/test/tracing/database/ioredis/test.js
+++ b/packages/collector/test/tracing/database/ioredis/test.js
@@ -1344,7 +1344,7 @@ function checkConnection(span, setupType) {
           useGlobalAgent: true,
           dirname: __dirname,
           env: {
-            INSTANA_IGNORE_ENDPOINTS: '{"redis": ["get"]}'
+            INSTANA_IGNORE_ENDPOINTS: 'redis:get'
           }
         });
         await controls.start();

--- a/packages/collector/test/tracing/database/ioredis/test.js
+++ b/packages/collector/test/tracing/database/ioredis/test.js
@@ -1289,7 +1289,7 @@ function checkConnection(span, setupType) {
 
       before(async () => {
         await customAgentControls.startAgent({
-          ignoreEndpoints: { redis: 'get|set' }
+          ignoreEndpoints: { redis: ['get', 'set'] }
         });
 
         controls = new ProcessControls({

--- a/packages/collector/test/tracing/database/redis/test.js
+++ b/packages/collector/test/tracing/database/redis/test.js
@@ -918,7 +918,7 @@ const globalAgent = require('../../../globalAgent');
                   env: {
                     REDIS_VERSION: redisVersion,
                     REDIS_PKG: redisPkg,
-                    INSTANA_IGNORE_ENDPOINTS: '{"redis": ["get","set"]}'
+                    INSTANA_IGNORE_ENDPOINTS: 'redis:get,set;'
                   }
                 });
                 await controls.start();

--- a/packages/collector/test/tracing/database/redis/test.js
+++ b/packages/collector/test/tracing/database/redis/test.js
@@ -859,7 +859,7 @@ const globalAgent = require('../../../globalAgent');
               let controls;
               before(async () => {
                 await customAgentControls.startAgent({
-                  ignoreEndpoints: { redis: 'get|set' }
+                  ignoreEndpoints: { redis: ['get', 'set'] }
                 });
 
                 controls = new ProcessControls({

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -718,23 +718,24 @@ function normalizeIgnoreEndpoints(config) {
       }
     });
   } else if (process.env.INSTANA_IGNORE_ENDPOINTS) {
-    // Expected format: "service:endpoint1,endpoint2;service2:endpoint1"
     try {
-      const parsedEndpoints = Object.fromEntries(
+      const ignoreEndpoints = Object.fromEntries(
         process.env.INSTANA_IGNORE_ENDPOINTS.split(';')
-          .map(entry => {
-            const [service, endpoints] = (entry || '').split(':');
-            if (!service || !endpoints) {
+          .map(serviceEntry => {
+            const [serviceName, endpointList] = (serviceEntry || '').split(':').map(part => part.trim());
+
+            if (!serviceName || !endpointList) {
               logger.warn(
-                `Invalid entry in INSTANA_IGNORE_ENDPOINTS ${process.env.INSTANA_IGNORE_ENDPOINTS}: ${entry}. Expected format is "service:endpoint1,endpoint2".`
+                `Invalid entry in INSTANA_IGNORE_ENDPOINTS ${process.env.INSTANA_IGNORE_ENDPOINTS}: "${serviceEntry}". Expected format is e.g. "service:endpoint1,endpoint2".`
               );
               return null;
             }
-            return [service.toLowerCase(), endpoints.split(',').map(endpoint => endpoint.trim().toLowerCase())];
+
+            return [serviceName.toLowerCase(), endpointList.split(',').map(endpoint => endpoint.trim().toLowerCase())];
           })
           .filter(Boolean)
       );
-      config.tracing.ignoreEndpoints = parsedEndpoints;
+      config.tracing.ignoreEndpoints = ignoreEndpoints;
     } catch (error) {
       logger.warn(
         `Failed to parse INSTANA_IGNORE_ENDPOINTS: ${process.env.INSTANA_IGNORE_ENDPOINTS}. Error: ${error.message}`

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -482,11 +482,21 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.ignoreEndpoints).to.deep.equal({ redis: ['get', 'set'] });
   });
 
+  it('should correctly parse INSTANA_IGNORE_ENDPOINTS containing multiple services and endpoints', () => {
+      process.env.INSTANA_IGNORE_ENDPOINTS = 'redis:get,set; dynamodb:query';
+      const config = normalizeConfig();
+      expect(config.tracing.ignoreEndpoints).to.deep.equal({
+        redis: ['get', 'set'],
+        dynamodb: ['query']
+      });
+    });
+
   it('should fallback to default if INSTANA_IGNORE_ENDPOINTS is set but has an invalid format', () => {
     process.env.INSTANA_IGNORE_ENDPOINTS = '"redis=get,set"';
     const config = normalizeConfig();
     expect(config.tracing.ignoreEndpoints).to.deep.equal({});
   });
+
   it('should apply ignore endpoints via config', () => {
     const config = normalizeConfig({
       tracing: {

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -477,13 +477,13 @@ describe('util.normalizeConfig', () => {
   });
 
   it('should apply ignore endpoints if the INSTANA_IGNORE_ENDPOINTS is set and valid', () => {
-    process.env.INSTANA_IGNORE_ENDPOINTS = '{"redis": ["get", "set"]}';
+    process.env.INSTANA_IGNORE_ENDPOINTS = 'redis:get,set;"';
     const config = normalizeConfig();
     expect(config.tracing.ignoreEndpoints).to.deep.equal({ redis: ['get', 'set'] });
   });
 
   it('should fallback to default if INSTANA_IGNORE_ENDPOINTS is set but has an invalid format', () => {
-    process.env.INSTANA_IGNORE_ENDPOINTS = '"redis": ["get", "set"]';
+    process.env.INSTANA_IGNORE_ENDPOINTS = '"redis=get,set"';
     const config = normalizeConfig();
     expect(config.tracing.ignoreEndpoints).to.deep.equal({});
   });

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -477,7 +477,7 @@ describe('util.normalizeConfig', () => {
   });
 
   it('should apply ignore endpoints if the INSTANA_IGNORE_ENDPOINTS is set and valid', () => {
-    process.env.INSTANA_IGNORE_ENDPOINTS = 'redis:get,set;"';
+    process.env.INSTANA_IGNORE_ENDPOINTS = 'redis:get,set;';
     const config = normalizeConfig();
     expect(config.tracing.ignoreEndpoints).to.deep.equal({ redis: ['get', 'set'] });
   });


### PR DESCRIPTION
Based on the design discussion, 
- Removed support for pipe-separated values in the agent’s ignore endpoints configuration; now only a string array (`[]`) is supported.
- Changed the format of `INSTANA_IGNORE_ENDPOINTS` from a JSON string to the format: `service:endpoint1,endpoint2;service2:endpoint1`.

https://github.ibm.com/instana/requests-for-discussion/pull/84