### PR TITLE
docs: updated outdated ibm public doc links

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,3 +1,3 @@
 # API
 
-This document has moved [here](https://www.ibm.com/docs/de/obi/current?topic=nodejs-instana-api).
+This document has moved [here](https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-instana-api).

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,3 +1,3 @@
 # Configuration
 
-This document has moved [here](https://www.ibm.com/docs/de/obi/current?topic=nodejs-collector-configuration).
+This document has moved [here](https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-configuration).

--- a/dockerfile-examples/README.md
+++ b/dockerfile-examples/README.md
@@ -1,7 +1,7 @@
 Examples Dockerfile
 ===================
 
-Dockerizing your Node.js application is a thing. Since the Instana Node.js collector uses some native addons (see [readme](https://www.ibm.com/docs/de/obi/current?topic=nodejs-collector-installation#native-add-ons)), it might be required to add additional operating system packages to your Docker image. This directory contains a few example Dockerfiles to test Docker builds with various base images and configurations.
+Dockerizing your Node.js application is a thing. Since the Instana Node.js collector uses some native addons (see [readme](https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#native-add-ons)), it might be required to add additional operating system packages to your Docker image. This directory contains a few example Dockerfiles to test Docker builds with various base images and configurations.
 
 This is probably relevant for you
 - dockerize your Node.js application

--- a/packages/aws-fargate/images/instana-aws-fargate/setup.sh
+++ b/packages/aws-fargate/images/instana-aws-fargate/setup.sh
@@ -4,5 +4,5 @@
 #######################################
 
 cd /instana
-npm rebuild || echo "Warning: Rebuilding native add-ons for @instana/fargate failed. Monitoring the Fargate tasks will work nonetheless, but you will miss some Node.js metrics (GC metrics, event loop metrics, ...). See https://www.ibm.com/docs/de/obi/current?topic=agents-monitoring-aws-fargate#build-dependencies-and-native-add-ons for details."
+npm rebuild || echo "Warning: Rebuilding native add-ons for @instana/aws-fargate failed. Monitoring the Fargate tasks will work nonetheless, but you will miss some Node.js metrics (GC metrics, event loop metrics, ...). See https://www.ibm.com/docs/en/instana-observability/current?topic=agents-aws-fargate#build-dependencies-and-native-add-ons for details."
 

--- a/packages/collector/API.md
+++ b/packages/collector/API.md
@@ -1,3 +1,3 @@
 # API
 
-This document has moved [here](https://www.ibm.com/docs/de/obi/current?topic=nodejs-instana-api).
+This document has moved [here](https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-instana-api).

--- a/packages/collector/CONFIGURATION.md
+++ b/packages/collector/CONFIGURATION.md
@@ -1,3 +1,3 @@
 # Configuration
 
-This document has moved [here](https://www.ibm.com/docs/de/obi/current?topic=nodejs-collector-configuration).
+This document has moved [here](https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-configuration).

--- a/packages/collector/src/announceCycle/agentready.js
+++ b/packages/collector/src/announceCycle/agentready.js
@@ -55,7 +55,7 @@ if (agentOpts.autoProfile) {
         'during module installation (npm install/yarn) or when npm install --no-optional or yarn --ignore-optional ' +
         'have been used to install dependencies. See the instructions to learn more about the requirements of the ' +
         'collector: ' +
-        'https://www.ibm.com/docs/de/obi/current?topic=nodejs-collector-installation#native-add-ons'
+        'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#native-add-ons'
     );
 
     fireMonitoringEvent();

--- a/packages/collector/src/bin/instrument-edgemicro-cli.js
+++ b/packages/collector/src/bin/instrument-edgemicro-cli.js
@@ -15,7 +15,7 @@
 // edgemicro start -o $org -e $env -k $key -s $secret
 //
 // Thus, there is no user controlled code when that Node.js process is starting up, and in turn our usual installation
-// documented at https://www.ibm.com/docs/de/obi/current?topic=nodejs-collector-installation can not be performed (in particular, there
+// documented at https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#installing-the-collector can not be performed (in particular, there
 // is no user controlled code to put the require('@instana/collector')(); into.
 //
 // The purpose of this executable is to fill this gap. It needs to be called after the edgemicro package has been

--- a/packages/collector/src/immediate.js
+++ b/packages/collector/src/immediate.js
@@ -23,7 +23,7 @@ const agentOpts = require('./agent/opts');
 // This file can be used with NODE_OPTIONS or `node --require` to instrument a Node.js app with Instana without
 // modifying the source code. See
 // eslint-disable-next-line max-len
-// https://www.ibm.com/docs/de/obi/current?topic=nodejs-collector-installation#installation-without-modifying-the-source-code
+// https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#activating-the-collector
 
 const isExcludedFromInstrumentation = coreUtil.excludedFromInstrumentation && coreUtil.excludedFromInstrumentation();
 

--- a/packages/collector/src/util/initializedTooLate.js
+++ b/packages/collector/src/util/initializedTooLate.js
@@ -27,9 +27,9 @@ exports.check = function check() {
         'It seems you have initialized the @instana/collector package too late. Please check our documentation on ' +
           'that, in particular ' +
           // eslint-disable-next-line max-len
-          'https://www.ibm.com/docs/de/obi/current?topic=nodejs-collector-installation#installing-the-nodejs-collector-package and ' +
+          'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#installing-the-collector and ' +
           // eslint-disable-next-line max-len
-          'https://www.ibm.com/docs/de/obi/current?topic=nodejs-collector-installation#common-pitfalls. Tracing might only work ' +
+          'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-troubleshooting. Tracing might only work ' +
           'partially with this setup, that is, some calls will not be captured.'
       );
       warningHasBeenLogged = true;

--- a/packages/collector/test/apps/babel-typescript/src/index.ts
+++ b/packages/collector/test/apps/babel-typescript/src/index.ts
@@ -39,7 +39,7 @@
 //     import morgan from 'morgan';
 //
 //     // The following statement is optional; it is only required if you want to use
-//     // Instana's Node.js API (https://www.ibm.com/docs/de/obi/current?topic=nodejs-instana-api):
+//     // Instana's Node.js API (https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-instana-api):
 //     @ts-ignore (in case you are using TypeScript, to avoid 'Could not find a declaration for '@instana/collector')
 //     import instana from '@instana/collector';
 //
@@ -61,7 +61,7 @@ import express from 'express';
 import morgan from 'morgan';
 
 // The following statement is optional; it is only required if you want to use
-// Instana's Node.js API (https://www.ibm.com/docs/de/obi/current?topic=nodejs-instana-api):
+// Instana's Node.js API (https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-instana-api):
 // @ts-ignore
 import instana from '@instana/collector';
 

--- a/packages/core/src/tracing/instrumentation/protocols/http2Server.js
+++ b/packages/core/src/tracing/instrumentation/protocols/http2Server.js
@@ -136,7 +136,7 @@ function shimEmit(realEmit) {
         // headers, we add the new trace ID to the incoming request so a customer's app can render it reliably into the
         // EUM snippet, see
         // eslint-disable-next-line max-len
-        // https://www.ibm.com/docs/de/obi/current?topic=websites-backend-correlation#retrieve-the-backend-trace-id-in-nodejs
+        // https://www.ibm.com/docs/en/instana-observability/current?topic=websites-backend-correlation#retrieve-the-backend-trace-id-in-nodejs
         headers['x-instana-t'] = span.t;
       }
 

--- a/packages/core/src/tracing/instrumentation/protocols/httpServer.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpServer.js
@@ -109,7 +109,7 @@ function shimEmit(realEmit) {
         // headers, we add the new trace ID to the incoming request so a customer's app can render it reliably into the
         // EUM snippet, see
         // eslint-disable-next-line max-len
-        // https://www.ibm.com/docs/de/obi/current?topic=websites-backend-correlation#retrieve-the-backend-trace-id-in-nodejs
+        // https://www.ibm.com/docs/en/instana-observability/current?topic=websites-backend-correlation#retrieve-the-backend-trace-id-in-nodejs
         req.headers['x-instana-t'] = span.t;
       }
 

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -234,10 +234,10 @@ exports.readAttribCaseInsensitive = function readAttribCaseInsensitive(object, k
  *
  * The situation is different when we are loaded via "--require" from a global installation -- this is the norm for
  * @instana/aws-fargate, @instana/google-cloud-run, the Kubernetes autotrace webhook
- * (https://www.ibm.com/docs/de/obi/current?topic=kubernetes-instana-autotrace-webhook) or when using the global
- * installation pattern for @instana/collector that does not require modifying the source code
- * (see * https://www.ibm.com/docs/de/obi/current?topic=nodejs-collector-installation#global-installation).
- *
+ * (https://www.ibm.com/docs/en/instana-observability/current?topic=kubernetes-instana-autotrace-webhook) or when
+ * using the global installation pattern for @instana/collector that does not require modifying the source code see(
+ * https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#installing-the-
+ * collector-globally).
  * In these scenarios, the module load path list does not include the application's node_module folder. Thus we need to
  * be a bit more clever when requiring a module from the application's dependencies. We solve this by constructing the
  * file system path of the desired module by using a known path from a module of the same package and the relative path

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -313,7 +313,7 @@ function normalizeAutomaticTracingEnabled(config) {
   if (!supportedTracingVersion(process.versions.node)) {
     logger.warn(
       'Not enabling automatic tracing, this is an unsupported version of Node.js. ' +
-        'See: https://www.ibm.com/docs/de/obi/current?topic=technologies-monitoring-nodejs#supported-nodejs-versions'
+        'See: https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-support-information#supported-nodejs-versions'
     );
     config.tracing.automaticTracingEnabled = false;
     return;

--- a/packages/google-cloud-run/images/instana-google-cloud-run/setup.sh
+++ b/packages/google-cloud-run/images/instana-google-cloud-run/setup.sh
@@ -3,4 +3,4 @@
 # (c) Copyright Instana Inc. and contributors 2020
 #######################################
 cd /instana
-npm rebuild || echo "Warning: Rebuilding native add-ons for @instana/google-cloud-run failed. Monitoring the Cloud Run service revision instance will work nonetheless, but you will miss some Node.js metrics (GC metrics, event loop metrics, ...). See https://www.ibm.com/docs/de/obi/current?topic=agents-monitoring-google-cloud-run#build-dependencies-and-native-add-ons for details."
+npm rebuild || echo "Warning: Rebuilding native add-ons for @instana/google-cloud-run failed. Monitoring the Cloud Run service revision instance will work nonetheless, but you will miss some Node.js metrics (GC metrics, event loop metrics, ...). See https://www.ibm.com/docs/en/instana-observability/current?topic=agents-google-cloud-run#build-dependencies-and-native-add-ons for details."

--- a/packages/opentelemetry-exporter/README.md
+++ b/packages/opentelemetry-exporter/README.md
@@ -8,7 +8,7 @@ An [OpenTelemetry exporter](https://opentelemetry.io/docs/js/exporters/) to Inst
 
 ## Instana and OpenTelemetry Versions
 
-Even though the [Instana Node.js SDK supports several versions of Node.js](https://www.ibm.com/docs/de/obi/current?topic=technologies-monitoring-nodejs#supported-nodejs-versions),
+Even though the [Instana Node.js SDK supports several versions of Node.js](https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-support-information#supported-nodejs-versions),
 users of the Instana Exporter must take into consideration the
 [versions supported by the OpenTelemetry instrumentator](https://github.com/open-telemetry/opentelemetry-js#supported-runtimes).
 

--- a/packages/shared-metrics/src/gc.js
+++ b/packages/shared-metrics/src/gc.js
@@ -56,7 +56,7 @@ const nativeModuleLoader = require('./util/nativeModuleRetry')({
     'typically occurs when native addons could not be built during module installation (npm install/yarn) or when ' +
     'npm install --no-optional or yarn --ignore-optional have been used to install dependencies. See the ' +
     'instructions to learn more about the requirements of the collector: ' +
-    'https://www.ibm.com/docs/de/obi/current?topic=nodejs-collector-installation#native-add-ons'
+    'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#native-add-ons'
 });
 
 /** @type {NodeJS.Timeout} */

--- a/packages/shared-metrics/src/libuv.js
+++ b/packages/shared-metrics/src/libuv.js
@@ -22,7 +22,7 @@ const nativeModuleLoader = require('./util/nativeModuleRetry')({
     'application. This typically occurs when native addons could not be built during module installation ' +
     '(npm install/yarn) or when npm install --no-optional or yarn --ignore-optional have been used to install ' +
     'dependencies. See the instructions to learn more about the requirements of the collector: ' +
-    'https://www.ibm.com/docs/de/obi/current?topic=nodejs-collector-installation#native-add-ons'
+    'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#native-add-ons'
 });
 
 nativeModuleLoader.once('loaded', eventLoopStats_ => {


### PR DESCRIPTION
Updated IBM Docs links from German  to English and updated outdated links. This ensures users are directed to the correct, English version of the documentation.
