### PR TITLE
fix: resolved Instana log calls being traced with custom logger setup

### DIFF
--- a/packages/collector/src/logger.js
+++ b/packages/collector/src/logger.js
@@ -42,7 +42,8 @@ exports.init = function init(config, isReInit) {
     //      We cannot fix this in our side.
     //      https://github.com/winstonjs/winston/issues/1854#issuecomment-710195110
     parentLogger = config.logger.child({
-      module: 'instana-nodejs-logger-parent'
+      module: 'instana-nodejs-logger-parent',
+      __in: 1
     });
   } else if (config.logger && hasLoggingFunctions(config.logger)) {
     // A custom non-bunyan/non-pino logger has been provided via config. We use it as is.

--- a/packages/collector/src/logger.js
+++ b/packages/collector/src/logger.js
@@ -49,8 +49,8 @@ exports.init = function init(config, isReInit) {
     // A custom non-bunyan/non-pino logger has been provided via config. We use it as is.
     // The __instana attribute identifies the Instana logger, distinguishing it from the client application logger,
     // and also prevents these logs from being traced
-
-    parentLogger = Object.assign({}, config.logger, { __instana: 1 });
+    // This setPropertyOf syntax preserves the properties and prototypes of config.logger
+    parentLogger = Object.setPrototypeOf({ ...config.logger, __instana: 1 }, Object.getPrototypeOf(config.logger));
   } else {
     // No custom logger has been provided via config, we create a new pino logger as the parent logger for all loggers
     // we create later on.

--- a/packages/collector/src/logger.js
+++ b/packages/collector/src/logger.js
@@ -49,10 +49,12 @@ exports.init = function init(config, isReInit) {
     // A custom non-bunyan/non-pino logger has been provided via config. We use it as is.
     // The __instana attribute identifies the Instana logger, distinguishing it from the client application logger,
     // and also prevents these logs from being traced
-    parentLogger = {
-      ...config.logger,
-      __instana: 1
-    };
+    // parentLogger = {
+    //   ...config.logger,
+    //   __instana: 1
+    // };
+
+    parentLogger = Object.assign(Object.create(Object.getPrototypeOf(config.logger)), config.logger, { __instana: 1 });
   } else {
     // No custom logger has been provided via config, we create a new pino logger as the parent logger for all loggers
     // we create later on.

--- a/packages/collector/src/logger.js
+++ b/packages/collector/src/logger.js
@@ -47,6 +47,8 @@ exports.init = function init(config, isReInit) {
     });
   } else if (config.logger && hasLoggingFunctions(config.logger)) {
     // A custom non-bunyan/non-pino logger has been provided via config. We use it as is.
+    // The __instana attribute identifies the Instana logger, distinguishing it from the client application logger,
+    // and also prevents these logs from being traced
     parentLogger = {
       ...config.logger,
       __instana: 1

--- a/packages/collector/src/logger.js
+++ b/packages/collector/src/logger.js
@@ -49,10 +49,10 @@ exports.init = function init(config, isReInit) {
     //       This will prevent these logs from being traced.
     parentLogger.__instana = true;
   } else if (config.logger && hasLoggingFunctions(config.logger)) {
-    // A custom non-bunyan/non-pino logger has been provided via config. We use it as is.
+    // CASE: Built-in console logger or log4js. We use it as is.
     // The __instana attribute identifies the Instana logger, distinguishing it from the client application logger,
     // and also prevents these logs from being traced
-    // This setPropertyOf syntax preserves the properties and prototypes of config.logger
+    // Extends config.logger with __instana while preserving its prototype and methods.
     parentLogger = Object.setPrototypeOf({ ...config.logger, __instana: 1 }, Object.getPrototypeOf(config.logger));
   } else {
     // No custom logger has been provided via config, we create a new pino logger as the parent logger for all loggers

--- a/packages/collector/src/logger.js
+++ b/packages/collector/src/logger.js
@@ -43,11 +43,14 @@ exports.init = function init(config, isReInit) {
     //      https://github.com/winstonjs/winston/issues/1854#issuecomment-710195110
     parentLogger = config.logger.child({
       module: 'instana-nodejs-logger-parent',
-      __in: 1
+      __instana: 1
     });
   } else if (config.logger && hasLoggingFunctions(config.logger)) {
     // A custom non-bunyan/non-pino logger has been provided via config. We use it as is.
-    parentLogger = config.logger;
+    parentLogger = {
+      ...config.logger,
+      __instana: 1
+    };
   } else {
     // No custom logger has been provided via config, we create a new pino logger as the parent logger for all loggers
     // we create later on.

--- a/packages/collector/src/logger.js
+++ b/packages/collector/src/logger.js
@@ -49,12 +49,8 @@ exports.init = function init(config, isReInit) {
     // A custom non-bunyan/non-pino logger has been provided via config. We use it as is.
     // The __instana attribute identifies the Instana logger, distinguishing it from the client application logger,
     // and also prevents these logs from being traced
-    // parentLogger = {
-    //   ...config.logger,
-    //   __instana: 1
-    // };
 
-    parentLogger = Object.assign(Object.create(Object.getPrototypeOf(config.logger)), config.logger, { __instana: 1 });
+    parentLogger = Object.assign({}, config.logger, { __instana: 1 });
   } else {
     // No custom logger has been provided via config, we create a new pino logger as the parent logger for all loggers
     // we create later on.

--- a/packages/collector/src/logger.js
+++ b/packages/collector/src/logger.js
@@ -42,9 +42,12 @@ exports.init = function init(config, isReInit) {
     //      We cannot fix this in our side.
     //      https://github.com/winstonjs/winston/issues/1854#issuecomment-710195110
     parentLogger = config.logger.child({
-      module: 'instana-nodejs-logger-parent',
-      __instana: 1
+      module: 'instana-nodejs-logger-parent'
     });
+
+    // CASE: Attach custom instana meta attribute to filter out internal instana logs.
+    //       This will prevent these logs from being traced.
+    parentLogger.__instana = true;
   } else if (config.logger && hasLoggingFunctions(config.logger)) {
     // A custom non-bunyan/non-pino logger has been provided via config. We use it as is.
     // The __instana attribute identifies the Instana logger, distinguishing it from the client application logger,
@@ -137,6 +140,11 @@ exports.getLogger = function getLogger(loggerName, reInitFn, level) {
       module: loggerName,
       threadId
     });
+
+    // CASE: Attach custom instana meta attribute to filter out internal instana logs.
+    //       This will prevent these logs from being traced.
+    // TODO: Will be removed in the refactoring PR for getLogger
+    _logger.__instana = true;
   } else {
     // Unknown logger type (neither bunyan nor pino), we simply return the user provided custom logger as-is.
     _logger = parentLogger;

--- a/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-bunyan-logger.js
+++ b/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-bunyan-logger.js
@@ -14,7 +14,6 @@ process.on('SIGTERM', () => {
 });
 
 const agentPort = process.env.AGENT_PORT;
-const buynan = require('bunyan');
 const instana = require('../../../..')({
   agentPort,
   level: 'warn',
@@ -23,6 +22,8 @@ const instana = require('../../../..')({
     forceTransmissionStartingAt: 1
   }
 });
+
+const buynan = require('bunyan');
 instana.setLogger(buynan.createLogger({ name: 'app-logger' }));
 
 let instanaLogger;

--- a/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-custom-dummy-logger.js
+++ b/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-custom-dummy-logger.js
@@ -15,15 +15,6 @@ process.on('SIGTERM', () => {
 
 const agentPort = process.env.AGENT_PORT;
 
-const dummyLogger = {
-  debug: function () {
-    // omit debug calls to not pollute test logs
-  },
-  info: console.log,
-  warn: console.warn,
-  error: console.error
-};
-
 const instana = require('../../../..')({
   agentPort,
   level: 'warn',
@@ -32,6 +23,15 @@ const instana = require('../../../..')({
     forceTransmissionStartingAt: 1
   }
 });
+
+const dummyLogger = {
+  debug: function () {
+    // omit debug calls to not pollute test logs
+  },
+  info: console.log,
+  warn: console.warn,
+  error: console.error
+};
 
 instana.setLogger(dummyLogger);
 

--- a/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-pino-logger.js
+++ b/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-pino-logger.js
@@ -13,7 +13,6 @@ process.on('SIGTERM', () => {
 });
 
 const agentPort = process.env.AGENT_PORT;
-const pino = require('pino');
 const instana = require('../../../..')({
   agentPort,
   level: 'warn',
@@ -22,6 +21,7 @@ const instana = require('../../../..')({
     forceTransmissionStartingAt: 1
   }
 });
+const pino = require('pino');
 instana.setLogger(pino({ name: 'app-logger' }));
 
 let instanaLogger;

--- a/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-winston-logger.js
+++ b/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-winston-logger.js
@@ -13,7 +13,7 @@ process.on('SIGTERM', () => {
 });
 
 const agentPort = process.env.AGENT_PORT;
-const winston = require('winston');
+
 const instana = require('../../../..')({
   agentPort,
   level: 'warn',
@@ -22,6 +22,8 @@ const instana = require('../../../..')({
     forceTransmissionStartingAt: 1
   }
 });
+
+const winston = require('winston');
 
 instana.setLogger(
   winston.createLogger({

--- a/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-winston-logger.js
+++ b/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-winston-logger.js
@@ -13,8 +13,6 @@ process.on('SIGTERM', () => {
 });
 
 const agentPort = process.env.AGENT_PORT;
-// TODO: move the import from here to below the collector initialization
-const winston = require('winston');
 const instana = require('../../../..')({
   agentPort,
   level: 'warn',
@@ -24,6 +22,7 @@ const instana = require('../../../..')({
   }
 });
 
+const winston = require('winston');
 instana.setLogger(
   winston.createLogger({
     level: 'info',

--- a/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-winston-logger.js
+++ b/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-winston-logger.js
@@ -13,7 +13,8 @@ process.on('SIGTERM', () => {
 });
 
 const agentPort = process.env.AGENT_PORT;
-
+// TODO: move the import from here to below the collector initialization
+const winston = require('winston');
 const instana = require('../../../..')({
   agentPort,
   level: 'warn',
@@ -22,8 +23,6 @@ const instana = require('../../../..')({
     forceTransmissionStartingAt: 1
   }
 });
-
-const winston = require('winston');
 
 instana.setLogger(
   winston.createLogger({

--- a/packages/collector/test/tracing/logger/instana-logger/test.js
+++ b/packages/collector/test/tracing/logger/instana-logger/test.js
@@ -56,8 +56,6 @@ mochaSuiteFn('tracing/instana-logger', function () {
         instanaLoggingMode: 'instana-receives-log4js-logger'
       });
 
-      // TODO: This test is failing. We can check for `this.__instana` in log4js instrumentation
-      //       in https://github.com/instana/nodejs/pull/1562
       it('log calls are not traced', () => verifyInstanaLoggingIsNotTraced());
     });
 
@@ -149,6 +147,10 @@ mochaSuiteFn('tracing/instana-logger', function () {
           // verify that nothing logged by Instana has been traced with winston
           const allWinstonSpans = testUtils.getSpansByName(spans, 'log.winston');
           expect(allWinstonSpans).to.be.empty;
+
+          // verify that nothing logged by Instana has been traced with log4js
+          const allLog4jsSpans = testUtils.getSpansByName(spans, 'log.log4js');
+          expect(allLog4jsSpans).to.be.empty;
         })
       );
     });

--- a/packages/collector/test/tracing/logger/instana-logger/test.js
+++ b/packages/collector/test/tracing/logger/instana-logger/test.js
@@ -58,7 +58,7 @@ mochaSuiteFn('tracing/instana-logger', function () {
 
       // TODO: This test is failing. We can check for `this.__instana` in log4js instrumentation
       //       in https://github.com/instana/nodejs/pull/1562
-      it.skip('log calls are not traced', () => verifyInstanaLoggingIsNotTraced());
+      it('log calls are not traced', () => verifyInstanaLoggingIsNotTraced());
     });
 
     describe('Instana receives a bunyan logger', () => {

--- a/packages/collector/test/tracing/logger/instana-logger/test.js
+++ b/packages/collector/test/tracing/logger/instana-logger/test.js
@@ -43,7 +43,7 @@ mochaSuiteFn('tracing/instana-logger', function () {
       it('log calls are not traced', () => verifyInstanaLoggingIsNotTraced());
     });
 
-    describe('Instana receives a non-pino logger', () => {
+    describe('Instana receives a custom dummy logger', () => {
       appControls.registerTestHooks({
         instanaLoggingMode: 'instana-receives-custom-dummy-logger'
       });
@@ -125,7 +125,7 @@ mochaSuiteFn('tracing/instana-logger', function () {
 
   function verifyInstanaLoggingIsNotTraced() {
     return appControls.trigger('trigger').then(async () => {
-      await testUtils.delay(250);
+      await testUtils.delay(500);
 
       return testUtils.retry(() =>
         agentControls.getSpans().then(spans => {

--- a/packages/core/src/tracing/instrumentation/loggers/bunyan.js
+++ b/packages/core/src/tracing/instrumentation/loggers/bunyan.js
@@ -29,6 +29,7 @@ function instrument(Logger) {
 function shimLog(markAsError) {
   return originalLog =>
     function () {
+      // The __instana attribute identifies the Instana logger, so prevent these logs from being traced.
       if (arguments.length === 0 || (this.fields && !!this.fields.__instana)) {
         // * arguments.length === 0 -> This is a logger.warn() type of call (without arguments), this will not log
         // anything but simply return whether the log level in question is enabled for this logger.

--- a/packages/core/src/tracing/instrumentation/loggers/bunyan.js
+++ b/packages/core/src/tracing/instrumentation/loggers/bunyan.js
@@ -29,7 +29,7 @@ function instrument(Logger) {
 function shimLog(markAsError) {
   return originalLog =>
     function () {
-      if (arguments.length === 0 || (this.fields && !!this.fields.__in)) {
+      if (arguments.length === 0 || (this.fields && !!this.fields.__instana)) {
         // * arguments.length === 0 -> This is a logger.warn() type of call (without arguments), this will not log
         // anything but simply return whether the log level in question is enabled for this logger.
         return originalLog.apply(this, arguments);

--- a/packages/core/src/tracing/instrumentation/loggers/bunyan.js
+++ b/packages/core/src/tracing/instrumentation/loggers/bunyan.js
@@ -29,7 +29,7 @@ function instrument(Logger) {
 function shimLog(markAsError) {
   return originalLog =>
     function () {
-      if (arguments.length === 0) {
+      if (arguments.length === 0 || (this.fields && !!this.fields.__in)) {
         // * arguments.length === 0 -> This is a logger.warn() type of call (without arguments), this will not log
         // anything but simply return whether the log level in question is enabled for this logger.
         return originalLog.apply(this, arguments);

--- a/packages/core/src/tracing/instrumentation/loggers/console.js
+++ b/packages/core/src/tracing/instrumentation/loggers/console.js
@@ -24,7 +24,7 @@ function shimLog(options) {
   return originalLog =>
     function () {
       // The __instana attribute identifies the Instana logger, so prevent these logs from being traced.
-      if (arguments.length === 0 || !!this.__instana) {
+      if (arguments.length === 0 || !!this?.__instana) {
         // * arguments.length === 0 -> This is a console.warn() type of call (without arguments), this will not log
         // anything but simply return whether the log level in question is enabled for this logger.
         return originalLog.apply(this, arguments);

--- a/packages/core/src/tracing/instrumentation/loggers/console.js
+++ b/packages/core/src/tracing/instrumentation/loggers/console.js
@@ -23,7 +23,7 @@ exports.init = function init() {
 function shimLog(options) {
   return originalLog =>
     function () {
-      if (arguments.length === 0) {
+      if (arguments.length === 0 || this.__instana) {
         // * arguments.length === 0 -> This is a console.warn() type of call (without arguments), this will not log
         // anything but simply return whether the log level in question is enabled for this logger.
         return originalLog.apply(this, arguments);

--- a/packages/core/src/tracing/instrumentation/loggers/console.js
+++ b/packages/core/src/tracing/instrumentation/loggers/console.js
@@ -24,7 +24,11 @@ function shimLog(options) {
   return originalLog =>
     function () {
       // The __instana attribute identifies the Instana logger, so prevent these logs from being traced.
-      if (arguments.length === 0 || !!this?.__instana) {
+      if (this.__instana) {
+        return originalLog.apply(this, arguments);
+      }
+
+      if (arguments.length === 0) {
         // * arguments.length === 0 -> This is a console.warn() type of call (without arguments), this will not log
         // anything but simply return whether the log level in question is enabled for this logger.
         return originalLog.apply(this, arguments);

--- a/packages/core/src/tracing/instrumentation/loggers/console.js
+++ b/packages/core/src/tracing/instrumentation/loggers/console.js
@@ -24,7 +24,7 @@ function shimLog(options) {
   return originalLog =>
     function () {
       // The __instana attribute identifies the Instana logger, so prevent these logs from being traced.
-      if (arguments.length === 0 || this.__instana) {
+      if (arguments.length === 0 || !!this.__instana) {
         // * arguments.length === 0 -> This is a console.warn() type of call (without arguments), this will not log
         // anything but simply return whether the log level in question is enabled for this logger.
         return originalLog.apply(this, arguments);

--- a/packages/core/src/tracing/instrumentation/loggers/console.js
+++ b/packages/core/src/tracing/instrumentation/loggers/console.js
@@ -23,6 +23,7 @@ exports.init = function init() {
 function shimLog(options) {
   return originalLog =>
     function () {
+      // The __instana attribute identifies the Instana logger, so prevent these logs from being traced.
       if (arguments.length === 0 || this.__instana) {
         // * arguments.length === 0 -> This is a console.warn() type of call (without arguments), this will not log
         // anything but simply return whether the log level in question is enabled for this logger.

--- a/packages/core/src/tracing/instrumentation/loggers/console.js
+++ b/packages/core/src/tracing/instrumentation/loggers/console.js
@@ -24,7 +24,7 @@ function shimLog(options) {
   return originalLog =>
     function () {
       // The __instana attribute identifies the Instana logger, so prevent these logs from being traced.
-      if (this.__instana) {
+      if (this?.__instana) {
         return originalLog.apply(this, arguments);
       }
 

--- a/packages/core/src/tracing/instrumentation/loggers/log4js.js
+++ b/packages/core/src/tracing/instrumentation/loggers/log4js.js
@@ -34,6 +34,7 @@ function instrumentLog4jsLogger(loggerModule) {
 
 function shimLog(originalLog) {
   return function (level) {
+    // The __instana attribute identifies the Instana logger, so prevent these logs from being traced.
     if (this.__instana || cls.skipExitTracing({ isActive, skipAllowRootExitSpanPresence: true })) {
       return originalLog.apply(this, arguments);
     }

--- a/packages/core/src/tracing/instrumentation/loggers/log4js.js
+++ b/packages/core/src/tracing/instrumentation/loggers/log4js.js
@@ -34,7 +34,7 @@ function instrumentLog4jsLogger(loggerModule) {
 
 function shimLog(originalLog) {
   return function (level) {
-    if (cls.skipExitTracing({ isActive, skipAllowRootExitSpanPresence: true })) {
+    if (this.__instana || cls.skipExitTracing({ isActive, skipAllowRootExitSpanPresence: true })) {
       return originalLog.apply(this, arguments);
     }
 

--- a/packages/core/src/tracing/instrumentation/loggers/log4js.js
+++ b/packages/core/src/tracing/instrumentation/loggers/log4js.js
@@ -35,7 +35,11 @@ function instrumentLog4jsLogger(loggerModule) {
 function shimLog(originalLog) {
   return function (level) {
     // The __instana attribute identifies the Instana logger, so prevent these logs from being traced.
-    if (this.__instana || cls.skipExitTracing({ isActive, skipAllowRootExitSpanPresence: true })) {
+    if (this.__instana) {
+      return originalLog.apply(this, arguments);
+    }
+
+    if (cls.skipExitTracing({ isActive, skipAllowRootExitSpanPresence: true })) {
       return originalLog.apply(this, arguments);
     }
 

--- a/packages/core/src/tracing/instrumentation/loggers/winston.js
+++ b/packages/core/src/tracing/instrumentation/loggers/winston.js
@@ -68,6 +68,13 @@ function shimLevelMethod(derivedLogger, key, markAsError) {
 
 function instrumentedLevelMethod(originalMethod, markAsError) {
   return function (message) {
+    // CASE: Customer is using a custom winston logger (instana.setLogger(winstonLogger)).
+    //       We create a winston child logger for all instana internal logs.
+    //       We should NOT trace these child logger logs. See collector/src/logger.js
+    if (this.__instana) {
+      return originalMethod.apply(this, arguments);
+    }
+
     if (cls.skipExitTracing({ isActive, skipAllowRootExitSpanPresence: true })) {
       return originalMethod.apply(this, arguments);
     }


### PR DESCRIPTION
refs [INSTA-27856](https://jsw.ibm.com/browse/INSTA-27856)

This PR rectifies the order of module imports in logger integration test files. 
And it resolves Instana log calls being traced with custom logger setup 

- [x] bunyan
- [x] winston
- [x] log4js
- [x] console logger
- [x] pino