### PR TITLE
fix: reduce the latency in throwing error for wrong collector config in lambda

### DIFF
--- a/packages/aws-lambda-auto-wrap/src/index.js
+++ b/packages/aws-lambda-auto-wrap/src/index.js
@@ -15,13 +15,23 @@ if (!wrappedHandler) {
     const targetHandler = loadTargetHandlerFunction();
     wrappedHandler = instana.wrap(targetHandler);
   } catch (err) {
+    // we can throw error from here, but even then there is the delay that we are trying to solve
+    // throw new localUtils.errors.lambda.ImportModuleError(err);
     console.error('Not traced', err);
   }
 }
 
 exports.handler = function instanaAutowrapHandler(event, context, callback) {
   if (!wrappedHandler) {
-    callback.apply(this, arguments);
+    // we can ignore this callback execution, but then the Lambda fn will work only on proper configuration
+    // also this need to called because otherwise the Lambda execution result is shown as Succeeded
+
+    //    Status: Succeeded
+    //    Test Event Name: test
+    //    Response:
+    //    null
+
+    return callback.apply(this, arguments);
   } else {
     return wrappedHandler(event, context, callback);
   }

--- a/packages/aws-lambda-auto-wrap/src/index.js
+++ b/packages/aws-lambda-auto-wrap/src/index.js
@@ -10,25 +10,21 @@ const localUtils = require('./utils');
 
 let wrappedHandler;
 
-// case 1: return directly from the root
-// result: there is a delay of 4 seconds in ap-northeast-1 region
-// return;
-
 if (!wrappedHandler) {
-  const targetHandler = loadTargetHandlerFunction();
-   // case 2: check for the targethandler and then return immediately
-   // result: there is 4 sec delay and no logs
-    if (!targetHandler) {
-      console.log('================= no targetHandler found');
-      return;
-    } else {
-      console.log('================== found', targetHandler);
-    }
-  wrappedHandler = instana.wrap(targetHandler);
+  try {
+    const targetHandler = loadTargetHandlerFunction();
+    wrappedHandler = instana.wrap(targetHandler);
+  } catch (err) {
+    console.error('Not traced', err);
+  }
 }
 
 exports.handler = function instanaAutowrapHandler(event, context, callback) {
-  return wrappedHandler(event, context, callback);
+  if (!wrappedHandler) {
+    callback.apply(this, arguments);
+  } else {
+    return wrappedHandler(event, context, callback);
+  }
 };
 
 function loadTargetHandlerFunction() {
@@ -49,13 +45,6 @@ function loadTargetHandlerFunction() {
 
 function requireTargetHandlerModule(lambdaTaskRoot, targetHandlerModuleFolder, targetHandlerModuleName) {
   const requirePath = localUtils.getImportPath(lambdaTaskRoot, targetHandlerModuleFolder, targetHandlerModuleName);
-
-//   if (requirePath.endsWith('.mjs')) {
-//     throw new localUtils.errors.lambda.ImportModuleError(
-//       'Your Lambda function is using an ES module. ' +
-//         "Please use the 'instana-aws-lambda-auto-wrap-esm.handler' as runtime handler."
-//     );
-// }
 
   try {
     return require(requirePath);

--- a/packages/aws-lambda-auto-wrap/src/index.js
+++ b/packages/aws-lambda-auto-wrap/src/index.js
@@ -10,8 +10,20 @@ const localUtils = require('./utils');
 
 let wrappedHandler;
 
+// case 1: return directly from the root
+// result: there is a delay of 4 seconds in ap-northeast-1 region
+// return;
+
 if (!wrappedHandler) {
   const targetHandler = loadTargetHandlerFunction();
+   // case 2: check for the targethandler and then return immediately
+   // result: there is 4 sec delay and no logs
+    if (!targetHandler) {
+      console.log('================= no targetHandler found');
+      return;
+    } else {
+      console.log('================== found', targetHandler);
+    }
   wrappedHandler = instana.wrap(targetHandler);
 }
 
@@ -37,6 +49,13 @@ function loadTargetHandlerFunction() {
 
 function requireTargetHandlerModule(lambdaTaskRoot, targetHandlerModuleFolder, targetHandlerModuleName) {
   const requirePath = localUtils.getImportPath(lambdaTaskRoot, targetHandlerModuleFolder, targetHandlerModuleName);
+
+//   if (requirePath.endsWith('.mjs')) {
+//     throw new localUtils.errors.lambda.ImportModuleError(
+//       'Your Lambda function is using an ES module. ' +
+//         "Please use the 'instana-aws-lambda-auto-wrap-esm.handler' as runtime handler."
+//     );
+// }
 
   try {
     return require(requirePath);


### PR DESCRIPTION
This PR fixes the delay in error throwing by the AWS Lambda function.

Context: When using Lambda with tracing enabled via Layers, we observed a delay in throwing errors when using an ESM handler instead of a standard CJS handler.

With this fix, misconfigurations in the handler are detected and reported earlier, ensuring that errors are thrown without unnecessary latency.