### PR TITLE
test: fixed wrong imports

### DIFF
--- a/packages/collector/test/tracing/misc/typescript/ts_esm/ts_esm_test.js
+++ b/packages/collector/test/tracing/misc/typescript/ts_esm/ts_esm_test.js
@@ -7,12 +7,12 @@
 const expect = require('chai').expect;
 const path = require('path');
 const { execSync } = require('child_process');
-const config = require('@instana/core/test/config');
+const config = require('../../../../../../core/test/config');
+const testUtils = require('../../../../../../core/test/test_util');
+const isLatestEsmSupportedVersion = require('../../../../../../core').util.esm.isLatestEsmSupportedVersion;
+const supportedVersion = require('../../../../../../core').tracing.supportedVersion;
 const ProcessControls = require('../../../../test_util/ProcessControls');
 const globalAgent = require('../../../../globalAgent');
-const testUtils = require('@instana/core/test/test_util');
-const isLatestEsmSupportedVersion = require('@instana/core').util.esm.isLatestEsmSupportedVersion;
-const supportedVersion = require('@instana/core').tracing.supportedVersion;
 
 const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 


### PR DESCRIPTION
The target test installs a specific collector version!

See package.json in packages/collector/test/tracing/misc/typescript/ts_esm
> "@instana/collector": "^3.19.0"

require('@instana/core') could import the **non** local version. Instead it will import the older installed version.