### PR TITLE
refactor: replaced startSpan positional arguments with optional object pattern

### DIFF
--- a/packages/aws-lambda/src/wrapper.js
+++ b/packages/aws-lambda/src/wrapper.js
@@ -96,15 +96,13 @@ function shimmedHandler(originalHandler, originalThis, originalArgs, _config) {
         w3cTraceContext.disableSampling();
       }
     } else {
-      entrySpan = tracing
-        .getCls()
-        .startSpan(
-          'aws.lambda.entry',
-          constants.ENTRY,
-          traceCorrelationData.traceId,
-          traceCorrelationData.parentId,
-          w3cTraceContext
-        );
+      entrySpan = tracing.getCls().startSpan({
+        spanName: 'aws.lambda.entry',
+        kind: constants.ENTRY,
+        traceId: traceCorrelationData.traceId,
+        parentSpanId: traceCorrelationData.parentId,
+        w3cTraceContext: w3cTraceContext
+      });
       tracingHeaders.setSpanAttributes(entrySpan, traceCorrelationData);
       const { arn, alias } = arnInfo;
       entrySpan.data.lambda = {

--- a/packages/collector/test/tracing/native_esm/customInstrumentation/squareCalc.js
+++ b/packages/collector/test/tracing/native_esm/customInstrumentation/squareCalc.js
@@ -36,7 +36,10 @@ function instrument(orgModule) {
       return originalCalculateSquare.apply(this, arguments);
     }
     return cls.ns.runAndReturn(() => {
-      const span = cls.startSpan('square-calc', EXIT, null, null);
+      const span = cls.startSpan({
+        spanName: 'square-calc',
+        kind: EXIT
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(instrument, 1);
 

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -250,14 +250,18 @@ class InstanaIgnoredSpan extends InstanaSpan {
 
 /**
  * Start a new span and set it as the current span.
- * @param {string} spanName
- * @param {number} kind
- * @param {string} traceId
- * @param {string} parentSpanId
- * @param {import('./w3c_trace_context/W3cTraceContext')} [w3cTraceContext]
+ * @param {Object} spanAttributes
+ * @param {string} [spanAttributes.spanName]
+ * @param {number} [spanAttributes.kind]
+ * @param {string} [spanAttributes.traceId]
+ * @param {string} [spanAttributes.parentSpanId]
+ * @param {import('./w3c_trace_context/W3cTraceContext')} [spanAttributes.w3cTraceContext]
  * @returns {InstanaSpan}
  */
-function startSpan(spanName, kind, traceId, parentSpanId, w3cTraceContext) {
+
+function startSpan(spanAttributes = {}) {
+  let { spanName, kind, traceId, parentSpanId, w3cTraceContext } = spanAttributes;
+
   tracingMetrics.incrementOpened();
   if (!kind || (kind !== ENTRY && kind !== EXIT && kind !== INTERMEDIATE)) {
     logger.warn(`Invalid span (${spanName}) without kind/with invalid kind: ${kind}, assuming EXIT.`);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/dynamodb.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/dynamodb.js
@@ -34,7 +34,10 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
 
     return cls.ns.runAndReturn(() => {
       const self = this;
-      const span = cls.startSpan(this.spanName, EXIT);
+      const span = cls.startSpan({
+        spanName: this.spanName,
+        kind: EXIT
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedMakeRequest, 1);
       // Data attribs: op and table

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/kinesis.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/kinesis.js
@@ -50,7 +50,10 @@ class InstanaAWSKinesis extends InstanaAWSProduct {
     }
 
     return cls.ns.runAndReturn(() => {
-      const span = cls.startSpan(this.spanName, EXIT);
+      const span = cls.startSpan({
+        spanName: this.spanName,
+        kind: EXIT
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedMakeRequest, 1);
       // Data attribs: op and stream

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/lambda.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/lambda.js
@@ -77,7 +77,10 @@ class InstanaAWSLambda extends InstanaAWSProduct {
     }
 
     return cls.ns.runAndReturn(() => {
-      const span = cls.startSpan(SPAN_NAME, EXIT);
+      const span = cls.startSpan({
+        spanName: SPAN_NAME,
+        kind: EXIT
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedMakeRequest, 1);
       span.data[this.spanName] = this.buildSpanData(originalArgs[0], originalArgs[1]);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/s3.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/s3.js
@@ -64,7 +64,10 @@ class InstanaAWSS3 extends InstanaAWSProduct {
     }
 
     return cls.ns.runAndReturn(() => {
-      const span = cls.startSpan(SPAN_NAME, EXIT);
+      const span = cls.startSpan({
+        spanName: SPAN_NAME,
+        kind: EXIT
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedMakeRequest, 1);
       span.data[this.spanName] = this.buildSpanData(originalArgs[0], originalArgs[1]);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/sns.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/sns.js
@@ -46,7 +46,10 @@ class InstanaAWSSNS extends InstanaAWSProduct {
 
     return cls.ns.runAndReturn(() => {
       const self = this;
-      const span = cls.startSpan(this.spanName, EXIT);
+      const span = cls.startSpan({
+        spanName: this.spanName,
+        kind: EXIT
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedMakeRequest, 1);
       span.data[this.spanName] = this.buildSpanData(originalArgs[1]);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/sqs.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/sqs.js
@@ -129,7 +129,10 @@ function instrumentedSendMessage(ctx, originalSendMessage, originalArgs) {
   }
 
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('sqs', EXIT);
+    const span = cls.startSpan({
+      spanName: 'sqs',
+      kind: EXIT
+    });
     span.ts = Date.now();
     span.stack = tracingUtil.getStackTrace(instrumentedSendMessage);
     span.data.sqs = {
@@ -243,7 +246,10 @@ function shimReceiveMessage(originalReceiveMessage) {
 
 function instrumentedReceiveMessage(ctx, originalReceiveMessage, originalArgs) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('sqs', ENTRY);
+    const span = cls.startSpan({
+      spanName: 'sqs',
+      kind: ENTRY
+    });
     span.stack = tracingUtil.getStackTrace(instrumentedSendMessage);
     span.data.sqs = {
       sort: sortTypes.ENTRY,

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
@@ -22,7 +22,10 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
 
     return cls.ns.runAndReturn(() => {
       const self = this;
-      const span = cls.startSpan(this.spanName, EXIT);
+      const span = cls.startSpan({
+        spanName: this.spanName,
+        kind: EXIT
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedSmithySend, 1);
       span.data[this.spanName] = this.buildSpanData(command.constructor.name, command.input);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/kinesis.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/kinesis.js
@@ -20,7 +20,10 @@ class InstanaAWSKinesis extends InstanaAWSProduct {
     const command = smithySendArgs[0];
     return cls.ns.runAndReturn(() => {
       const self = this;
-      const span = cls.startSpan(this.spanName, EXIT);
+      const span = cls.startSpan({
+        spanName: this.spanName,
+        kind: EXIT
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedSmithySend, 1);
       const operation = this.convertOperationName(command.constructor.name);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/lambda.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/lambda.js
@@ -74,7 +74,10 @@ class InstanaAWSLambda extends InstanaAWSProduct {
     }
 
     return cls.ns.runAndReturn(() => {
-      const span = cls.startSpan(SPAN_NAME, EXIT);
+      const span = cls.startSpan({
+        spanName: SPAN_NAME,
+        kind: EXIT
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedMakeRequest, 1);
       span.data[this.spanName] = this.buildSpanData(smithySendArgs[0], smithySendArgs[0].input);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/s3.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/s3.js
@@ -63,7 +63,10 @@ class InstanaAWSS3 extends InstanaAWSProduct {
 
     return cls.ns.runAndReturn(() => {
       const self = this;
-      const span = cls.startSpan(this.spanName, EXIT);
+      const span = cls.startSpan({
+        spanName: this.spanName,
+        kind: EXIT
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedSmithySend, 1);
       span.data[this.spanName] = this.buildSpanData(command.constructor.name, command.input);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sns.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sns.js
@@ -30,7 +30,10 @@ class InstanaAWSNS extends InstanaAWSProduct {
 
     return cls.ns.runAndReturn(() => {
       const self = this;
-      const span = cls.startSpan(this.spanName, EXIT);
+      const span = cls.startSpan({
+        spanName: this.spanName,
+        kind: EXIT
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedSmithySend, 1);
 

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
@@ -155,7 +155,10 @@ class InstanaAWSSQS extends InstanaAWSProduct {
 
     return cls.ns.runAndReturn(() => {
       const self = this;
-      const span = cls.startSpan(SPAN_NAME, EXIT);
+      const span = cls.startSpan({
+        spanName: SPAN_NAME,
+        kind: EXIT
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentExit, 2);
       span.data.sqs = this.buildSpanData(operation, sendMessageInput);
@@ -223,7 +226,10 @@ class InstanaAWSSQS extends InstanaAWSProduct {
     return cls.ns.runAndReturn(() => {
       const self = this;
 
-      const span = cls.startSpan(SPAN_NAME, ENTRY);
+      const span = cls.startSpan({
+        spanName: SPAN_NAME,
+        kind: ENTRY
+      });
       span.stack = tracingUtil.getStackTrace(this.instrumentEntry, 2);
       span.data.sqs = this.buildSpanData(operation, sendMessageInput);
 

--- a/packages/core/src/tracing/instrumentation/cloud/azure/blob.js
+++ b/packages/core/src/tracing/instrumentation/cloud/azure/blob.js
@@ -72,7 +72,10 @@ function instrumentingOperation({
   const accountName = accntName;
   const op = operation;
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan(exports.spanName, constants.EXIT);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(instrumentingOperation);
     span.data.azstorage = {
       containerName,

--- a/packages/core/src/tracing/instrumentation/cloud/gcp/pubsub.js
+++ b/packages/core/src/tracing/instrumentation/cloud/gcp/pubsub.js
@@ -100,7 +100,10 @@ function instrumentedPublishMessage(ctx, originalPublishMessage, originalArgs) {
   }
 
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('gcps', EXIT);
+    const span = cls.startSpan({
+      spanName: 'gcps',
+      kind: EXIT
+    });
     span.ts = Date.now();
     span.stack = tracingUtil.getStackTrace(instrumentedPublishMessage);
     span.data.gcps = {
@@ -192,12 +195,12 @@ function instrumentedEmitMessage(ctx, originalEmit, originalArgs) {
     }
 
     const { projid, sub } = parseSubscription(message._subscriber && message._subscriber._subscription);
-    const span = cls.startSpan(
-      'gcps',
-      ENTRY,
-      tracingUtil.readAttribCaseInsensitive(attribtes, traceIdHeaderNameLowerCase),
-      tracingUtil.readAttribCaseInsensitive(attribtes, spanIdHeaderNameLowerCase)
-    );
+    const span = cls.startSpan({
+      spanName: 'gcps',
+      kind: ENTRY,
+      traceId: tracingUtil.readAttribCaseInsensitive(attribtes, traceIdHeaderNameLowerCase),
+      parentSpanId: tracingUtil.readAttribCaseInsensitive(attribtes, spanIdHeaderNameLowerCase)
+    });
     span.ts = Date.now();
     span.stack = tracingUtil.getStackTrace(instrumentedEmitMessage);
     span.data.gcps = {

--- a/packages/core/src/tracing/instrumentation/cloud/gcp/storage.js
+++ b/packages/core/src/tracing/instrumentation/cloud/gcp/storage.js
@@ -393,7 +393,10 @@ function shim(instrumented, original) {
 
 function instrumentedOperation(operation, extractorPre, extractorPost, ctx, original, originalArgs) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('gcs', constants.EXIT);
+    const span = cls.startSpan({
+      spanName: 'gcs',
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(instrumentedOperation, 1);
     span.data.gcs = {
       op: operation
@@ -425,7 +428,10 @@ function instrumentedOperation(operation, extractorPre, extractorPost, ctx, orig
 
 function instrumentedCreateStream(operation, bindEvent, finalEvent, ctx, original, originalArgs) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('gcs', constants.EXIT);
+    const span = cls.startSpan({
+      spanName: 'gcs',
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(instrumentedCreateStream, 1);
     span.data.gcs = {
       op: operation

--- a/packages/core/src/tracing/instrumentation/database/couchbase.js
+++ b/packages/core/src/tracing/instrumentation/database/couchbase.js
@@ -413,7 +413,10 @@ function instrumentTransactions(cluster, connectionStr) {
 
               shimmer.wrap(attempt, obj[0].fnName, originalFn => {
                 return function instanaCommitRollbackOverride() {
-                  const span = cls.startSpan(exports.spanName, constants.EXIT);
+                  const span = cls.startSpan({
+                    spanName: exports.spanName,
+                    kind: constants.EXIT
+                  });
                   span.stack = tracingUtil.getStackTrace(instanaCommitRollbackOverride);
                   span.ts = Date.now();
                   span.data.couchbase = {
@@ -465,7 +468,10 @@ function instrumentOperation({ connectionStr, bucketName, getBucketTypeFn, sql, 
 
     return cls.ns.runAndReturn(() => {
       const bucketType = getBucketTypeFn && getBucketTypeFn();
-      const span = cls.startSpan(exports.spanName, constants.EXIT);
+      const span = cls.startSpan({
+        spanName: exports.spanName,
+        kind: constants.EXIT
+      });
       span.stack = tracingUtil.getStackTrace(original);
       span.ts = Date.now();
       span.data.couchbase = {

--- a/packages/core/src/tracing/instrumentation/database/db2.js
+++ b/packages/core/src/tracing/instrumentation/database/db2.js
@@ -505,7 +505,10 @@ function instrumentQueryResultHelper(ctx, originalArgs, originalFunction, stmt, 
 function createSpan(stmt, fn, connectionStr) {
   // eslint-disable-next-line max-len
   // https://github.ibm.com/instana/backend/blob/develop/forge/src/main/java/com/instana/forge/connection/database/ibmdb2/IbmDb2Span.java
-  const span = cls.startSpan(exports.spanName, constants.EXIT);
+  const span = cls.startSpan({
+    spanName: exports.spanName,
+    kind: constants.EXIT
+  });
   span.stack = tracingUtil.getStackTrace(fn);
   span.ts = Date.now();
   span.data.db2 = {

--- a/packages/core/src/tracing/instrumentation/database/elasticsearch.js
+++ b/packages/core/src/tracing/instrumentation/database/elasticsearch.js
@@ -134,7 +134,10 @@ function instrumentApi(client, actionPath, clusterInfo) {
     }
 
     return cls.ns.runAndReturn(() => {
-      const span = cls.startSpan(exports.spanName, constants.EXIT);
+      const span = cls.startSpan({
+        spanName: exports.spanName,
+        kind: constants.EXIT
+      });
       span.stack = tracingUtil.getStackTrace(instrumentedAction);
       span.data.elasticsearch = {
         action,
@@ -414,7 +417,10 @@ function instrumentedRequest(ctx, origEsReq, originalArgs) {
   const httpPath = params.path;
 
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan(exports.spanName, constants.EXIT);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(instrumentedRequest, 1);
     span.data.elasticsearch = {
       endpoint: httpPath

--- a/packages/core/src/tracing/instrumentation/database/ioredis.js
+++ b/packages/core/src/tracing/instrumentation/database/ioredis.js
@@ -77,7 +77,10 @@ function instrumentSendCommand(original) {
 
     const argsForOriginal = arguments;
     return cls.ns.runAndReturn(() => {
-      const span = cls.startSpan(exports.spanName, constants.EXIT);
+      const span = cls.startSpan({
+        spanName: exports.spanName,
+        kind: constants.EXIT
+      });
       span.stack = tracingUtil.getStackTrace(wrappedInternalSendCommand);
 
       const connection = `${client.options.host}:${client.options.port}`;
@@ -153,7 +156,10 @@ function instrumentMultiOrPipelineCommand(commandName, original) {
     // create a new cls context parent to track the multi/pipeline child calls
     const clsContextForMultiOrPipeline = cls.ns.createContext();
     cls.ns.enter(clsContextForMultiOrPipeline);
-    const span = cls.startSpan(exports.spanName, constants.EXIT);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(wrappedInternalMultiOrPipelineCommand);
     span.data.redis = {
       connection,

--- a/packages/core/src/tracing/instrumentation/database/memcached.js
+++ b/packages/core/src/tracing/instrumentation/database/memcached.js
@@ -69,7 +69,10 @@ function instrumentedCommand(ctx, originalCommand, originaCommandArgs) {
   return cls.ns.runAndReturn(() => {
     const originalQuery = originaCommandArgs[0];
 
-    const span = cls.startSpan(SPAN_NAME, EXIT);
+    const span = cls.startSpan({
+      spanName: SPAN_NAME,
+      kind: EXIT
+    });
     span.ts = Date.now();
     span.stack = tracingUtil.getStackTrace(instrumentedCommand);
 

--- a/packages/core/src/tracing/instrumentation/database/mongodb.js
+++ b/packages/core/src/tracing/instrumentation/database/mongodb.js
@@ -135,7 +135,10 @@ function shimCmapGetMore(original) {
 
 function instrumentedCmapQuery(ctx, originalQuery, originalArgs) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan(exports.spanName, constants.EXIT);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(instrumentedCmapQuery, 1);
 
     const namespace = originalArgs[0];
@@ -165,7 +168,10 @@ function instrumentedCmapQuery(ctx, originalQuery, originalArgs) {
 
 function instrumentedCmapMethod(ctx, originalMethod, originalArgs, command) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan(exports.spanName, constants.EXIT);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(instrumentedCmapQuery, 1);
 
     let namespace = originalArgs[0];
@@ -205,7 +211,10 @@ function instrumentedCmapMethod(ctx, originalMethod, originalArgs, command) {
 
 function instrumentedCmapGetMore(ctx, originalMethod, originalArgs) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan(exports.spanName, constants.EXIT);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(instrumentedCmapQuery, 1);
 
     const namespace = originalArgs[0];
@@ -247,7 +256,10 @@ function shimLegacyWrite(original) {
 
 function instrumentedLegacyWrite(ctx, originalWrite, originalArgs) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan(exports.spanName, constants.EXIT);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(instrumentedLegacyWrite);
 
     let hostname;

--- a/packages/core/src/tracing/instrumentation/database/mssql.js
+++ b/packages/core/src/tracing/instrumentation/database/mssql.js
@@ -60,7 +60,10 @@ function instrumentedMethod(ctx, originalFunction, originalArgs, stackTraceRef, 
   const command = commandProvider(originalArgs);
 
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan(exports.spanName, constants.EXIT);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(stackTraceRef);
     span.data.mssql = {
       stmt: tracingUtil.shortenDatabaseStatement(command),

--- a/packages/core/src/tracing/instrumentation/database/mysql.js
+++ b/packages/core/src/tracing/instrumentation/database/mysql.js
@@ -163,7 +163,10 @@ function instrumentedAccessFunction(
   }
 
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan(exports.spanName, constants.EXIT);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: constants.EXIT
+    });
     span.b = { s: 1 };
     span.stack = tracingUtil.getStackTrace(instrumentedAccessFunction);
     span.data.mysql = {

--- a/packages/core/src/tracing/instrumentation/database/pg.js
+++ b/packages/core/src/tracing/instrumentation/database/pg.js
@@ -53,7 +53,10 @@ function instrumentedQuery(ctx, originalQuery, argsForOriginalQuery) {
   const config = argsForOriginalQuery[0];
 
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan(exports.spanName, constants.EXIT);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(instrumentedQuery);
     span.data.pg = {
       stmt: tracingUtil.shortenDatabaseStatement(typeof config === 'string' ? config : config.text),

--- a/packages/core/src/tracing/instrumentation/database/pgNative.js
+++ b/packages/core/src/tracing/instrumentation/database/pgNative.js
@@ -128,7 +128,10 @@ function shimQueryOrExecuteSync(isExecute, original) {
 
 function startSpan(ctx, originalFn, originalArgs, statement, stackTraceRef) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan(exports.spanName, constants.EXIT);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(stackTraceRef);
     span.data.pg = {
       stmt: tracingUtil.shortenDatabaseStatement(statement),
@@ -162,7 +165,10 @@ function startSpan(ctx, originalFn, originalArgs, statement, stackTraceRef) {
 
 function startSpanBeforeSync(ctx, originalFn, originalArgs, statement, stackTraceRef) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan(exports.spanName, constants.EXIT);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(stackTraceRef);
     span.data.pg = {
       stmt: tracingUtil.shortenDatabaseStatement(statement),

--- a/packages/core/src/tracing/instrumentation/database/prisma.js
+++ b/packages/core/src/tracing/instrumentation/database/prisma.js
@@ -140,7 +140,10 @@ function instrumentRequest(original) {
 
 function instrumentedRequest(ctx, originalRequest, argsForOriginalRequest) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('prisma', EXIT);
+    const span = cls.startSpan({
+      spanName: 'prisma',
+      kind: EXIT
+    });
     span.stack = getStackTrace(instrumentedRequest, 1);
     const params = argsForOriginalRequest[0] || {};
 

--- a/packages/core/src/tracing/instrumentation/database/redis.js
+++ b/packages/core/src/tracing/instrumentation/database/redis.js
@@ -236,7 +236,10 @@ function instrumentCommand(original, command, address, cbStyle) {
     }
 
     return cls.ns.runAndReturn(() => {
-      const span = cls.startSpan(exports.spanName, constants.EXIT);
+      const span = cls.startSpan({
+        spanName: exports.spanName,
+        kind: constants.EXIT
+      });
       span.stack = tracingUtil.getStackTrace(instrumentCommand);
 
       span.data.redis = {
@@ -314,9 +317,17 @@ function instrumentMultiExec(origCtx, origArgs, original, address, isAtomic, cbS
     let span;
 
     if (skipExitResult.allowRootExitSpan) {
-      span = cls.startSpan(exports.spanName, constants.EXIT);
+      span = cls.startSpan({
+        spanName: exports.spanName,
+        kind: constants.EXIT
+      });
     } else {
-      span = cls.startSpan(exports.spanName, constants.EXIT, parentSpan.t, parentSpan.s);
+      span = cls.startSpan({
+        spanName: exports.spanName,
+        kind: constants.EXIT,
+        traceId: parentSpan.t,
+        parentSpanId: parentSpan.s
+      });
     }
 
     span.stack = tracingUtil.getStackTrace(instrumentMultiExec);

--- a/packages/core/src/tracing/instrumentation/loggers/bunyan.js
+++ b/packages/core/src/tracing/instrumentation/loggers/bunyan.js
@@ -49,7 +49,10 @@ function shimLog(markAsError) {
 
 function instrumentedLog(ctx, originalLog, originalArgs, markAsError) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('log.bunyan', constants.EXIT);
+    const span = cls.startSpan({
+      spanName: 'log.bunyan',
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(instrumentedLog);
     const fields = originalArgs[0];
     let message = originalArgs[1];

--- a/packages/core/src/tracing/instrumentation/loggers/console.js
+++ b/packages/core/src/tracing/instrumentation/loggers/console.js
@@ -45,7 +45,10 @@ function shimLog(options) {
 
 function instrumentedLog(ctx, originalLog, originalArgs, options) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('log.console', constants.EXIT);
+    const span = cls.startSpan({
+      spanName: 'log.console',
+      kind: constants.EXIT
+    });
 
     span.stack = tracingUtil.getStackTrace(instrumentedLog);
     const firstArg = originalArgs[0];

--- a/packages/core/src/tracing/instrumentation/loggers/log4js.js
+++ b/packages/core/src/tracing/instrumentation/loggers/log4js.js
@@ -65,7 +65,10 @@ function instrumentedLog(ctx, originalArgs, originalLog, markAsError) {
       message = util.format(...originalArgs.slice(1));
     }
 
-    const span = cls.startSpan('log.log4js', constants.EXIT);
+    const span = cls.startSpan({
+      spanName: 'log.log4js',
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(instrumentedLog);
     span.data.log = {
       message

--- a/packages/core/src/tracing/instrumentation/loggers/pino.js
+++ b/packages/core/src/tracing/instrumentation/loggers/pino.js
@@ -50,7 +50,10 @@ function shimGenLog(originalGenLog) {
 
         const ctx = this;
         return cls.ns.runAndReturn(() => {
-          const span = cls.startSpan('log.pino', constants.EXIT);
+          const span = cls.startSpan({
+            spanName: 'log.pino',
+            kind: constants.EXIT
+          });
           span.stack = tracingUtil.getStackTrace(log);
 
           if (typeof mergingObject === 'string') {

--- a/packages/core/src/tracing/instrumentation/loggers/winston.js
+++ b/packages/core/src/tracing/instrumentation/loggers/winston.js
@@ -157,7 +157,10 @@ function levelIsError(level) {
 
 function createSpan(ctx, originalMethod, originalArgs, message, markAsError) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('log.winston', constants.EXIT);
+    const span = cls.startSpan({
+      spanName: 'log.winston',
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(createSpan);
     span.data.log = {
       message

--- a/packages/core/src/tracing/instrumentation/messaging/bull.js
+++ b/packages/core/src/tracing/instrumentation/messaging/bull.js
@@ -86,7 +86,10 @@ function instrumentedJobCreate(ctx, originalJobCreate, originalArgs, options) {
   return cls.ns.runAndReturn(() => {
     // inherit parent if exists. eg: ENTRY http server
     // or is root if no parent present
-    const span = cls.startSpan(exports.spanName, EXIT);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: EXIT
+    });
     span.ts = Date.now();
     span.stack = tracingUtil.getStackTrace(instrumentedJobCreate, 1);
     span.data.bull = {
@@ -146,7 +149,10 @@ function instrumentedJobCreateBulk(ctx, originalJobCreateBulk, originalArgs) {
 
   immediateJobs.forEach(job => {
     cls.ns.run(() => {
-      const span = cls.startSpan(exports.spanName, EXIT);
+      const span = cls.startSpan({
+        spanName: exports.spanName,
+        kind: EXIT
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(instrumentedJobCreateBulk, 2);
       span.data.bull = {
@@ -233,7 +239,13 @@ function instrumentedProcessJob(ctx, originalProcessJob, originalArgs) {
       return originalProcessJob.apply(ctx, originalArgs);
     }
 
-    const span = cls.startSpan(exports.spanName, ENTRY, spanT, spanP);
+    const span = cls.startSpan({
+      spanName: exports.spanName,
+      kind: ENTRY,
+      traceId: spanT,
+      parentSpanId: spanP
+    });
+
     span.ts = Date.now();
     span.stack = tracingUtil.getStackTrace(instrumentedProcessJob, 1);
     span.data.bull = {

--- a/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
@@ -82,7 +82,10 @@ function shimmedSend(originalSend) {
 
 function instrumentedSend(ctx, originalSend, originalArgs, topic, messages) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('kafka', constants.EXIT);
+    const span = cls.startSpan({
+      spanName: 'kafka',
+      kind: constants.EXIT
+    });
     if (Array.isArray(messages)) {
       span.b = { s: messages.length };
       addTraceContextHeaderToAllMessages(messages, span);
@@ -148,7 +151,10 @@ function instrumentedSendBatch(ctx, originalSendBatch, originalArgs, topicMessag
   });
 
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('kafka', constants.EXIT);
+    const span = cls.startSpan({
+      spanName: 'kafka',
+      kind: constants.EXIT
+    });
     span.stack = tracingUtil.getStackTrace(instrumentedSend);
     topicMessages.forEach(topicMessage => {
       addTraceContextHeaderToAllMessages(topicMessage.messages, span);
@@ -257,7 +263,12 @@ function instrumentedEachMessage(originalEachMessage) {
         return originalEachMessage.apply(ctx, originalArgs);
       }
 
-      const span = cls.startSpan('kafka', constants.ENTRY, traceId, parentSpanId);
+      const span = cls.startSpan({
+        spanName: 'kafka',
+        kind: constants.ENTRY,
+        traceId: traceId,
+        parentSpanId: parentSpanId
+      });
       if (longTraceId) {
         span.lt = longTraceId;
       }
@@ -340,7 +351,12 @@ function instrumentedEachBatch(originalEachBatch) {
         return originalEachBatch.apply(ctx, originalArgs);
       }
 
-      const span = cls.startSpan('kafka', constants.ENTRY, traceId, parentSpanId);
+      const span = cls.startSpan({
+        spanName: 'kafka',
+        kind: constants.ENTRY,
+        traceId: traceId,
+        parentSpanId: parentSpanId
+      });
       if (longTraceId) {
         span.lt = longTraceId;
       }

--- a/packages/core/src/tracing/instrumentation/messaging/kafkaNode.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafkaNode.js
@@ -67,7 +67,10 @@ function instrumentedSend(ctx, originalSend, produceRequests, cb) {
   }
 
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('kafka', constants.EXIT);
+    const span = cls.startSpan({
+      spanName: 'kafka',
+      kind: constants.EXIT
+    });
     const produceRequest = produceRequests[0];
     span.b = { s: produceRequests.length };
     span.stack = tracingUtil.getStackTrace(instrumentedSend);
@@ -117,7 +120,10 @@ function shimEmit(original) {
     }
 
     return cls.ns.runAndReturn(() => {
-      const span = cls.startSpan('kafka', constants.ENTRY);
+      const span = cls.startSpan({
+        spanName: 'kafka',
+        kind: constants.ENTRY
+      });
       span.stack = [];
       span.data.kafka = {
         access: 'consume',

--- a/packages/core/src/tracing/instrumentation/messaging/nats.js
+++ b/packages/core/src/tracing/instrumentation/messaging/nats.js
@@ -165,7 +165,10 @@ function instrumentedPublish(ctx, originalPublish, originalArgs, isLatest) {
   const originalCallback = callbackIndex >= 0 ? originalArgs[callbackIndex] : null;
 
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('nats', constants.EXIT);
+    const span = cls.startSpan({
+      spanName: 'nats',
+      kind: constants.EXIT
+    });
     span.ts = Date.now();
     span.stack = tracingUtil.getStackTrace(instrumentedPublish);
     span.data.nats = {
@@ -355,7 +358,12 @@ function instrumentedSubscribeCallback(natsUrl, subject, originalSubscribeCallba
       }
 
       if (isActive) {
-        const span = cls.startSpan('nats', constants.ENTRY, traceId, parentSpanId);
+        const span = cls.startSpan({
+          spanName: 'nats',
+          kind: constants.ENTRY,
+          traceId: traceId,
+          parentSpanId: parentSpanId
+        });
         span.ts = Date.now();
         span.stack = tracingUtil.getStackTrace(instrumentedSubscribeCallback);
 

--- a/packages/core/src/tracing/instrumentation/messaging/natsStreaming.js
+++ b/packages/core/src/tracing/instrumentation/messaging/natsStreaming.js
@@ -70,7 +70,10 @@ function instrumentedPublish(ctx, originalPublish, originalArgs) {
   const originalCallback = typeof originalArgs[2] === 'function' ? originalArgs[2] : null;
 
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('nats.streaming', constants.EXIT);
+    const span = cls.startSpan({
+      spanName: 'nats.streaming',
+      kind: constants.EXIT
+    });
     span.ts = Date.now();
     span.stack = tracingUtil.getStackTrace(instrumentedPublish);
     span.data.nats = {
@@ -153,7 +156,10 @@ function captureMessageSpan(ctx, originalEmit, originalArgs, subject) {
     if (!span) {
       // Unexpected: There was no raw nats entry, in fact, there was no active span at all. We can still trace the
       // current nats.streaming entry.
-      span = cls.startSpan('nats.streaming', constants.ENTRY);
+      span = cls.startSpan({
+        spanName: 'nats.streaming',
+        kind: constants.ENTRY
+      });
     }
 
     span.ts = Date.now();

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -139,7 +139,10 @@ function instrumentedProduce(ctx, originalProduce, originalArgs) {
     typeof ctx._cb_configs.event.delivery_cb === 'function';
 
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('kafka', constants.EXIT);
+    const span = cls.startSpan({
+      spanName: 'kafka',
+      kind: constants.EXIT
+    });
     const topic = originalArgs[0];
 
     span.stack = tracingUtil.getStackTrace(instrumentedProduce, 1);
@@ -270,7 +273,13 @@ function instrumentedConsumerEmit(ctx, originalEmit, originalArgs) {
         return originalEmit.apply(ctx, originalArgs);
       }
 
-      const span = cls.startSpan('kafka', constants.ENTRY, traceId, parentSpanId);
+      const span = cls.startSpan({
+        spanName: 'kafka',
+        kind: constants.ENTRY,
+        traceId: traceId,
+        parentSpanId: parentSpanId
+      });
+
       if (longTraceId) {
         span.lt = longTraceId;
       }

--- a/packages/core/src/tracing/instrumentation/protocols/graphql.js
+++ b/packages/core/src/tracing/instrumentation/protocols/graphql.js
@@ -140,7 +140,10 @@ function traceQueryOrMutation(
     if (!span) {
       // If there hasn't been an entry span that we repurposed into a graphql.server entry span, we need to start a new
       // root entry span here.
-      span = cls.startSpan('graphql.server', constants.ENTRY);
+      span = cls.startSpan({
+        spanName: 'graphql.server',
+        kind: constants.ENTRY
+      });
     }
     span.stack = tracingUtil.getStackTrace(stackTraceRef);
     span.data.graphql = {
@@ -180,7 +183,12 @@ function traceSubscriptionUpdate(
 
   if (parentSpan && !constants.isExitSpan(parentSpan) && parentSpan.t && parentSpan.s) {
     return cls.ns.runAndReturn(() => {
-      const span = cls.startSpan('graphql.client', constants.EXIT, parentSpan.t, parentSpan.s);
+      const span = cls.startSpan({
+        spanName: 'graphql.client',
+        kind: constants.EXIT,
+        traceId: parentSpan.t,
+        parentSpanId: parentSpan.s
+      });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(stackTraceRef);
       span.data.graphql = {

--- a/packages/core/src/tracing/instrumentation/protocols/grpcJs.js
+++ b/packages/core/src/tracing/instrumentation/protocols/grpcJs.js
@@ -330,7 +330,12 @@ function createInstrumentedServerHandler(name, type, originalHandler) {
       const incomingTraceId = readMetadata(metadata, constants.traceIdHeaderName);
       const incomingSpanId = readMetadata(metadata, constants.spanIdHeaderName);
 
-      const span = cls.startSpan('rpc-server', constants.ENTRY, incomingTraceId, incomingSpanId);
+      const span = cls.startSpan({
+        spanName: 'rpc-server',
+        kind: constants.ENTRY,
+        traceId: incomingTraceId,
+        parentSpanId: incomingSpanId
+      });
       span.data.rpc = {
         call: dropLeadingSlash(name),
         flavor: 'grpc'
@@ -394,7 +399,10 @@ function instrumentedClientMethod(
   modifyArgsFn
 ) {
   return cls.ns.runAndReturn(() => {
-    const span = cls.startSpan('rpc-client', constants.EXIT);
+    const span = cls.startSpan({
+      spanName: 'rpc-client',
+      kind: constants.EXIT
+    });
     span.ts = Date.now();
     span.stack = tracingUtil.getStackTrace(instrumentedClientMethod);
 

--- a/packages/core/src/tracing/instrumentation/protocols/http2Client.js
+++ b/packages/core/src/tracing/instrumentation/protocols/http2Client.js
@@ -88,7 +88,12 @@ function instrumentClientHttp2Session(clientHttp2Session) {
     }
 
     return cls.ns.runAndReturn(() => {
-      const span = cls.startSpan('node.http.client', constants.EXIT, parentSpan?.t, parentSpan?.s);
+      const span = cls.startSpan({
+        spanName: 'node.http.client',
+        kind: constants.EXIT,
+        traceId: parentSpan?.t,
+        parentSpanId: parentSpan?.s
+      });
 
       // startSpan updates the W3C trace context and writes it back to CLS, so we have to refetch the updated context
       // object from CLS.

--- a/packages/core/src/tracing/instrumentation/protocols/http2Server.js
+++ b/packages/core/src/tracing/instrumentation/protocols/http2Server.js
@@ -105,13 +105,13 @@ function shimEmit(realEmit) {
         return realEmit.apply(originalThis, originalArgs);
       }
 
-      const span = cls.startSpan(
-        exports.spanName,
-        constants.ENTRY,
-        processedHeaders.traceId,
-        processedHeaders.parentId,
-        w3cTraceContext
-      );
+      const span = cls.startSpan({
+        spanName: exports.spanName,
+        kind: constants.ENTRY,
+        traceId: processedHeaders.traceId,
+        parentSpanId: processedHeaders.parentId,
+        w3cTraceContext: w3cTraceContext
+      });
       tracingHeaders.setSpanAttributes(span, processedHeaders);
 
       const authority = headers[HTTP2_HEADER_AUTHORITY];

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -200,7 +200,12 @@ function instrument(coreModule, forceHttps) {
 
     cls.ns.run(() => {
       // NOTE: Check for parentSpan existence, because of allowRootExitSpan is being enabled
-      const span = cls.startSpan('node.http.client', constants.EXIT, parentSpan?.t, parentSpan?.s);
+      const span = cls.startSpan({
+        spanName: 'node.http.client',
+        kind: constants.EXIT,
+        traceId: parentSpan?.t,
+        parentSpanId: parentSpan?.s
+      });
 
       // startSpan updates the W3C trace context and writes it back to CLS, so we have to refetch the updated context
       // object from CLS.

--- a/packages/core/src/tracing/instrumentation/protocols/httpServer.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpServer.js
@@ -87,7 +87,14 @@ function shimEmit(realEmit) {
         return realEmit.apply(originalThis, originalArgs);
       }
 
-      const span = cls.startSpan(exports.spanName, constants.ENTRY, headers.traceId, headers.parentId, w3cTraceContext);
+      const span = cls.startSpan({
+        spanName: exports.spanName,
+        kind: constants.ENTRY,
+        traceId: headers.traceId,
+        parentSpanId: headers.parentId,
+        w3cTraceContext: w3cTraceContext
+      });
+
       tracingHeaders.setSpanAttributes(span, headers);
 
       // Capture the URL before application code gets access to the incoming message. Libraries like express manipulate

--- a/packages/core/src/tracing/instrumentation/protocols/nativeFetch.js
+++ b/packages/core/src/tracing/instrumentation/protocols/nativeFetch.js
@@ -105,7 +105,12 @@ function instrument() {
 
     return cls.ns.runAndReturn(() => {
       // NOTE: Check for parentSpan existence, because of allowRootExitSpan is being enabled
-      const span = cls.startSpan('node.http.client', constants.EXIT, parentSpan?.t, parentSpan?.s);
+      const span = cls.startSpan({
+        spanName: 'node.http.client',
+        kind: constants.EXIT,
+        traceId: parentSpan?.t,
+        parentSpanId: parentSpan?.s
+      });
 
       // startSpan updates the W3C trace context and writes it back to CLS, so we have to refetch the updated context
       w3cTraceContext = cls.getW3cTraceContext();

--- a/packages/core/src/tracing/opentelemetry-instrumentations/wrap.js
+++ b/packages/core/src/tracing/opentelemetry-instrumentations/wrap.js
@@ -72,7 +72,10 @@ module.exports.init = (_config, cls) => {
 
     try {
       cls.ns.runAndReturn(() => {
-        const instanaSpan = cls.startSpan('otel', kind);
+        const instanaSpan = cls.startSpan({
+          spanName: 'otel',
+          kind: kind
+        });
         instanaSpan.data = {
           tags: Object.assign({ name: otelSpan.name }, otelSpan.attributes),
           resource: otelSpan.resource.attributes

--- a/packages/core/src/tracing/sdk/sdk.js
+++ b/packages/core/src/tracing/sdk/sdk.js
@@ -282,7 +282,12 @@ module.exports = function (isCallbackApi) {
         null;
 
     return runInContext(() => {
-      const span = cls.startSpan('sdk', kind, traceId, parentSpanId);
+      const span = cls.startSpan({
+        spanName: 'sdk',
+        kind: kind,
+        traceId: traceId,
+        parentSpanId: parentSpanId
+      });
       span.stack = tracingUtil.getStackTrace(stackTraceRef);
       span.data.sdk = {
         name,

--- a/packages/core/test/tracing/cls_test.js
+++ b/packages/core/test/tracing/cls_test.js
@@ -28,7 +28,10 @@ describe('tracing/cls', () => {
 
   it('must initialize a new valid span', () => {
     cls.ns.run(() => {
-      const span = cls.startSpan('cls-test-run', constants.EXIT);
+      const span = cls.startSpan({
+        spanName: 'cls-test-run',
+        kind: constants.EXIT
+      });
       expect(span).to.be.an('object');
       expect(span.n).to.equal('cls-test-run');
       expect(span.t).to.be.a('string');
@@ -66,7 +69,11 @@ describe('tracing/cls', () => {
 
   it('must not set span.f without process identity provider', () => {
     cls.ns.run(() => {
-      const newSpan = cls.startSpan('cls-test-run', constants.EXIT);
+      const newSpan = cls.startSpan({
+        spanName: 'cls-test-run',
+        kind: constants.EXIT
+      });
+
       expect(newSpan).to.not.have.property('f');
     });
   });
@@ -74,7 +81,11 @@ describe('tracing/cls', () => {
   it('must not set span.f if process identity provider does not support getFrom', () => {
     cls.init({}, {});
     cls.ns.run(() => {
-      const newSpan = cls.startSpan('cls-test-run', constants.EXIT);
+      const newSpan = cls.startSpan({
+        spanName: 'cls-test-run',
+        kind: constants.EXIT
+      });
+
       expect(newSpan).to.not.have.property('f');
     });
   });
@@ -92,7 +103,11 @@ describe('tracing/cls', () => {
       }
     );
     cls.ns.run(() => {
-      const newSpan = cls.startSpan('cls-test-run', constants.EXIT);
+      const newSpan = cls.startSpan({
+        spanName: 'cls-test-run',
+        kind: constants.EXIT
+      });
+
       expect(newSpan.f).to.deep.equal({
         e: String(process.pid),
         h: undefined
@@ -105,8 +120,14 @@ describe('tracing/cls', () => {
     let newSpan;
 
     cls.ns.run(() => {
-      parentSpan = cls.startSpan('Mr-Brady', constants.ENTRY);
-      newSpan = cls.startSpan('Peter-Brady', constants.EXIT);
+      parentSpan = cls.startSpan({
+        spanName: 'Mr-Brady',
+        kind: constants.ENTRY
+      });
+      newSpan = cls.startSpan({
+        spanName: 'Peter-Brady',
+        kind: constants.EXIT
+      });
     });
     expect(newSpan.t).to.equal(parentSpan.t);
     expect(newSpan.p).to.equal(parentSpan.s);
@@ -116,40 +137,87 @@ describe('tracing/cls', () => {
     cls.ns.run(() => {
       cls.setTracingLevel('0');
       expect(cls.tracingSuppressed()).to.equal(true);
-      cls.startSpan('Antonio-Andolini', constants.ENTRY);
+      cls.startSpan({
+        spanName: 'Antonio-Andolini',
+        kind: constants.ENTRY
+      });
       expect(cls.tracingSuppressed()).to.equal(true);
-      cls.startSpan('Vito-Corleone', constants.EXIT);
+
+      cls.startSpan({
+        spanName: 'Vito-Corleone',
+        kind: constants.EXIT
+      });
       expect(cls.tracingSuppressed()).to.equal(true);
-      cls.startSpan('Michael-Corleone', constants.EXIT);
+
+      cls.startSpan({
+        spanName: 'Michael-Corleone',
+        kind: constants.EXIT
+      });
       expect(cls.tracingSuppressed()).to.equal(true);
 
       cls.ns.run(() => {
         cls.setTracingLevel('1');
         expect(cls.tracingSuppressed()).to.equal(false);
-        cls.startSpan('Antonio-Andolini', constants.EXIT);
+
+        cls.startSpan({
+          spanName: 'Antonio-Andolini',
+          kind: constants.EXIT
+        });
         expect(cls.tracingSuppressed()).to.equal(false);
-        cls.startSpan('Vito-Corleone', constants.EXIT);
+
+        cls.startSpan({
+          spanName: 'Vito-Corleone',
+          kind: constants.EXIT
+        });
         expect(cls.tracingSuppressed()).to.equal(false);
-        cls.startSpan('Michael-Corleone', constants.EXIT);
+
+        cls.startSpan({
+          spanName: 'Michael-Corleone',
+          kind: constants.EXIT
+        });
         expect(cls.tracingSuppressed()).to.equal(false);
 
         cls.ns.run(() => {
           cls.setTracingLevel('0');
           expect(cls.tracingSuppressed()).to.equal(true);
-          cls.startSpan('Antonio-Andolini', constants.EXIT);
+
+          cls.startSpan({
+            spanName: 'Antonio-Andolini',
+            kind: constants.EXIT
+          });
           expect(cls.tracingSuppressed()).to.equal(true);
-          cls.startSpan('Vito-Corleone', constants.EXIT);
+
+          cls.startSpan({
+            spanName: 'Vito-Corleone',
+            kind: constants.EXIT
+          });
           expect(cls.tracingSuppressed()).to.equal(true);
-          cls.startSpan('Michael-Corleone', constants.EXIT);
+
+          cls.startSpan({
+            spanName: 'Michael-Corleone',
+            kind: constants.EXIT
+          });
           expect(cls.tracingSuppressed()).to.equal(true);
 
           cls.ns.run(() => {
             expect(cls.tracingSuppressed()).to.equal(true);
-            cls.startSpan('Antonio-Andolini', constants.EXIT);
+
+            cls.startSpan({
+              spanName: 'Antonio-Andolini',
+              kind: constants.EXIT
+            });
             expect(cls.tracingSuppressed()).to.equal(true);
-            cls.startSpan('Vito-Corleone', constants.EXIT);
+
+            cls.startSpan({
+              spanName: 'Vito-Corleone',
+              kind: constants.EXIT
+            });
             expect(cls.tracingSuppressed()).to.equal(true);
-            cls.startSpan('Michael-Corleone', constants.EXIT);
+
+            cls.startSpan({
+              spanName: 'Michael-Corleone',
+              kind: constants.EXIT
+            });
             expect(cls.tracingSuppressed()).to.equal(true);
           });
         });
@@ -163,9 +231,18 @@ describe('tracing/cls', () => {
     let intermediateSpan;
 
     cls.ns.run(() => {
-      entrySpan = cls.startSpan('node.http.server', constants.ENTRY);
-      exitSpan = cls.startSpan('mongo', constants.EXIT);
-      intermediateSpan = cls.startSpan('intermediate', constants.INTERMEDIATE);
+      entrySpan = cls.startSpan({
+        spanName: 'node.http.server',
+        kind: constants.ENTRY
+      });
+      exitSpan = cls.startSpan({
+        spanName: 'mongo',
+        kind: constants.EXIT
+      });
+      intermediateSpan = cls.startSpan({
+        spanName: 'intermediate',
+        kind: constants.INTERMEDIATE
+      });
     });
 
     expect(entrySpan.k).to.equal(constants.ENTRY);
@@ -187,7 +264,10 @@ describe('tracing/cls', () => {
   it('new spans need to have an empty data object', () => {
     cls.init({}, {});
     cls.ns.run(() => {
-      const span = cls.startSpan('something.something', constants.ENTRY);
+      const span = cls.startSpan({
+        spanName: 'something.something',
+        kind: constants.ENTRY
+      });
       expect(span.data).to.be.an('object');
       expect(Object.keys(span.data)).to.have.lengthOf(0);
       expect(span.data.service).to.not.exist;
@@ -197,7 +277,10 @@ describe('tracing/cls', () => {
   it('must use the configured service name', () => {
     cls.init({ serviceName: 'Forsvarets Efterretningstjeneste' }, {});
     cls.ns.run(() => {
-      const span = cls.startSpan('something.something', constants.ENTRY);
+      const span = cls.startSpan({
+        spanName: 'something.something',
+        kind: constants.ENTRY
+      });
       expect(span.data.service).to.equal('Forsvarets Efterretningstjeneste');
     });
   });
@@ -207,7 +290,10 @@ describe('tracing/cls', () => {
       expect(context[cls.currentEntrySpanKey]).to.equal(undefined);
       expect(context[cls.currentSpanKey]).to.equal(undefined);
 
-      const span = cls.startSpan('node.http.server', constants.ENTRY);
+      const span = cls.startSpan({
+        spanName: 'node.http.server',
+        kind: constants.ENTRY
+      });
       expect(context[cls.currentEntrySpanKey]).to.equal(span);
       expect(context[cls.currentSpanKey]).to.equal(span);
 
@@ -227,7 +313,11 @@ describe('tracing/cls', () => {
         }
       });
 
-      cls.startSpan('Vito-Corleone', constants.EXIT);
+      cls.startSpan({
+        spanName: 'Vito-Corleone',
+        kind: constants.ENTRY
+      });
+
       expect(cls.skipExitTracing()).to.equal(false);
     });
   });
@@ -242,7 +332,11 @@ describe('tracing/cls', () => {
       });
 
       expect(cls.skipExitTracing()).to.equal(true);
-      cls.startSpan('Antonio-Andolini', constants.EXIT);
+
+      cls.startSpan({
+        spanName: 'Antonio-Andolini',
+        kind: constants.EXIT
+      });
       expect(cls.skipExitTracing()).to.equal(true);
     });
   });
@@ -252,7 +346,10 @@ describe('tracing/cls', () => {
       expect(context[cls.currentEntrySpanKey]).to.equal(undefined);
       expect(context[cls.currentSpanKey]).to.equal(undefined);
 
-      const span = cls.startSpan('node.http.server', constants.ENTRY);
+      const span = cls.startSpan({
+        spanName: 'node.http.server',
+        kind: constants.ENTRY
+      });
       span.data.much = 'data';
       span.stack = ['a', 'b', 'c'];
       expect(context[cls.currentEntrySpanKey]).to.equal(span);


### PR DESCRIPTION
Refactored the `startSpan` function to use an optional object pattern instead of multiple positional arguments. This improves readability, allows passing only the necessary values, and eliminates the need to remember the argument order.

ref INSTA-26148