### PR TITLE
test: fixed esm app run logic

### DIFF
--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -73,7 +73,7 @@ class ProcessControls {
             opts.appPath = updatedPath;
           }
         } else if (opts?.dirname) {
-          const esmApp = fs.readdirSync(opts.dirname).find(f => f.endsWith('.mjs'));
+          const esmApp = fs.readdirSync(opts.dirname).includes('app.mjs');
           if (esmApp) {
             opts.execArgv = resolveEsmLoader();
             opts.appPath = path.join(opts.dirname, 'app.mjs');


### PR DESCRIPTION
This PR ensures the app.mjs exists in the path for proper ESM execution
see: `opts.appPath = path.join(opts.dirname, 'app.mjs');`