### PR TITLE
refactor: removed ignore endpoints config from cls

### DIFF
--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -317,7 +317,7 @@ function startSpan(spanAttributes = {}) {
     span.addCleanup(ns.set(w3cTraceContextKey, w3cTraceContext));
   }
 
-  const filteredSpan = applySpanFilter(span);
+  const filteredSpan = applyFilter(span);
 
   // If the span was filtered out, we do not process it further.
   // Instead, we return an 'InstanaIgnoredSpan' instance to explicitly indicate that it was excluded from tracing.
@@ -682,12 +682,6 @@ function skipExitTracing(options) {
   }
 
   return skip;
-}
-/**
- * @param {InstanaSpan | import("../core").InstanaBaseSpan} span
- */
-function applySpanFilter(span) {
-  return applyFilter(span);
 }
 
 module.exports = {

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -29,10 +29,6 @@ let serviceName;
 let processIdentityProvider = null;
 /** @type {Boolean} */
 let allowRootExitSpan;
-/**
- * @type {import('../tracing').IgnoreEndpoints}
- */
-let ignoreEndpoints;
 
 /*
  * Access the Instana namespace in continuation local storage.
@@ -56,15 +52,6 @@ function init(config, _processIdentityProvider) {
   }
   processIdentityProvider = _processIdentityProvider;
   allowRootExitSpan = config?.tracing?.allowRootExitSpan;
-  ignoreEndpoints = config?.tracing?.ignoreEndpoints;
-}
-/**
- * @param {import('../util/normalizeConfig').AgentConfig} extraConfig
- */
-function activate(extraConfig) {
-  if (extraConfig?.tracing?.ignoreEndpoints) {
-    ignoreEndpoints = extraConfig.tracing.ignoreEndpoints;
-  }
 }
 
 class InstanaSpan {
@@ -700,10 +687,7 @@ function skipExitTracing(options) {
  * @param {InstanaSpan | import("../core").InstanaBaseSpan} span
  */
 function applySpanFilter(span) {
-  if (ignoreEndpoints) {
-    return applyFilter({ span, ignoreEndpoints });
-  }
-  return span;
+  return applyFilter(span);
 }
 
 module.exports = {
@@ -731,6 +715,5 @@ module.exports = {
   enterAsyncContext,
   leaveAsyncContext,
   runInAsyncContext,
-  runPromiseInAsyncContext,
-  activate
+  runPromiseInAsyncContext
 };

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -272,7 +272,7 @@ function initInstrumenations(_config) {
 exports.activate = function activate(extraConfig = {}) {
   if (tracingEnabled && !tracingActivated) {
     tracingActivated = true;
-    cls.activate(extraConfig);
+    coreUtil.spanFilter.activate(extraConfig);
     spanBuffer.activate(extraConfig);
     opentracing.activate();
     sdk.activate();

--- a/packages/core/src/util/index.js
+++ b/packages/core/src/util/index.js
@@ -21,6 +21,7 @@ const hook = require('./hook');
 const esm = require('./esm');
 const preloadFlags = require('./getPreloadFlags');
 const configNormalizers = require('./configNormalizers');
+const spanFilter = require('./spanFilter');
 
 /** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
@@ -36,6 +37,7 @@ exports.init = function init(config) {
   preloadFlags.init(config);
   iitmHook.init(config);
   configNormalizers.init(config);
+  spanFilter.init(config);
 };
 
 exports.applicationUnderMonitoring = applicationUnderMonitoring;
@@ -85,3 +87,4 @@ exports.iitmHook = iitmHook;
 exports.hook = hook;
 exports.esm = esm;
 exports.configNormalizers = configNormalizers;
+exports.spanFilter = spanFilter;

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -4,6 +4,27 @@
 
 'use strict';
 
+/**
+ * @type {import('../tracing').IgnoreEndpoints}
+ */
+let ignoreEndpoints;
+
+/**
+ * @param {import('../util/normalizeConfig').InstanaConfig} config
+ */
+function init(config) {
+  ignoreEndpoints = config?.tracing?.ignoreEndpoints;
+}
+
+/**
+ * @param {import('../util/normalizeConfig').AgentConfig} extraConfig
+ */
+function activate(extraConfig) {
+  if (extraConfig?.tracing?.ignoreEndpoints) {
+    ignoreEndpoints = extraConfig.tracing.ignoreEndpoints;
+  }
+}
+
 // List of span types to allowed to ignore
 // 'kafka_placeholder' used as a temporary span type for testing, until the Kafka support is implemented.
 const IGNORABLE_SPAN_TYPES = ['redis', 'dynamodb', 'kafka_placeholder'];
@@ -94,14 +115,14 @@ function shouldIgnore(span, ignoreEndpointsConfig) {
 }
 
 /**
- * @param {{ span: import('../core').InstanaBaseSpan, ignoreEndpoints: import('../tracing').IgnoreEndpoints}} params
+ * @param {import('../core').InstanaBaseSpan} span
  * @returns {import('../core').InstanaBaseSpan | null}
  */
-function applyFilter({ span, ignoreEndpoints }) {
+function applyFilter(span) {
   if (ignoreEndpoints && shouldIgnore(span, ignoreEndpoints)) {
     return null;
   }
   return span;
 }
 
-module.exports = { applyFilter };
+module.exports = { applyFilter, activate, init };

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -13,7 +13,9 @@ let ignoreEndpoints;
  * @param {import('../util/normalizeConfig').InstanaConfig} config
  */
 function init(config) {
-  ignoreEndpoints = config?.tracing?.ignoreEndpoints;
+  if (config?.tracing?.ignoreEndpoints) {
+    ignoreEndpoints = config.tracing.ignoreEndpoints;
+  }
 }
 
 /**

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -125,4 +125,4 @@ function applyFilter(span) {
   return span;
 }
 
-module.exports = { applyFilter, activate, init };
+module.exports = { applyFilter, activate, init, shouldIgnore };

--- a/packages/core/test/tracing/cls_test.js
+++ b/packages/core/test/tracing/cls_test.js
@@ -395,35 +395,4 @@ describe('tracing/cls', () => {
       expect(span.data.redis.connection).to.equal('http://localhost');
     });
   });
-  it('should return InstanaIgnoredSpan when the span is configured to be ignored', () => {
-    cls.ns.run(() => {
-      cls.init({
-        tracing: {
-          ignoreEndpoints: {
-            redis: [{ methods: ['get'] }]
-          }
-        }
-      });
-      const span = cls.startSpan({
-        spanName: 'redis',
-        kind: constants.EXIT,
-        spanData: {
-          redis: {
-            operation: 'get',
-            connection: 'http://localhost'
-          }
-        }
-      });
-      expect(span.constructor.name).to.equal('InstanaIgnoredSpan');
-      expect(span).to.be.an('object');
-      expect(span.n).to.equal('redis');
-      expect(span.t).to.be.a('string');
-      expect(span.k).to.equal(constants.EXIT);
-      expect(span.data).to.be.an('object');
-      expect(Object.keys(span.data)).to.have.lengthOf(1);
-      expect(span.data.redis).to.be.exist;
-      expect(span.data.redis.operation).to.equal('get');
-      expect(span.data.redis.connection).to.equal('http://localhost');
-    });
-  });
 });

--- a/packages/core/test/util/spanFilter_test.js
+++ b/packages/core/test/util/spanFilter_test.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const { shouldIgnore } = require('../../src/util/spanFilter');
+const { applyFilter, shouldIgnore, init } = require('../../src/util/spanFilter');
 
 const span = {
   t: '1234567803',
@@ -21,252 +21,312 @@ const span = {
 };
 
 describe('util.spanFilter', () => {
-  let ignoreEndpoints = {
-    redis: [{ methods: ['GET', 'TYPE'] }],
-    dynamodb: [{ methods: ['QUERY'] }]
-  };
-  it('should return true when the span should be ignored', () => {
-    span.data.redis.operation = 'GET';
-    expect(shouldIgnore(span, ignoreEndpoints)).equal(true);
-  });
-
-  it('should return false when command is not in the ignore list', () => {
-    span.data.redis.operation = 'HGET';
-    expect(shouldIgnore(span, ignoreEndpoints)).equal(false);
-  });
-
-  it('should return false when span.n does not match any endpoint in config', () => {
-    span.n = 'node.http.client';
-    expect(shouldIgnore(span, ignoreEndpoints)).equal(false);
-  });
-  it('should return false when no ignoreconfiguration', () => {
-    span.data.redis.operation = 'GET';
-    expect(shouldIgnore({ span, ignoreEndpoints: {} })).equal(false);
-  });
-  it('should return true when the dynamodb span operation is in the ignore list', () => {
-    span.n = 'dynamodb';
-    span.data = {
-      dynamodb: {
-        operation: 'Query'
-      }
-    };
-    expect(shouldIgnore(span, ignoreEndpoints)).equal(true);
-  });
-
-  it('should return false when the operation is not in the ignore list', () => {
-    span.data.dynamodb.operation = 'PutItem';
-    expect(shouldIgnore(span, ignoreEndpoints)).equal(false);
-  });
-
-  describe('util.spanFilter: advanced filtering', () => {
-    it('return truewhen an advanced config for multiple services is applied and the Redis config matches', () => {
-      ignoreEndpoints = {
-        redis: [{ methods: ['type', 'get'] }],
-        kafka_placeholder: [{ methods: ['*'], endpoints: ['topic1', 'topic2'] }]
+  describe('applyFilter', () => {
+    before(() => {
+      const config = {
+        tracing: {
+          ignoreEndpoints: {
+            redis: [{ methods: ['GET', 'TYPE'] }],
+            dynamodb: [{ methods: ['QUERY'] }],
+            kafka_placeholder: [{ methods: ['send', 'consume'], endpoints: ['topic3'] }]
+          }
+        }
       };
+      init(config);
+    });
+
+    it('should return null when the span should be ignored', () => {
+      span.data.redis.operation = 'GET';
+      expect(applyFilter(span)).to.equal(null);
+    });
+
+    it('should return the span when command is not in the ignore list', () => {
+      span.data.redis.operation = 'HGET';
+      expect(applyFilter(span)).to.equal(span);
+    });
+
+    it('should return the span when span.n does not match any endpoint in config', () => {
+      span.n = 'node.http.client';
+      expect(applyFilter(span)).to.equal(span);
+    });
+
+    it('should return span when no ignore configuration is provided', () => {
+      span.data.redis.operation = 'GET';
+      expect(applyFilter(span)).to.equal(span);
+    });
+
+    it('should return null when the dynamodb span operation is in the ignore list', () => {
+      span.n = 'dynamodb';
+      span.data = {
+        dynamodb: {
+          operation: 'Query'
+        }
+      };
+      expect(applyFilter(span)).to.equal(null);
+    });
+
+    it('should return the dynamodb span when the operation is not in the ignore list', () => {
+      span.data.dynamodb.operation = 'PutItem';
+      expect(applyFilter(span)).to.equal(span);
+    });
+    it('return null when an advanced config for multiple services is applied and the Redis config matches', () => {
       span.n = 'redis';
       span.data = {
         redis: {
           operation: 'type'
         }
       };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+      expect(applyFilter(span)).to.equal(null);
+    });
+  });
+  describe('shouldIgnore', () => {
+    let ignoreEndpoints = {
+      redis: [{ methods: ['GET', 'TYPE'] }],
+      dynamodb: [{ methods: ['QUERY'] }]
+    };
+    it('should return true when the span should be ignored', () => {
+      span.data.redis.operation = 'GET';
+      expect(shouldIgnore(span, ignoreEndpoints)).equal(true);
     });
 
-    it('return true when both method and endpoint criteria match', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{ methods: ['send', 'consume'], endpoints: ['topic3'] }]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'send',
-          endpoints: ['topic3']
-        }
-      };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+    it('should return false when command is not in the ignore list', () => {
+      span.data.redis.operation = 'HGET';
+      expect(shouldIgnore(span, ignoreEndpoints)).equal(false);
     });
 
-    it('return true when "*" is specified for methods config', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{ methods: ['*'], endpoints: ['topic1', 'topic2'] }]
-      };
-      span.n = 'kafka_placeholder';
+    it('should return false when span.n does not match any endpoint in config', () => {
+      span.n = 'node.http.client';
+      expect(shouldIgnore(span, ignoreEndpoints)).equal(false);
+    });
+    it('should return false when no ignoreconfiguration', () => {
+      span.data.redis.operation = 'GET';
+      expect(shouldIgnore({ span, ignoreEndpoints: {} })).equal(false);
+    });
+    it('should return true when the dynamodb span operation is in the ignore list', () => {
+      span.n = 'dynamodb';
       span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: 'topic1'
+        dynamodb: {
+          operation: 'Query'
         }
       };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+      expect(shouldIgnore(span, ignoreEndpoints)).equal(true);
     });
 
-    it('return true when  "*" is specified for endpoints config', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{ methods: ['consume'], endpoints: ['*'] }]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: 'topic1'
-        }
-      };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+    it('should return false when the operation is not in the ignore list', () => {
+      span.data.dynamodb.operation = 'PutItem';
+      expect(shouldIgnore(span, ignoreEndpoints)).equal(false);
     });
 
-    it('return true when "*" are used for both methods and endpoints config', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{ methods: ['*'], endpoints: ['*'] }]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: 'topic1'
-        }
-      };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
-    });
+    describe('util.spanFilter: advanced filtering', () => {
+      it('return true when an advanced config for multiple services is applied and the Redis config matches', () => {
+        ignoreEndpoints = {
+          redis: [{ methods: ['type', 'get'] }],
+          kafka_placeholder: [{ methods: ['*'], endpoints: ['topic1', 'topic2'] }]
+        };
+        span.n = 'redis';
+        span.data = {
+          redis: {
+            operation: 'type'
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+      });
 
-    it('return true when advanced config with endpoints as an array matches one of the span endpoints', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{ methods: ['consume'], endpoints: ['topic1', 'topic2'] }]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: ['topic1', 'topic3']
-        }
-      };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
-    });
+      it('return true when both method and endpoint criteria match', () => {
+        ignoreEndpoints = {
+          kafka_placeholder: [{ methods: ['send', 'consume'], endpoints: ['topic3'] }]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'send',
+            endpoints: ['topic3']
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+      });
 
-    it('return true when advanced config with endpoints as an array matches all of the span endpoints', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{ methods: ['consume'], endpoints: ['topic1', 'topic2'] }]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: ['topic1', 'topic2']
-        }
-      };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
-    });
+      it('return true when "*" is specified for methods config', () => {
+        ignoreEndpoints = {
+          kafka_placeholder: [{ methods: ['*'], endpoints: ['topic1', 'topic2'] }]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'consume',
+            endpoints: 'topic1'
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+      });
 
-    it('returns false when endpoints as an array does not match any of the span endpoints', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{ methods: ['consume'], endpoints: ['topic1', 'topic2'] }]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: ['topic3', 'topic4']
-        }
-      };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
-    });
+      it('return true when  "*" is specified for endpoints config', () => {
+        ignoreEndpoints = {
+          kafka_placeholder: [{ methods: ['consume'], endpoints: ['*'] }]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'consume',
+            endpoints: 'topic1'
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+      });
 
-    it('returns false when the method config does not match', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{ methods: ['send'], endpoints: ['topic3'] }]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: 'topic3'
-        }
-      };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
-    });
+      it('return true when "*" are used for both methods and endpoints config', () => {
+        ignoreEndpoints = {
+          kafka_placeholder: [{ methods: ['*'], endpoints: ['*'] }]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'consume',
+            endpoints: 'topic1'
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+      });
 
-    it('returns false when the endpoint config does not match', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{ methods: ['consume'], endpoints: ['topic1'] }]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: 'topic2'
-        }
-      };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
-    });
+      it('return true when advanced config with endpoints as an array matches one of the span endpoints', () => {
+        ignoreEndpoints = {
+          kafka_placeholder: [{ methods: ['consume'], endpoints: ['topic1', 'topic2'] }]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'consume',
+            endpoints: ['topic1', 'topic3']
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+      });
 
-    it('returns false when empty configuration arrays are provided', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{ methods: [], endpoints: [] }]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: 'topic2'
-        }
-      };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
-    });
+      it('return true when advanced config with endpoints as an array matches all of the span endpoints', () => {
+        ignoreEndpoints = {
+          kafka_placeholder: [{ methods: ['consume'], endpoints: ['topic1', 'topic2'] }]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'consume',
+            endpoints: ['topic1', 'topic2']
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+      });
 
-    it('returns false when the configurations does not specify any filtering criteria', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{}]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: 'topic2'
-        }
-      };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
-    });
+      it('returns false when endpoints as an array does not match any of the span endpoints', () => {
+        ignoreEndpoints = {
+          kafka_placeholder: [{ methods: ['consume'], endpoints: ['topic1', 'topic2'] }]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'consume',
+            endpoints: ['topic3', 'topic4']
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
+      });
 
-    it('returns false when the configurations specify unsupported filtering criteria', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{ operation: ['consume'], topics: ['topic2'] }]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: 'topic2'
-        }
-      };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
-    });
+      it('returns false when the method config does not match', () => {
+        ignoreEndpoints = {
+          kafka_placeholder: [{ methods: ['send'], endpoints: ['topic3'] }]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'consume',
+            endpoints: 'topic3'
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
+      });
 
-    it('returns false when the configurations specify unsupported service', () => {
-      ignoreEndpoints = {
-        amqp: [{ methods: ['consume'], endpoints: ['topic2'] }]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: 'topic2'
-        }
-      };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
-    });
+      it('returns false when the endpoint config does not match', () => {
+        ignoreEndpoints = {
+          kafka_placeholder: [{ methods: ['consume'], endpoints: ['topic1'] }]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'consume',
+            endpoints: 'topic2'
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
+      });
 
-    it('returns false when the config having endpoints and span havig empty endpoints array', () => {
-      ignoreEndpoints = {
-        kafka_placeholder: [{ methods: ['consume'], endpoints: ['topic2'] }]
-      };
-      span.n = 'kafka_placeholder';
-      span.data = {
-        kafka_placeholder: {
-          operation: 'consume',
-          endpoints: []
-        }
-      };
-      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
+      it('returns false when empty configuration arrays are provided', () => {
+        ignoreEndpoints = {
+          kafka_placeholder: [{ methods: [], endpoints: [] }]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'consume',
+            endpoints: 'topic2'
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
+      });
+
+      it('returns false when the configurations does not specify any filtering criteria', () => {
+        ignoreEndpoints = {
+          kafka_placeholder: [{}]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'consume',
+            endpoints: 'topic2'
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
+      });
+
+      it('returns false when the configurations specify unsupported filtering criteria', () => {
+        ignoreEndpoints = {
+          kafka_placeholder: [{ operation: ['consume'], topics: ['topic2'] }]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'consume',
+            endpoints: 'topic2'
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
+      });
+
+      it('returns false when the configurations specify unsupported service', () => {
+        ignoreEndpoints = {
+          amqp: [{ methods: ['consume'], endpoints: ['topic2'] }]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'consume',
+            endpoints: 'topic2'
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
+      });
+
+      it('returns false when the config having endpoints and span havig empty endpoints array', () => {
+        ignoreEndpoints = {
+          kafka_placeholder: [{ methods: ['consume'], endpoints: ['topic2'] }]
+        };
+        span.n = 'kafka_placeholder';
+        span.data = {
+          kafka_placeholder: {
+            operation: 'consume',
+            endpoints: []
+          }
+        };
+        expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
+      });
     });
   });
 });


### PR DESCRIPTION
Refactored: Moved the `ignoreEndpoints` configuration from cls to `spanFilter`, improving decoupling.