### PR TITLE
ci: updated pipeline to trigger slack notifications for each task on lambda layer publish

### DIFF
--- a/packages/aws-lambda/layer/bin/publish-layer.sh
+++ b/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -294,6 +294,8 @@ popd > /dev/null
 export AWS_PAGER=""
 export AWS_MAX_ATTEMPTS=$AWS_CLI_RETRY_MAX_ATTEMPTS
 
+BUILD_SHOULD_FAIL=0
+
 if [[ -z $SKIP_AWS_PUBLISH_LAYER ]]; then
   echo "step 6/9: publishing $ZIP_NAME as AWS Lambda layer $LAYER_NAME to specifed regions"
 
@@ -342,6 +344,7 @@ if [[ -z $SKIP_AWS_PUBLISH_LAYER ]]; then
 
     if [[ -z $lambda_layer_version ]] || [[ ! $lambda_layer_version =~ ^[0-9]+$ ]]; then
       echo "   + ERROR: Failed to publish layer in region $region, continuing to the next region."
+      BUILD_SHOULD_FAIL=1
       continue
     fi
 
@@ -403,3 +406,7 @@ echo "step 9/9: cleaning up"
 rm -rf $TMP_ZIP_DIR
 rm -rf $ZIP_NAME
 
+if [[ $BUILD_SHOULD_FAIL -eq 1 ]]; then
+  echo "Error: At least one layer upload failed. Exiting with error code 1."
+  exit 1
+fi

--- a/packages/serverless/ci/pipeline.yaml
+++ b/packages/serverless/ci/pipeline.yaml
@@ -401,6 +401,23 @@ jobs:
                 AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
                 AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
                 nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
+          on_success:
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':white_check_mark:'
+              text: |
+                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-x86_64`."
+              attachments: *slack-alert-attachements-success
+          on_failure: &slack-notify-failure-lambda
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':check-failed:'
+              text: |
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-x86_64`."
+              attachments: *slack-alert-attachements-failure
+          on_error: *slack-notify-failure-lambda
 
       - task: build-and-publish-aws-lambda-layer-and-image-arm64
         privileged: true
@@ -425,6 +442,24 @@ jobs:
                 AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
                 AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
                 nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
+          on_success:
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':white_check_mark:'
+              text: |
+                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-arm64`."
+              attachments: *slack-alert-attachements-success
+          on_failure: &slack-notify-failure-lambda
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':check-failed:'
+              text: |
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-arm64`."
+              attachments: *slack-alert-attachements-failure
+          on_error: *slack-notify-failure-lambda
+
       - task: build-and-publish-aws-lambda-layer-and-image-china-x86_64
         privileged: true
         image: dind-nodejs-aws-jq-image
@@ -448,6 +483,23 @@ jobs:
                 AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
                 AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
                 nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
+          on_success:
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':white_check_mark:'
+              text: |
+                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-china-x86_64`."
+              attachments: *slack-alert-attachements-success
+          on_failure: &slack-notify-failure-lambda
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':check-failed:'
+              text: |
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-china-x86_64`."
+              attachments: *slack-alert-attachements-failure
+          on_error: *slack-notify-failure-lambda
 
       - task: build-and-publish-aws-lambda-layer-and-image-china-arm64
         privileged: true
@@ -474,23 +526,23 @@ jobs:
                 AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
                 nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
 
-    on_success:
-      put: slack-alert
-      params:
-        channel: '#team-node'
-        icon_emoji: ':white_check_mark:'
-        text: |
-              :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)) and the corresponding container image `icr.io/instana/aws-lambda-nodejs` have been released.
-        attachments: *slack-alert-attachements-success
-    on_failure: &slack-notify-failure-lambda
-      put: slack-alert
-      params:
-        channel: '#team-node'
-        icon_emoji: ':check-failed:'
-        text: |
-              :x: Building/publishing a new version of the Instana Node.js AWS Lambda layer and the container image `icr.io/instana/aws-lambda-nodejs` has failed.
-        attachments: *slack-alert-attachements-failure
-    on_error: *slack-notify-failure-lambda
+            on_success:
+              put: slack-alert
+              params:
+                channel: '#team-node'
+                icon_emoji: ':white_check_mark:'
+                text: |
+                      :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-china-arm64`."
+                attachments: *slack-alert-attachements-success
+            on_failure: &slack-notify-failure-lambda
+              put: slack-alert
+              params:
+                channel: '#team-node'
+                icon_emoji: ':check-failed:'
+                text: |
+                      :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-china-arm64`."
+                attachments: *slack-alert-attachements-failure
+            on_error: *slack-notify-failure-lambda
 
   - name: azure-container-services-nodejs-container-image-layer
     serial: true


### PR DESCRIPTION
Trigger Slack notifications for each task during Lambda layer publish to accurately track task status. 

Right now, if the layer publish fails in any region, the Slack notification still shows success because the build isn't failing when the layer publish fails.

With this update, if a publish fails in any region, the remaining regions will still continue. At the end of each task, the task will fail and trigger the corresponding Slack notification. This will give separate Slack notifications for each of the four tasks in the AWS Lambda layer publish process.

ref INSTA-12860