### PR TITLE
test: added winston transport to test

### DIFF
--- a/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-winston-logger.js
+++ b/packages/collector/test/tracing/logger/instana-logger/app-instana-receives-winston-logger.js
@@ -25,7 +25,8 @@ const instana = require('../../../..')({
 
 instana.setLogger(
   winston.createLogger({
-    level: 'info'
+    level: 'info',
+    transports: [new winston.transports.Console()]
   })
 );
 


### PR DESCRIPTION
Winston does not create transports by default!

From https://github.com/winstonjs/winston?tab=readme-ov-file#usage

> Note that the default logger doesn't have any transports by default. You need add transports by yourself, and leaving the default logger without any transports may produce a high memory usage issue.