### PR TITLE
test: added allow root exit span apps for bull and amqp

### DIFF
--- a/packages/collector/test/tracing/messaging/amqp/allowRootExitSpanApp.mjs
+++ b/packages/collector/test/tracing/messaging/amqp/allowRootExitSpanApp.mjs
@@ -1,0 +1,45 @@
+/*
+ * (c) Copyright IBM Corp. 2025
+ */
+
+'use strict';
+
+// NOTE: c8 bug https://github.com/bcoe/c8/issues/166
+process.on('SIGTERM', () => {
+  process.disconnect();
+  process.exit(0);
+});
+
+import delay from '../../../../../core/test/test_util/delay.js';
+import amqp from 'amqplib';
+import { exchange } from './amqpUtil.js';
+
+const logPrefix = `amqp Allow Root Exit Span App (${process.pid}):\t`;
+let connection;
+
+(async function run() {
+  // wait til Instana is ready
+  await delay(1000);
+
+  amqp
+    .connect(process.env.AMQP)
+    .then(_connection => {
+      connection = _connection;
+      return connection.createChannel();
+    })
+    .then(channel => {
+      log('amqp connection established');
+      channel.publish(exchange, '', Buffer.from('welcome'));
+      log('Sent message');
+      channel.close();
+      connection.close();
+    })
+    .catch(log);
+})();
+
+function log() {
+  /* eslint-disable no-console */
+  const args = Array.prototype.slice.call(arguments);
+  args[0] = logPrefix + args[0];
+  console.log.apply(console, args);
+}

--- a/packages/collector/test/tracing/messaging/amqp/test.js
+++ b/packages/collector/test/tracing/messaging/amqp/test.js
@@ -23,7 +23,7 @@ const agentControls = globalAgent.instance;
 let publisherControls;
 let consumerControls;
 
-const mochaSuiteFn = supportedVersion(process.versions.node) ? describe.only : describe.skip;
+const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 
 ['latest', 'v0'].forEach(version => {
   mochaSuiteFn(`tracing/amqp: ${version}`, function () {
@@ -47,7 +47,10 @@ const mochaSuiteFn = supportedVersion(process.versions.node) ? describe.only : d
         before(async () => {
           controls = new ProcessControls({
             useGlobalAgent: true,
-            appPath: path.join(__dirname, 'allowRootExitSpanApp')
+            appPath: path.join(__dirname, 'allowRootExitSpanApp'),
+            env: {
+              INSTANA_ALLOW_ROOT_EXIT_SPAN: 1
+            }
           });
 
           await controls.start(null, null, true);

--- a/packages/collector/test/tracing/messaging/amqp/test.js
+++ b/packages/collector/test/tracing/messaging/amqp/test.js
@@ -23,7 +23,7 @@ const agentControls = globalAgent.instance;
 let publisherControls;
 let consumerControls;
 
-const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
+const mochaSuiteFn = supportedVersion(process.versions.node) ? describe.only : describe.skip;
 
 ['latest', 'v0'].forEach(version => {
   mochaSuiteFn(`tracing/amqp: ${version}`, function () {

--- a/packages/collector/test/tracing/messaging/bull/allowRootExitSpanApp.mjs
+++ b/packages/collector/test/tracing/messaging/bull/allowRootExitSpanApp.mjs
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright IBM Corp. 2025
+ */
+
+'use strict';
+
+// NOTE: c8 bug https://github.com/bcoe/c8/issues/166
+process.on('SIGTERM', () => {
+  process.disconnect();
+  process.exit(0);
+});
+
+import delay from '../../../../../core/test/test_util/delay.js';
+import Queue from 'bull';
+
+const logPrefix = `Bull Allow Root Exit Span App (${process.pid}):\t`;
+const queueName = process.env.BULL_QUEUE_NAME;
+const redisServer = process.env.REDIS_SERVER;
+const bullJobName = process.env.BULL_JOB_NAME;
+
+(async function run() {
+  // wait till Instana is ready
+  await delay(1000);
+
+  log(`Creating job queue ${queueName} with job name ${bullJobName} with redis server ${redisServer}`);
+  const sender = new Queue(queueName, redisServer);
+  sender.add(bullJobName, { foo: 'bar' });
+  log('Sent job to queue');
+  await sender.close();
+})();
+
+function log() {
+  /* eslint-disable no-console */
+  const args = Array.prototype.slice.call(arguments);
+  args[0] = logPrefix + args[0];
+  console.log.apply(console, args);
+}

--- a/packages/collector/test/tracing/messaging/bull/test.js
+++ b/packages/collector/test/tracing/messaging/bull/test.js
@@ -35,7 +35,7 @@ if (process.env.BULL_QUEUE_NAME) {
   queueName = `${process.env.BULL_QUEUE_NAME}${semver.major(process.versions.node)}`;
 }
 
-const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
+const mochaSuiteFn = supportedVersion(process.versions.node) ? describe.only : describe.skip;
 
 const retryTime = 1000;
 

--- a/packages/collector/test/tracing/messaging/bull/test.js
+++ b/packages/collector/test/tracing/messaging/bull/test.js
@@ -35,7 +35,7 @@ if (process.env.BULL_QUEUE_NAME) {
   queueName = `${process.env.BULL_QUEUE_NAME}${semver.major(process.versions.node)}`;
 }
 
-const mochaSuiteFn = supportedVersion(process.versions.node) ? describe.only : describe.skip;
+const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 
 const retryTime = 1000;
 
@@ -823,7 +823,8 @@ mochaSuiteFn('tracing/messaging/bull', function () {
         env: {
           REDIS_SERVER: `redis://${process.env.REDIS}`,
           BULL_QUEUE_NAME: queueName,
-          BULL_JOB_NAME: 'steve'
+          BULL_JOB_NAME: 'steve',
+          INSTANA_ALLOW_ROOT_EXIT_SPAN: 1
         }
       });
 


### PR DESCRIPTION
This PR adds rootExitSpan tests for bull and amqp.

As per the current logic, `rootExitSpanApp.js` or by default `app.js` files were running in ESM test (logic in ProcessControls) as a replacement.

We are getting the flaky tests now because of the newly added ESM test for bull. As the bull test ran, the amqp rootExitSpanApp test was also running parallel causing some timing issues.

This weird issue was happening in the first place due to a combination of factors:

- the dynamic importing structure of ESM and 
- synchronous module loading of the commonjs app and 
- also the asynchronous behavior of message queues

So currently adding this ESM tests fixes this issue.