### PR TITLE
refactor: updated config priority order for ignoring endpoints

### DIFF
--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -24,14 +24,17 @@ function init(config) {
 function activate(extraConfig) {
   /**
    * Configuration priority order:
-   * 1. In-code configuration/environment variable from `normalizeConfig`
-   * 2. Agent configuration (loaded later)
+   * 1. In-code configuration
+   * 2. Environment variables:
+   *    - `INSTANA_IGNORE_ENDPOINTS_PATH`
+   *    - `INSTANA_IGNORE_ENDPOINTS`
+   * 3. Agent configuration (loaded later)
    *
    * Since the agent configuration is loaded later, we first check
    * if `ignoreEndpoints` already has a value (set via env or code). If not, we
    * fall back to the agent's configuration (`extraConfig.tracing.ignoreEndpoints`).
    *
-   *  TODO: This logic is currently broken by design and will be fixed in INSTA-817.
+   * TODO: Perform a major refactoring of configuration priority ordering in INSTA-817.
    */
 
   if ((!ignoreEndpoints || Object.keys(ignoreEndpoints).length === 0) && extraConfig?.tracing?.ignoreEndpoints) {

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -31,7 +31,7 @@ function activate(extraConfig) {
    * 3. Agent configuration (loaded later)
    *
    * Since the agent configuration is loaded later, we first check
-   * if `ignoreEndpoints` already has a value (set via env or code). If not, we
+   * that `ignoreEndpoints` MUST be empty. If not, we
    * fall back to the agent's configuration (`extraConfig.tracing.ignoreEndpoints`).
    *
    * TODO: Perform a major refactoring of configuration priority ordering in INSTA-817.

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -31,13 +31,13 @@ function activate(extraConfig) {
    * 3. Agent configuration (loaded later)
    *
    * Since the agent configuration is loaded later, we first check
-   * that `ignoreEndpoints` MUST be empty. If not, we
-   * fall back to the agent's configuration (`extraConfig.tracing.ignoreEndpoints`).
+   * that `ignoreEndpoints` MUST be empty. If yes, we
+   * are allowed to fall back to the agent's configuration (`extraConfig.tracing.ignoreEndpoints`).
    *
    * TODO: Perform a major refactoring of configuration priority ordering in INSTA-817.
    */
-
-  if ((!ignoreEndpoints || Object.keys(ignoreEndpoints).length === 0) && extraConfig?.tracing?.ignoreEndpoints) {
+  const isIgnoreEndpointsEmpty = !ignoreEndpoints || Object.keys(ignoreEndpoints).length === 0;
+  if (isIgnoreEndpointsEmpty && extraConfig?.tracing?.ignoreEndpoints) {
     ignoreEndpoints = extraConfig.tracing.ignoreEndpoints;
   }
 }

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -22,7 +22,19 @@ function init(config) {
  * @param {import('../util/normalizeConfig').AgentConfig} extraConfig
  */
 function activate(extraConfig) {
-  if (extraConfig?.tracing?.ignoreEndpoints) {
+  /**
+   * Configuration priority order:
+   * 1. In-code configuration/environment variable from `normalizeConfig`
+   * 2. Agent configuration (loaded later)
+   *
+   * Since the agent configuration is loaded later, we first check
+   * if `ignoreEndpoints` already has a value (set via env or code). If not, we
+   * fall back to the agent's configuration (`extraConfig.tracing.ignoreEndpoints`).
+   *
+   *  TODO: This logic is currently broken by design and will be fixed in INSTA-817.
+   */
+
+  if ((!ignoreEndpoints || Object.keys(ignoreEndpoints).length === 0) && extraConfig?.tracing?.ignoreEndpoints) {
     ignoreEndpoints = extraConfig.tracing.ignoreEndpoints;
   }
 }


### PR DESCRIPTION
Previously, `ignoreEndpoints` was always overridden by the agent's configuration.  

With this change, if `ignoreEndpoints` is defined via environment variables or in-code configuration, it will be used as a priority. Otherwise, it will fall back to the agent's configuration if available, 

**In-code configuration > Environment variables > Agent YAML configuration**  

**Note:** We will do a big refactoring in INSTA-817.