### PR TITLE
refactor: applied batch endpoint filtering rules

### DIFF
--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -77,7 +77,7 @@ function matchEndpoints(span, ignoreconfig) {
    */
   return spanEndpoints.every((/** @type {string} */ endpoint) =>
     ignoreconfig.endpoints.some(
-      e => e?.toLowerCase() === endpoint?.toLowerCase() // Case-insensitive match for endpoint names
+      e => e?.toLowerCase() === endpoint?.toLowerCase()
     )
   );
 }
@@ -153,7 +153,8 @@ function applyFilter(span) {
 /**
  * Parses the endpoints field in span data.
  *
- * In Kafka batch produce scenarios, the `endpoints` field is a comma-separated string
+ * Use Case: In Kafka, when sendBatch is executed, the endpoints field contains a comma-separated string of topic names.
+ * We filtering we treat the endpoints as an array.
  * (e.g., `"test-topic-1,test-topic-2"`).
  *
  * @param {string} endpoints

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -63,15 +63,20 @@ function matchEndpoints(span, ignoreconfig) {
     return true;
   }
   /**
-   * Batch Handling Logic:
-   * 1. If every endpoint in the span is present in the `ignoreconfig.endpoints`, the span is ignored.
+   * General rules:
+   * 1. If every endpoint in the span is present in `ignoreconfig.endpoints`, the span is ignored.
    * 2. If at least one endpoint is not in the ignored list, the span is traced.
-   * This ensures that partial matches do not cause unintended ignores in batch operations.
+   *    This ensures that partial matches do not cause unintended ignores in batch operations.
    *
-   * Case: - Batch Processing in kafka (sendBatch):
+   * Case 1: Single Endpoint (General Case)
+   * - Normally, a span contains only one endpoint, which is represented as an array with a single value.
+   * - If this endpoint exists in `ignoreconfig.endpoints`, the span is ignored.
+   * - Otherwise, the span is traced as usual.
+   *
+   * Case 2: Batch Processing in Kafka (`sendBatch`)
    * - In Kafka, the `sendBatch` operation allows sending messages to multiple topics in a single request.
-   * - We generate a single span for the batch operation and attach all topic names as a comma-separated list.
-   * - If all topics*in the batch appear in `ignoreconfig.endpoints`, the span is ignored.
+   * - A single span is generated for the batch operation, attaching all topic names as a comma-separated list.
+   * - If all topics in the batch appear in `ignoreconfig.endpoints`, the span is ignored.
    * - If at least one topic is not ignored, the span remains traced, ensuring visibility where needed.
    */
   return spanEndpoints.every((/** @type {string} */ endpoint) =>
@@ -157,7 +162,7 @@ function applyFilter(span) {
  * Case 3: If endpoints is an array(future cases). In this case, we return it as-is
  *         since filtering logic expects an array internally.
  *
- * For filtering endpoints is always treated as an array,
+ * For filtering, endpoints in span always treated as an array,
  *
  * @param {string} endpoints
  */

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -154,7 +154,7 @@ function applyFilter(span) {
  * Parses the endpoints field in span data.
  *
  * Use Case: In Kafka, when sendBatch is executed, the endpoints field contains a comma-separated string of topic names.
- * We filtering we treat the endpoints as an array.
+ * For filtering we treat the endpoints as an array.
  * (e.g., `"test-topic-1,test-topic-2"`).
  *
  * @param {string} endpoints

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -63,16 +63,17 @@ function matchEndpoints(span, ignoreconfig) {
     return true;
   }
   /**
-   * Batch Handling Logic: Determines whether a span should be ignored based on its endpoints.
+   * Batch Handling Logic:
    * General Rules:
    * 1. If every endpoint in the span is present in the `ignoreconfig.endpoints`, the span is ignored.
    * 2. If at least one endpoint is not in the ignored list, the span is traced.
-   * 3. This ensures that partial matches do not cause unintended ignores in batch operations.
+   * This ensures that partial matches do not cause unintended ignores in batch operations.
    *
-   * Case 1 - Batch Processing in kafka (sendBatch scenarios):
-   * - Consider a case where a Kafka `sendBatch` operation sends messages to multiple topics in one request.
-   * - If all topics in the batch are in the ignore list, the span is ignored.
-   * - If even one topic is not ignored, the span remains traced, ensuring visibility where needed.
+   * Case: - Batch Processing in kafka (sendBatch):
+   * - In Kafka, the `sendBatch` operation allows sending messages to multiple topics in a single request.
+   * - We generate a single span for the batch operation and attach all topic names as a comma-separated list.
+   * - If all topics*in the batch appear in `ignoreconfig.endpoints`, the span is ignored.
+   * - If at least one topic is not ignored, the span remains traced, ensuring visibility where needed.
    */
   return spanEndpoints.every((/** @type {string} */ endpoint) =>
     ignoreconfig.endpoints.some(
@@ -150,7 +151,7 @@ function applyFilter(span) {
 }
 
 /**
- * Parses the `endpoints` field in span data.
+ * Parses the endpoints field in span data.
  *
  * In Kafka batch produce scenarios, the `endpoints` field is a comma-separated string
  * (e.g., `"test-topic-1,test-topic-2"`).


### PR DESCRIPTION
Improved the `shouldIgnore` function to handle batch processing cases, particularly in `sendBatch` scenarios (e.g., Kafka). The updated logic ensures that spans are ignored only if **all** endpoints in a batch match the ignore configuration.

### Changes:
- Modified the filtering logic to check whether **every** endpoint in the span is listed in `ignoreconfig.endpoints`.
- Added detailed inline comments explaining the special case of batch processing and its effect on span filtering.

### Why This Change?
- Previously, spans containing multiple endpoints could be incorrectly ignored even if few endpoints configured to be traced.
- This enhancement ensures **partial matches do not cause unintended ignores**, improving visibility in distributed tracing.
- It is especially useful in Kafka batch produces, where multiple topics are involved in a single span.



