### PR TITLE
fix: resolved calling callback twice in agent connection

### DIFF
--- a/packages/core/src/util/index.js
+++ b/packages/core/src/util/index.js
@@ -60,7 +60,11 @@ exports.atMostOnce = function atMostOnce(name, cb) {
       args: Array.prototype.slice.call(arguments)
     };
 
-    logger.debug(`Function ${name} was called ${callCount} times. This time with the following arguments: ${argObj}`);
+    logger.debug(
+      `Function ${name} was called ${callCount} times. This time with the following arguments: ${JSON.stringify(
+        argObj
+      )}`
+    );
   };
 };
 


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-27881

> {"level":20,"time":"2025-02-25T13:27:58.692Z","name":"@instana/collector","module":"index","threadId":0,"module":"@instana/core","__in":1,"module":"util/atMostOnce","msg":"Function callback for announceNodeCollector was called 2 times. This time with the following arguments: [object Object]"}


Problem:
Status Code != 200 is returned. We call the callback the first time.
Then, we also receive the request event callback. Second time called.
We have to protect against calling the callback twice.