### PR TITLE
fix: reduced noise for dependency calculation debug logs

### DIFF
--- a/packages/core/test/test_util/index.js
+++ b/packages/core/test/test_util/index.js
@@ -22,7 +22,8 @@ module.exports = {
       debug: () => {},
       info: () => {},
       warn: () => {},
-      error: () => {}
+      error: () => {},
+      trace: () => {}
     };
   },
   isCI: require('./is_ci'),

--- a/packages/shared-metrics/src/util/DependencyDistanceCalculator.js
+++ b/packages/shared-metrics/src/util/DependencyDistanceCalculator.js
@@ -175,7 +175,7 @@ class DependencyDistanceCalculator {
       mainModulePath = require.resolve(dependency);
     } catch (requireResolveErr) {
       // ignore
-      logger.debug(
+      logger.trace(
         `Ignoring failure to resolve the path to dependency ${dependency} for dependency distance calculation.`
       );
     }
@@ -184,7 +184,7 @@ class DependencyDistanceCalculator {
       // Could not find the package.json for this dependency so we cannot analyze it further, which means we are done
       // with it.
       localCountDownLatchForThisNode.countDown();
-      logger.debug(`No main module path for dependency ${dependency}.`);
+      logger.trace(`No main module path for dependency ${dependency}.`);
       return;
     }
 

--- a/packages/shared-metrics/src/util/DependencyDistanceCalculator.js
+++ b/packages/shared-metrics/src/util/DependencyDistanceCalculator.js
@@ -184,7 +184,7 @@ class DependencyDistanceCalculator {
       // Could not find the package.json for this dependency so we cannot analyze it further, which means we are done
       // with it.
       localCountDownLatchForThisNode.countDown();
-      logger.trace(`No main module path for dependency ${dependency}.`);
+      logger.trace(`Ignoring ${dependency} for dependency distance calculation, could not find main module path.`);
       return;
     }
 


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-27904

We often have seen these debug logs in customer logs

> No main module path for fsevents

e.g. `fsevents` for example is an optional dependency (see package-lock.json). If it cannot be installed, the customer sees this log. Its super useless.

TBH we don't care if the module in your package.json was installed or not.

The easiest fix for now is to reduce the log to trace. It won't show up when using `INSTANA_DEBUG=true`.
Furthermore I pimped the log.

`INSTANA_LOG_LEVEL=trace` can be used instead. We should make more use of trace vs debug.

I want to merge #1556 first.