### PR TITLE
test: installed shared metrics for manual tracer installation

### DIFF
--- a/packages/collector/test/prevent_instrumenting_multiple_times/test.js
+++ b/packages/collector/test/prevent_instrumenting_multiple_times/test.js
@@ -46,6 +46,17 @@ describe('prevent initializing @instana/collector multiple times', function () {
       tmpDir
     );
 
+    // NOTE: Override the shared metrics npm dependency with the local code base
+    const sharedMetrics = path.join(__dirname, '..', '..', '..', 'shared-metrics');
+    runCommandSync('npm pack', sharedMetrics);
+
+    const sharedMetricsVersion = require(`${copath}/package.json`).version;
+    runCommandSync(
+      // eslint-disable-next-line max-len
+      `npm install --production --no-optional --no-audit ${sharedMetrics}/instana-shared-metrics-${sharedMetricsVersion}.tgz`,
+      tmpDir
+    );
+
     controls = new ProcessControls({
       appPath: path.join(__dirname, '..', 'apps', 'express'),
       execArgv: ['--require', pathToSeparateInstanaCollector],

--- a/packages/collector/test/tracing/sdk/multiple_installations/cjs/test.js
+++ b/packages/collector/test/tracing/sdk/multiple_installations/cjs/test.js
@@ -56,6 +56,16 @@ mochaSuiteFn('[CJS] tracing/sdk/multiple_installations', function () {
       tmpDir
     );
 
+    // NOTE: Override the shared-metrics npm dependency with the local code base to be able to debug.
+    const sharedMetricsPath = path.join(__dirname, '..', '..', '..', '..', '..', '..', 'shared-metrics');
+    testUtils.runCommandSync('npm pack', copath);
+
+    const smVersion = require(`${sharedMetricsPath}/package.json`).version;
+    testUtils.runCommandSync(
+      `npm install --production --no-optional --no-audit ${sharedMetricsPath}/instana-shared-metrics-${smVersion}.tgz`,
+      tmpDir
+    );
+
     controls = new ProcessControls({
       useGlobalAgent: true,
       cwd: path.join(__dirname, 'src'),


### PR DESCRIPTION
We need the shared metrics package as well,
because otherwise it will use the released shared metrics package. And if you have a change locally, it won't take it.