### PR TITLE
refactor: created serverless logger init method

### DIFF
--- a/packages/aws-fargate/src/activate.js
+++ b/packages/aws-fargate/src/activate.js
@@ -16,16 +16,12 @@ const { tracing, util: coreUtil } = instanaCore;
 const { normalizeConfig } = coreUtil;
 
 let logger = consoleLogger;
+logger.init();
 
 const config = normalizeConfig({});
 config.logger = logger;
 
 function init() {
-  // NOTE: We accept for `process.env.INSTANA_DEBUG` any string value - does not have to be "true".
-  if (process.env.INSTANA_DEBUG || process.env.INSTANA_LOG_LEVEL) {
-    logger.setLevel(process.env.INSTANA_DEBUG ? 'debug' : process.env.INSTANA_LOG_LEVEL);
-  }
-
   instanaCore.preInit();
 
   metrics.init(config, function onReady(err, ecsContainerPayload) {

--- a/packages/aws-lambda/src/wrapper.js
+++ b/packages/aws-lambda/src/wrapper.js
@@ -17,7 +17,7 @@ const captureHeaders = require('./capture_headers');
 
 const { tracing } = instanaCore;
 const { tracingHeaders, constants, spanBuffer } = tracing;
-let logger = consoleLogger;
+let logger;
 let config;
 
 let coldStart = true;
@@ -239,12 +239,10 @@ function init(event, arnInfo, _config) {
   if (config.logger) {
     logger = config.logger;
   } else {
-    config.logger = logger;
-  }
+    logger = consoleLogger;
+    logger.init(config);
 
-  // NOTE: We accept for `process.env.INSTANA_DEBUG` any string value - does not have to be "true".
-  if (process.env.INSTANA_DEBUG || config.level || process.env.INSTANA_LOG_LEVEL) {
-    logger.setLevel(process.env.INSTANA_DEBUG ? 'debug' : config.level || process.env.INSTANA_LOG_LEVEL);
+    config.logger = logger;
   }
 
   ssm.init({ logger });

--- a/packages/azure-container-services/src/activate.js
+++ b/packages/azure-container-services/src/activate.js
@@ -13,6 +13,7 @@ const { tracing, util: coreUtil } = instanaCore;
 const { normalizeConfig } = coreUtil;
 
 let logger = consoleLogger;
+logger.init();
 
 // TODO: Why do we normalize the config from core here?
 const config = normalizeConfig({});
@@ -23,10 +24,6 @@ const config = normalizeConfig({});
 config.logger = logger;
 
 function init() {
-  // NOTE: We accept for `process.env.INSTANA_DEBUG` any string value - does not have to be "true".
-  if (process.env.INSTANA_DEBUG || process.env.INSTANA_LOG_LEVEL) {
-    logger.setLevel(process.env.INSTANA_DEBUG ? 'debug' : process.env.INSTANA_LOG_LEVEL);
-  }
   // For more details about environment variables in azure, please see
   // https://learn.microsoft.com/en-us/azure/app-service/reference-app-settings?tabs=kudu%2Cdotnet#app-environment
   if (!process.env.WEBSITE_OWNER_NAME && !process.env.WEBSITE_SITE_NAME && !process.env.WEBSITE_RESOURCE_GROUP) {

--- a/packages/collector/src/index.js
+++ b/packages/collector/src/index.js
@@ -106,7 +106,7 @@ function init(_config) {
     logger = newLogger;
   });
 
-  // NOTE: By default we set our instana internal bunyan logger
+  // NOTE: By default we set our instana internal logger
   config.logger = logger;
 
   agentOpts.init(config);

--- a/packages/google-cloud-run/src/activate.js
+++ b/packages/google-cloud-run/src/activate.js
@@ -15,16 +15,12 @@ const { tracing, util: coreUtil } = instanaCore;
 const { normalizeConfig } = coreUtil;
 
 let logger = consoleLogger;
+logger.init();
 
 const config = normalizeConfig({});
 config.logger = logger;
 
 function init() {
-  // NOTE: We accept for `process.env.INSTANA_DEBUG` any string value - does not have to be "true".
-  if (process.env.INSTANA_DEBUG || process.env.INSTANA_LOG_LEVEL) {
-    logger.setLevel(process.env.INSTANA_DEBUG ? 'debug' : process.env.INSTANA_LOG_LEVEL);
-  }
-
   if (!process.env.K_REVISION) {
     logger.error(
       'Initializing @instana/google-cloud-run failed. The environment variable K_REVISION is not set. This container ' +

--- a/packages/serverless-collector/src/activate.js
+++ b/packages/serverless-collector/src/activate.js
@@ -13,16 +13,12 @@ const { normalizeConfig } = coreUtil;
 const customMetrics = require('./metrics');
 
 let logger = consoleLogger;
+logger.init();
 
 const config = normalizeConfig({});
 config.logger = logger;
 
 async function init() {
-  // NOTE: We accept for `process.env.INSTANA_DEBUG` any string value - does not have to be "true".
-  if (process.env.INSTANA_DEBUG || process.env.INSTANA_LOG_LEVEL) {
-    logger.setLevel(process.env.INSTANA_DEBUG ? 'debug' : process.env.INSTANA_LOG_LEVEL);
-  }
-
   // NOTE: This package does not support autotracing.
   // NOTE: This package does not support metrics.
 

--- a/packages/serverless/src/console_logger.js
+++ b/packages/serverless/src/console_logger.js
@@ -25,6 +25,13 @@ function createLogFn(level, fn) {
   };
 }
 
+exports.init = function init(config = {}) {
+  // NOTE: We accept for `process.env.INSTANA_DEBUG` any string value - does not have to be "true".
+  if (process.env.INSTANA_DEBUG || config.level || process.env.INSTANA_LOG_LEVEL) {
+    exports.setLevel(process.env.INSTANA_DEBUG ? 'debug' : config.level || process.env.INSTANA_LOG_LEVEL);
+  }
+};
+
 exports.setLevel = function setLevel(level) {
   // eslint-disable-next-line yoda
   if (typeof level === 'number' && 0 < level && level <= 50) {


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-13498

- All serverless pkg should use one `logger.init` fn.
- We handle the log level in a centralized place.