### PR TITLE
chore: added default return for check esm fn

### DIFF
--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -76,7 +76,7 @@ class ProcessControls {
             opts.appPath = updatedPath;
           }
         } else if (opts?.dirname) {
-          const esmApp = testUtils.checkESMApp({ dirPath: opts.dirname });
+          const esmApp = testUtils.checkESMApp({ appPath: path.join(opts.dirname, 'app.mjs') });
           if (esmApp) {
             opts.execArgv = resolveEsmLoader();
             opts.appPath = path.join(opts.dirname, 'app.mjs');

--- a/packages/core/test/test_util/check_esm_app.js
+++ b/packages/core/test/test_util/check_esm_app.js
@@ -37,6 +37,8 @@ module.exports = function checkESMApp(obj = {}) {
       // check 'esm/' directory first, then fallback to the main directory
       return findESMFile(esmDir) || findESMFile(dirPath);
     }
+
+    return false;
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Error checking ESM file:', error.message);


### PR DESCRIPTION
This change will make sure the ProcessControl uses the same logic for checking ESM app.

the `dirPath` logic checks for any .mjs files as it is used in `hooks.js` and we don't have a filename at the time of hooks execution