### PR TITLE
fix: type error fixes to v3

### DIFF
--- a/packages/shared-metrics/src/gc.js
+++ b/packages/shared-metrics/src/gc.js
@@ -43,7 +43,7 @@ exports.currentPayload = {
 
 exports.activate = function activate() {
   activateHasBeenCalled = true;
-  if (gcStats) {
+  if (gcStats && typeof gcStats.on === 'function') {
     actuallyActivate();
   }
 };
@@ -65,7 +65,7 @@ let senseIntervalHandle;
 nativeModuleLoader.once('loaded', gcStats_ => {
   gcStats = gcStats_;
   exports.currentPayload.statsSupported = true;
-  if (activateHasBeenCalled) {
+  if (activateHasBeenCalled && gcStats && typeof gcStats.on === 'function') {
     actuallyActivate();
   }
 });

--- a/packages/shared-metrics/src/libuv.js
+++ b/packages/shared-metrics/src/libuv.js
@@ -42,7 +42,9 @@ Object.defineProperty(exports, 'currentPayload', {
 });
 
 function sense() {
-  if (eventLoopStats) {
+  // CASE: If the c++ module does not support the env, it might export `sense` as undefined.
+  //       See https://github.com/bripkens/event-loop-stats/blob/v1.4.1/src/eventLoopStats.js#L1-L2
+  if (eventLoopStats && eventLoopStats.sense) {
     const stats = eventLoopStats.sense();
     stats.statsSupported = true;
     return stats;


### PR DESCRIPTION
This PR contains the fixes for `gcStats.on` and `eventLoopStats.sense` type errors