### PR TITLE
chore(serverless): used object pattern for send method in backend_con…

### DIFF
--- a/packages/serverless/src/backend_connector.js
+++ b/packages/serverless/src/backend_connector.js
@@ -439,7 +439,7 @@ function onTimeout(localUseLambdaExtension, req, resourcePath, payload, finalLam
     destroyRequest(req);
 
     // Retry the request immediately, this time sending it to serverless-acceptor directly.
-    send({ resourcePath, payload, finalLambdaRequest, handleCallback });
+    send({ resourcePath, payload, finalLambdaRequest, callback: handleCallback });
   } else {
     // We are not using the Lambda extension, because we are either not in an AWS Lambda, or a previous request to the
     // extension has already failed. Thus, this is a timeout from talking directly to serverless-acceptor

--- a/packages/serverless/src/backend_connector.js
+++ b/packages/serverless/src/backend_connector.js
@@ -115,16 +115,16 @@ exports.setLogger = function setLogger(_logger) {
  */
 exports.sendBundle = function sendBundle(bundle, finalLambdaRequest, callback) {
   logger.debug(`Sending bundle to Instana (no. of spans: ${bundle?.spans?.length ?? 'unknown'})`);
-  send({ resourcePath: '/bundle', bundle, finalLambdaRequest, callback });
+  send({ resourcePath: '/bundle', payload: bundle, finalLambdaRequest, callback });
 };
 
 exports.sendMetrics = function sendMetrics(metrics, callback) {
-  send({ resourcePath: '/metrics', metrics, finalLambdaRequest: false, callback });
+  send({ resourcePath: '/metrics', payload: metrics, finalLambdaRequest: false, callback });
 };
 
 exports.sendSpans = function sendSpans(spans, callback) {
   logger.debug(`Sending spans to Instana (no. of spans: ${spans.length})`);
-  send({ resourcePath: '/traces', spans, finalLambdaRequest: false, callback });
+  send({ resourcePath: '/traces', payload: spans, finalLambdaRequest: false, callback });
 };
 
 let heartbeatInterval;


### PR DESCRIPTION
…nector

refs https://jsw.ibm.com/browse/INSTA-13498