### PR TITLE
fix: improved log for precompiled binary loading failure

### DIFF
--- a/packages/shared-metrics/src/gc.js
+++ b/packages/shared-metrics/src/gc.js
@@ -46,7 +46,7 @@ exports.init = function init() {
     nativeModuleName: 'gcstats.js',
     moduleRoot: path.join(__dirname, '..'),
     message:
-      'Could not load gcstats.js. Garbage collection information will not be available in Instana for this ' +
+      'Could not load gcstats.js. Garbage collection information will not be available for this ' +
       'application. This typically occurs when native add-ons fail to build during module installation. ' +
       'However, general tracing functionality is unaffected. Enable debug logging for more details. ' +
       'For more information on native add-on, visit: ' +

--- a/packages/shared-metrics/src/gc.js
+++ b/packages/shared-metrics/src/gc.js
@@ -48,8 +48,8 @@ exports.init = function init() {
     message:
       'Could not load gcstats.js. Garbage collection information will not be available for this ' +
       'application. ' +
-      'However, general tracing functionality is unaffected. Enable debug logging for more details. ' +
-      'For more information on native add-on, visit: ' +
+      "However, general tracing functionality remains unaffected. Enable debug logs with 'INSTANA_DEBUG=true' " +
+      'for more details about the error. For more information on native add-ons, visit: ' +
       'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#native-add-ons'
   });
 

--- a/packages/shared-metrics/src/gc.js
+++ b/packages/shared-metrics/src/gc.js
@@ -47,7 +47,7 @@ exports.init = function init() {
     moduleRoot: path.join(__dirname, '..'),
     message:
       'Could not load gcstats.js. Garbage collection information will not be available for this ' +
-      'application. This typically occurs when native add-ons fail to build during module installation. ' +
+      'application. ' +
       'However, general tracing functionality is unaffected. Enable debug logging for more details. ' +
       'For more information on native add-on, visit: ' +
       'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#native-add-ons'

--- a/packages/shared-metrics/src/gc.js
+++ b/packages/shared-metrics/src/gc.js
@@ -46,10 +46,10 @@ exports.init = function init() {
     nativeModuleName: 'gcstats.js',
     moduleRoot: path.join(__dirname, '..'),
     message:
-      'Could not load gcstats.js. You will not be able to see GC information in Instana for this application. This ' +
-      'typically occurs when native addons could not be built during module installation (npm install/yarn) or when ' +
-      'npm install --no-optional or yarn --ignore-optional have been used to install dependencies. See the ' +
-      'instructions to learn more about the requirements of the collector: ' +
+      'Could not load gcstats.js. You will not be able to see GC information in Instana for this application. ' +
+      'This typically occurs when native add-ons could not be built during module installation (npm install/yarn) or ' +
+      'when npm install --no-optional, yarn --ignore-optional, or the AutoTrace webhook was used to install ' +
+      'dependencies. See the instructions to learn more about the requirements of the collector: ' +
       'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#native-add-ons'
   });
 

--- a/packages/shared-metrics/src/gc.js
+++ b/packages/shared-metrics/src/gc.js
@@ -46,10 +46,10 @@ exports.init = function init() {
     nativeModuleName: 'gcstats.js',
     moduleRoot: path.join(__dirname, '..'),
     message:
-      'Could not load gcstats.js. You will not be able to see GC information in Instana for this application. ' +
-      'This typically occurs when native add-ons could not be built during module installation (npm install/yarn) or ' +
-      'when npm install --no-optional, yarn --ignore-optional, or the AutoTrace webhook was used to install ' +
-      'dependencies. See the instructions to learn more about the requirements of the collector: ' +
+      'Could not load gcstats.js. Garbage collection information will not be available in Instana for this ' +
+      'application. This typically occurs when native add-ons fail to build during module installation. ' +
+      'However, general tracing functionality is unaffected. Enable debug logging for more details. ' +
+      'For more information on native add-on, visit: ' +
       'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#native-add-ons'
   });
 

--- a/packages/shared-metrics/src/libuv.js
+++ b/packages/shared-metrics/src/libuv.js
@@ -20,7 +20,7 @@ exports.init = function init() {
     moduleRoot: path.join(__dirname, '..'),
     message:
       'Could not load event-loop-stats. Event loop information will not be available for this ' +
-      'application. This typically occurs when native add-ons fail to build during module installation. ' +
+      'application. ' +
       'However, general tracing functionality remains unaffected. Enable debug logging for more details. ' +
       'For more information on native add-ons, visit: ' +
       'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#native-add-ons'

--- a/packages/shared-metrics/src/libuv.js
+++ b/packages/shared-metrics/src/libuv.js
@@ -21,8 +21,8 @@ exports.init = function init() {
     message:
       'Could not load event-loop-stats. Event loop information will not be available for this ' +
       'application. ' +
-      'However, general tracing functionality remains unaffected. Enable debug logging for more details. ' +
-      'For more information on native add-ons, visit: ' +
+      "However, general tracing functionality remains unaffected. Enable debug logs with 'INSTANA_DEBUG=true' " +
+      'for more details about the error. For more information on native add-ons, visit: ' +
       'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#native-add-ons'
   });
 

--- a/packages/shared-metrics/src/libuv.js
+++ b/packages/shared-metrics/src/libuv.js
@@ -20,9 +20,9 @@ exports.init = function init() {
     moduleRoot: path.join(__dirname, '..'),
     message:
       'Could not load event-loop-stats. You will only see limited event loop information in Instana for this ' +
-      'application. This typically occurs when native addons could not be built during module installation ' +
-      '(npm install/yarn) or when npm install --no-optional or yarn --ignore-optional have been used to install ' +
-      'dependencies. See the instructions to learn more about the requirements of the collector: ' +
+      'application. This typically occurs when native add-ons could not be built during module installation ' +
+      '(npm install/yarn) or when npm install --no-optional, yarn --ignore-optional, or the AutoTrace webhook was ' +
+      'used to install dependencies. See the instructions to learn more about the collector requirements: ' +
       'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#native-add-ons'
   });
 

--- a/packages/shared-metrics/src/libuv.js
+++ b/packages/shared-metrics/src/libuv.js
@@ -19,7 +19,7 @@ exports.init = function init() {
     nativeModuleName: 'event-loop-stats',
     moduleRoot: path.join(__dirname, '..'),
     message:
-      'Could not load event-loop-stats. Event loop information will not be available in Instana for this ' +
+      'Could not load event-loop-stats. Event loop information will not be available for this ' +
       'application. This typically occurs when native add-ons fail to build during module installation. ' +
       'However, general tracing functionality remains unaffected. Enable debug logging for more details. ' +
       'For more information on native add-ons, visit: ' +

--- a/packages/shared-metrics/src/libuv.js
+++ b/packages/shared-metrics/src/libuv.js
@@ -19,10 +19,10 @@ exports.init = function init() {
     nativeModuleName: 'event-loop-stats',
     moduleRoot: path.join(__dirname, '..'),
     message:
-      'Could not load event-loop-stats. You will only see limited event loop information in Instana for this ' +
-      'application. This typically occurs when native add-ons could not be built during module installation ' +
-      '(npm install/yarn) or when npm install --no-optional, yarn --ignore-optional, or the AutoTrace webhook was ' +
-      'used to install dependencies. See the instructions to learn more about the collector requirements: ' +
+      'Could not load event-loop-stats. Event loop information will be limited in Instana for this application. ' +
+      'This typically occurs when native add-ons fail to build during module installation. ' +
+      'However, general tracing functionality remains unaffected. Enable debug logging for more details. ' +
+      'For more information on native add-ons, visit: ' +
       'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#native-add-ons'
   });
 

--- a/packages/shared-metrics/src/libuv.js
+++ b/packages/shared-metrics/src/libuv.js
@@ -19,8 +19,8 @@ exports.init = function init() {
     nativeModuleName: 'event-loop-stats',
     moduleRoot: path.join(__dirname, '..'),
     message:
-      'Could not load event-loop-stats. Event loop information will be limited in Instana for this application. ' +
-      'This typically occurs when native add-ons fail to build during module installation. ' +
+      'Could not load event-loop-stats. Event loop information will not be available in Instana for this ' +
+      'application. This typically occurs when native add-ons fail to build during module installation. ' +
       'However, general tracing functionality remains unaffected. Enable debug logging for more details. ' +
       'For more information on native add-ons, visit: ' +
       'https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-installation#native-add-ons'

--- a/packages/shared-metrics/src/util/nativeModuleRetry.js
+++ b/packages/shared-metrics/src/util/nativeModuleRetry.js
@@ -228,8 +228,8 @@ function copyPrecompiled(opts, loaderEmitter, callback) {
             // corresponding Node.js version.
             logger.debug(
               `Failed to load precompiled build for ${opts.nativeModuleName} ${label}. ` +
-                'Precompiled binary extraction was blocked, possibly due to a read-only filesystem or an unavailable ' +
-                `compatible prebuilt binary for the Node.js ${process.version}. ${error?.message} ${error?.stack}`
+                'Precompiled binary extraction has failed, possibly due to a read-only filesystem or unknown' +
+                `system operation error for the Node.js ${process.version}. ${error?.message} ${error?.stack}`
             );
             callback(false);
           });

--- a/packages/shared-metrics/src/util/nativeModuleRetry.js
+++ b/packages/shared-metrics/src/util/nativeModuleRetry.js
@@ -228,7 +228,7 @@ function copyPrecompiled(opts, loaderEmitter, callback) {
             // corresponding Node.js version.
             logger.debug(
               `Failed to load precompiled build for ${opts.nativeModuleName} ${label}. ` +
-                'Precompiled binary extraction has failed, possibly due to a read-only filesystem or unknown' +
+                'Precompiled binary extraction has failed, possibly due to a read-only filesystem or an unknown' +
                 `system operation error for the Node.js ${process.version}. ${error?.message} ${error?.stack}`
             );
             callback(false);

--- a/packages/shared-metrics/src/util/nativeModuleRetry.js
+++ b/packages/shared-metrics/src/util/nativeModuleRetry.js
@@ -224,13 +224,12 @@ function copyPrecompiled(opts, loaderEmitter, callback) {
             // version from the instrumentation image, which is currently compiled only for Node.js v21.
             // If the application runs a different Node.js version and the filesystem is read-only, extraction may fail,
             // preventing collection of certain telemetry data (garbage collection and event loop stats).
-            // TODO: Known issue tracked under INSTA-6673.
+            // TODO: Fix the issue tracked under INSTA-6673. Ensure prebuilt binaries are available for the
+            // corresponding Node.js version.
             logger.debug(
-              `Failed to load precompiled build for ${opts.nativeModuleName} ${label}: ${error?.message}. ` +
-                // eslint-disable-next-line max-len
-                'Precompiled binary extraction was blocked due to restricted filesystem access or an unavailable compatible build. ' +
-                'Certain telemetry data, such as garbage collection and event loop statistics, may not be available. ' +
-                `Stack Trace: ${error?.stack}`
+              `Failed to load precompiled build for ${opts.nativeModuleName} ${label}. ` +
+                'Precompiled binary extraction was blocked due to a read-only filesystem and an unavailable ' +
+                `compatible prebuilt binary for the Node.js ${process.version}. ${error?.message} ${error?.stack}`
             );
             callback(false);
           });

--- a/packages/shared-metrics/src/util/nativeModuleRetry.js
+++ b/packages/shared-metrics/src/util/nativeModuleRetry.js
@@ -228,7 +228,7 @@ function copyPrecompiled(opts, loaderEmitter, callback) {
             // corresponding Node.js version.
             logger.debug(
               `Failed to load precompiled build for ${opts.nativeModuleName} ${label}. ` +
-                'Precompiled binary extraction was blocked due to a read-only filesystem and an unavailable ' +
+                'Precompiled binary extraction was blocked, possibly due to a read-only filesystem or an unavailable ' +
                 `compatible prebuilt binary for the Node.js ${process.version}. ${error?.message} ${error?.stack}`
             );
             callback(false);


### PR DESCRIPTION
## Why?

Previously, the failure to load precompiled binaries was logged as a warning, which could give customers the impression that something critical had failed. Since a separate warning log already exists for this scenario, the detailed failure message has been moved to the debug level to avoid redundancy and unnecessary log precedence while still retaining the stack trace for troubleshooting.

Additionally, the log message has been updated to provide better insights into potential causes, such as restricted filesystem access or an unknown system error, improving diagnostic clarity.

Ref: [INSTA-31177](https://jsw.ibm.com/browse/INSTA-31177)