### PR TITLE
fix: changed internal logger timestamp to ISO string

### DIFF
--- a/packages/collector/src/logger.js
+++ b/packages/collector/src/logger.js
@@ -73,7 +73,8 @@ exports.init = function init(config, isReInit) {
       {
         ...parentLogger.levels,
         level: parentLogger.level || 'info',
-        base: parentLogger.bindings()
+        base: parentLogger.bindings(),
+        timestamp: () => `,"time":"${new Date().toISOString()}"`
       },
       multiStream
     );


### PR DESCRIPTION
This was by default UNIX format for pino