### PR TITLE
refactor: optimized aws v3 initialization

### DIFF
--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/dynamodb.js
@@ -13,6 +13,10 @@ const { InstanaAWSProduct } = require('./instana_aws_product');
 const SPAN_NAME = 'dynamodb';
 
 class InstanaAWSDynamoDB extends InstanaAWSProduct {
+  constructor() {
+    super(SPAN_NAME);
+  }
+
   instrumentedSmithySend(ctx, isActive, originalSend, smithySendArgs) {
     if (cls.skipExitTracing({ isActive })) {
       return originalSend.apply(ctx, smithySendArgs);
@@ -93,4 +97,4 @@ class InstanaAWSDynamoDB extends InstanaAWSProduct {
   }
 }
 
-module.exports = new InstanaAWSDynamoDB(SPAN_NAME);
+module.exports = InstanaAWSDynamoDB;

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/kinesis.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/kinesis.js
@@ -12,6 +12,10 @@ const { InstanaAWSProduct } = require('./instana_aws_product');
 const SPAN_NAME = 'kinesis';
 
 class InstanaAWSKinesis extends InstanaAWSProduct {
+  constructor() {
+    super(SPAN_NAME);
+  }
+
   instrumentedSmithySend(ctx, isActive, originalSend, smithySendArgs) {
     if (cls.skipExitTracing({ isActive })) {
       return originalSend.apply(ctx, smithySendArgs);
@@ -81,4 +85,4 @@ class InstanaAWSKinesis extends InstanaAWSProduct {
   }
 }
 
-module.exports = new InstanaAWSKinesis(SPAN_NAME);
+module.exports = InstanaAWSKinesis;

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/lambda.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/lambda.js
@@ -15,6 +15,10 @@ const SPAN_NAME = 'aws.lambda.invoke';
 const CUSTOM_SERVICE_NAME = 'lambda';
 
 class InstanaAWSLambda extends InstanaAWSProduct {
+  constructor() {
+    super(SPAN_NAME, null, CUSTOM_SERVICE_NAME);
+  }
+
   propagateInstanaHeaders(originalArgs, span, suppressed = false) {
     const params = originalArgs[0].input;
     let clientContextContentBase64;
@@ -118,4 +122,4 @@ class InstanaAWSLambda extends InstanaAWSProduct {
   }
 }
 
-module.exports = new InstanaAWSLambda(SPAN_NAME, null, CUSTOM_SERVICE_NAME);
+module.exports = InstanaAWSLambda;

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/s3.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/s3.js
@@ -50,10 +50,13 @@ const operationsInfo = {
 };
 
 const operations = Object.keys(operationsInfo);
-
 const SPAN_NAME = 's3';
 
 class InstanaAWSS3 extends InstanaAWSProduct {
+  constructor() {
+    super(SPAN_NAME, operations);
+  }
+
   instrumentedSmithySend(ctx, isActive, originalSend, smithySendArgs) {
     if (cls.skipExitTracing({ isActive })) {
       return originalSend.apply(ctx, smithySendArgs);
@@ -119,4 +122,4 @@ class InstanaAWSS3 extends InstanaAWSProduct {
   }
 }
 
-module.exports = new InstanaAWSS3(SPAN_NAME, operations);
+module.exports = InstanaAWSS3;

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sns.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sns.js
@@ -11,12 +11,15 @@ const { InstanaAWSProduct } = require('./instana_aws_product');
 const { logTooManyAttributesWarningOnce } = require('../aws_utils');
 
 const SPAN_NAME = 'sns';
-
 let logger = require('../../../../../logger').getLogger('tracing/sns/v3', newLogger => {
   logger = newLogger;
 });
 
 class InstanaAWSNS extends InstanaAWSProduct {
+  constructor() {
+    super(SPAN_NAME);
+  }
+
   instrumentedSmithySend(ctx, isActive, originalSend, smithySendArgs) {
     const skipTracingResult = cls.skipExitTracing({ extendedResponse: true, isActive });
 
@@ -130,4 +133,4 @@ class InstanaAWSNS extends InstanaAWSProduct {
   }
 }
 
-module.exports = new InstanaAWSNS(SPAN_NAME);
+module.exports = InstanaAWSNS;

--- a/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
+++ b/packages/core/src/tracing/instrumentation/cloud/aws-sdk/v3/sqs.js
@@ -35,10 +35,13 @@ const operationsInfo = {
 };
 
 const operations = Object.keys(operationsInfo);
-
 const SPAN_NAME = 'sqs';
 
 class InstanaAWSSQS extends InstanaAWSProduct {
+  constructor() {
+    super(SPAN_NAME, operations);
+  }
+
   init(hook, shimmer) {
     // < 3.481.0
     // refs https://github.com/instana/nodejs/commit/6ae90e74fee5c47cc4ade67d21c4885d34c08847
@@ -403,4 +406,4 @@ class InstanaAWSSQS extends InstanaAWSProduct {
   }
 }
 
-module.exports = new InstanaAWSSQS(SPAN_NAME, operations);
+module.exports = InstanaAWSSQS;


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-13498

Extracted from #1556 

With this refactoring, we can easily forward the `config` object now to the aws v3 pkg. Each class is instantiated with the `config` object, which contains the logger.