### PR TITLE
refactor: added new span class for ignored span

### DIFF
--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -219,7 +219,9 @@ class InstanaPseudoSpan extends InstanaSpan {
   }
 }
 /**
- * This class represents an ignored span when accessing the `currentSpan`.
+* This class represents an ignored span. We need this representation for the endpoint filtering feature because
+ * when a customer accesses the current span via `instana.currentSpan()`, we do not want to return a "NoopSpan".
+ * Instead, we return this ignored span instance so the trace ID remains accessible.
  * It overrides the `transmit` and `cancel` methods to to ensure that the span is never sent, only cleaned up.
  */
 // eslint-disable-next-line no-unused-vars

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -219,7 +219,7 @@ class InstanaPseudoSpan extends InstanaSpan {
   }
 }
 /**
-* This class represents an ignored span. We need this representation for the endpoint filtering feature because
+ * This class represents an ignored span. We need this representation for the endpoint filtering feature because
  * when a customer accesses the current span via `instana.currentSpan()`, we do not want to return a "NoopSpan".
  * Instead, we return this ignored span instance so the trace ID remains accessible.
  * It overrides the `transmit` and `cancel` methods to to ensure that the span is never sent, only cleaned up.

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -219,6 +219,32 @@ class InstanaPseudoSpan extends InstanaSpan {
   }
 }
 
+// This class represents an ignored span and overrides the `transmit` and `cancel` methods
+// to ensure that the span is never sent, only cleaned up.
+// eslint-disable-next-line no-unused-vars
+class InstanaIgnoredSpan extends InstanaSpan {
+  transmit() {
+    if (!this.transmitted && !this.manualEndMode) {
+      this.cleanup();
+      this.transmitted = true;
+    }
+  }
+
+  transmitManual() {
+    if (!this.transmitted) {
+      this.cleanup();
+      this.transmitted = true;
+    }
+  }
+
+  cancel() {
+    if (!this.transmitted) {
+      this.cleanup();
+      this.transmitted = true;
+    }
+  }
+}
+
 /**
  * Start a new span and set it as the current span.
  * @param {string} spanName

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -218,9 +218,10 @@ class InstanaPseudoSpan extends InstanaSpan {
     }
   }
 }
-
-// This class represents an ignored span and overrides the `transmit` and `cancel` methods
-// to ensure that the span is never sent, only cleaned up.
+/**
+ * This class represents an ignored span when accessing the `currentSpan`.
+ * It overrides the `transmit` and `cancel` methods to to ensure that the span is never sent, only cleaned up.
+ */
 // eslint-disable-next-line no-unused-vars
 class InstanaIgnoredSpan extends InstanaSpan {
   transmit() {


### PR DESCRIPTION
The addition of `InstanaIgnoredSpan` serves to address case where a span is intentionally ignored via configuration and should not be transmitted or placed into the span buffer. 