### PR TITLE
test: updated failing tests for root exit span

### DIFF
--- a/packages/collector/test/tracing/sdk/allowRootExitSpans/app_default.js
+++ b/packages/collector/test/tracing/sdk/allowRootExitSpans/app_default.js
@@ -18,11 +18,9 @@ require('../../../../src')({
 
 const fetch = require('node-fetch-v2');
 
-const url = 'https://www.example.com';
-
 function main() {
   setTimeout(async () => {
-    await fetch(url);
+    await fetch('https://example.com');
   }, 100);
 }
 

--- a/packages/collector/test/tracing/sdk/allowRootExitSpans/app_with_entry.js
+++ b/packages/collector/test/tracing/sdk/allowRootExitSpans/app_with_entry.js
@@ -15,29 +15,26 @@ const instana = require('../../../../src')({
     allowRootExitSpan: true
   }
 });
-
+const { delay } = require('../../../../../core/test/test_util');
 const fetch = require('node-fetch-v2');
 
-const url = 'https://www.example.com';
+const executeRequest = async () => {
+  let error;
 
-/* eslint-disable no-console */
-function main() {
-  setTimeout(() => {
-    instana.sdk.async
-      .startEntrySpan('test-timeout-span')
-      .then(async () => {
-        try {
-          await fetch(url);
-        } catch (error) {
-          console.log(error);
-        } finally {
-          instana.sdk.async.completeEntrySpan();
-        }
-      })
-      .catch(err => {
-        instana.sdk.async.completeEntrySpan(err);
-        console.log('Error starting test-timeout-span:', err);
-      });
-  }, 100);
-}
-main();
+  try {
+    await instana.sdk.async.startEntrySpan('my-translation-service');
+    await fetch('https://example.com');
+  } catch (err) {
+    error = err;
+  } finally {
+    instana.sdk.async.completeEntrySpan(error);
+  }
+};
+
+// Main function to execute the request with delay
+const runApp = async () => {
+  await delay(200);
+  await executeRequest(); // Execute the request
+};
+
+runApp();


### PR DESCRIPTION

The test has failed multiple times. Here’s the link to the pipeline: [Pipeline Link](https://cloud.ibm.com/devops/pipelines/tekton/c2cd6a8d-ea5a-47b0-913e-cd172d63833f/runs/bf858a35-28f1-4709-ad2a-44c950ae8272/test-ci-collector-tracing-general-task/run-test-group?env_id=ibm:yp:eu-de). The test has been refactored.