### PR TITLE
refactor: improved logic for ignoring endpoints

### DIFF
--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -272,19 +272,18 @@ class InstanaIgnoredSpan extends InstanaSpan {
  * @param {string} [spanAttributes.traceId]
  * @param {string} [spanAttributes.parentSpanId]
  * @param {import('./w3c_trace_context/W3cTraceContext')} [spanAttributes.w3cTraceContext]
- * @param {Object} [spanAttributes.spanContextData]
+ * @param {Object} [spanAttributes.spanData]
  * @returns {InstanaSpan}
  */
 
 function startSpan(spanAttributes = {}) {
-  let { spanName, kind, traceId, parentSpanId, w3cTraceContext, spanContextData } = spanAttributes;
+  let { spanName, kind, traceId, parentSpanId, w3cTraceContext, spanData } = spanAttributes;
 
   tracingMetrics.incrementOpened();
   if (!kind || (kind !== ENTRY && kind !== EXIT && kind !== INTERMEDIATE)) {
     logger.warn(`Invalid span (${spanName}) without kind/with invalid kind: ${kind}, assuming EXIT.`);
     kind = EXIT;
   }
-  const spanData = spanContextData || {};
 
   const span = new InstanaSpan(spanName, spanData);
   span.k = kind;

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -402,7 +402,7 @@ function putPseudoSpan(spanName, kind, traceId, spanId) {
 /**
  * Adds an ignored span to the CLS context, serving as a holder for a trace ID and span ID.
  * Customers can access the current span via `instana.currentSpan()`, and we avoid returning a "NoopSpan".
- * Instead, we need this ignored span instance to ensure the trace ID remains accessible.
+ * We need this ignored span instance to ensure the trace ID remains accessible for future cases such as propagating the trace ID although suppression is on to reactivate a trace.
  * These spans will not be sent to the backend.
  * @param {Object} options - The options for the span.
  * @param {string} options.spanName

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -402,7 +402,8 @@ function putPseudoSpan(spanName, kind, traceId, spanId) {
 /**
  * Adds an ignored span to the CLS context, serving as a holder for a trace ID and span ID.
  * Customers can access the current span via `instana.currentSpan()`, and we avoid returning a "NoopSpan".
- * We need this ignored span instance to ensure the trace ID remains accessible for future cases such as propagating the trace ID although suppression is on to reactivate a trace.
+ * We need this ignored span instance to ensure the trace ID remains accessible for future cases such as propagating
+ * the trace ID although suppression is on to reactivate a trace.
  * These spans will not be sent to the backend.
  * @param {Object} options - The options for the span.
  * @param {string} options.spanName

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -63,7 +63,7 @@ function init(config, _processIdentityProvider) {
  * @param {import('../util/normalizeConfig').AgentConfig} extraConfig
  */
 function activate(extraConfig) {
-  if (extraConfig.tracing.ignoreEndpoints) {
+  if (extraConfig?.tracing?.ignoreEndpoints) {
     ignoreEndpoints = extraConfig.tracing.ignoreEndpoints;
   }
 }
@@ -705,6 +705,7 @@ function sanitizeSpan(span) {
   if (ignoreEndpoints) {
     return applyFilter({ span, ignoreEndpoints });
   }
+  return span;
 }
 
 module.exports = {

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -332,8 +332,9 @@ function startSpan(spanAttributes = {}) {
     span.addCleanup(ns.set(w3cTraceContextKey, w3cTraceContext));
   }
 
-  const sanitizedspan = sanitizeSpan(span);
-  if (!sanitizedspan) {
+  const filteredSpan = applySpanFilter(span);
+  // If the span is filtered out, we return 'InstanaIgnoredSpan' class to indicate the span is ignored.
+  if (!filteredSpan) {
     return setIgnoredSpan({
       spanName: span.n,
       kind: span.k,
@@ -701,7 +702,7 @@ function skipExitTracing(options) {
 /**
  * @param {InstanaSpan | import("../core").InstanaBaseSpan} span
  */
-function sanitizeSpan(span) {
+function applySpanFilter(span) {
   if (ignoreEndpoints) {
     return applyFilter({ span, ignoreEndpoints });
   }

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -332,7 +332,9 @@ function startSpan(spanAttributes = {}) {
   }
 
   const filteredSpan = applySpanFilter(span);
-  // If the span is filtered out, we return 'InstanaIgnoredSpan' class to indicate the span is ignored.
+
+  // If the span was filtered out, we do not process it further.
+  // Instead, we return an 'InstanaIgnoredSpan' instance to explicitly indicate that it was excluded from tracing.
   if (!filteredSpan) {
     return setIgnoredSpan({
       spanName: span.n,

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -417,12 +417,6 @@ function setIgnoredSpan({ spanName, kind, traceId, parentId, data = {} }) {
 
   const span = new InstanaIgnoredSpan(spanName, data);
   span.k = kind;
-
-  if (!traceId) {
-    logger.warn(`Cannot start an ignored span without a trace ID: ${spanName}, ${kind}`);
-    return;
-  }
-
   span.t = traceId;
   span.p = parentId;
 

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -258,10 +258,10 @@ function initInstrumenations(_config) {
 exports.activate = function activate(extraConfig = {}) {
   if (tracingEnabled && !tracingActivated) {
     tracingActivated = true;
+    cls.activate(extraConfig);
     spanBuffer.activate(extraConfig);
     opentracing.activate();
     sdk.activate();
-    cls.activate(extraConfig);
 
     if (automaticTracingEnabled) {
       instrumentations.forEach(instrumentationKey => {

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -15,14 +15,14 @@ const tracingUtil = require('./tracingUtil');
 const spanBuffer = require('./spanBuffer');
 const supportedVersion = require('./supportedVersion');
 const { otelInstrumentations } = require('./opentelemetry-instrumentations');
+const cls = require('./cls');
 const coreUtil = require('../util');
 
 let tracingEnabled = false;
 let tracingActivated = false;
 let instrumenationsInitialized = false;
 let automaticTracingEnabled = false;
-/** @type {import('./cls')} */
-let cls = null;
+
 /** @type {import('../util/normalizeConfig').InstanaConfig} */
 let config = null;
 
@@ -203,7 +203,6 @@ exports.init = function init(_config, downstreamConnection, _processIdentityProv
     tracingHeaders.init(config);
     spanBuffer.init(config, downstreamConnection);
     opentracing.init(config, automaticTracingEnabled, processIdentityProvider);
-    cls = require('./cls');
     cls.init(config, processIdentityProvider);
     sdk.init(cls);
 
@@ -262,6 +261,7 @@ exports.activate = function activate(extraConfig = {}) {
     spanBuffer.activate(extraConfig);
     opentracing.activate();
     sdk.activate();
+    cls.activate(extraConfig);
 
     if (automaticTracingEnabled) {
       instrumentations.forEach(instrumentationKey => {

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/dynamodb.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/dynamodb.js
@@ -35,13 +35,15 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
     if (cls.skipExitTracing({ isActive })) {
       return originalMakeRequest.apply(ctx, originalArgs);
     }
-    // Data attributes: operation, table
-    const spanData = {
-      [this.spanName]: this.buildSpanData(ctx, originalArgs[0], originalArgs[1])
-    };
 
     return cls.ns.runAndReturn(() => {
       const self = this;
+
+      // Data attributes: operation, table
+      const spanData = {
+        [this.spanName]: this.buildSpanData(ctx, originalArgs[0], originalArgs[1])
+      };
+
       const span = cls.startSpan({
         spanName: this.spanName,
         kind: EXIT,

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/dynamodb.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/dynamodb.js
@@ -35,7 +35,7 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
     if (cls.skipExitTracing({ isActive })) {
       return originalMakeRequest.apply(ctx, originalArgs);
     }
-    // Data attribs: op and table
+    // Data attributes: operation, table
     const spanData = {
       [this.spanName]: this.buildSpanData(ctx, originalArgs[0], originalArgs[1])
     };
@@ -45,7 +45,7 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
       const span = cls.startSpan({
         spanName: this.spanName,
         kind: EXIT,
-        spanData: spanData
+        spanData
       });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedMakeRequest, 1);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/dynamodb.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/dynamodb.js
@@ -35,17 +35,20 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
     if (cls.skipExitTracing({ isActive })) {
       return originalMakeRequest.apply(ctx, originalArgs);
     }
+    // Data attribs: op and table
+    const spanData = {
+      [this.spanName]: this.buildSpanData(ctx, originalArgs[0], originalArgs[1])
+    };
 
     return cls.ns.runAndReturn(() => {
       const self = this;
       const span = cls.startSpan({
         spanName: this.spanName,
-        kind: EXIT
+        kind: EXIT,
+        spanContextData: spanData
       });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedMakeRequest, 1);
-      // Data attribs: op and table
-      span.data[this.spanName] = this.buildSpanData(ctx, originalArgs[0], originalArgs[1]);
 
       if (typeof originalArgs[2] === 'function') {
         // callback case

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/dynamodb.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v2/dynamodb.js
@@ -45,7 +45,7 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
       const span = cls.startSpan({
         spanName: this.spanName,
         kind: EXIT,
-        spanContextData: spanData
+        spanData: spanData
       });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedMakeRequest, 1);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
@@ -31,7 +31,7 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
       const span = cls.startSpan({
         spanName: this.spanName,
         kind: EXIT,
-        spanContextData: spanData
+        spanData: spanData
       });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedSmithySend, 1);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
@@ -23,16 +23,18 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
     }
 
     const command = smithySendArgs[0];
-
+    const spanData = {
+      [this.spanName]: this.buildSpanData(command.constructor.name, command.input)
+    };
     return cls.ns.runAndReturn(() => {
       const self = this;
       const span = cls.startSpan({
         spanName: this.spanName,
-        kind: EXIT
+        kind: EXIT,
+        spanContextData: spanData
       });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedSmithySend, 1);
-      span.data[this.spanName] = this.buildSpanData(command.constructor.name, command.input);
       this.captureRegion(ctx, span);
 
       if (typeof smithySendArgs[1] === 'function') {

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
@@ -31,7 +31,7 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
       const span = cls.startSpan({
         spanName: this.spanName,
         kind: EXIT,
-        spanData: spanData
+        spanData
       });
       span.ts = Date.now();
       span.stack = tracingUtil.getStackTrace(this.instrumentedSmithySend, 1);

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
@@ -23,11 +23,12 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
     }
 
     const command = smithySendArgs[0];
-    const spanData = {
-      [this.spanName]: this.buildSpanData(command.constructor.name, command.input)
-    };
     return cls.ns.runAndReturn(() => {
       const self = this;
+
+      const spanData = {
+        [this.spanName]: this.buildSpanData(command.constructor.name, command.input)
+      };
       const span = cls.startSpan({
         spanName: this.spanName,
         kind: EXIT,

--- a/packages/core/src/tracing/instrumentation/database/ioredis.js
+++ b/packages/core/src/tracing/instrumentation/database/ioredis.js
@@ -92,7 +92,7 @@ function instrumentSendCommand(original) {
       const span = cls.startSpan({
         spanName: exports.spanName,
         kind: constants.EXIT,
-        spanData: spanData
+        spanData
       });
       span.stack = tracingUtil.getStackTrace(wrappedInternalSendCommand);
 
@@ -167,7 +167,7 @@ function instrumentMultiOrPipelineCommand(commandName, original) {
     const span = cls.startSpan({
       spanName: exports.spanName,
       kind: constants.EXIT,
-      spanData: spanData
+      spanData
     });
     span.stack = tracingUtil.getStackTrace(wrappedInternalMultiOrPipelineCommand);
 

--- a/packages/core/src/tracing/instrumentation/database/ioredis.js
+++ b/packages/core/src/tracing/instrumentation/database/ioredis.js
@@ -82,13 +82,13 @@ function instrumentSendCommand(original) {
     // if (client.isCluster) {
     //  connection = client.startupNodes.map(node => `${node.host}:${node.port}`).join(',');
 
-    const spanData = {
-      redis: {
-        connection,
-        operation: command.name.toLowerCase()
-      }
-    };
     return cls.ns.runAndReturn(() => {
+      const spanData = {
+        redis: {
+          connection,
+          operation: command.name.toLowerCase()
+        }
+      };
       const span = cls.startSpan({
         spanName: exports.spanName,
         kind: constants.EXIT,

--- a/packages/core/src/tracing/instrumentation/database/ioredis.js
+++ b/packages/core/src/tracing/instrumentation/database/ioredis.js
@@ -92,7 +92,7 @@ function instrumentSendCommand(original) {
       const span = cls.startSpan({
         spanName: exports.spanName,
         kind: constants.EXIT,
-        spanContextData: spanData
+        spanData: spanData
       });
       span.stack = tracingUtil.getStackTrace(wrappedInternalSendCommand);
 
@@ -167,7 +167,7 @@ function instrumentMultiOrPipelineCommand(commandName, original) {
     const span = cls.startSpan({
       spanName: exports.spanName,
       kind: constants.EXIT,
-      spanContextData: spanData
+      spanData: spanData
     });
     span.stack = tracingUtil.getStackTrace(wrappedInternalMultiOrPipelineCommand);
 

--- a/packages/core/src/tracing/instrumentation/database/ioredis.js
+++ b/packages/core/src/tracing/instrumentation/database/ioredis.js
@@ -76,23 +76,25 @@ function instrumentSendCommand(original) {
     }
 
     const argsForOriginal = arguments;
+    const connection = `${client.options.host}:${client.options.port}`;
+
+    // TODO: https://jsw.ibm.com/browse/INSTA-14540
+    // if (client.isCluster) {
+    //  connection = client.startupNodes.map(node => `${node.host}:${node.port}`).join(',');
+
+    const spanData = {
+      redis: {
+        connection,
+        operation: command.name.toLowerCase()
+      }
+    };
     return cls.ns.runAndReturn(() => {
       const span = cls.startSpan({
         spanName: exports.spanName,
-        kind: constants.EXIT
+        kind: constants.EXIT,
+        spanContextData: spanData
       });
       span.stack = tracingUtil.getStackTrace(wrappedInternalSendCommand);
-
-      const connection = `${client.options.host}:${client.options.port}`;
-
-      // TODO: https://jsw.ibm.com/browse/INSTA-14540
-      // if (client.isCluster) {
-      //  connection = client.startupNodes.map(node => `${node.host}:${node.port}`).join(',');
-
-      span.data.redis = {
-        connection,
-        operation: command.name.toLowerCase()
-      };
 
       callback = cls.ns.bind(onResult);
       command.promise.then(
@@ -156,15 +158,18 @@ function instrumentMultiOrPipelineCommand(commandName, original) {
     // create a new cls context parent to track the multi/pipeline child calls
     const clsContextForMultiOrPipeline = cls.ns.createContext();
     cls.ns.enter(clsContextForMultiOrPipeline);
+    const spanData = {
+      redis: {
+        connection,
+        operation: commandName
+      }
+    };
     const span = cls.startSpan({
       spanName: exports.spanName,
-      kind: constants.EXIT
+      kind: constants.EXIT,
+      spanContextData: spanData
     });
     span.stack = tracingUtil.getStackTrace(wrappedInternalMultiOrPipelineCommand);
-    span.data.redis = {
-      connection,
-      operation: commandName
-    };
 
     const multiOrPipeline = original.apply(this, arguments);
     shimmer.wrap(

--- a/packages/core/src/tracing/instrumentation/database/redis.js
+++ b/packages/core/src/tracing/instrumentation/database/redis.js
@@ -244,7 +244,7 @@ function instrumentCommand(original, command, address, cbStyle) {
       const span = cls.startSpan({
         spanName: exports.spanName,
         kind: constants.EXIT,
-        spanContextData: spanData
+        spanData: spanData
       });
       span.stack = tracingUtil.getStackTrace(instrumentCommand);
 
@@ -327,7 +327,7 @@ function instrumentMultiExec(origCtx, origArgs, original, address, isAtomic, cbS
       span = cls.startSpan({
         spanName: exports.spanName,
         kind: constants.EXIT,
-        spanContextData: spanData
+        spanData: spanData
       });
     } else {
       span = cls.startSpan({
@@ -335,7 +335,7 @@ function instrumentMultiExec(origCtx, origArgs, original, address, isAtomic, cbS
         kind: constants.EXIT,
         traceId: parentSpan.t,
         parentSpanId: parentSpan.s,
-        spanContextData: spanData
+        spanData: spanData
       });
     }
 

--- a/packages/core/src/tracing/instrumentation/database/redis.js
+++ b/packages/core/src/tracing/instrumentation/database/redis.js
@@ -234,13 +234,14 @@ function instrumentCommand(original, command, address, cbStyle) {
     if (cls.skipExitTracing({ isActive })) {
       return original.apply(origCtx, origArgs);
     }
-    const spanData = {
-      redis: {
-        connection: address || origCtx.address,
-        operation: command
-      }
-    };
+
     return cls.ns.runAndReturn(() => {
+      const spanData = {
+        redis: {
+          connection: address || origCtx.address,
+          operation: command
+        }
+      };
       const span = cls.startSpan({
         spanName: exports.spanName,
         kind: constants.EXIT,

--- a/packages/core/src/tracing/instrumentation/database/redis.js
+++ b/packages/core/src/tracing/instrumentation/database/redis.js
@@ -244,7 +244,7 @@ function instrumentCommand(original, command, address, cbStyle) {
       const span = cls.startSpan({
         spanName: exports.spanName,
         kind: constants.EXIT,
-        spanData: spanData
+        spanData
       });
       span.stack = tracingUtil.getStackTrace(instrumentCommand);
 
@@ -327,7 +327,7 @@ function instrumentMultiExec(origCtx, origArgs, original, address, isAtomic, cbS
       span = cls.startSpan({
         spanName: exports.spanName,
         kind: constants.EXIT,
-        spanData: spanData
+        spanData
       });
     } else {
       span = cls.startSpan({
@@ -335,7 +335,7 @@ function instrumentMultiExec(origCtx, origArgs, original, address, isAtomic, cbS
         kind: constants.EXIT,
         traceId: parentSpan.t,
         parentSpanId: parentSpan.s,
-        spanData: spanData
+        spanData
       });
     }
 

--- a/packages/core/src/tracing/instrumentation/database/redis.js
+++ b/packages/core/src/tracing/instrumentation/database/redis.js
@@ -234,7 +234,7 @@ function instrumentCommand(original, command, address, cbStyle) {
     if (cls.skipExitTracing({ isActive })) {
       return original.apply(origCtx, origArgs);
     }
-    const data = {
+    const spanData = {
       redis: {
         connection: address || origCtx.address,
         operation: command
@@ -244,14 +244,9 @@ function instrumentCommand(original, command, address, cbStyle) {
       const span = cls.startSpan({
         spanName: exports.spanName,
         kind: constants.EXIT,
-        spanContextData: data
+        spanContextData: spanData
       });
       span.stack = tracingUtil.getStackTrace(instrumentCommand);
-
-      span.data.redis = {
-        connection: address || origCtx.address,
-        operation: command
-      };
 
       let userProvidedCallback;
 
@@ -321,7 +316,7 @@ function instrumentMultiExec(origCtx, origArgs, original, address, isAtomic, cbS
 
   return cls.ns.runAndReturn(() => {
     let span;
-    const data = {
+    const spanData = {
       redis: {
         connection: address,
         // pipeline = batch
@@ -332,7 +327,7 @@ function instrumentMultiExec(origCtx, origArgs, original, address, isAtomic, cbS
       span = cls.startSpan({
         spanName: exports.spanName,
         kind: constants.EXIT,
-        spanContextData: data
+        spanContextData: spanData
       });
     } else {
       span = cls.startSpan({
@@ -340,7 +335,7 @@ function instrumentMultiExec(origCtx, origArgs, original, address, isAtomic, cbS
         kind: constants.EXIT,
         traceId: parentSpan.t,
         parentSpanId: parentSpan.s,
-        spanContextData: data
+        spanContextData: spanData
       });
     }
 

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -182,7 +182,7 @@ exports.addSpan = function (span) {
     return;
   }
 
-  // Apply necessary transformations to the span (e.g., renaming properties, modifying data).
+  // Transform internal span data format into external (backend) readable format.
   span = applySpanTransformation(span);
 
   if (span.t == null) {

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -6,7 +6,6 @@
 'use strict';
 
 const tracingMetrics = require('./metrics');
-const { applyFilter } = require('../util/spanFilter');
 const { transform } = require('./backend_mappers');
 
 /** @type {import('../core').GenericLogger} */
@@ -89,10 +88,6 @@ const batchBucketWidth = 18;
 
 /** @type {BatchingBucketMap} */
 const batchingBuckets = new Map();
-/**
- * @type {import('../tracing').IgnoreEndpoints}
- */
-let ignoreEndpoints;
 
 /**
  * @param {import('../util/normalizeConfig').InstanaConfig} config
@@ -104,7 +99,6 @@ exports.init = function init(config, _downstreamConnection) {
   forceTransmissionStartingAt = config.tracing.forceTransmissionStartingAt;
   transmissionDelay = config.tracing.transmissionDelay;
   batchingEnabled = config.tracing.spanBatchingEnabled;
-  ignoreEndpoints = config.tracing.ignoreEndpoints;
   initialDelayBeforeSendingSpans = Math.max(transmissionDelay, minDelayBeforeSendingSpans);
   isFaaS = false;
   transmitImmediate = false;
@@ -137,9 +131,6 @@ exports.activate = function activate(extraConfig) {
   if (extraConfig?.tracing) {
     if (extraConfig.tracing.spanBatchingEnabled) {
       batchingEnabled = true;
-    }
-    if (extraConfig.tracing.ignoreEndpoints) {
-      ignoreEndpoints = extraConfig.tracing.ignoreEndpoints;
     }
   }
 
@@ -191,8 +182,8 @@ exports.addSpan = function (span) {
     return;
   }
 
-  // Process the span, apply any transformations, and implement filtering if necessary.
-  const processedSpan = processSpan(span);
+  // Apply necessary transformations to the span (e.g., renaming properties, modifying data).
+  const processedSpan = applySpanTransformation(span);
   if (!processedSpan) {
     return;
   }
@@ -506,13 +497,6 @@ function removeSpansIfNecessary() {
  * @param {import('../core').InstanaBaseSpan} span
  * @returns {import('../core').InstanaBaseSpan} span
  */
-function processSpan(span) {
-  if (ignoreEndpoints) {
-    span = applyFilter({ span, ignoreEndpoints });
-
-    if (!span) {
-      return null;
-    }
-  }
+function applySpanTransformation(span) {
   return transform(span);
 }

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -183,11 +183,7 @@ exports.addSpan = function (span) {
   }
 
   // Apply necessary transformations to the span (e.g., renaming properties, modifying data).
-  const processedSpan = applySpanTransformation(span);
-  if (!processedSpan) {
-    return;
-  }
-  span = processedSpan;
+  span = applySpanTransformation(span);
 
   if (span.t == null) {
     logger.warn(`Span of type ${span.n} has no trace ID. Not transmitting this span`);

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -4,10 +4,9 @@
 
 'use strict';
 
-// TODO: Refactoring of this function.
+// TODO:
 // Currently, filtering is based solely on span.data[span.n].operation.
 // In the future, additional fields (like operation) may need to be considered for filtering.
-// Endpoint configuration for ignoring might also change.
 
 // List of span types to allowed to ignore
 const IGNORABLE_SPAN_TYPES = ['redis', 'dynamodb'];
@@ -27,7 +26,6 @@ function shouldIgnore(span, endpoints) {
 
   // Retrieve the operation(s) from the span data. In some cases, the 'operation' field may be an array.
   // This handles both the cases where 'operation' is a string or an array of strings.
-
   const operations = Array.isArray(span.data?.[span.n]?.operation)
     ? span.data[span.n].operation
     : [span.data?.[span.n]?.operation];

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -4,6 +4,11 @@
 
 'use strict';
 
+// TODO: Refactoring of this function.
+// Currently, filtering is based solely on span.data[span.n].operation.
+// In the future, additional fields (like operation) may need to be considered for filtering.
+// Endpoint configuration for ignoring might also change.
+
 // List of span types to allowed to ignore
 const IGNORABLE_SPAN_TYPES = ['redis', 'dynamodb'];
 
@@ -20,18 +25,24 @@ function shouldIgnore(span, endpoints) {
   const endpoint = endpoints[span.n];
   if (!endpoint) return false;
 
-  // The endpoint already been converted to lowercase during parsing, so here we are normalizing
-  // the operation for case-insensitive comparison
-  const operation = span.data?.[span.n]?.operation?.toLowerCase();
-  if (!operation) return false;
+  // Retrieve the operation(s) from the span data. In some cases, the 'operation' field may be an array.
+  // This handles both the cases where 'operation' is a string or an array of strings.
+
+  const operations = Array.isArray(span.data?.[span.n]?.operation)
+    ? span.data[span.n].operation
+    : [span.data?.[span.n]?.operation];
+
+  if (!operations.length) return false;
 
   // We support both array and string formats for endpoints, but the string format is not shared publicly.
   if (Array.isArray(endpoint)) {
-    return endpoint.some(op => op.toLowerCase() === operation);
+    return endpoint.some(op =>
+      operations.some((/** @type {string} */ operation) => op.toLowerCase() === operation.toLowerCase())
+    );
   }
 
   if (typeof endpoint === 'string') {
-    return endpoint.toLowerCase() === operation;
+    return operations.some((/** @type {string} */ operation) => operation.toLowerCase() === endpoint.toLowerCase());
   }
 
   return false;

--- a/packages/core/test/tracing/cls_test.js
+++ b/packages/core/test/tracing/cls_test.js
@@ -369,12 +369,12 @@ describe('tracing/cls', () => {
       expect(reducedSpan.stack).to.not.exist;
     });
   });
-it('should return the span with correct data when span data is provided', () => {
+  it('should return the span with correct data when span data is provided', () => {
     cls.ns.run(() => {
       const span = cls.startSpan({
         spanName: 'redis',
         kind: constants.EXIT,
-        spanContextData: {
+        spanData: {
           redis: {
             operation: 'get',
             connection: 'http://localhost'
@@ -407,7 +407,7 @@ it('should return the span with correct data when span data is provided', () => 
       const span = cls.startSpan({
         spanName: 'redis',
         kind: constants.EXIT,
-        spanContextData: {
+        spanData: {
           redis: {
             operation: 'get',
             connection: 'http://localhost'

--- a/packages/core/test/tracing/cls_test.js
+++ b/packages/core/test/tracing/cls_test.js
@@ -369,4 +369,58 @@ describe('tracing/cls', () => {
       expect(reducedSpan.stack).to.not.exist;
     });
   });
+it('should return the span with correct data when span data is provided', () => {
+    cls.ns.run(() => {
+      const span = cls.startSpan({
+        spanName: 'redis',
+        kind: constants.EXIT,
+        spanContextData: {
+          redis: {
+            operation: 'get',
+            connection: 'http://localhost'
+          }
+        }
+      });
+      expect(span).to.be.an('object');
+      expect(span.n).to.equal('redis');
+      expect(span.t).to.be.a('string');
+      expect(span.s).to.be.a('string');
+      expect(span.k).to.equal(constants.EXIT);
+      expect(span.error).to.not.exist;
+      expect(span.ec).to.equal(0);
+      expect(span.ts).to.be.a('number');
+      expect(span.d).to.equal(0);
+      expect(span.stack).to.deep.equal([]);
+      expect(span.data).to.be.an('object');
+      expect(Object.keys(span.data)).to.have.lengthOf(1);
+    });
+  });
+  it('should return InstanaIgnoredSpan when the span is configured to be ignored', () => {
+    cls.ns.run(() => {
+      cls.init({
+        tracing: {
+          ignoreEndpoints: {
+            redis: ['get']
+          }
+        }
+      });
+      const span = cls.startSpan({
+        spanName: 'redis',
+        kind: constants.EXIT,
+        spanContextData: {
+          redis: {
+            operation: 'get',
+            connection: 'http://localhost'
+          }
+        }
+      });
+      expect(span.constructor.name).to.equal('InstanaIgnoredSpan');
+      expect(span).to.be.an('object');
+      expect(span.n).to.equal('redis');
+      expect(span.t).to.be.a('string');
+      expect(span.k).to.equal(constants.EXIT);
+      expect(span.data).to.be.an('object');
+      expect(Object.keys(span.data)).to.have.lengthOf(1);
+    });
+  });
 });

--- a/packages/core/test/tracing/cls_test.js
+++ b/packages/core/test/tracing/cls_test.js
@@ -393,6 +393,9 @@ describe('tracing/cls', () => {
       expect(span.stack).to.deep.equal([]);
       expect(span.data).to.be.an('object');
       expect(Object.keys(span.data)).to.have.lengthOf(1);
+      expect(span.data.redis).to.be.exist;
+      expect(span.data.redis.operation).to.equal('get');
+      expect(span.data.redis.connection).to.equal('http://localhost');
     });
   });
   it('should return InstanaIgnoredSpan when the span is configured to be ignored', () => {
@@ -421,6 +424,9 @@ describe('tracing/cls', () => {
       expect(span.k).to.equal(constants.EXIT);
       expect(span.data).to.be.an('object');
       expect(Object.keys(span.data)).to.have.lengthOf(1);
+      expect(span.data.redis).to.be.exist;
+      expect(span.data.redis.operation).to.equal('get');
+      expect(span.data.redis.connection).to.equal('http://localhost');
     });
   });
 });

--- a/packages/core/test/tracing/spanBuffer_test.js
+++ b/packages/core/test/tracing/spanBuffer_test.js
@@ -567,20 +567,6 @@ describe('tracing/spanBuffer', () => {
       });
     });
     describe('when applying span transformations', () => {
-      before(() => {
-        spanBuffer.init(
-          {
-            tracing: {
-              maxBufferedSpans: 1000
-            }
-          },
-          {
-            /* downstreamConnection */
-            sendSpans: function () {}
-          }
-        );
-      });
-
       beforeEach(() => spanBuffer.activate());
 
       afterEach(() => spanBuffer.deactivate());

--- a/packages/core/test/tracing/spanBuffer_test.js
+++ b/packages/core/test/tracing/spanBuffer_test.js
@@ -566,12 +566,12 @@ describe('tracing/spanBuffer', () => {
         verifyNoBatching(span1, span2);
       });
     });
-    describe('when ignoreEndpoints is configured', () => {
+    describe('when applying span transformations', () => {
       before(() => {
         spanBuffer.init(
           {
             tracing: {
-              ignoreEndpoints: { redis: ['get'] }
+              maxBufferedSpans: 1000
             }
           },
           {
@@ -597,13 +597,7 @@ describe('tracing/spanBuffer', () => {
         }
       };
 
-      it('should ignore the redis span when the operation is listed in the ignoreEndpoints config', () => {
-        spanBuffer.addSpan(span);
-        const spans = spanBuffer.getAndResetSpans();
-        expect(spans).to.have.lengthOf(0);
-      });
-
-      it('should transform the redis span if the operation is not specified in the ignoreEndpoints config', () => {
+      it('should correctly transform the Redis span by renaming the operation property', () => {
         span.data.redis.operation = 'set';
         spanBuffer.addSpan(span);
         const spans = spanBuffer.getAndResetSpans();
@@ -611,7 +605,7 @@ describe('tracing/spanBuffer', () => {
         expect(span.data.redis.command).to.equal('set');
         expect(span.data.redis).to.not.have.property('operation');
       });
-      it('should return the span unmodified for unsupported ignore endpoints', () => {
+      it('should return the span unchanged for non-mapped types', () => {
         span.n = 'http';
         spanBuffer.addSpan(span);
         const spans = spanBuffer.getAndResetSpans();


### PR DESCRIPTION
Refactored the implementation of ignored endpoints by moving the filtering logic to startSpan. This change makes it easier to extend in the future, simplifies modification, and resolves the issue with accessing the current span for ignored span.

Tasks

- [x] - Refactor the existing span filter logic within the `startSpan` function.  
- [x] - Get the ignore endpoints config in cls
- [x] - Perform the span mapping within the span buffer while adding a span.  

Pending 

- [x] - Apply filtering based on  operation as well as endpoints https://github.com/instana/nodejs/pull/1580.  
- [ ] - An integration test for the ignore endpoint (New PR)

ref INSTA-26148
