### PR TITLE
test: added delay in test to resolve intermittent failure

### DIFF
--- a/packages/collector/test/tracing/sdk/allowRootExitSpans/test.js
+++ b/packages/collector/test/tracing/sdk/allowRootExitSpans/test.js
@@ -40,7 +40,7 @@ mochaSuiteFn('tracing/sdk/rootExitSpans', function () {
     });
 
     it('should collect spans including sdk wrap', async () => {
-      await delay(100);
+      await delay(200);
 
       await retry(async () => {
         const spans = await agentControls.getSpans();
@@ -66,7 +66,7 @@ mochaSuiteFn('tracing/sdk/rootExitSpans', function () {
     });
 
     it('should trace single exit span only', async () => {
-      await delay(100);
+      await delay(200);
 
       await retry(async () => {
         const spans = await globalAgent.instance.getSpans();


### PR DESCRIPTION
The test was failing intermittently due to timing issues. Increased the delay to provide enough time for the required conditions to be met, ensuring the test runs more reliably. 

ref https://cloud.ibm.com/devops/pipelines/tekton/c2cd6a8d-ea5a-47b0-913e-cd172d63833f/runs/16854594-c254-418c-82d3-afa562aa4a87/test-ci-collector-tracing-general-task/run-test-group?env_id=ibm:yp:eu-de