### PR TITLE
test: enabled LocalStack Lambda invocation on ARM64

### DIFF
--- a/docker-compose-base.yaml
+++ b/docker-compose-base.yaml
@@ -204,7 +204,7 @@ services:
        - ./db2/db2_data:/db2_data
 
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
     image: localstack/localstack:latest
     hostname: localstack
     ports:

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/lambda/utils.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/lambda/utils.js
@@ -13,14 +13,12 @@ const {
 const AdmZip = require('adm-zip');
 const { isCI } = require('@instana/core/test/test_util');
 /**
- *  Local stack is disabled if running in CI environment or on an ARM64 architecture.
- *  Lambda invocation is currently not running on ARM64 architectures, and we haven't tested
- *  it on Tekton yet.
- *  refs https://github.com/localstack/localstack/issues/8878
- *  TODO: Implement support for running Lambda function tests on LocalStack with Tekton and ARM64 architecture.
+ * LocalStack is disabled when running in a CI environment.
+ * Lambda invocation has not yet been tested on Tekton.
+ * TODO: Add support for running Lambda function tests on LocalStack with Tekton.
  */
 exports.isLocalStackDisabled = function () {
-  return isCI() || process.arch === 'arm64';
+  return isCI();
 };
 
 exports.getClientConfig = function () {


### PR DESCRIPTION
LocalStack was previously disabled on ARM64 for Lambda invocation tests due to [issue #8878](https://github.com/localstack/localstack/issues/8878). When running alongside other containers locally, the tests were failing. However, in our new test setup and with the latest version of LocalStack, the issue appears to be resolved.