### PR TITLE
fix: resolved logging objects being undefined or missing

### DIFF
--- a/packages/aws-fargate/src/activate.js
+++ b/packages/aws-fargate/src/activate.js
@@ -70,8 +70,9 @@ function init() {
       // eslint-disable-next-line no-unused-expressions
       process.send && process.send('instana.aws-fargate.initialized');
     } catch (e) {
-      logger.error(`Initializing @instana/aws-fargate failed. This fargate task will not be monitored. 
-        ${JSON.stingify(e)}`);
+      logger.error(
+        `Initializing @instana/aws-fargate failed. This fargate task will not be monitored. ${e.message} ${e.stack}`
+      );
     }
   });
 }

--- a/packages/aws-fargate/src/activate.js
+++ b/packages/aws-fargate/src/activate.js
@@ -30,7 +30,9 @@ function init() {
 
   metrics.init(config, function onReady(err, ecsContainerPayload) {
     if (err) {
-      logger.error('Initializing @instana/aws-fargate failed. This fargate task will not be monitored.', err);
+      logger.error(
+        `Initializing @instana/aws-fargate failed. This fargate task will not be monitored. ${err.message} ${err.stack}`
+      );
       metrics.deactivate();
       return;
     }
@@ -68,7 +70,8 @@ function init() {
       // eslint-disable-next-line no-unused-expressions
       process.send && process.send('instana.aws-fargate.initialized');
     } catch (e) {
-      logger.error('Initializing @instana/aws-fargate failed. This fargate task will not be monitored.', e);
+      logger.error(`Initializing @instana/aws-fargate failed. This fargate task will not be monitored. 
+        ${JSON.stingify(e)}`);
     }
   });
 }

--- a/packages/aws-lambda/src/metrics/npmPackageDescription.js
+++ b/packages/aws-lambda/src/metrics/npmPackageDescription.js
@@ -16,7 +16,7 @@ exports.currentPayload = undefined;
 exports.activate = function activate() {
   coreUtil.applicationUnderMonitoring.getMainPackageJsonStartingAtDirectory(rootDir.root, (err, pckg) => {
     if (err) {
-      logger.warn('Failed to determine main package json. Reason: ', err.message, err.stack);
+      logger.warn(`Failed to determine main package json. Reason: ${err.message} ${err.stack}`);
     }
 
     if (!err && pckg) {

--- a/packages/aws-lambda/src/metrics/npmPackageName.js
+++ b/packages/aws-lambda/src/metrics/npmPackageName.js
@@ -16,7 +16,7 @@ exports.currentPayload = undefined;
 exports.activate = function activate() {
   coreUtil.applicationUnderMonitoring.getMainPackageJsonStartingAtDirectory(rootDir.root, (err, pckg) => {
     if (err) {
-      logger.warn('Failed to determine main package json. Reason: ', err.message, err.stack);
+      logger.warn(`Failed to determine main package json. Reason: ${err.message} ${err.stack}`);
     }
 
     if (!err && pckg) {

--- a/packages/aws-lambda/src/metrics/npmPackageVersion.js
+++ b/packages/aws-lambda/src/metrics/npmPackageVersion.js
@@ -16,7 +16,7 @@ exports.currentPayload = undefined;
 exports.activate = function activate() {
   coreUtil.applicationUnderMonitoring.getMainPackageJsonStartingAtDirectory(rootDir.root, (err, pckg) => {
     if (err) {
-      logger.warn('Failed to determine main package json. Reason: ', err.message, err.stack);
+      logger.warn(`Failed to determine main package json. Reason: ${err.message} ${err.stack}`);
     }
 
     if (!err && pckg) {

--- a/packages/collector/src/actions/source.js
+++ b/packages/collector/src/actions/source.js
@@ -37,7 +37,7 @@ exports.getSourceFile = (request, multiCb) => {
 function readFile(request, multiCb) {
   fs.readFile(request.args.file, { encoding: 'utf8' }, (error, content) => {
     if (error) {
-      logger.debug('Failed to retrieve source file for user request: %s.', request.args.file, { error });
+      logger.debug(`Failed to retrieve source file for user request: ${request.args.file}. ${error}`);
       multiCb({
         error: `Could not load file. Error: ${error.message}`
       });

--- a/packages/collector/src/actions/source.js
+++ b/packages/collector/src/actions/source.js
@@ -37,7 +37,9 @@ exports.getSourceFile = (request, multiCb) => {
 function readFile(request, multiCb) {
   fs.readFile(request.args.file, { encoding: 'utf8' }, (error, content) => {
     if (error) {
-      logger.debug(`Failed to retrieve source file for user request: ${request.args.file}. ${error}`);
+      logger.debug(
+        `Failed to retrieve source file for user request: ${request.args.file}. ${error.message} ${error.stack}`
+      );
       multiCb({
         error: `Could not load file. Error: ${error.message}`
       });

--- a/packages/collector/src/agent/requestHandler.js
+++ b/packages/collector/src/agent/requestHandler.js
@@ -61,8 +61,10 @@ function handleRequest(request) {
 function sendResponse(request, response) {
   agentConnection.sendAgentResponseToAgent(request.messageId, response, error => {
     if (error) {
-      logger.warn(`Failed to send agent response for action ${request.action} and message ID ${request.messageId}`);
-      logger.warn(`Error: ${error.message} ${error.stack}`);
+      logger.warn(
+        `Failed to send agent response for action ${request.action} and message ID ${request.messageId}.
+        Error: ${error.message} ${error.stack}`
+      );
     }
   });
 }

--- a/packages/collector/src/agent/requestHandler.js
+++ b/packages/collector/src/agent/requestHandler.js
@@ -62,7 +62,7 @@ function sendResponse(request, response) {
   agentConnection.sendAgentResponseToAgent(request.messageId, response, error => {
     if (error) {
       logger.warn(`Failed to send agent response for action ${request.action} and message ID ${request.messageId}`);
-      logger.warn(`Error: ${error}`);
+      logger.warn(`Error: ${error.message} ${error.stack}`);
     }
   });
 }

--- a/packages/collector/src/agent/requestHandler.js
+++ b/packages/collector/src/agent/requestHandler.js
@@ -61,9 +61,8 @@ function handleRequest(request) {
 function sendResponse(request, response) {
   agentConnection.sendAgentResponseToAgent(request.messageId, response, error => {
     if (error) {
-      logger.warn('Failed to send agent response for action %s and message ID %s', request.action, request.messageId, {
-        error
-      });
+      logger.warn(`Failed to send agent response for action ${request.action} and message ID ${request.messageId}`);
+      logger.warn(`Error: ${error}`);
     }
   });
 }

--- a/packages/collector/src/agentConnection.js
+++ b/packages/collector/src/agentConnection.js
@@ -372,9 +372,9 @@ function sendData(path, data, cb, ignore404 = false) {
 
   const payloadAsString = JSON.stringify(data, circularReferenceRemover());
   if (typeof logger.trace === 'function') {
-    logger.trace('Sending data to %s', path);
+    logger.trace(`Sending data to ${path}.`);
   } else {
-    logger.debug('Sending data to %s %o', path, agentOpts);
+    logger.debug(`Sending data to ${path}, ${agentOpts}`);
   }
 
   // Convert payload to a buffer to correctly identify content-length ahead of time.

--- a/packages/collector/src/agentConnection.js
+++ b/packages/collector/src/agentConnection.js
@@ -271,7 +271,7 @@ exports.sendSpans = function sendSpans(spans, cb) {
       logger.debug(`Failed to send: ${JSON.stringify(spanInfo)}`);
     } else {
       const spanInfo = getSpanLengthInfo(spans);
-      logger.debug(`Successfully sent:${JSON.stringify(spanInfo)}`);
+      logger.debug(`Successfully sent: ${JSON.stringify(spanInfo)}`);
     }
     cb(err);
   });
@@ -374,7 +374,7 @@ function sendData(path, data, cb, ignore404 = false) {
   if (typeof logger.trace === 'function') {
     logger.trace('Sending data to %s', path);
   } else {
-    logger.debug('Sending data to %s', path, agentOpts);
+    logger.debug('Sending data to %s %o', path, agentOpts);
   }
 
   // Convert payload to a buffer to correctly identify content-length ahead of time.

--- a/packages/collector/src/announceCycle/agentready.js
+++ b/packages/collector/src/announceCycle/agentready.js
@@ -214,7 +214,9 @@ function sendEOLEvent() {
     },
     err => {
       if (err) {
-        logger.debug('Sending a monitoring event for the Node.js version end-of-life check has failed.', err);
+        logger.debug(
+          `Sending a monitoring event for the Node.js version end-of-life check has failed. ${JSON.stringify(err)}`
+        );
       }
     }
   );

--- a/packages/collector/src/announceCycle/agentready.js
+++ b/packages/collector/src/announceCycle/agentready.js
@@ -215,7 +215,7 @@ function sendEOLEvent() {
     err => {
       if (err) {
         logger.debug(
-          `Sending a monitoring event for the Node.js version end-of-life check has failed. ${JSON.stringify(err)}`
+          `Sending a monitoring event for the Node.js version end-of-life check has failed. ${err.message} ${err.stack}`
         );
       }
     }

--- a/packages/collector/src/announceCycle/unannounced.js
+++ b/packages/collector/src/announceCycle/unannounced.js
@@ -95,7 +95,7 @@ function tryToAnnounce(ctx, retryDelay = initialRetryDelay) {
       logger.error(
         "Failed to parse the JSON payload from the Instana host agent's response. Establishing the connection" +
           `to the Instana host agent will be retried in ${retryDelay} ms. The response payload was ${rawResponse}.` +
-          `${e?.message} ${e?.stack}`
+          `${e.message} ${e.stack}`
       );
       setTimeout(tryToAnnounce, retryDelay, ctx, nextRetryDelay).unref();
       return;

--- a/packages/collector/src/announceCycle/unannounced.js
+++ b/packages/collector/src/announceCycle/unannounced.js
@@ -93,11 +93,9 @@ function tryToAnnounce(ctx, retryDelay = initialRetryDelay) {
       agentResponse = JSON.parse(rawResponse);
     } catch (e) {
       logger.error(
-        "Failed to parse the JSON payload from the Instana host agent's response. Establishing the " +
-          'connection to the Instana host agent will be retried in %s ms. The response payload was %s.',
-        retryDelay,
-        rawResponse,
-        e
+        "Failed to parse the JSON payload from the Instana host agent's response. Establishing the connection" +
+          `to the Instana host agent will be retried in ${retryDelay} ms. The response payload was ${rawResponse}.` +
+          `${e?.message} ${e?.stack}`
       );
       setTimeout(tryToAnnounce, retryDelay, ctx, nextRetryDelay).unref();
       return;

--- a/packages/collector/src/index.js
+++ b/packages/collector/src/index.js
@@ -118,7 +118,7 @@ function init(_config) {
     require('./metrics').init(config);
   }
 
-  logger.info('@instana/collector module version:', require(path.join(__dirname, '..', 'package.json')).version);
+  logger.info('@instana/collector module version: %s', require(path.join(__dirname, '..', 'package.json')).version);
   require('./announceCycle').start();
 
   return init;

--- a/packages/collector/src/index.js
+++ b/packages/collector/src/index.js
@@ -118,7 +118,7 @@ function init(_config) {
     require('./metrics').init(config);
   }
 
-  logger.info('@instana/collector module version: %s', require(path.join(__dirname, '..', 'package.json')).version);
+  logger.info(`@instana/collector module version: ${require(path.join(__dirname, '..', 'package.json')).version}`);
   require('./announceCycle').start();
 
   return init;

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -310,11 +310,11 @@ function putPseudoSpan(spanName, kind, traceId, spanId) {
   span.k = kind;
 
   if (!traceId) {
-    logger.warn('Cannot start a pseudo span without a trace ID', spanName, kind);
+    logger.warn(`Cannot start a pseudo span without a trace ID": ${spanName}, ${kind}`);
     return;
   }
   if (!spanId) {
-    logger.warn('Cannot start a pseudo span without a span ID', spanName, kind);
+    logger.warn(`Cannot start a pseudo span without a span ID": ${spanName}, ${kind}`);
     return;
   }
 

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -310,7 +310,7 @@ function putPseudoSpan(spanName, kind, traceId, spanId) {
   span.k = kind;
 
   if (!traceId) {
-    logger.warn(`Cannot start a pseudo span without a trace ID": ${spanName}, ${kind}`);
+    logger.warn(`Cannot start a pseudo span without a trace ID: ${spanName}, ${kind}`);
     return;
   }
   if (!spanId) {

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -314,7 +314,7 @@ function putPseudoSpan(spanName, kind, traceId, spanId) {
     return;
   }
   if (!spanId) {
-    logger.warn(`Cannot start a pseudo span without a span ID": ${spanName}, ${kind}`);
+    logger.warn(`Cannot start a pseudo span without a span ID: ${spanName}, ${kind}`);
     return;
   }
 

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -458,7 +458,7 @@ function transmitSpans() {
   // since sending spans downstream will take a few milliseconds, even that will be rare (and it is acceptable).
   downstreamConnection.sendSpans(spansToSend, function sendSpans(/** @type {Error} */ error) {
     if (error) {
-      logger.warn(`Failed to transmit spans, will retry in ${transmissionDelay} ms. ${error?.message} ${error?.stack}`);
+      logger.warn(`Failed to transmit spans, will retry in ${transmissionDelay} ms. ${error.message} ${error.stack}`);
       spans = spans.concat(spansToSend);
       removeSpansIfNecessary();
     }

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -458,7 +458,7 @@ function transmitSpans() {
   // since sending spans downstream will take a few milliseconds, even that will be rare (and it is acceptable).
   downstreamConnection.sendSpans(spansToSend, function sendSpans(/** @type {Error} */ error) {
     if (error) {
-      logger.warn(`Failed to transmit spans, will retry in ${transmissionDelay} ms.`, error.message);
+      logger.warn(`Failed to transmit spans, will retry in ${transmissionDelay} ms. ${error?.message} ${error?.stack}`);
       spans = spans.concat(spansToSend);
       removeSpansIfNecessary();
     }

--- a/packages/core/src/util/applicationUnderMonitoring.js
+++ b/packages/core/src/util/applicationUnderMonitoring.js
@@ -98,7 +98,7 @@ function readFile(packageJsonPath, cb) {
     try {
       parsedMainPackageJson = JSON.parse(contents);
     } catch (e) {
-      logger.warn(`Package.json file ${packageJsonPath} cannot be parsed: ${e?.message} ${e?.stack}`);
+      logger.warn(`Package.json file ${packageJsonPath} cannot be parsed: ${e.message} ${e.stack}`);
       return cb(e, null);
     }
     return cb(null, parsedMainPackageJson);

--- a/packages/core/src/util/applicationUnderMonitoring.js
+++ b/packages/core/src/util/applicationUnderMonitoring.js
@@ -98,7 +98,7 @@ function readFile(packageJsonPath, cb) {
     try {
       parsedMainPackageJson = JSON.parse(contents);
     } catch (e) {
-      logger.warn('Package.json file %s cannot be parsed: %s', packageJsonPath, e);
+      logger.warn(`Package.json file ${packageJsonPath} cannot be parsed: ${e?.message} ${e?.stack}`);
       return cb(e, null);
     }
     return cb(null, parsedMainPackageJson);

--- a/packages/core/src/util/atMostOnce.js
+++ b/packages/core/src/util/atMostOnce.js
@@ -32,9 +32,10 @@ module.exports = function atMostOnce(name, cb) {
     if (callCount === 1) {
       return cb.apply(null, arguments);
     }
-
-    logger.debug('Function %s was called %s times. This time with the following arguments.', name, callCount, {
+    const argObj = {
       args: Array.prototype.slice.call(arguments)
-    });
+    };
+
+    logger.debug(`Function ${name} was called ${callCount} times. This time with the following arguments: ${argObj}`);
   };
 };

--- a/packages/google-cloud-run/src/activate.js
+++ b/packages/google-cloud-run/src/activate.js
@@ -37,9 +37,8 @@ function init() {
 
   metrics.init(config, function onReady(err, serviceRevisionPayload) {
     if (err) {
-      logger.error(
-        `Initializing @instana/google-cloud-run failed. This container instance will not be monitored. ${err}`
-      );
+      logger.error('Initializing @instana/google-cloud-run failed. This container instance will not be monitored.');
+      logger.error(`Error: ${err.message} ${err.stack}`);
       metrics.deactivate();
       return;
     }

--- a/packages/google-cloud-run/src/activate.js
+++ b/packages/google-cloud-run/src/activate.js
@@ -37,8 +37,10 @@ function init() {
 
   metrics.init(config, function onReady(err, serviceRevisionPayload) {
     if (err) {
-      logger.error('Initializing @instana/google-cloud-run failed. This container instance will not be monitored.');
-      logger.error(`Error: ${err.message} ${err.stack}`);
+      logger.error(
+        `Initializing @instana/google-cloud-run failed. This container instance will not be monitored. 
+        Error: ${err.message} ${err.stack}`
+      );
       metrics.deactivate();
       return;
     }

--- a/packages/google-cloud-run/src/activate.js
+++ b/packages/google-cloud-run/src/activate.js
@@ -38,8 +38,7 @@ function init() {
   metrics.init(config, function onReady(err, serviceRevisionPayload) {
     if (err) {
       logger.error(
-        'Initializing @instana/google-cloud-run failed. This container instance will not be monitored.',
-        err
+        `Initializing @instana/google-cloud-run failed. This container instance will not be monitored. ${err}`
       );
       metrics.deactivate();
       return;

--- a/packages/serverless-collector/src/activate.js
+++ b/packages/serverless-collector/src/activate.js
@@ -47,7 +47,9 @@ async function init() {
     // eslint-disable-next-line no-unused-expressions
     process.send && process.send('instana.serverless-collector.initialized');
   } catch (e) {
-    logger.error('Initializing @instana/serverless-collector failed. This process will not be traced.', e);
+    logger.error(
+      `Initializing @instana/serverless-collector failed. This process will not be traced. ${e?.message} ${e?.stack}`
+    );
   }
 }
 

--- a/packages/serverless-collector/src/activate.js
+++ b/packages/serverless-collector/src/activate.js
@@ -48,7 +48,7 @@ async function init() {
     process.send && process.send('instana.serverless-collector.initialized');
   } catch (e) {
     logger.error(
-      `Initializing @instana/serverless-collector failed. This process will not be traced. ${e?.message} ${e?.stack}`
+      `Initializing @instana/serverless-collector failed. This process will not be traced. ${e.message} ${e.stack}`
     );
   }
 }

--- a/packages/serverless-collector/src/metrics/name.js
+++ b/packages/serverless-collector/src/metrics/name.js
@@ -19,7 +19,7 @@ module.exports = (config, logger) => {
   return new Promise(resolve => {
     instanaCore.util.applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule(config, (err, packageJson) => {
       if (err) {
-        logger.debug(`Failed to determine main package.json.', ${JSON.stingify(err)}`);
+        logger.debug(`Failed to determine main package.json. ${err.message} ${err.stack}`);
         return resolve();
       }
 

--- a/packages/serverless-collector/src/metrics/name.js
+++ b/packages/serverless-collector/src/metrics/name.js
@@ -19,7 +19,7 @@ module.exports = (config, logger) => {
   return new Promise(resolve => {
     instanaCore.util.applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule(config, (err, packageJson) => {
       if (err) {
-        logger.debug('Failed to determine main package.json.', err);
+        logger.debug(`Failed to determine main package.json.', ${JSON.stingify(err)}`);
         return resolve();
       }
 

--- a/packages/serverless/src/backend_connector.js
+++ b/packages/serverless/src/backend_connector.js
@@ -400,13 +400,13 @@ function send(resourcePath, payload, finalLambdaRequest, callback) {
         if (proxyAgent) {
           logger.warn(
             'Could not send traces and metrics to Instana. Could not connect to the configured proxy ' +
-              `${process.env[proxyEnvVar]}.`,
-            e
+              `${process.env[proxyEnvVar]}.` +
+              `${e.message} ${e.stack}`
           );
         } else {
           logger.warn(
             `Could not send traces and metrics to Instana. The Instana back end seems to be unavailable. 
-            ${JSON.stringify(e)}`
+            ${e.message} , ${e.stack}`
           );
         }
       }

--- a/packages/serverless/src/backend_connector.js
+++ b/packages/serverless/src/backend_connector.js
@@ -404,7 +404,10 @@ function send(resourcePath, payload, finalLambdaRequest, callback) {
             e
           );
         } else {
-          logger.warn('Could not send traces and metrics to Instana. The Instana back end seems to be unavailable.', e);
+          logger.warn(
+            `Could not send traces and metrics to Instana. The Instana back end seems to be unavailable. 
+            ${JSON.stringify(e)}`
+          );
         }
       }
 

--- a/packages/shared-metrics/src/description.js
+++ b/packages/shared-metrics/src/description.js
@@ -31,7 +31,7 @@ exports.activate = function activate(config) {
   attempts++;
   applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule(config, (err, packageJson) => {
     if (err) {
-      return logger.warn('Failed to determine main package json. Reason: ', err.message, err.stack);
+      return logger.warn(`Failed to determine main package json. Reason: ${err.message} ${err.stack}`);
     } else if (!packageJson && attempts < MAX_ATTEMPTS) {
       setTimeout(() => {
         exports.activate(config);

--- a/packages/shared-metrics/src/healthchecks.js
+++ b/packages/shared-metrics/src/healthchecks.js
@@ -79,7 +79,7 @@ function gatherHealthcheckResults() {
     .catch(function onHealthcheckResultFailure(/** @type {*} */ err) {
       // @ts-ignore
       exports.currentPayload = {};
-      logger.warn(`Unexpected error while getting healthcheck results. ${err?.message} ${err?.stack}`);
+      logger.warn(`Unexpected error while getting healthcheck results. ${err.message} ${err.stack}`);
       timeoutHandle = setTimeout(gatherHealthcheckResults, timeBetweenHealthcheckCalls);
       timeoutHandle.unref();
     });

--- a/packages/shared-metrics/src/healthchecks.js
+++ b/packages/shared-metrics/src/healthchecks.js
@@ -79,7 +79,7 @@ function gatherHealthcheckResults() {
     .catch(function onHealthcheckResultFailure(/** @type {*} */ err) {
       // @ts-ignore
       exports.currentPayload = {};
-      logger.warn('Unexpected error while getting healthcheck results', err);
+      logger.warn(`Unexpected error while getting healthcheck results. ${err?.message} ${err?.stack}`);
       timeoutHandle = setTimeout(gatherHealthcheckResults, timeBetweenHealthcheckCalls);
       timeoutHandle.unref();
     });

--- a/packages/shared-metrics/src/keywords.js
+++ b/packages/shared-metrics/src/keywords.js
@@ -31,7 +31,7 @@ exports.activate = function activate(config) {
   attempts++;
   applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule(config, (err, packageJson) => {
     if (err) {
-      return logger.warn('Failed to determine main package json. Reason: ', err.message, err.stack);
+      return logger.warn(`Failed to determine main package json. Reason: ${err?.message} ${err?.stack}`);
     } else if (!packageJson && attempts < MAX_ATTEMPTS) {
       setTimeout(() => {
         exports.activate(config);

--- a/packages/shared-metrics/src/keywords.js
+++ b/packages/shared-metrics/src/keywords.js
@@ -31,7 +31,7 @@ exports.activate = function activate(config) {
   attempts++;
   applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule(config, (err, packageJson) => {
     if (err) {
-      return logger.warn(`Failed to determine main package json. Reason: ${err?.message} ${err?.stack}`);
+      return logger.warn(`Failed to determine main package json. Reason: ${err.message} ${err.stack}`);
     } else if (!packageJson && attempts < MAX_ATTEMPTS) {
       setTimeout(() => {
         exports.activate(config);

--- a/packages/shared-metrics/src/name.js
+++ b/packages/shared-metrics/src/name.js
@@ -32,7 +32,7 @@ exports.activate = function activate(config) {
 
   applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule(config, (err, packageJson) => {
     if (err) {
-      return logger.warn(`Failed to determine main package json. Reason: ${err?.message} ${err?.stack}`);
+      return logger.warn(`Failed to determine main package json. Reason: ${err.message} ${err.stack}`);
     } else if (!packageJson && attempts < exports.MAX_ATTEMPTS) {
       logger.debug('Main package.json could not be found. Will try again later.');
 

--- a/packages/shared-metrics/src/name.js
+++ b/packages/shared-metrics/src/name.js
@@ -32,7 +32,7 @@ exports.activate = function activate(config) {
 
   applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule(config, (err, packageJson) => {
     if (err) {
-      return logger.warn('Failed to determine main package json. Reason: ', err.message, err.stack);
+      return logger.warn(`Failed to determine main package json. Reason: ${err?.message} ${err?.stack}`);
     } else if (!packageJson && attempts < exports.MAX_ATTEMPTS) {
       logger.debug('Main package.json could not be found. Will try again later.');
 

--- a/packages/shared-metrics/src/util/nativeModuleRetry.js
+++ b/packages/shared-metrics/src/util/nativeModuleRetry.js
@@ -206,12 +206,16 @@ function copyPrecompiled(opts, loaderEmitter, callback) {
             callback(true);
           })
           .catch(error => {
-            logger.warn(`Copying the precompiled build for ${opts.nativeModuleName} ${label} failed. ${error}`);
+            logger.warn(
+              `Copying the precompiled build for ${opts.nativeModuleName} ${label} failed. 
+              ${error.message} ${error.stack}`
+            );
             callback(false);
           });
       })
       .catch(tarErr => {
-        logger.warn(`Unpacking the precompiled build for ${opts.nativeModuleName} ${label} failed. ${tarErr}`);
+        logger.warn(`Unpacking the precompiled build for ${opts.nativeModuleName} ${label} failed. 
+          ${tarErr.message} ${tarErr.stack}`);
         callback(false);
       });
   });

--- a/packages/shared-metrics/src/util/nativeModuleRetry.js
+++ b/packages/shared-metrics/src/util/nativeModuleRetry.js
@@ -206,12 +206,12 @@ function copyPrecompiled(opts, loaderEmitter, callback) {
             callback(true);
           })
           .catch(error => {
-            logger.warn(`Copying the precompiled build for ${opts.nativeModuleName} ${label} failed.`, error);
+            logger.warn(`Copying the precompiled build for ${opts.nativeModuleName} ${label} failed. ${error}`);
             callback(false);
           });
       })
       .catch(tarErr => {
-        logger.warn(`Unpacking the precompiled build for ${opts.nativeModuleName} ${label} failed.`, tarErr);
+        logger.warn(`Unpacking the precompiled build for ${opts.nativeModuleName} ${label} failed. ${tarErr}`);
         callback(false);
       });
   });
@@ -245,7 +245,9 @@ function findNativeModulePath(opts) {
     opts.nativeModuleParentPath = path.join(opts.nativeModulePath, '..');
     return true;
   } catch (e) {
-    logger.debug(`Could not find location for ${opts.nativeModuleName}. Will create a path for it.`, e);
+    logger.debug(
+      `Could not find location for ${opts.nativeModuleName}. Will create a path for it. ${e?.message} ${e.stack}`
+    );
     return createNativeModulePath(opts);
   }
 }

--- a/packages/shared-metrics/src/util/nativeModuleRetry.js
+++ b/packages/shared-metrics/src/util/nativeModuleRetry.js
@@ -250,7 +250,7 @@ function findNativeModulePath(opts) {
     return true;
   } catch (e) {
     logger.debug(
-      `Could not find location for ${opts.nativeModuleName}. Will create a path for it. ${e?.message} ${e.stack}`
+      `Could not find location for ${opts.nativeModuleName}. Will create a path for it. ${e.message} ${e.stack}`
     );
     return createNativeModulePath(opts);
   }

--- a/packages/shared-metrics/src/version.js
+++ b/packages/shared-metrics/src/version.js
@@ -30,7 +30,7 @@ exports.activate = function activate(config) {
   attempts++;
   applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule(config, (err, packageJson) => {
     if (err) {
-      return logger.warn(`Failed to determine main package json. Reason: ${err?.message} ${err?.stack}`);
+      return logger.warn(`Failed to determine main package json. Reason: ${err.message} ${err.stack}`);
     } else if (!packageJson && attempts < MAX_ATTEMPTS) {
       setTimeout(() => {
         exports.activate(config);

--- a/packages/shared-metrics/src/version.js
+++ b/packages/shared-metrics/src/version.js
@@ -30,7 +30,7 @@ exports.activate = function activate(config) {
   attempts++;
   applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule(config, (err, packageJson) => {
     if (err) {
-      return logger.warn('Failed to determine main package json. Reason: ', err.message, err.stack);
+      return logger.warn(`Failed to determine main package json. Reason: ${err?.message} ${err?.stack}`);
     } else if (!packageJson && attempts < MAX_ATTEMPTS) {
       setTimeout(() => {
         exports.activate(config);


### PR DESCRIPTION
- refs [INSTA-12533](https://jsw.ibm.com/browse/INSTA-12533)
- some log messages did not log the corresponding objects


note:
In some places, I have used `%s`, and `%o` notations.
In some places where JSON.stringify is already used, I followed the same to keep the logs clean and more readable.