### PR TITLE
feat(serverless): added request id to instana debug logs

### DIFF
--- a/packages/aws-lambda/test/Control.js
+++ b/packages/aws-lambda/test/Control.js
@@ -28,6 +28,7 @@ function Control(opts) {
   this.downstreamDummyPort = this.opts.downstreamDummyPort || portfinder();
   this.downstreamDummyUrl = this.opts.downstreamDummyUrl || `http://localhost:${this.downstreamDummyPort}`;
 
+  this.disableInstanaDebug = this.opts.disableInstanaDebug === true;
   this.longHandlerRun = this.opts.longHandlerRun || false;
   this.proxyPort = this.opts.proxyPort;
 }

--- a/packages/aws-lambda/test/using_api/test.js
+++ b/packages/aws-lambda/test/using_api/test.js
@@ -40,6 +40,8 @@ function prelude(opts) {
   // NOTE: locally we run "npm run test:debug" (INSTANA_DEBUG is on by default!)
   if (opts.disableInstanaDebug) {
     env.INSTANA_DEBUG = undefined;
+  } else {
+    env.INSTANA_DEBUG = 'true';
   }
 
   return env;

--- a/packages/aws-lambda/test/using_api/test.js
+++ b/packages/aws-lambda/test/using_api/test.js
@@ -349,15 +349,21 @@ describe('Using the API', function () {
       if (expectSpansAndMetrics) {
         // eslint-disable-next-line
         console.log('comparing expected debug logs to:', body.logs.debug);
-        expect(body.logs.debug).to.include('Sending data to Instana (/serverless/bundle).');
-        expect(body.logs.debug).to.include('Sent data to Instana (/serverless/bundle).');
-        expect(body.logs.info).to.be.empty;
-        expect(body.logs.warn).to.deep.equal([
-          'INSTANA_DISABLE_CA_CHECK is set, which means that the server certificate will not be verified against the ' +
-            'list of known CAs. This makes your service vulnerable to MITM attacks when connecting to Instana. ' +
-            'This setting should never be used in production, unless you use our on-premises product and are unable ' +
-            'to operate the Instana back end with a certificate with a known root CA.'
-        ]);
+
+        expect(body.logs.debug).to.satisfy(logs => {
+          return logs.some(log => /\[\w+\] Sending data to Instana \(\/serverless\/metrics\)/.test(log));
+        });
+
+        expect(body.logs.debug).to.satisfy(logs => {
+          return logs.some(log => /\[\w+\] Sent data to Instana \(\/serverless\/metrics\)/.test(log));
+        });
+
+        expect(body.logs.warn).to.satisfy(logs => {
+          return logs.some(log =>
+            // eslint-disable-next-line max-len
+            /\[\w+\] INSTANA_DISABLE_CA_CHECK is set/.test(log)
+          );
+        });
         expect(body.logs.error).to.be.empty;
         expect(body.currentSpanConstructor).to.equal('SpanHandle');
         expect(body.currentSpan).to.exist;

--- a/packages/google-cloud-run/test/using_api/test.js
+++ b/packages/google-cloud-run/test/using_api/test.js
@@ -104,17 +104,17 @@ describe('Using the API', function () {
     expect(response.message).to.equal('Hello Cloud Run!');
 
     expect(response.logs.debug).to.satisfy(logs => {
-      return logs.some(log => /\[\w+\] Sending data to Instana \(\/serverless\/metrics\)/.test(log));
+      return logs.some(log => /\[instana_\w+\] Sending data to Instana \(\/serverless\/metrics\)/.test(log));
     });
 
     expect(response.logs.debug).to.satisfy(logs => {
-      return logs.some(log => /\[\w+\] Sent data to Instana \(\/serverless\/metrics\)/.test(log));
+      return logs.some(log => /\[instana_\w+\] Sent data to Instana \(\/serverless\/metrics\)/.test(log));
     });
 
     expect(response.logs.warn).to.satisfy(logs => {
       return logs.some(log =>
         // eslint-disable-next-line max-len
-        /\[\w+\] INSTANA_DISABLE_CA_CHECK is set/.test(log)
+        /\[instana_\w+\] INSTANA_DISABLE_CA_CHECK is set/.test(log)
       );
     });
 

--- a/packages/google-cloud-run/test/using_api/test.js
+++ b/packages/google-cloud-run/test/using_api/test.js
@@ -102,15 +102,23 @@ describe('Using the API', function () {
     expect(response).to.be.an('object');
 
     expect(response.message).to.equal('Hello Cloud Run!');
-    expect(response.logs.debug).to.contain('Sending data to Instana (/serverless/metrics).');
-    expect(response.logs.debug).to.contain('Sent data to Instana (/serverless/metrics).');
+
+    expect(response.logs.debug).to.satisfy(logs => {
+      return logs.some(log => /\[\w+\] Sending data to Instana \(\/serverless\/metrics\)/.test(log));
+    });
+
+    expect(response.logs.debug).to.satisfy(logs => {
+      return logs.some(log => /\[\w+\] Sent data to Instana \(\/serverless\/metrics\)/.test(log));
+    });
+
+    expect(response.logs.warn).to.satisfy(logs => {
+      return logs.some(log =>
+        // eslint-disable-next-line max-len
+        /\[\w+\] INSTANA_DISABLE_CA_CHECK is set/.test(log)
+      );
+    });
+
     expect(response.logs.info).to.be.empty;
-    expect(response.logs.warn).to.deep.equal([
-      'INSTANA_DISABLE_CA_CHECK is set, which means that the server certificate will not be verified against the ' +
-        'list of known CAs. This makes your service vulnerable to MITM attacks when connecting to Instana. This ' +
-        'setting should never be used in production, unless you use our on-premises product and are unable to ' +
-        'operate the Instana back end with a certificate with a known root CA.'
-    ]);
     expect(response.logs.error).to.be.empty;
 
     expect(response.currentSpan.span.n).to.equal('node.http.server');

--- a/packages/serverless/src/backend_connector.js
+++ b/packages/serverless/src/backend_connector.js
@@ -123,7 +123,7 @@ exports.sendBundle = function sendBundle(bundle, finalLambdaRequest, callback) {
 
 exports.sendMetrics = function sendMetrics(metrics, callback) {
   const requestId = getRequestId();
-  logger.debug(`[${requestId}] Sending metrics to Instana (no. of metrics: ${metrics?.length})`);
+  logger.debug(`[${requestId}] Sending metrics to Instana (no. of metrics: ${metrics?.plugins?.length})`);
   send({ resourcePath: '/metrics', payload: metrics, finalLambdaRequest: false, callback, requestId });
 };
 

--- a/packages/serverless/src/logger.js
+++ b/packages/serverless/src/logger.js
@@ -10,6 +10,8 @@
 // 30 = info
 let minLevel = 30;
 
+const DEBUG_LEVEL = 20;
+
 const consoleLogger = {
   debug: createLogFn(20, console.debug || console.log),
   info: createLogFn(30, console.log),
@@ -40,6 +42,24 @@ class InstanaServerlessLogger {
    */
   setLogger(_logger) {
     this.logger = _logger;
+  }
+
+  isInDebugMode() {
+    if (!instanaServerlessLogger.logger) return false;
+
+    if (typeof instanaServerlessLogger.logger.level === 'function') {
+      return instanaServerlessLogger.logger.level() === DEBUG_LEVEL;
+    }
+
+    if (typeof instanaServerlessLogger.logger.level === 'number') {
+      return instanaServerlessLogger.logger.level === DEBUG_LEVEL;
+    }
+
+    if (typeof instanaServerlessLogger.logger.getLevel === 'function') {
+      return instanaServerlessLogger.logger.getLevel() === DEBUG_LEVEL;
+    }
+
+    return minLevel === DEBUG_LEVEL;
   }
 
   info() {


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-13498

Background: On Lambda for example requests will get frozen and wake up again if the handler is unfrozen.
We have to understand which log belongs to which request to understand flows and behaviors.

