### PR TITLE
test: updated the span order for otel sampler

### DIFF
--- a/packages/opentelemetry-sampler/test/test.js
+++ b/packages/opentelemetry-sampler/test/test.js
@@ -63,16 +63,17 @@ mochaSuiteFn('Instana OpenTelemetry Sampler', function () {
 
       await retry(async () => {
         const spans = await appControls.getSpans();
-        const spanNames = [
+        const spanNames = spans.map(s => s.data.operation);
+        const expectedSpanNames = [
           'middleware - query',
           'middleware - expressInit',
           'request handler - /otel-test',
           'tcp.connect',
           'tls.connect',
-          'GET',
-          'GET /otel-test'
+          'GET /otel-test',
+          'GET'
         ];
-        expect(spanNames).to.eql(spans.map(s => s.data.operation));
+        expect(spanNames).to.have.members(expectedSpanNames);
         expect(spans.length).to.eql(7);
       });
     });
@@ -121,16 +122,18 @@ mochaSuiteFn('Instana OpenTelemetry Sampler', function () {
         path: '/get-otel-spans',
         suppressTracing: true
       });
-      const spanNames = [
+
+      const spanNames = resp.spans.map(s => s.name);
+      const expectedSpanNames = [
         'middleware - query',
         'middleware - expressInit',
         'request handler - /otel-test',
         'tcp.connect',
         'tls.connect',
-        'GET',
-        'GET /otel-test'
+        'GET /otel-test',
+        'GET'
       ];
-      expect(spanNames).to.eql(resp.spans.map(s => s.name));
+      expect(spanNames).to.have.members(expectedSpanNames);
       expect(resp.spans.length).to.be.gte(7);
     });
   });

--- a/packages/opentelemetry-sampler/test/test.js
+++ b/packages/opentelemetry-sampler/test/test.js
@@ -69,8 +69,8 @@ mochaSuiteFn('Instana OpenTelemetry Sampler', function () {
           'request handler - /otel-test',
           'tcp.connect',
           'tls.connect',
-          'GET /otel-test',
-          'GET'
+          'GET',
+          'GET /otel-test'
         ];
         expect(spanNames).to.eql(spans.map(s => s.data.operation));
         expect(spans.length).to.eql(7);
@@ -127,8 +127,8 @@ mochaSuiteFn('Instana OpenTelemetry Sampler', function () {
         'request handler - /otel-test',
         'tcp.connect',
         'tls.connect',
-        'GET /otel-test',
-        'GET'
+        'GET',
+        'GET /otel-test'
       ];
       expect(spanNames).to.eql(resp.spans.map(s => s.name));
       expect(resp.spans.length).to.be.gte(7);


### PR DESCRIPTION
It seems that the order of spans received in the test has changed. Initially, it followed this order, but we updated the order as part of [this commit](https://github.com/instana/nodejs/pull/1017/files#diff-8b67ece1f3aa325e00cc1da09e31f51e0f0b40c134c1fbd6868caf6003b5c81eL67). The test assertion wasn't ideal, so it has now been updated to disregard the order of the received spans.