### PR TITLE
chore: updated mocharc for mocha watch

### DIFF
--- a/packages/autoprofile/test/.mocharc.js
+++ b/packages/autoprofile/test/.mocharc.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const mochaOptions = {
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
 
 process.env.NODE_ENV = 'test';

--- a/packages/aws-fargate/test/.mocharc.js
+++ b/packages/aws-fargate/test/.mocharc.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const mochaOptions = {
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
 
 process.env.NODE_ENV = 'test';

--- a/packages/aws-lambda-auto-wrap/test/.mocharc.js
+++ b/packages/aws-lambda-auto-wrap/test/.mocharc.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const mochaOptions = {
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
 
 process.env.NODE_ENV = 'test';

--- a/packages/aws-lambda/test/.mocharc.js
+++ b/packages/aws-lambda/test/.mocharc.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const mochaOptions = {
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
 
 process.env.NODE_ENV = 'test';

--- a/packages/azure-container-services/test/.mocharc.js
+++ b/packages/azure-container-services/test/.mocharc.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const mochaOptions = {
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
 
 process.env.NODE_ENV = 'test';

--- a/packages/collector/test/.mocharc.js
+++ b/packages/collector/test/.mocharc.js
@@ -2,7 +2,8 @@
 
 const mochaOptions = {
   file: ['test/initEnv.js'],
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
 
 // To address the certificate authorization issue with node-fetch, process.env.NODE_TLS_REJECT_UNAUTHORIZED

--- a/packages/core/test/.mocharc.js
+++ b/packages/core/test/.mocharc.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const mochaOptions = {
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
 
 process.env.NODE_ENV = 'test';

--- a/packages/google-cloud-run/test/.mocharc.js
+++ b/packages/google-cloud-run/test/.mocharc.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const mochaOptions = {
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
 
 process.env.NODE_ENV = 'test';

--- a/packages/metrics-util/test/.mocharc.js
+++ b/packages/metrics-util/test/.mocharc.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const mochaOptions = {
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
 
 module.exports = mochaOptions;

--- a/packages/opentelemetry-exporter/test/.mocharc.js
+++ b/packages/opentelemetry-exporter/test/.mocharc.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const mochaOptions = {
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
 
 process.env.NODE_ENV = 'test';

--- a/packages/opentelemetry-sampler/test/.mocharc.js
+++ b/packages/opentelemetry-sampler/test/.mocharc.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const mochaOptions = {
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
 
 process.env.NODE_ENV = 'test';

--- a/packages/serverless-collector/test/.mocharc.js
+++ b/packages/serverless-collector/test/.mocharc.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const mochaOptions = {
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
 
 process.env.NODE_ENV = 'test';

--- a/packages/serverless/test/.mocharc.js
+++ b/packages/serverless/test/.mocharc.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const mochaOptions = {
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
 
 process.env.NODE_ENV = 'test';

--- a/packages/shared-metrics/test/.mocharc.js
+++ b/packages/shared-metrics/test/.mocharc.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const mochaOptions = {
-  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*']
+  ignore: ['node_modules/**/*', 'test/**/node_modules/**/*'],
+  watchFiles: ['test/**/*', '../*/src/**/*']
 };
+
 process.env.NODE_ENV = 'test';
 module.exports = mochaOptions;


### PR DESCRIPTION
When you saved a src file in another pkg, mocha watch did not re-run. Improved the mocha watch files option.
I guess we could add one mocharc.js file for all packages, but can be changed later.