### PR TITLE
ci: fixed slack alert issue related to AWS Lambda layer publishing

### DIFF
--- a/packages/serverless/ci/pipeline.yaml
+++ b/packages/serverless/ci/pipeline.yaml
@@ -401,23 +401,23 @@ jobs:
                 AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
                 AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
                 nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
-          on_success:
-            put: slack-alert
-            params:
-              channel: '#team-node'
-              icon_emoji: ':white_check_mark:'
-              text: |
-                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-x86_64`."
-              attachments: *slack-alert-attachements-success
-          on_failure: &slack-notify-failure-lambda
-            put: slack-alert
-            params:
-              channel: '#team-node'
-              icon_emoji: ':check-failed:'
-              text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-x86_64`."
-              attachments: *slack-alert-attachements-failure
-          on_error: *slack-notify-failure-lambda
+        on_success:
+          put: slack-alert
+          params:
+            channel: '#team-node'
+            icon_emoji: ':white_check_mark:'
+            text: |
+                  :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-x86_64`."
+            attachments: *slack-alert-attachements-success
+        on_failure: &slack-notify-failure-lambda
+          put: slack-alert
+          params:
+            channel: '#team-node'
+            icon_emoji: ':check-failed:'
+            text: |
+                  :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-x86_64`."
+            attachments: *slack-alert-attachements-failure
+        on_error: *slack-notify-failure-lambda
 
       - task: build-and-publish-aws-lambda-layer-and-image-arm64
         privileged: true
@@ -442,23 +442,23 @@ jobs:
                 AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
                 AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
                 nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
-          on_success:
-            put: slack-alert
-            params:
-              channel: '#team-node'
-              icon_emoji: ':white_check_mark:'
-              text: |
-                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-arm64`."
-              attachments: *slack-alert-attachements-success
-          on_failure: &slack-notify-failure-lambda
-            put: slack-alert
-            params:
-              channel: '#team-node'
-              icon_emoji: ':check-failed:'
-              text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-arm64`."
-              attachments: *slack-alert-attachements-failure
-          on_error: *slack-notify-failure-lambda
+        on_success:
+          put: slack-alert
+          params:
+            channel: '#team-node'
+            icon_emoji: ':white_check_mark:'
+            text: |
+                  :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-arm64`."
+            attachments: *slack-alert-attachements-success
+        on_failure: &slack-notify-failure-lambda
+          put: slack-alert
+          params:
+            channel: '#team-node'
+            icon_emoji: ':check-failed:'
+            text: |
+                  :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-arm64`."
+            attachments: *slack-alert-attachements-failure
+        on_error: *slack-notify-failure-lambda
 
       - task: build-and-publish-aws-lambda-layer-and-image-china-x86_64
         privileged: true
@@ -483,23 +483,23 @@ jobs:
                 AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
                 AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
                 nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
-          on_success:
-            put: slack-alert
-            params:
-              channel: '#team-node'
-              icon_emoji: ':white_check_mark:'
-              text: |
-                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-china-x86_64`."
-              attachments: *slack-alert-attachements-success
-          on_failure: &slack-notify-failure-lambda
-            put: slack-alert
-            params:
-              channel: '#team-node'
-              icon_emoji: ':check-failed:'
-              text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-china-x86_64`."
-              attachments: *slack-alert-attachements-failure
-          on_error: *slack-notify-failure-lambda
+        on_success:
+          put: slack-alert
+          params:
+            channel: '#team-node'
+            icon_emoji: ':white_check_mark:'
+            text: |
+                  :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-china-x86_64`."
+            attachments: *slack-alert-attachements-success
+        on_failure: &slack-notify-failure-lambda
+          put: slack-alert
+          params:
+            channel: '#team-node'
+            icon_emoji: ':check-failed:'
+            text: |
+                  :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-china-x86_64`."
+            attachments: *slack-alert-attachements-failure
+        on_error: *slack-notify-failure-lambda
 
       - task: build-and-publish-aws-lambda-layer-and-image-china-arm64
         privileged: true
@@ -526,23 +526,23 @@ jobs:
                 AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
                 nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
 
-            on_success:
-              put: slack-alert
-              params:
-                channel: '#team-node'
-                icon_emoji: ':white_check_mark:'
-                text: |
-                      :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-china-arm64`."
-                attachments: *slack-alert-attachements-success
-            on_failure: &slack-notify-failure-lambda
-              put: slack-alert
-              params:
-                channel: '#team-node'
-                icon_emoji: ':check-failed:'
-                text: |
-                      :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-china-arm64`."
-                attachments: *slack-alert-attachements-failure
-            on_error: *slack-notify-failure-lambda
+        on_success:
+          put: slack-alert
+          params:
+            channel: '#team-node'
+            icon_emoji: ':white_check_mark:'
+            text: |
+                  :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-china-arm64`."
+            attachments: *slack-alert-attachements-success
+        on_failure: &slack-notify-failure-lambda
+          put: slack-alert
+          params:
+            channel: '#team-node'
+            icon_emoji: ':check-failed:'
+            text: |
+                  :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-china-arm64`."
+            attachments: *slack-alert-attachements-failure
+        on_error: *slack-notify-failure-lambda
 
   - name: azure-container-services-nodejs-container-image-layer
     serial: true

--- a/packages/serverless/ci/pipeline.yaml
+++ b/packages/serverless/ci/pipeline.yaml
@@ -365,14 +365,15 @@ jobs:
   - name: aws-lambda-layer-and-container-image
     serial: true
     plan:
-      - get: dind-nodejs-aws-jq-image
-      - get: instana-aws-lambda-npm-package
-        trigger: true
-        params:
-          skip_download: true
-      - get: nodejs-repository
-        passed:
-        - self-update
+      - in_parallel:
+        - get: dind-nodejs-aws-jq-image
+        - get: instana-aws-lambda-npm-package
+          trigger: true
+          params:
+            skip_download: true
+        - get: nodejs-repository
+          passed:
+          - self-update
 
       - load_var: package-version
         file: instana-aws-lambda-npm-package/version
@@ -407,7 +408,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':white_check_mark:'
               text: |
-                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-x86_64`."
+                    :white_check_mark: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the AWS regions (x86_64 architecture).
               attachments: *slack-alert-attachements-success
           on_failure: &slack-notify-failure-lambda
             put: slack-alert
@@ -415,7 +416,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':check-failed:'
               text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-x86_64`."
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the AWS regions (x86_64 architecture).
               attachments: *slack-alert-attachements-failure
           on_error: *slack-notify-failure-lambda
 
@@ -448,7 +449,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':white_check_mark:'
               text: |
-                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-arm64`."
+                    :white_check_mark: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the AWS regions (arm64 architecture).
               attachments: *slack-alert-attachements-success
           on_failure: &slack-notify-failure-lambda
             put: slack-alert
@@ -456,7 +457,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':check-failed:'
               text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-arm64`."
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the AWS regions (arm64 architecture).
               attachments: *slack-alert-attachements-failure
           on_error: *slack-notify-failure-lambda
 
@@ -489,7 +490,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':white_check_mark:'
               text: |
-                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-china-x86_64`."
+                    :white_check_mark: The AWS Lambda layer for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the China regions (x86_64 architecture).
               attachments: *slack-alert-attachements-success
           on_failure: &slack-notify-failure-lambda
             put: slack-alert
@@ -497,7 +498,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':check-failed:'
               text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-china-x86_64`."
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the China regions (x86_64 architecture).
               attachments: *slack-alert-attachements-failure
           on_error: *slack-notify-failure-lambda
 
@@ -531,7 +532,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':white_check_mark:'
               text: |
-                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-china-arm64`."
+                    :white_check_mark: The AWS Lambda layer for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the China regions (arm64 architecture).
               attachments: *slack-alert-attachements-success
           on_failure: &slack-notify-failure-lambda
             put: slack-alert
@@ -539,7 +540,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':check-failed:'
               text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-china-arm64`."
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the China regions (arm64 architecture).
               attachments: *slack-alert-attachements-failure
           on_error: *slack-notify-failure-lambda
 

--- a/packages/serverless/ci/pipeline.yaml
+++ b/packages/serverless/ci/pipeline.yaml
@@ -525,7 +525,6 @@ jobs:
                 AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
                 AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
                 nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
-
         on_success:
           put: slack-alert
           params:

--- a/packages/serverless/ci/pipeline.yaml
+++ b/packages/serverless/ci/pipeline.yaml
@@ -365,183 +365,183 @@ jobs:
   - name: aws-lambda-layer-and-container-image
     serial: true
     plan:
-      - in_parallel:
-        - get: dind-nodejs-aws-jq-image
-        - get: instana-aws-lambda-npm-package
-          trigger: true
-          params:
-            skip_download: true
-        - get: nodejs-repository
-          passed:
-          - self-update
+      - get: dind-nodejs-aws-jq-image
+      - get: instana-aws-lambda-npm-package
+        trigger: true
+        params:
+          skip_download: true
+      - get: nodejs-repository
+        passed:
+        - self-update
 
       - load_var: package-version
         file: instana-aws-lambda-npm-package/version
         reveal: true
+      
+      - in_parallel:
+        - task: build-and-publish-aws-lambda-layer-and-image-x86_64
+          privileged: true
+          image: dind-nodejs-aws-jq-image
+          config:
+            platform: linux
+            inputs:
+              - name: nodejs-repository
+            run:
+              path: entrypoint.sh
+              args:
+              - bash
+              - -ceux
+              - |
+                  BUILD_LAYER_WITH=npm \
+                  NO_PROMPT=true \
+                  CONTAINER_REGISTRY_USER=iamapikey \
+                  CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
+                  AWS_ACCESS_KEY_ID=((aws-ci-manage-lambda-layers.aws_access_key_id)) \
+                  AWS_SECRET_ACCESS_KEY=((aws-ci-manage-lambda-layers.aws_secret_access_key)) \
+                  AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
+                  AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
+                  nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
+          on_success:
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':white_check_mark:'
+              text: |
+                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-x86_64`."
+              attachments: *slack-alert-attachements-success
+          on_failure: &slack-notify-failure-lambda
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':check-failed:'
+              text: |
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-x86_64`."
+              attachments: *slack-alert-attachements-failure
+          on_error: *slack-notify-failure-lambda
 
-      - task: build-and-publish-aws-lambda-layer-and-image-x86_64
-        privileged: true
-        image: dind-nodejs-aws-jq-image
-        config:
-          platform: linux
-          inputs:
-            - name: nodejs-repository
-          run:
-            path: entrypoint.sh
-            args:
-            - bash
-            - -ceux
-            - |
-                BUILD_LAYER_WITH=npm \
-                NO_PROMPT=true \
-                CONTAINER_REGISTRY_USER=iamapikey \
-                CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
-                AWS_ACCESS_KEY_ID=((aws-ci-manage-lambda-layers.aws_access_key_id)) \
-                AWS_SECRET_ACCESS_KEY=((aws-ci-manage-lambda-layers.aws_secret_access_key)) \
-                AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
-                AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
-                nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
-        on_success:
-          put: slack-alert
-          params:
-            channel: '#team-node'
-            icon_emoji: ':white_check_mark:'
-            text: |
-                  :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-x86_64`."
-            attachments: *slack-alert-attachements-success
-        on_failure: &slack-notify-failure-lambda
-          put: slack-alert
-          params:
-            channel: '#team-node'
-            icon_emoji: ':check-failed:'
-            text: |
-                  :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-x86_64`."
-            attachments: *slack-alert-attachements-failure
-        on_error: *slack-notify-failure-lambda
+        - task: build-and-publish-aws-lambda-layer-and-image-arm64
+          privileged: true
+          image: dind-nodejs-aws-jq-image
+          config:
+            platform: linux
+            inputs:
+              - name: nodejs-repository
+            run:
+              path: entrypoint.sh
+              args:
+              - bash
+              - -ceux
+              - |
+                  BUILD_LAYER_WITH=npm \
+                  NO_PROMPT=true \
+                  LAMBDA_ARCHITECTURE=arm64 \
+                  CONTAINER_REGISTRY_USER=iamapikey \
+                  CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
+                  AWS_ACCESS_KEY_ID=((aws-ci-manage-lambda-layers.aws_access_key_id)) \
+                  AWS_SECRET_ACCESS_KEY=((aws-ci-manage-lambda-layers.aws_secret_access_key)) \
+                  AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
+                  AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
+                  nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
+          on_success:
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':white_check_mark:'
+              text: |
+                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-arm64`."
+              attachments: *slack-alert-attachements-success
+          on_failure: &slack-notify-failure-lambda
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':check-failed:'
+              text: |
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-arm64`."
+              attachments: *slack-alert-attachements-failure
+          on_error: *slack-notify-failure-lambda
 
-      - task: build-and-publish-aws-lambda-layer-and-image-arm64
-        privileged: true
-        image: dind-nodejs-aws-jq-image
-        config:
-          platform: linux
-          inputs:
-            - name: nodejs-repository
-          run:
-            path: entrypoint.sh
-            args:
-            - bash
-            - -ceux
-            - |
-                BUILD_LAYER_WITH=npm \
-                NO_PROMPT=true \
-                LAMBDA_ARCHITECTURE=arm64 \
-                CONTAINER_REGISTRY_USER=iamapikey \
-                CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
-                AWS_ACCESS_KEY_ID=((aws-ci-manage-lambda-layers.aws_access_key_id)) \
-                AWS_SECRET_ACCESS_KEY=((aws-ci-manage-lambda-layers.aws_secret_access_key)) \
-                AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
-                AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
-                nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
-        on_success:
-          put: slack-alert
-          params:
-            channel: '#team-node'
-            icon_emoji: ':white_check_mark:'
-            text: |
-                  :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-arm64`."
-            attachments: *slack-alert-attachements-success
-        on_failure: &slack-notify-failure-lambda
-          put: slack-alert
-          params:
-            channel: '#team-node'
-            icon_emoji: ':check-failed:'
-            text: |
-                  :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-arm64`."
-            attachments: *slack-alert-attachements-failure
-        on_error: *slack-notify-failure-lambda
+        - task: build-and-publish-aws-lambda-layer-and-image-china-x86_64
+          privileged: true
+          image: dind-nodejs-aws-jq-image
+          config:
+            platform: linux
+            inputs:
+              - name: nodejs-repository
+            run:
+              path: entrypoint.sh
+              args:
+              - bash
+              - -ceux
+              - |
+                  BUILD_LAYER_WITH=npm \
+                  NO_PROMPT=true \
+                  PUBLISH_TO_CHINA_REGIONS=true \
+                  CONTAINER_REGISTRY_USER=iamapikey \
+                  CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
+                  AWS_ACCESS_KEY_ID=((aws-ci-manage-lambda-layers.aws_access_key_id)) \
+                  AWS_SECRET_ACCESS_KEY=((aws-ci-manage-lambda-layers.aws_secret_access_key)) \
+                  AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
+                  AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
+                  nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
+          on_success:
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':white_check_mark:'
+              text: |
+                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-china-x86_64`."
+              attachments: *slack-alert-attachements-success
+          on_failure: &slack-notify-failure-lambda
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':check-failed:'
+              text: |
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-china-x86_64`."
+              attachments: *slack-alert-attachements-failure
+          on_error: *slack-notify-failure-lambda
 
-      - task: build-and-publish-aws-lambda-layer-and-image-china-x86_64
-        privileged: true
-        image: dind-nodejs-aws-jq-image
-        config:
-          platform: linux
-          inputs:
-            - name: nodejs-repository
-          run:
-            path: entrypoint.sh
-            args:
-            - bash
-            - -ceux
-            - |
-                BUILD_LAYER_WITH=npm \
-                NO_PROMPT=true \
-                PUBLISH_TO_CHINA_REGIONS=true \
-                CONTAINER_REGISTRY_USER=iamapikey \
-                CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
-                AWS_ACCESS_KEY_ID=((aws-ci-manage-lambda-layers.aws_access_key_id)) \
-                AWS_SECRET_ACCESS_KEY=((aws-ci-manage-lambda-layers.aws_secret_access_key)) \
-                AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
-                AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
-                nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
-        on_success:
-          put: slack-alert
-          params:
-            channel: '#team-node'
-            icon_emoji: ':white_check_mark:'
-            text: |
-                  :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-china-x86_64`."
-            attachments: *slack-alert-attachements-success
-        on_failure: &slack-notify-failure-lambda
-          put: slack-alert
-          params:
-            channel: '#team-node'
-            icon_emoji: ':check-failed:'
-            text: |
-                  :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-china-x86_64`."
-            attachments: *slack-alert-attachements-failure
-        on_error: *slack-notify-failure-lambda
-
-      - task: build-and-publish-aws-lambda-layer-and-image-china-arm64
-        privileged: true
-        image: dind-nodejs-aws-jq-image
-        config:
-          platform: linux
-          inputs:
-            - name: nodejs-repository
-          run:
-            path: entrypoint.sh
-            args:
-            - bash
-            - -ceux
-            - |
-                BUILD_LAYER_WITH=npm \
-                NO_PROMPT=true \
-                LAMBDA_ARCHITECTURE=arm64 \
-                PUBLISH_TO_CHINA_REGIONS=true \
-                CONTAINER_REGISTRY_USER=iamapikey \
-                CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
-                AWS_ACCESS_KEY_ID=((aws-ci-manage-lambda-layers.aws_access_key_id)) \
-                AWS_SECRET_ACCESS_KEY=((aws-ci-manage-lambda-layers.aws_secret_access_key)) \
-                AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
-                AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
-                nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
-        on_success:
-          put: slack-alert
-          params:
-            channel: '#team-node'
-            icon_emoji: ':white_check_mark:'
-            text: |
-                  :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-china-arm64`."
-            attachments: *slack-alert-attachements-success
-        on_failure: &slack-notify-failure-lambda
-          put: slack-alert
-          params:
-            channel: '#team-node'
-            icon_emoji: ':check-failed:'
-            text: |
-                  :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-china-arm64`."
-            attachments: *slack-alert-attachements-failure
-        on_error: *slack-notify-failure-lambda
+        - task: build-and-publish-aws-lambda-layer-and-image-china-arm64
+          privileged: true
+          image: dind-nodejs-aws-jq-image
+          config:
+            platform: linux
+            inputs:
+              - name: nodejs-repository
+            run:
+              path: entrypoint.sh
+              args:
+              - bash
+              - -ceux
+              - |
+                  BUILD_LAYER_WITH=npm \
+                  NO_PROMPT=true \
+                  LAMBDA_ARCHITECTURE=arm64 \
+                  PUBLISH_TO_CHINA_REGIONS=true \
+                  CONTAINER_REGISTRY_USER=iamapikey \
+                  CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
+                  AWS_ACCESS_KEY_ID=((aws-ci-manage-lambda-layers.aws_access_key_id)) \
+                  AWS_SECRET_ACCESS_KEY=((aws-ci-manage-lambda-layers.aws_secret_access_key)) \
+                  AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
+                  AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
+                  nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
+          on_success:
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':white_check_mark:'
+              text: |
+                    :white_check_mark: The Instana Node.js AWS Lambda layer for package version ((.:package-version)). Successfully completed task `build-and-publish-aws-lambda-layer-and-image-china-arm64`."
+              attachments: *slack-alert-attachements-success
+          on_failure: &slack-notify-failure-lambda
+            put: slack-alert
+            params:
+              channel: '#team-node'
+              icon_emoji: ':check-failed:'
+              text: |
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed during the task `build-and-publish-aws-lambda-layer-and-image-china-arm64`."
+              attachments: *slack-alert-attachements-failure
+          on_error: *slack-notify-failure-lambda
 
   - name: azure-container-services-nodejs-container-image-layer
     serial: true


### PR DESCRIPTION
This PR addresses two issues:

- The current implementation causes all remaining tasks to be skipped if one task fails.
- Slack notifications were not working for each tasks. 

ref [INSTA-22682](https://jsw.ibm.com/browse/INSTA-22682)