### PR TITLE
ci: updated the slack notification message for aws lambda layer publish

### DIFF
--- a/packages/serverless/ci/pipeline.yaml
+++ b/packages/serverless/ci/pipeline.yaml
@@ -408,7 +408,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':white_check_mark:'
               text: |
-                    :white_check_mark: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the AWS regions (x86_64 architecture).
+                    :white_check_mark: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has been successfully deployed to all the non-cn regions (x86_64 architecture).
               attachments: *slack-alert-attachements-success
           on_failure: &slack-notify-failure-lambda
             put: slack-alert
@@ -416,7 +416,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':check-failed:'
               text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the AWS regions (x86_64 architecture).
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to non-cn regions (x86_64 architecture).
               attachments: *slack-alert-attachements-failure
           on_error: *slack-notify-failure-lambda
 
@@ -449,7 +449,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':white_check_mark:'
               text: |
-                    :white_check_mark: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the AWS regions (arm64 architecture).
+                    :white_check_mark: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has been successfully deployed to all the non-cn regions (arm64 architecture).
               attachments: *slack-alert-attachements-success
           on_failure: &slack-notify-failure-lambda
             put: slack-alert
@@ -457,7 +457,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':check-failed:'
               text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the AWS regions (arm64 architecture).
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to non-cn regions (arm64 architecture).
               attachments: *slack-alert-attachements-failure
           on_error: *slack-notify-failure-lambda
 
@@ -490,7 +490,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':white_check_mark:'
               text: |
-                    :white_check_mark: The AWS Lambda layer for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the China regions (x86_64 architecture).
+                    :white_check_mark: The AWS Lambda layer for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the cn regions (x86_64 architecture).
               attachments: *slack-alert-attachements-success
           on_failure: &slack-notify-failure-lambda
             put: slack-alert
@@ -498,7 +498,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':check-failed:'
               text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the China regions (x86_64 architecture).
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the cn regions (x86_64 architecture).
               attachments: *slack-alert-attachements-failure
           on_error: *slack-notify-failure-lambda
 
@@ -532,7 +532,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':white_check_mark:'
               text: |
-                    :white_check_mark: The AWS Lambda layer for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the China regions (arm64 architecture).
+                    :white_check_mark: The AWS Lambda layer for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the cn regions (arm64 architecture).
               attachments: *slack-alert-attachements-success
           on_failure: &slack-notify-failure-lambda
             put: slack-alert
@@ -540,7 +540,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':check-failed:'
               text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the China regions (arm64 architecture).
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the cn regions (arm64 architecture).
               attachments: *slack-alert-attachements-failure
           on_error: *slack-notify-failure-lambda
 

--- a/packages/serverless/ci/pipeline.yaml
+++ b/packages/serverless/ci/pipeline.yaml
@@ -408,7 +408,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':white_check_mark:'
               text: |
-                    :white_check_mark: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has been successfully deployed to all the non-cn regions (x86_64 architecture).
+                    :white_check_mark: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has been successfully deployed to all the *non-cn* regions (x86_64 architecture).
               attachments: *slack-alert-attachements-success
           on_failure: &slack-notify-failure-lambda
             put: slack-alert
@@ -416,7 +416,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':check-failed:'
               text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to non-cn regions (x86_64 architecture).
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to *non-cn* regions (x86_64 architecture).
               attachments: *slack-alert-attachements-failure
           on_error: *slack-notify-failure-lambda
 
@@ -449,7 +449,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':white_check_mark:'
               text: |
-                    :white_check_mark: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has been successfully deployed to all the non-cn regions (arm64 architecture).
+                    :white_check_mark: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has been successfully deployed to all the *non-cn* regions (arm64 architecture).
               attachments: *slack-alert-attachements-success
           on_failure: &slack-notify-failure-lambda
             put: slack-alert
@@ -457,7 +457,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':check-failed:'
               text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to non-cn regions (arm64 architecture).
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to *non-cn* regions (arm64 architecture).
               attachments: *slack-alert-attachements-failure
           on_error: *slack-notify-failure-lambda
 
@@ -490,7 +490,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':white_check_mark:'
               text: |
-                    :white_check_mark: The AWS Lambda layer for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the cn regions (x86_64 architecture).
+                    :white_check_mark: The AWS Lambda layer for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the *cn* regions (x86_64 architecture).
               attachments: *slack-alert-attachements-success
           on_failure: &slack-notify-failure-lambda
             put: slack-alert
@@ -498,7 +498,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':check-failed:'
               text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the cn regions (x86_64 architecture).
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the *cn* regions (x86_64 architecture).
               attachments: *slack-alert-attachements-failure
           on_error: *slack-notify-failure-lambda
 
@@ -532,7 +532,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':white_check_mark:'
               text: |
-                    :white_check_mark: The AWS Lambda layer for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the cn regions (arm64 architecture).
+                    :white_check_mark: The AWS Lambda layer for the Instana Node.js package version ((.:package-version)) has been successfully deployed to the *cn* regions (arm64 architecture).
               attachments: *slack-alert-attachements-success
           on_failure: &slack-notify-failure-lambda
             put: slack-alert
@@ -540,7 +540,7 @@ jobs:
               channel: '#team-node'
               icon_emoji: ':check-failed:'
               text: |
-                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the cn regions (arm64 architecture).
+                    :x: The AWS Lambda layer deployment for the Instana Node.js package version ((.:package-version)) has failed while publishing to the *cn* regions (arm64 architecture).
               attachments: *slack-alert-attachements-failure
           on_error: *slack-notify-failure-lambda
 


### PR DESCRIPTION
Added the clear message for slack notifications to scope the regions, whether its cn or non-cn.