### PR TITLE
fix: pino agent stream messages were undefined

### DIFF
--- a/packages/collector/src/agent/loggerToAgentStream.js
+++ b/packages/collector/src/agent/loggerToAgentStream.js
@@ -15,6 +15,12 @@ module.exports = {
    * @param {*} record
    */
   write: function write(record) {
+    try {
+      record = JSON.parse(record);
+    } catch (error) {
+      // ignore
+    }
+
     const logLevel = getAgentLogLevel(record.level);
     let message = `Node.js collector (pid: ${process.pid}, reporting pid: ${pidStore.pid}): ${record.msg}`;
     let stack = null;


### PR DESCRIPTION
Fixes pino agent stream msgs being 'undefined'.

We have to parse before sending it to the agentstream.