### PR TITLE
test: added leave for agentready_test.js

### DIFF
--- a/packages/collector/test/announceCycle/agentready_test.js
+++ b/packages/collector/test/announceCycle/agentready_test.js
@@ -76,6 +76,7 @@ describe('agent ready state', () => {
 
     after(() => {
       sinon.restore();
+      agentreadyState.leave();
     });
 
     it('should activate all components', () => {


### PR DESCRIPTION
This is a unit test.
It starts agent ready.
Agent ready starts a timeout in a custom interval. If we do not end it, the timeout gets activated in other tests! This was really hard to fix.