### PR TITLE
test: added short-term solution for multiple esm apps + describes

### DIFF
--- a/packages/collector/test/hooks.js
+++ b/packages/collector/test/hooks.js
@@ -34,6 +34,9 @@ exports.mochaHooks = {
   beforeEach() {
     const testFile = this.currentTest.file;
 
+    // NOTE: This is a general check if the target test file
+    //       supports ESM. We do not care which .mjs files are used for
+    //       the individual describes.
     if (process.env.RUN_ESM) {
       const folderPath = path.dirname(testFile);
       const esmApp = checkESMApp({ dirPath: folderPath });

--- a/packages/collector/test/tracing/messaging/bull/test.js
+++ b/packages/collector/test/tracing/messaging/bull/test.js
@@ -41,16 +41,16 @@ const retryTime = 1000;
 
 mochaSuiteFn('tracing/messaging/bull', function () {
   this.timeout(config.getTestTimeout() * 3);
-
   globalAgent.setUpCleanUpHooks();
   const agentControls = globalAgent.instance;
 
   describe('tracing enabled, no suppression', function () {
     let senderControls;
 
-    before(async () => {
+    before(async function () {
       senderControls = new ProcessControls({
         appPath: path.join(__dirname, 'sender'),
+        mocha: this,
         useGlobalAgent: true,
         env: {
           REDIS_SERVER: 'redis://127.0.0.1:6379',
@@ -82,9 +82,10 @@ mochaSuiteFn('tracing/messaging/bull', function () {
         let receiverControls;
         const receiveMethod = 'Process';
 
-        before(async () => {
+        before(async function () {
           receiverControls = new ProcessControls({
             appPath: path.join(__dirname, 'receiver'),
+            mocha: this,
             useGlobalAgent: true,
             env: {
               REDIS_SERVER: 'redis://127.0.0.1:6379',
@@ -288,9 +289,10 @@ mochaSuiteFn('tracing/messaging/bull', function () {
       let receiverControls;
       const receiveMethod = 'Promise';
 
-      before(async () => {
+      before(async function () {
         receiverControls = new ProcessControls({
           appPath: path.join(__dirname, 'receiver'),
+          mocha: this,
           useGlobalAgent: true,
           env: {
             REDIS_SERVER: 'redis://127.0.0.1:6379',
@@ -631,9 +633,10 @@ mochaSuiteFn('tracing/messaging/bull', function () {
 
     let senderControls;
 
-    before(async () => {
+    before(async function () {
       senderControls = new ProcessControls({
         appPath: path.join(__dirname, 'sender'),
+        mocha: this,
         useGlobalAgent: true,
         tracingEnabled: false,
         env: {
@@ -662,9 +665,10 @@ mochaSuiteFn('tracing/messaging/bull', function () {
       let receiverControls;
       const receiveMethod = 'Process';
 
-      before(async () => {
+      before(async function () {
         receiverControls = new ProcessControls({
           appPath: path.join(__dirname, 'receiver'),
+          mocha: this,
           useGlobalAgent: true,
           tracingEnabled: false,
           env: {
@@ -724,9 +728,10 @@ mochaSuiteFn('tracing/messaging/bull', function () {
   describe('tracing enabled but suppressed', () => {
     let senderControls;
 
-    before(async () => {
+    before(async function () {
       senderControls = new ProcessControls({
         appPath: path.join(__dirname, 'sender'),
+        mocha: this,
         useGlobalAgent: true,
         env: {
           REDIS_SERVER: 'redis://127.0.0.1:6379',
@@ -754,9 +759,10 @@ mochaSuiteFn('tracing/messaging/bull', function () {
       let receiverControls;
       const receiveMethod = 'Promise';
 
-      before(async () => {
+      before(async function () {
         receiverControls = new ProcessControls({
           appPath: path.join(__dirname, 'receiver'),
+          mocha: this,
           useGlobalAgent: true,
           env: {
             REDIS_SERVER: 'redis://127.0.0.1:6379',
@@ -816,9 +822,10 @@ mochaSuiteFn('tracing/messaging/bull', function () {
   describe('allowRootExitSpan', function () {
     let controls;
 
-    before(async () => {
+    before(async function () {
       controls = new ProcessControls({
         useGlobalAgent: true,
+        mocha: this,
         appPath: path.join(__dirname, 'allowRootExitSpanApp'),
         env: {
           REDIS_SERVER: `redis://${process.env.REDIS}`,

--- a/packages/core/test/test_util/check_esm_app.js
+++ b/packages/core/test/test_util/check_esm_app.js
@@ -17,6 +17,7 @@ module.exports = function checkESMApp(obj = {}) {
       }
 
       // checking inside esm/ subfolder relative to appPath
+      // NOTE: 'esm/'is not implemented or used yet.
       const esmAppPath = path.join(path.dirname(appPath), 'esm', path.basename(appPath));
       if (fs.existsSync(esmAppPath)) {
         return esmAppPath;
@@ -35,6 +36,7 @@ module.exports = function checkESMApp(obj = {}) {
       };
 
       // check 'esm/' directory first, then fallback to the main directory
+      // NOTE: 'esm/'is not implemented or used yet.
       return findESMFile(esmDir) || findESMFile(dirPath);
     }
   } catch (error) {


### PR DESCRIPTION
- `allowRootExitSpan` app in bull test was executed although it did not have an esm implementation
- We are not sure what long term solution look like.
- This is accaptable for now.
- Note: We only have to this this if multiple mjs files are in a folder!