### PR TITLE
chore: added ci- and build- prefixed branches for auto deletion after 60 days

### DIFF
--- a/.github/workflows/cleanup-branches.yaml
+++ b/.github/workflows/cleanup-branches.yaml
@@ -47,7 +47,7 @@ jobs:
 
           git fetch --prune --all
 
-          for branch in $(git branch -r | grep -E 'origin/(chore-|docs-|fix-|feat-|test-|refactor-)'); do
+          for branch in $(git branch -r | grep -E 'origin/(chore-|docs-|fix-|feat-|test-|refactor-|ci-|build-)'); do
             branch_name=$(echo "$branch" | sed 's|origin/||')
 
             pr_info=$(gh pr list --state merged --base main --head "$branch_name" --json mergedAt)


### PR DESCRIPTION
We missed adding ci- and build- prefixed branches to the auto deletion process. 
As we may have branches starting with these prefixes, this update ensures that 
they will be deleted if they are older than 60 days.