### PR TITLE
test: mocha after not called for aws fargate tests

### DIFF
--- a/packages/aws-fargate/package.json
+++ b/packages/aws-fargate/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "audit": "npm audit --omit=dev",
     "node_modules:exists": "mkdir -p node_modules",
-    "test": "mocha $npm_config_watch --config=test/.mocharc.js --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json --sort $(find test -iname '*test.js')",
+    "test": "mocha $npm_config_watch --config=test/.mocharc.js --sort $(find test -iname '*test.js')",
     "test:debug": "WITH_STDOUT=true npm run test",
     "test:ci": "mocha --config=test/.mocharc.js --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json 'test/**/*test.js'",
     "lint": "eslint src test images",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "audit": "npm audit --omit=dev",
-    "test": "USE_OPENTRACING_DEBUG_IMPL=true mocha $npm_config_watch --config=test/.mocharc.js --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json --sort $(find test -iname '*test.js')",
+    "test": "USE_OPENTRACING_DEBUG_IMPL=true mocha $npm_config_watch --config=test/.mocharc.js --sort $(find test -iname '*test.js')",
     "test:debug": "WITH_STDOUT=true npm run test",
     "test:ci": "mocha --config=test/.mocharc.js --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json 'test/**/*test.js'",
     "lint": "eslint src test",


### PR DESCRIPTION
Omg this bug drove me crazy.

I had a failing aws-fargate test.
And I could not quit the test with CTRL+C.
Then I figured out the mocha after hook is not called. So the processes are not stopped.

:( 

1. No reporters for local testing
2. [FailureReporter](https://github.com/instana/nodejs/blob/main/packages/core/test/test_util/failureReporter.js) is broken. It radically destroys the process and then mocha after is not called!

