### PR TITLE
refactor: updated the filtering logic to support advanced configurations

### DIFF
--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -123,8 +123,8 @@ if (customInstrumentations.length > 0) {
 
 /**
  * @typedef {Object} IgnoreEndpointConfig
- * @property {string | string[]} methods
- * @property {string[]=} [endpoints]
+ * @property {string | string[]} [methods]
+ * @property {string | string[]} [endpoints]
  */
 /** @type {Array.<InstanaInstrumentedModule>} */
 let additionalInstrumentationModules = [];

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -118,9 +118,14 @@ if (customInstrumentations.length > 0) {
  */
 
 /**
- * @typedef {Object.<string, string[]|string>}  IgnoreEndpoints
+ * @typedef {Object.<string, string[]|string|IgnoreEndpointConfig[]>}  IgnoreEndpoints
  */
 
+/**
+ * @typedef {Object} IgnoreEndpointConfig
+ * @property {string | string[]} method - A method or list of methods to ignore.
+ * @property {string[]=} [endpoints] - A list of endpoints to ignore (optional).
+ */
 /** @type {Array.<InstanaInstrumentedModule>} */
 let additionalInstrumentationModules = [];
 /** @type {Object.<string, InstanaInstrumentedModule>} */

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -123,8 +123,8 @@ if (customInstrumentations.length > 0) {
 
 /**
  * @typedef {Object} IgnoreEndpointConfig
- * @property {string | string[]} [methods]
- * @property {string | string[]} [endpoints]
+ * @property {string[]} [methods]
+ * @property {string[]} [endpoints]
  */
 /** @type {Array.<InstanaInstrumentedModule>} */
 let additionalInstrumentationModules = [];

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -123,8 +123,8 @@ if (customInstrumentations.length > 0) {
 
 /**
  * @typedef {Object} IgnoreEndpointConfig
- * @property {string | string[]} method - A method or list of methods to ignore.
- * @property {string[]=} [endpoints] - A list of endpoints to ignore (optional).
+ * @property {string | string[]} methods
+ * @property {string[]=} [endpoints]
  */
 /** @type {Array.<InstanaInstrumentedModule>} */
 let additionalInstrumentationModules = [];

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -118,11 +118,10 @@ if (customInstrumentations.length > 0) {
  */
 
 /**
- * @typedef {Object.<string, string[]|string|IgnoreEndpointConfig[]>}  IgnoreEndpoints
+ * @typedef {Object.<string,IgnoreEndpointsFields[]>}  IgnoreEndpoints
  */
-
 /**
- * @typedef {Object} IgnoreEndpointConfig
+ * @typedef {Object} IgnoreEndpointsFields
  * @property {string[]} [methods]
  * @property {string[]} [endpoints]
  */

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -710,7 +710,7 @@ function normalizeIgnoreEndpoints(config) {
       const normalizedService = service.toLowerCase();
 
       if (Array.isArray(endpoints)) {
-        // temprory type fix, will be removed in https://github.com/instana/nodejs/pull/1585.
+        // temporary type fix, will be removed in https://github.com/instana/nodejs/pull/1585.
         // @ts-ignore
         config.tracing.ignoreEndpoints[normalizedService] = endpoints.map(endpoint =>
           typeof endpoint === 'string' ? endpoint.toLowerCase() : endpoint

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -710,7 +710,7 @@ function normalizeIgnoreEndpoints(config) {
       const normalizedService = service.toLowerCase();
 
       if (Array.isArray(endpoints)) {
-        // temprory type fix, will be removed in https://github.com/instana/nodejs/pull/1585 .
+        // temprory type fix, will be removed in https://github.com/instana/nodejs/pull/1585.
         // @ts-ignore
         config.tracing.ignoreEndpoints[normalizedService] = endpoints.map(endpoint =>
           typeof endpoint === 'string' ? endpoint.toLowerCase() : endpoint

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -713,9 +713,11 @@ function normalizeIgnoreEndpoints(config) {
         // temporary type fix, will be removed in https://github.com/instana/nodejs/pull/1585.
         // @ts-ignore
         config.tracing.ignoreEndpoints[normalizedService] = endpoints.map(endpoint =>
+          // @ts-ignore
           typeof endpoint === 'string' ? endpoint.toLowerCase() : endpoint
         );
       } else if (typeof endpoints === 'string') {
+        // @ts-ignore
         config.tracing.ignoreEndpoints[normalizedService] = [endpoints?.toLowerCase()];
       } else {
         logger.warn(

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -710,6 +710,8 @@ function normalizeIgnoreEndpoints(config) {
       const normalizedService = service.toLowerCase();
 
       if (Array.isArray(endpoints)) {
+        // temprory fix, will be removed. 
+        // @ts-ignore
         config.tracing.ignoreEndpoints[normalizedService] = endpoints.map(endpoint =>
           typeof endpoint === 'string' ? endpoint.toLowerCase() : endpoint
         );

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -710,7 +710,7 @@ function normalizeIgnoreEndpoints(config) {
       const normalizedService = service.toLowerCase();
 
       if (Array.isArray(endpoints)) {
-        // temprory fix, will be removed. 
+        // temprory type fix, will be removed in https://github.com/instana/nodejs/pull/1585 .
         // @ts-ignore
         config.tracing.ignoreEndpoints[normalizedService] = endpoints.map(endpoint =>
           typeof endpoint === 'string' ? endpoint.toLowerCase() : endpoint

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -83,8 +83,8 @@ function shouldIgnore(span, ignoreEndpointsConfig) {
       return config.toLowerCase() === spanOperation;
     }
 
-    // For advanced filtering: the config is provided as an object.
-    // For instance, for a Kafka, the config like { methods: ['consume'], endpoints: ['t1'] }.
+    // For advanced filtering:
+    // For e.g., for a Kafka, the config like { methods: ['consume'], endpoints: ['t1'] }.
     if (typeof config === 'object') {
       // Case where config does not specify any filtering criteria.
       if (!config.methods && !config.endpoints) {

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -5,7 +5,7 @@
 'use strict';
 
 // List of span types to allowed to ignore
-// 'kafka_placeholder' used as a temporary span type for Kafka until the support is implemented.
+// 'kafka_placeholder' used as a temporary span type for testing, until the Kafka support is implemented.
 const IGNORABLE_SPAN_TYPES = ['redis', 'dynamodb', 'kafka_placeholder'];
 
 /**

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -22,15 +22,13 @@ function matchEndpoints(span, config) {
     return false;
   }
 
-  const configuredEndpoints = Array.isArray(config.endpoints) ? config.endpoints : [config.endpoints];
-
   // If * is present, any endpoint will match.
-  if (configuredEndpoints.includes('*')) {
+  if (config.endpoints.includes('*')) {
     return true;
   }
 
   return spanEndpoints.some((/** @type {string} */ endpoint) =>
-    configuredEndpoints.some((/** @type {string} */ e) => e?.toLowerCase() === endpoint?.toLowerCase())
+    config.endpoints.some((/** @type {string} */ e) => e?.toLowerCase() === endpoint?.toLowerCase())
   );
 }
 
@@ -46,8 +44,6 @@ function matchMethods(span, config) {
   if (config.methods) {
     if (Array.isArray(config.methods)) {
       methodMatches = config.methods.includes('*') || config.methods.some(m => m?.toLowerCase() === spanOperation);
-    } else if (typeof config.methods === 'string') {
-      methodMatches = config.methods === '*' || config.methods.toLowerCase() === spanOperation;
     }
   }
 

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -8,64 +8,110 @@
 const IGNORABLE_SPAN_TYPES = ['redis', 'dynamodb', 'kafka'];
 
 /**
- * @param {import('../core').InstanaBaseSpan} span
+ * @param {import("../core").InstanaBaseSpan} span
+ * @param {string | string []} config
+ * @returns {boolean}
+ */
+function matchOperation(span, config) {
+  const spanOperation = span.data[span.n]?.operation?.toLowerCase();
+  if (!spanOperation) {
+    return false;
+  }
+
+  if (typeof config === 'string') {
+    return config.toLowerCase() === spanOperation;
+  }
+
+  if (Array.isArray(config)) {
+    return config.some(op => typeof op === 'string' && op?.toLowerCase() === spanOperation);
+  }
+
+  return false;
+}
+
+/**
+ * @param {import("../core").InstanaBaseSpan} span
+ * @param {import('../tracing').IgnoreEndpointConfig} config
+ * @returns {boolean}
+ */
+function matchEndpoints(span, config) {
+  const rawEndpoints = span.data[span.n]?.endpoints;
+  const spanEndpoints = Array.isArray(rawEndpoints) ? rawEndpoints : [rawEndpoints].filter(Boolean);
+
+  if (!spanEndpoints.length) {
+    return false;
+  }
+
+  const configuredEndpoints = Array.isArray(config.endpoints) ? config.endpoints : [config.endpoints];
+
+  // If * is present, any endpoint will match.
+  if (configuredEndpoints.includes('*')) {
+    return true;
+  }
+
+  return spanEndpoints.some(endpoint =>
+    configuredEndpoints.some((/** @type {string} */ e) => e?.toLowerCase() === endpoint?.toLowerCase())
+  );
+}
+
+/**
+ * @param {import("../core").InstanaBaseSpan} span
+ * @param {import('../tracing').IgnoreEndpointConfig} config
+ * @returns {boolean}
+ */
+function matchMethods(span, config) {
+  const spanOperation = span.data[span.n]?.operation?.toLowerCase();
+  let methodMatches = false;
+
+  if (config.methods) {
+    if (Array.isArray(config.methods)) {
+      methodMatches = config.methods.includes('*') || config.methods.some(m => m?.toLowerCase() === spanOperation);
+    } else if (typeof config.methods === 'string') {
+      methodMatches = config.methods === '*' || config.methods.toLowerCase() === spanOperation;
+    }
+  }
+
+  return methodMatches;
+}
+
+/**
+ * @param {import("../core").InstanaBaseSpan} span
  * @param {import('../tracing').IgnoreEndpoints} ignoreEndpointsConfig
  * @returns {boolean}
  */
 function shouldIgnore(span, ignoreEndpointsConfig) {
-  // Skip if the span type is not in the ignored list
   if (!IGNORABLE_SPAN_TYPES.includes(span.n)) {
     return false;
   }
 
   const ignoreConfigs = ignoreEndpointsConfig[span.n];
-  if (!ignoreConfigs) return false;
-
-  const spanOperation = span.data[span.n]?.operation?.toLowerCase();
-  const spanEndpoints = Array.isArray(span.data[span.n]?.endpoints)
-    ? span.data[span.n].endpoints
-    : [span.data[span.n]?.endpoints].filter(Boolean);
-
-  if (!spanOperation && !spanEndpoints.legth) {
+  if (!ignoreConfigs) {
     return false;
   }
-
-  // We support string, array, object formats for the config, but the string format is not shared publicly.
-  // If the ignoreConfigs is a simple string, compare it with the operation.
+  // For basic filtering: when the configuration is provided as a simple string
+  // (e.g., "redis.get" or "dynamodb.query"), directly compare it to the span's operation.
   if (typeof ignoreConfigs === 'string') {
-    return ignoreConfigs?.toLowerCase() === spanOperation;
+    return matchOperation(span, ignoreConfigs);
   }
 
   return ignoreConfigs.some(config => {
+    // For basic filtering: when the configuration is provided as a simple string array
+    // (e.g., "redis:['get,'set']"
     if (typeof config === 'string') {
-      return config?.toLowerCase() === spanOperation;
+      return matchOperation(span, config);
     }
-
-    // If the config is an object, proceed with methods and endpoints checks.
+    // For advanced filtering: the configuration is provided as an object.
+    // For instance, for a Kafka span, the configuration like { methods: ['consume'], endpoints: ['t1'] }.
     if (typeof config === 'object') {
-      let methodMatches = false;
-      if (config.methods) {
-        if (Array.isArray(config.methods)) {
-          methodMatches = config.methods.includes('*') || config.methods.some(m => m?.toLowerCase() === spanOperation);
-        } else if (typeof config.methods === 'string') {
-          methodMatches = config.methods === '*' || config.methods?.toLowerCase() === spanOperation;
-        }
+      if (config.methods && !matchMethods(span, config)) {
+        return false;
       }
-
-      if (!methodMatches) return false;
-
-      const configuredEndpoints = Array.isArray(config.endpoints) ? config.endpoints : [config.endpoints];
-
-      // If the config endpoints include the '*', then ignore endpoint matching completely.
-      // This means, for example, if the method is "consume", all endpoints(topics) with that operation will be ignored.
-      if (configuredEndpoints.includes('*')) {
-        return true;
+      if (config.endpoints && !matchEndpoints(span, config)) {
+        return false;
       }
-      return spanEndpoints.some((/** @type {string} */ endpoint) =>
-        configuredEndpoints.some(e => e?.toLowerCase() === endpoint?.toLowerCase())
-      );
+      // extend the cases in future
+      return true;
     }
-
     return false;
   });
 }

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -5,7 +5,8 @@
 'use strict';
 
 // List of span types to allowed to ignore
-const IGNORABLE_SPAN_TYPES = ['redis', 'dynamodb', 'kafka'];
+// 'kafka_placeholder' used as a temporary span type for Kafka until the support is implemented.
+const IGNORABLE_SPAN_TYPES = ['redis', 'dynamodb', 'kafka_placeholder'];
 
 /**
  * @param {import("../core").InstanaBaseSpan} span
@@ -81,16 +82,21 @@ function shouldIgnore(span, ignoreEndpointsConfig) {
       return config.toLowerCase() === spanOperation;
     }
 
-    // For advanced filtering: the configuration is provided as an object.
-    // For instance, for a Kafka span, the configuration like { methods: ['consume'], endpoints: ['t1'] }.
+    // For advanced filtering: the config is provided as an object.
+    // For instance, for a Kafka, the config like { methods: ['consume'], endpoints: ['t1'] }.
     if (typeof config === 'object') {
+      // Case where config does not specify any filtering criteria.
+      if (!config.methods && !config.endpoints) {
+        return false;
+      }
+
       if (config.methods && !matchMethods(span, config)) {
         return false;
       }
       if (config.endpoints && !matchEndpoints(span, config)) {
         return false;
       }
-      // extend the cases in future
+      // extend more filtering cases in future
       return true;
     }
     return false;

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -10,10 +10,14 @@ const IGNORABLE_SPAN_TYPES = ['redis', 'dynamodb', 'kafka_placeholder'];
 
 /**
  * @param {import('../core').InstanaBaseSpan} span
- * @param {import('../tracing').IgnoreEndpointConfig} ignoreconfig
+ * @param {import('../tracing').IgnoreEndpointsFields} ignoreconfig
  * @returns {boolean}
  */
 function matchEndpoints(span, ignoreconfig) {
+  // TODO:
+  // Normalizing the endpoints will be addressed in future PRs.
+  // For Kafka span data, the endpoints correspond to the service field,
+  // which may contain multiple values.
   const spanEndpoints = Array.isArray(span.data[span.n]?.endpoints)
     ? span.data[span.n].endpoints
     : [span.data[span.n]?.endpoints].filter(Boolean);
@@ -28,13 +32,13 @@ function matchEndpoints(span, ignoreconfig) {
   }
 
   return spanEndpoints.some((/** @type {string} */ endpoint) =>
-    ignoreconfig.endpoints.some((/** @type {string} */ e) => e?.toLowerCase() === endpoint?.toLowerCase())
+    ignoreconfig.endpoints.some(e => e?.toLowerCase() === endpoint?.toLowerCase())
   );
 }
 
 /**
  * @param {import("../core").InstanaBaseSpan} span
- * @param {import('../tracing').IgnoreEndpointConfig} ignoreconfig
+ * @param {import('../tracing').IgnoreEndpointsFields} ignoreconfig
  * @returns {boolean}
  */
 function matchMethods(span, ignoreconfig) {
@@ -69,14 +73,18 @@ function shouldIgnore(span, ignoreEndpointsConfig) {
   const spanOperation = span.data[span.n]?.operation?.toLowerCase();
   // For basic filtering: when the configuration is provided as a simple string
   // (e.g., "redis.get" or "dynamodb.query"), directly compare it to the span's operation.
+  // TODO: will be removed
   if (typeof ignoreConfigs === 'string') {
+    // @ts-ignore
     return ignoreConfigs.toLowerCase() === spanOperation;
   }
 
   return ignoreConfigs.some(ignoreconfig => {
     // For basic filtering: when the configuration is provided as a simple string array
     // (e.g., "redis:['get,'set']"
+    // TODO: will be removed
     if (typeof ignoreconfig === 'string') {
+      // @ts-ignore
       return ignoreconfig.toLowerCase() === spanOperation;
     }
 

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -9,7 +9,7 @@
 const IGNORABLE_SPAN_TYPES = ['redis', 'dynamodb', 'kafka_placeholder'];
 
 /**
- * @param {import("../core").InstanaBaseSpan} span
+ * @param {import('../core').InstanaBaseSpan} span
  * @param {import('../tracing').IgnoreEndpointConfig} config
  * @returns {boolean}
  */
@@ -60,6 +60,7 @@ function matchMethods(span, config) {
  * @returns {boolean}
  */
 function shouldIgnore(span, ignoreEndpointsConfig) {
+  // Skip if the span type is not in the ignored list
   if (!IGNORABLE_SPAN_TYPES.includes(span.n)) {
     return false;
   }

--- a/packages/core/test/util/spanFilter_test.js
+++ b/packages/core/test/util/spanFilter_test.js
@@ -19,7 +19,19 @@ const span = {
     }
   }
 };
-const ignoreEndpoints = {
+const span1 = {
+  t: '1234567803',
+  s: '1234567892',
+  p: '1234567891',
+  n: 'kafka',
+  k: 2,
+  data: {
+    kafka: {
+      operation: ''
+    }
+  }
+};
+let ignoreEndpoints = {
   redis: ['GET', 'TYPE'],
   dynamodb: ['QUERY']
 };
@@ -56,5 +68,64 @@ describe('util.spanFilter', () => {
   it('should return the dynamodb span when the operation is not in the ignore list', () => {
     span.data.dynamodb.operation = 'PutItem';
     expect(applyFilter({ span, ignoreEndpoints })).equal(span);
+  });
+  describe('applyFilter Advanced Filtering', () => {
+    it.skip('should return null for a Redis span matching the string rule', () => {
+      ignoreEndpoints = {
+        redis: ['type', 'get'],
+        kafka: [
+          'consume',
+          'publish',
+          { method: ['*'], endpoints: ['topic1', 'topic2'] },
+          { method: ['publish', 'consume'], endpoints: ['topic3'] }
+        ]
+      };
+      span.data = {
+        redis: {
+          operation: 'type'
+        }
+      };
+      expect(applyFilter({ span, ignoreEndpoints })).to.equal(null);
+    });
+    it('should return null for a Kafka span with matching operation and endpoint', () => {
+      ignoreEndpoints = {
+        kafka: [{ method: ['publish', 'consume'], endpoints: ['topic3'] }]
+      };
+      span1.data = {
+        kafka: {
+          operation: 'publish',
+          endpoints: ['topic3']
+        }
+      };
+      expect(applyFilter({ span: span1, ignoreEndpoints })).to.equal(null);
+    });
+
+    it('should return null for a Kafka span using wildcard method filtering', () => {
+      ignoreEndpoints = {
+        redis: ['type', 'get'],
+        kafka: [{ method: ['*'], endpoints: ['topic1', 'topic2'] }]
+      };
+      span1.data = {
+        kafka: {
+          operation: 'consume',
+          endpoints: 'topic1'
+        }
+      };
+      expect(applyFilter({ span: span1, ignoreEndpoints })).to.equal(null);
+    });
+
+    it('should return null for a Kafka span matching a string rule in a mixed configuration', () => {
+      ignoreEndpoints = {
+        redis: ['type', 'get'],
+        kafka: ['consume', 'publish', { method: ['publish'], endpoints: ['topic3'] }]
+      };
+      span1.data = {
+        kafka: {
+          operation: 'consume',
+          endpoints: 'topic3'
+        }
+      };
+      expect(applyFilter({ span: span1, ignoreEndpoints })).to.equal(null);
+    });
   });
 });

--- a/packages/core/test/util/spanFilter_test.js
+++ b/packages/core/test/util/spanFilter_test.js
@@ -66,8 +66,8 @@ describe('util.spanFilter', () => {
         kafka: [
           'consume',
           'publish',
-          { method: ['*'], endpoints: ['topic1', 'topic2'] },
-          { method: ['publish', 'consume'], endpoints: ['topic3'] }
+          { methods: ['*'], endpoints: ['topic1', 'topic2'] },
+          { methods: ['publish', 'consume'], endpoints: ['topic3'] }
         ]
       };
       span.data = {
@@ -80,7 +80,7 @@ describe('util.spanFilter', () => {
 
     it('should return null for Kafka span with matching operation and endpoint', () => {
       ignoreEndpoints = {
-        kafka: [{ method: ['publish', 'consume'], endpoints: ['topic3'] }]
+        kafka: [{ methods: ['publish', 'consume'], endpoints: ['topic3'] }]
       };
       span.n = 'kafka';
       span.data = {
@@ -92,9 +92,9 @@ describe('util.spanFilter', () => {
       expect(applyFilter({ span: span, ignoreEndpoints })).to.equal(null);
     });
 
-    it('should return null for a Kafka span using wildcard method filtering', () => {
+    it('should return null for a Kafka span using wildcard methods filtering', () => {
       ignoreEndpoints = {
-        kafka: [{ method: ['*'], endpoints: ['topic1', 'topic2'] }]
+        kafka: [{ methods: ['*'], endpoints: ['topic1', 'topic2'] }]
       };
       span.n = 'kafka';
       span.data = {
@@ -106,9 +106,9 @@ describe('util.spanFilter', () => {
       expect(applyFilter({ span: span, ignoreEndpoints })).to.equal(null);
     });
 
-     it.skip('should return null for a Kafka span using wildcard endpoint filtering', () => {
+     it('should return null for a Kafka span using wildcard endpoint filtering', () => {
        ignoreEndpoints = {
-         kafka: [{ method: ['consume'], endpoints: ['*'] }]
+         kafka: [{ methods: ['consume'], endpoints: ['*'] }]
        };
        span.n = 'kafka';
        span.data = {

--- a/packages/core/test/util/spanFilter_test.js
+++ b/packages/core/test/util/spanFilter_test.js
@@ -60,14 +60,11 @@ describe('util.spanFilter', () => {
   });
 
   describe('advanced filtering with mixed config', () => {
-    beforeEach(() => {
+    it('returns null when a Redis span matching an advanced ignore config having other services', () => {
       ignoreEndpoints = {
         redis: ['type', 'get'],
         kafka_placeholder: ['consume', 'send', { methods: ['*'], endpoints: ['topic1', 'topic2'] }]
       };
-    });
-
-    it('returns null when a Redis span matching an advanced ignore config having other services', () => {
       span.n = 'redis';
       span.data = {
         redis: {

--- a/packages/core/test/util/spanFilter_test.js
+++ b/packages/core/test/util/spanFilter_test.js
@@ -106,19 +106,19 @@ describe('util.spanFilter', () => {
       expect(applyFilter({ span: span, ignoreEndpoints })).to.equal(null);
     });
 
-     it('should return null for a Kafka span using wildcard endpoint filtering', () => {
-       ignoreEndpoints = {
-         kafka: [{ methods: ['consume'], endpoints: ['*'] }]
-       };
-       span.n = 'kafka';
-       span.data = {
-         kafka: {
-           operation: 'consume',
-           endpoints: 'topic1'
-         }
-       };
-       expect(applyFilter({ span: span, ignoreEndpoints })).to.equal(null);
-     });
+    it('should return null for a Kafka span using wildcard endpoint filtering', () => {
+      ignoreEndpoints = {
+        kafka: [{ methods: ['consume'], endpoints: ['*'] }]
+      };
+      span.n = 'kafka';
+      span.data = {
+        kafka: {
+          operation: 'consume',
+          endpoints: 'topic1'
+        }
+      };
+      expect(applyFilter({ span: span, ignoreEndpoints })).to.equal(null);
+    });
 
     it('should return null for a Kafka span matching a string rule in a mixed configuration', () => {
       ignoreEndpoints = {

--- a/packages/core/test/util/spanFilter_test.js
+++ b/packages/core/test/util/spanFilter_test.js
@@ -87,7 +87,7 @@ describe('util.spanFilter', () => {
       expect(applyFilter({ span, ignoreEndpoints })).to.equal(null);
     });
 
-    it('returns null when "*" is specified for methodsconfig', () => {
+    it('returns null when "*" is specified for methods config', () => {
       ignoreEndpoints = {
         kafka_placeholder: [{ methods: ['*'], endpoints: ['topic1', 'topic2'] }]
       };
@@ -124,34 +124,6 @@ describe('util.spanFilter', () => {
         kafka_placeholder: {
           operation: 'consume',
           endpoints: 'topic1'
-        }
-      };
-      expect(applyFilter({ span, ignoreEndpoints })).to.equal(null);
-    });
-
-    it('returns null when a simple string config is applied', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: 'consume'
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: 'topic3'
-        }
-      };
-      expect(applyFilter({ span, ignoreEndpoints })).to.equal(null);
-    });
-
-    it('returns null when a simple string in method config is applied', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{ methods: 'consume' }]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: 'topic3'
         }
       };
       expect(applyFilter({ span, ignoreEndpoints })).to.equal(null);

--- a/packages/core/test/util/spanFilter_test.js
+++ b/packages/core/test/util/spanFilter_test.js
@@ -22,8 +22,8 @@ const span = {
 
 describe('util.spanFilter', () => {
   let ignoreEndpoints = {
-    redis: ['GET', 'TYPE'],
-    dynamodb: ['QUERY']
+    redis: [{ methods: ['GET', 'TYPE'] }],
+    dynamodb: [{ methods: ['QUERY'] }]
   };
   it('should return null when the span should be ignored', () => {
     span.data.redis.operation = 'GET';
@@ -61,7 +61,7 @@ describe('util.spanFilter', () => {
   describe('util.spanFilter: advanced filtering', () => {
     it('returns null when an advanced config for multiple services is applied and the Redis config matches', () => {
       ignoreEndpoints = {
-        redis: ['type', 'get'],
+        redis: [{ methods: ['type', 'get'] }],
         kafka_placeholder: [{ methods: ['*'], endpoints: ['topic1', 'topic2'] }]
       };
       span.n = 'redis';


### PR DESCRIPTION
Refactored span filtering logic to support advanced configurations for future Kafka support

**Changes:**

- Replaced the original simple endpoint filtering logic with a more flexible, advanced configuration
  that supports both simple string/array and object-based configs.
- Introduced new helper functions:
  • `matchEndpoints`
  • `matchMethods`
- Extended the tests to cover more cases.

Example config we expected:

```
ignoreEndpoints = {
    <service1>: [<methods_values>],
    <service2>: [{ methods: [<methods_values>], endpoints: [<endpoint_values>] }]
 };
```

**Next**

- [x] Parsing logic for config  #1585 (RFR)

This PR merge against branch `feat-ignore-endpoints-kafka`

ref INSTA-26148