### PR TITLE
chore: updated the eslint rule to disable no-restricted-syntax

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,6 +70,7 @@ module.exports = {
     'no-plusplus': 'off',
     'no-promise-executor-return': 'off',
     'no-restricted-globals': 'off',
+    'no-restricted-syntax': 'off',
     'no-underscore-dangle': 'off',
     'no-use-before-define': ['error', 'nofunc'],
     'no-var': 'error',

--- a/bin/currency/generate-currency-report.js
+++ b/bin/currency/generate-currency-report.js
@@ -129,7 +129,6 @@ function jsonToMarkdown(data) {
     // eslint-disable-next-line max-len
     '|--------------|---------|---------|-----------------------------|----------------|-------------|------------|------|--------------|--------------|\n';
 
-  // eslint-disable-next-line no-restricted-syntax
   for (const entry of data) {
     // eslint-disable-next-line max-len
     markdown += `| ${entry.name} | ${entry.lastSupportedVersion} | ${entry.latestVersion} | ${entry.publishedAt} | ${entry.policy} | ${entry.daysBehind} day/s | ${entry.upToDate} | ${entry.note} | ${entry.cloudNative} | ${entry.isBeta} |\n`;

--- a/packages/autoprofile/lib/profile.js
+++ b/packages/autoprofile/lib/profile.js
@@ -3,8 +3,6 @@
  * (c) Copyright Instana Inc. and contributors 2020
  */
 
-/* eslint-disable no-restricted-syntax */
-
 'use strict';
 
 const process = require('process');

--- a/packages/autoprofile/lib/samplers/allocation_sampler.js
+++ b/packages/autoprofile/lib/samplers/allocation_sampler.js
@@ -62,7 +62,6 @@ class AllocationSampler {
 
   buildProfile(duration, timespan) {
     const roots = new Set();
-    // eslint-disable-next-line no-restricted-syntax
     for (const child of this.top.children.values()) {
       roots.add(child);
     }

--- a/packages/autoprofile/lib/samplers/async_sampler.js
+++ b/packages/autoprofile/lib/samplers/async_sampler.js
@@ -3,8 +3,6 @@
  * (c) Copyright Instana Inc. and contributors 2020
  */
 
-/* eslint-disable no-restricted-syntax */
-
 'use strict';
 
 const { uninstrumentedFs: fs } = require('@instana/core');

--- a/packages/autoprofile/lib/samplers/cpu_sampler.js
+++ b/packages/autoprofile/lib/samplers/cpu_sampler.js
@@ -50,7 +50,6 @@ class CpuSampler {
 
   buildProfile(duration, timespan) {
     const roots = new Set();
-    // eslint-disable-next-line no-restricted-syntax
     for (const child of this.top.children.values()) {
       roots.add(child);
     }

--- a/packages/collector/src/announceCycle/defaultGatewayParser.js
+++ b/packages/collector/src/announceCycle/defaultGatewayParser.js
@@ -51,7 +51,6 @@ exports._parseFile = async function _parseFile(filename) {
   }
 
   logger.debug(`Successfully opened ${filename} for reading to determine the default gateway IP.`);
-  // eslint-disable-next-line no-restricted-syntax
   for (const line of fileContent.split('\n')) {
     const fields = line.split('\t');
     if (exports._isDefaultGatewayLine(fields)) {

--- a/packages/collector/test/tracing/database/redis/app.js
+++ b/packages/collector/test/tracing/database/redis/app.js
@@ -140,7 +140,6 @@ app.get('/blocking', async (req, res) => {
 });
 
 app.get('/scan-iterator', async (req, res) => {
-  // eslint-disable-next-line no-restricted-syntax
   for await (const key of connection.scanIterator()) {
     try {
       await connection.get(key);

--- a/packages/collector/test/tracing/messaging/nats/subscriber.js
+++ b/packages/collector/test/tracing/messaging/nats/subscriber.js
@@ -38,7 +38,6 @@ if (process.env.NATS_VERSION === 'latest') {
     const sub = nats.subscribe('publish-test-subject');
 
     (async () => {
-      // eslint-disable-next-line no-restricted-syntax
       for await (const m of sub) {
         const msg = sc.decode(m.data);
         log(`publish-test-subject: received: "${msg}"`);
@@ -57,7 +56,6 @@ if (process.env.NATS_VERSION === 'latest') {
     let currentSpan;
 
     (async () => {
-      // eslint-disable-next-line no-restricted-syntax
       for await (const m of sub2) {
         const msg = sc.decode(m.data);
         log(`subscribe-test-subject: received: "${msg}"`);

--- a/packages/core/src/tracing/instrumentation/messaging/nats.js
+++ b/packages/core/src/tracing/instrumentation/messaging/nats.js
@@ -302,7 +302,6 @@ function instrumentedSubscribe(ctx, originalSubscribe, originalSubscribeArgs, is
       const createIterator = async function* instanaIterator() {
         cls.ns.enter(currentCtx);
 
-        // eslint-disable-next-line no-restricted-syntax
         for await (const msg of sub) {
           await new Promise(resolve => {
             instrumentedSubscribeCallback(ctx._natsUrl, subject, resolve, currentCtx, isLatest)(null, msg);
@@ -332,7 +331,6 @@ function instrumentedSubscribeCallback(natsUrl, subject, originalSubscribeCallba
     }
 
     if (isLatest && msg && msg.headers) {
-      // eslint-disable-next-line no-restricted-syntax
       for (const [key, value] of msg.headers) {
         if (key === constants.traceLevelHeaderName && value[0] === '0') {
           suppressed = true;

--- a/packages/core/src/util/clone.js
+++ b/packages/core/src/util/clone.js
@@ -29,7 +29,6 @@ module.exports = function clone(x) {
   if (typeof x === 'object') {
     r = {};
 
-    // eslint-disable-next-line no-restricted-syntax
     for (const key in x) {
       // eslint-disable-next-line no-prototype-builtins
       if (x.hasOwnProperty(key)) {

--- a/packages/core/src/util/compression.js
+++ b/packages/core/src/util/compression.js
@@ -67,7 +67,6 @@ function applyCompressionToObject(path, prev, next, excludeList) {
   const result = {};
   let addedProps = 0;
 
-  // eslint-disable-next-line no-restricted-syntax
   for (const nKey in next) {
     // eslint-disable-next-line no-prototype-builtins
     if (next.hasOwnProperty(nKey)) {
@@ -121,7 +120,7 @@ function isExcluded(path, excludeList) {
   }
 
   // Compare the given path to all excludeList entries.
-  // eslint-disable-next-line no-restricted-syntax
+
   outer: for (let i = 0; i < excludeList.length; i++) {
     if (excludeList[i].length !== path.length) {
       // The excludeList entry and then given path have different lengths, this cannot be a match. Continue with next

--- a/packages/shared-metrics/src/healthchecks.js
+++ b/packages/shared-metrics/src/healthchecks.js
@@ -57,7 +57,6 @@ function gatherHealthcheckResults() {
       /** @type {Object.<string, *>} */
       const previousResults = exports.currentPayload;
 
-      // eslint-disable-next-line no-restricted-syntax
       for (const key in adminHealthcheckResults) {
         // eslint-disable-next-line no-prototype-builtins
         if (adminHealthcheckResults.hasOwnProperty(key)) {


### PR DESCRIPTION
Our team follows the [Airbnb JavaScript style guide](https://github.com/airbnb/javascript/blob/6499695ac11c4640ed0f77f8865a1adcb32d3239/packages/eslint-config-airbnb-base/rules/style.js#L340-L358), and `no-restricted-syntax` rule recommends avoiding constructs like `for..in`, `for..of`, labeled statements, I believe that these constructs can be practical in some cases for our project. Specifically, we are comfortable using `for` loops when needed. 

Since we’ve already ignored this rule in 15 places across our codebase, disabling it globally would simplify our ESLint configuration and eliminate the need for repetitive exclusions. This change allows us to focus on more relevant rules for our code while maintaining the flexibility to use `for` loops and similar constructs where appropriate and avoid adding unwanted comments.

I think it’s reasonable to disable this rule for our team.