### PR TITLE
feat(kafka): added option to disable downstream suppression for ignored endpoints

### DIFF
--- a/packages/collector/test/tracing/messaging/kafkajs/test.js
+++ b/packages/collector/test/tracing/messaging/kafkajs/test.js
@@ -1156,9 +1156,9 @@ mochaSuiteFn('tracing/kafkajs', function () {
         await retry(async () => {
           const spans = await agentControls.getSpans();
           // 2 x HTTP server (1 x consumer, 1 x producer)
-          // 2 x HTTP client (producer)(consumer)
-          // 1 x Kafka consume span (consumer)
-          expect(spans).to.have.lengthOf(5);
+          // 4 x HTTP client (1 producer)(2 consumer)
+          // 2 x Kafka consume span (consumer)
+          expect(spans).to.have.lengthOf(8);
 
           // Flow: HTTP entry (producer) (traced)
           //       ├── Kafka Produce (traced)

--- a/packages/collector/test/tracing/messaging/kafkajs/test.js
+++ b/packages/collector/test/tracing/messaging/kafkajs/test.js
@@ -1101,7 +1101,7 @@ mochaSuiteFn('tracing/kafkajs', function () {
       });
     });
 
-    describe('when suppression is disabled via INSTANA_DISABLE_SUPRESSION', function () {
+    describe('when downstream suppression is disabled via INSTANA_DISABLE_SUPRESSION', function () {
       before(async () => {
         consumerControls = new ProcessControls({
           appPath: path.join(__dirname, 'consumer'),

--- a/packages/collector/test/tracing/messaging/kafkajs/test.js
+++ b/packages/collector/test/tracing/messaging/kafkajs/test.js
@@ -1101,7 +1101,7 @@ mochaSuiteFn('tracing/kafkajs', function () {
       });
     });
 
-    describe('when downstream suppression is disabled via INSTANA_DISABLE_SUPRESSION', function () {
+    describe('when downstream suppression is disabled via INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION', function () {
       before(async () => {
         consumerControls = new ProcessControls({
           appPath: path.join(__dirname, 'consumer'),
@@ -1109,7 +1109,7 @@ mochaSuiteFn('tracing/kafkajs', function () {
           env: {
             // basic ignoring config for send
             INSTANA_IGNORE_ENDPOINTS: 'kafka:send',
-            INSTANA_DISABLE_SUPRESSION: true
+            INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION: true
           }
         });
 

--- a/packages/collector/test/tracing/messaging/kafkajs/test.js
+++ b/packages/collector/test/tracing/messaging/kafkajs/test.js
@@ -1100,6 +1100,92 @@ mochaSuiteFn('tracing/kafkajs', function () {
         });
       });
     });
+
+    describe('when suppression is disabled via INSTANA_DISABLE_SUPRESSION', function () {
+      before(async () => {
+        consumerControls = new ProcessControls({
+          appPath: path.join(__dirname, 'consumer'),
+          useGlobalAgent: true,
+          env: {
+            // basic ignoring config for send
+            INSTANA_IGNORE_ENDPOINTS: 'kafka:send',
+            INSTANA_DISABLE_SUPRESSION: true
+          }
+        });
+
+        producerControls = new ProcessControls({
+          appPath: path.join(__dirname, 'producer'),
+          useGlobalAgent: true
+        });
+
+        await consumerControls.startAndWaitForAgentConnection();
+        await producerControls.startAndWaitForAgentConnection();
+      });
+
+      beforeEach(async () => {
+        await agentControls.clearReceivedTraceData();
+      });
+
+      after(async () => {
+        await producerControls.stop();
+        await consumerControls.stop();
+      });
+
+      it('should ignore only the kafka call send and should trace downstream calls', async () => {
+        const message = {
+          key: 'someKey',
+          value: 'someMessage'
+        };
+        await producerControls.sendRequest({
+          method: 'POST',
+          path: '/send-messages',
+          simple: true,
+          body: JSON.stringify(message),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        });
+
+        await consumerControls.sendRequest({
+          method: 'GET',
+          path: '/health',
+          simple: true
+        });
+
+        await delay(200);
+        await retry(async () => {
+          const spans = await agentControls.getSpans();
+          // 2 x HTTP server (1 x consumer, 1 x producer)
+          // 2 x HTTP client (producer)(consumer)
+          // 1 x Kafka consume span (consumer)
+          expect(spans).to.have.lengthOf(5);
+
+          // Flow: HTTP entry (producer) (traced)
+          //       ├── Kafka Produce (traced)
+          //       │      └── Kafka Consume → HTTP (ignored)
+          //       └── HTTP exit (traced)
+          //
+          //      HTTP entry (consumer) (traced)
+          const kafkaProducerSpan = spans.find(span => span.n === 'kafka' && span.k === 2);
+          const producerHttpSpan = spans.find(
+            span => span.n === 'node.http.server' && span.k === 1 && span.data.http.url === '/send-messages'
+          );
+          const producerHttpExitSpan = spans.find(span => span.n === 'node.http.client' && span.k === 2);
+          const consumerHttpSpan = spans.find(
+            span => span.n === 'node.http.server' && span.k === 1 && span.data.http.url === '/health'
+          );
+
+          expect(kafkaProducerSpan).to.exist;
+          expect(kafkaProducerSpan.data.kafka).to.include({
+            service: 'test-topic-1',
+            access: 'send'
+          });
+          expect(producerHttpSpan).to.exist;
+          expect(producerHttpExitSpan).to.exist;
+          expect(consumerHttpSpan).to.exist;
+        });
+      });
+    });
   });
 
   function resetMessages(consumer) {

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -155,7 +155,7 @@ class InstanaSpan {
     // Indicates whether downstream suppression should be propagated.
     // By default, suppression is enabled.
     // If set to false, downstream suppression will be disabled, and suppression propagation will not occur.
-    Object.defineProperty(this, 'isSuppressed', {
+    Object.defineProperty(this, 'shouldSuppressDownstream', {
       value: true,
       writable: true,
       enumerable: false
@@ -257,7 +257,7 @@ class InstanaIgnoredSpan extends InstanaSpan {
     // By default, downstream suppression for ignoring endpoints is enabled.
     // If the environment variable `INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION` is set,
     // should not suppress the downstream calls.
-    this.isSuppressed = !ignoreEndpointsDisableSuppression;
+    this.shouldSuppressDownstream = !ignoreEndpointsDisableSuppression;
   }
 
   transmit() {

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -30,7 +30,7 @@ let processIdentityProvider = null;
 /** @type {Boolean} */
 let allowRootExitSpan;
 /** @type {Boolean} */
-let ignoreEndpointsDownStreamSuppression = true;
+let ignoreEndpointsDisableDownStreamSuppression;
 
 /*
  * Access the Instana namespace in continuation local storage.
@@ -54,7 +54,7 @@ function init(config, _processIdentityProvider) {
   }
   processIdentityProvider = _processIdentityProvider;
   allowRootExitSpan = config?.tracing?.allowRootExitSpan;
-  ignoreEndpointsDownStreamSuppression = config?.tracing?.ignoreEndpointsDisableSuppression;
+  ignoreEndpointsDisableDownStreamSuppression = config?.tracing?.ignoreEndpointsDisableSuppression;
 }
 
 class InstanaSpan {
@@ -152,9 +152,6 @@ class InstanaSpan {
       writable: true,
       enumerable: false
     });
-    // This property was introduced as part of the ignoring endpoint feature
-    // and determines whether suppression should be propagated downstream.
-    // By default, downstream suppression triggered by a span is disabled.
     // This property "shouldSuppressDownstream" currently applicable only for ignoring endpoints.
     // When a span is ignored, downstream suppression is automatically enabled.
     // However, if required, downstream suppression propagation can be explicitly disabled
@@ -261,7 +258,7 @@ class InstanaIgnoredSpan extends InstanaSpan {
     // By default, downstream suppression for ignoring endpoints is enabled.
     // If the environment variable `INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION` is set,
     // should not suppress the downstream calls.
-    this.shouldSuppressDownstream = !ignoreEndpointsDownStreamSuppression;
+    this.shouldSuppressDownstream = !ignoreEndpointsDisableDownStreamSuppression;
   }
 
   transmit() {

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -159,7 +159,7 @@ class InstanaSpan {
     // When a span is ignored, suppression is automatically enabled (`true`),
     // propagating suppression headers downstream.
     // However, if required, downstream suppression propagation can be explicitly disabled
-    // by setting this property to `false`.
+    // via the env variable `INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION`.
     Object.defineProperty(this, 'shouldSuppressDownstream', {
       value: false,
       writable: true,

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -460,7 +460,7 @@ function setIgnoredSpan({ spanName, kind, traceId, parentId, data = {} }) {
 
     // For entry spans, we need to retain suppression information to ensure that
     // tracing is suppressed for all internal (!) subsequent outgoing (exit) calls.
-    // By default, downstream suppression is enabled.
+    // By default, downstream suppression for ignored spans is enabled.
     // If the environment variable `INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION is set,
     // should not suppress the downstream calls.
     if (span.shouldSuppressDownstream) setTracingLevel('0');

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -156,7 +156,7 @@ class InstanaSpan {
     // and determines whether suppression should be propagated downstream.
     // By default, downstream suppression triggered by a span is disabled.
     // This property "shouldSuppressDownstream" currently applicable only for ignoring endpoints.
-    // When a span is ignored, suppression is automatically enabled (`true`),
+    // When a span is ignored, downstream suppression is automatically enabled.
     // propagating suppression headers downstream.
     // However, if required, downstream suppression propagation can be explicitly disabled
     // via the env variable `INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION`.

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -152,6 +152,14 @@ class InstanaSpan {
       writable: true,
       enumerable: false
     });
+    // Indicates whether downstream suppression should be propagated.
+    // By default, suppression is enabled.
+    // If set to false, downstream suppression will be disabled, and suppression propagation will not occur.
+    Object.defineProperty(this, 'isSuppressed', {
+      value: true,
+      writable: true,
+      enumerable: false
+    });
   }
 
   /**
@@ -245,9 +253,11 @@ class InstanaIgnoredSpan extends InstanaSpan {
   constructor(name, data) {
     super(name, data);
 
+    this.isIgnored = true;
     // By default, downstream suppression for ignoring endpoints is enabled.
-    // If the environment variable `INSTANA_DISABLE_SUPPRESSION` is set, should not suppress the downstream calls.
-    this.isIgnored = !ignoreEndpointsDisableSuppression;
+    // If the environment variable `INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION` is set,
+    // should not suppress the downstream calls.
+    this.isSuppressed = !ignoreEndpointsDisableSuppression;
   }
 
   transmit() {
@@ -446,7 +456,8 @@ function setIgnoredSpan({ spanName, kind, traceId, parentId, data = {} }) {
     // For entry spans, we need to retain suppression information to ensure that
     // tracing is suppressed for all internal (!) subsequent outgoing (exit) calls.
     // By default, downstream suppression is enabled.
-    // If the environment variable `INSTANA_DISABLE_SUPPRESSION` is set, should not suppress the downstream calls.
+    // If the environment variable `INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION is set,
+    // should not suppress the downstream calls.
     if (!ignoreEndpointsDisableSuppression) setTracingLevel('0');
   }
 

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -157,7 +157,6 @@ class InstanaSpan {
     // By default, downstream suppression triggered by a span is disabled.
     // This property "shouldSuppressDownstream" currently applicable only for ignoring endpoints.
     // When a span is ignored, downstream suppression is automatically enabled.
-    // propagating suppression headers downstream.
     // However, if required, downstream suppression propagation can be explicitly disabled
     // via the env variable `INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION`.
     Object.defineProperty(this, 'shouldSuppressDownstream', {

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -155,7 +155,7 @@ class InstanaSpan {
     // This property was introduced as part of the ignoring endpoint feature
     // and determines whether suppression should be propagated downstream.
     // By default, downstream suppression triggered by a span is disabled.
-    // This property currently applicable only for ignoring endpoints.
+    // This property "shouldSuppressDownstream" currently applicable only for ignoring endpoints.
     // When a span is ignored, suppression is automatically enabled (`true`),
     // propagating suppression headers downstream.
     // However, if required, suppression propagation can be explicitly disabled

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -463,7 +463,7 @@ function setIgnoredSpan({ spanName, kind, traceId, parentId, data = {} }) {
     // By default, downstream suppression is enabled.
     // If the environment variable `INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION is set,
     // should not suppress the downstream calls.
-    if (!ignoreEndpointsDownStreamSuppression) setTracingLevel('0');
+    if (span.shouldSuppressDownstream) setTracingLevel('0');
   }
 
   // Set the span object as the currently active span in the active CLS context and also add a cleanup hook for when

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -158,7 +158,7 @@ class InstanaSpan {
     // This property "shouldSuppressDownstream" currently applicable only for ignoring endpoints.
     // When a span is ignored, suppression is automatically enabled (`true`),
     // propagating suppression headers downstream.
-    // However, if required, suppression propagation can be explicitly disabled
+    // However, if required, downstream suppression propagation can be explicitly disabled
     // by setting this property to `false`.
     Object.defineProperty(this, 'shouldSuppressDownstream', {
       value: false,

--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -154,7 +154,7 @@ class InstanaSpan {
     });
     // This property was introduced as part of the ignoring endpoint feature
     // and determines whether suppression should be propagated downstream.
-    // By default, suppression is disabled.
+    // By default, downstream suppression triggered by a span is disabled.
     // This property currently applicable only for ignoring endpoints.
     // When a span is ignored, suppression is automatically enabled (`true`),
     // propagating suppression headers downstream.

--- a/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
@@ -92,7 +92,7 @@ function instrumentedSend(ctx, originalSend, originalArgs, topic, messages) {
     });
     if (Array.isArray(messages)) {
       span.b = { s: messages.length };
-      setTraceHeaders({ messages, span, suppressDownstream: span.shouldSuppressDownstream });
+      setTraceHeaders({ messages, span });
     }
     span.stack = tracingUtil.getStackTrace(instrumentedSend);
 
@@ -167,8 +167,7 @@ function instrumentedSendBatch(ctx, originalSendBatch, originalArgs, topicMessag
     topicMessages.forEach(topicMessage => {
       setTraceHeaders({
         messages: topicMessage.messages,
-        span,
-        suppressDownstream: span.shouldSuppressDownstream
+        span
       });
     });
 
@@ -457,8 +456,8 @@ function removeInstanaHeadersFromMessage(message) {
   }
 }
 
-function setTraceHeaders({ messages, span, suppressDownstream }) {
-  if (suppressDownstream) {
+function setTraceHeaders({ messages, span }) {
+  if (span.shouldSuppressDownstream) {
     // Suppress trace propagation to downstream services.
     addTraceLevelSuppressionToAllMessages(messages);
   } else {

--- a/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
@@ -92,7 +92,7 @@ function instrumentedSend(ctx, originalSend, originalArgs, topic, messages) {
     });
     if (Array.isArray(messages)) {
       span.b = { s: messages.length };
-      setTraceHeaders({ messages, span, ignored: span.isIgnored, suppressDownstream: span.shouldSuppressDownstream });
+      setTraceHeaders({ messages, span, suppressDownstream: span.shouldSuppressDownstream });
     }
     span.stack = tracingUtil.getStackTrace(instrumentedSend);
 
@@ -168,7 +168,6 @@ function instrumentedSendBatch(ctx, originalSendBatch, originalArgs, topicMessag
       setTraceHeaders({
         messages: topicMessage.messages,
         span,
-        ignored: span.isIgnored,
         suppressDownstream: span.shouldSuppressDownstream
       });
     });
@@ -458,9 +457,9 @@ function removeInstanaHeadersFromMessage(message) {
   }
 }
 
-function setTraceHeaders({ messages, span, ignored, suppressDownstream }) {
-  if (ignored && suppressDownstream) {
-    // If the span is ignored, suppress trace propagation to downstream services.
+function setTraceHeaders({ messages, span, suppressDownstream }) {
+  if (suppressDownstream) {
+    // Suppress trace propagation to downstream services.
     addTraceLevelSuppressionToAllMessages(messages);
   } else {
     // Otherwise, inject the trace context into the headers for propagation.

--- a/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
@@ -92,7 +92,7 @@ function instrumentedSend(ctx, originalSend, originalArgs, topic, messages) {
     });
     if (Array.isArray(messages)) {
       span.b = { s: messages.length };
-      setTraceHeaders({ messages, span, ignored: span.isIgnored, suppressed: span.isSuppressed });
+      setTraceHeaders({ messages, span, ignored: span.isIgnored, suppressDownstream: span.shouldSuppressDownstream });
     }
     span.stack = tracingUtil.getStackTrace(instrumentedSend);
 
@@ -169,7 +169,7 @@ function instrumentedSendBatch(ctx, originalSendBatch, originalArgs, topicMessag
         messages: topicMessage.messages,
         span,
         ignored: span.isIgnored,
-        suppressed: span.isSuppressed
+        suppressDownstream: span.shouldSuppressDownstream
       });
     });
 
@@ -458,8 +458,8 @@ function removeInstanaHeadersFromMessage(message) {
   }
 }
 
-function setTraceHeaders({ messages, span, ignored, suppressed }) {
-  if (ignored && suppressed) {
+function setTraceHeaders({ messages, span, ignored, suppressDownstream }) {
+  if (ignored && suppressDownstream) {
     // If the span is ignored, suppress trace propagation to downstream services.
     addTraceLevelSuppressionToAllMessages(messages);
   } else {

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -157,7 +157,7 @@ function instrumentedProduce(ctx, originalProduce, originalArgs) {
       headers: originalArgs[6],
       span,
       ignored: span.isIgnored,
-      suppressed: span.isSuppressed
+      suppressDownstream: span.shouldSuppressDownstream
     });
 
     if (deliveryCb) {
@@ -389,8 +389,8 @@ function logDeprecationKafkaAvroMessage() {
     '[Deprecation Warning] The support for kafka-avro library is deprecated and might be removed in the next major release. See https://github.com/waldophotos/kafka-avro/issues/120'
   );
 }
-function setTraceHeaders({ headers, span, ignored, suppressed }) {
-  if (ignored && suppressed) {
+function setTraceHeaders({ headers, span, ignored, suppressDownstream }) {
+  if (ignored && suppressDownstream) {
     // If the span is ignored, suppress trace propagation to downstream services.
     return addTraceLevelSuppression(headers);
   } else {

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -156,7 +156,6 @@ function instrumentedProduce(ctx, originalProduce, originalArgs) {
     originalArgs[6] = setTraceHeaders({
       headers: originalArgs[6],
       span,
-      ignored: span.isIgnored,
       suppressDownstream: span.shouldSuppressDownstream
     });
 
@@ -389,9 +388,9 @@ function logDeprecationKafkaAvroMessage() {
     '[Deprecation Warning] The support for kafka-avro library is deprecated and might be removed in the next major release. See https://github.com/waldophotos/kafka-avro/issues/120'
   );
 }
-function setTraceHeaders({ headers, span, ignored, suppressDownstream }) {
-  if (ignored && suppressDownstream) {
-    // If the span is ignored, suppress trace propagation to downstream services.
+function setTraceHeaders({ headers, span, suppressDownstream }) {
+  if (suppressDownstream) {
+    // Suppress trace propagation to downstream services.
     return addTraceLevelSuppression(headers);
   } else {
     // Otherwise, inject the trace context into the headers for propagation.

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -155,8 +155,7 @@ function instrumentedProduce(ctx, originalProduce, originalArgs) {
 
     originalArgs[6] = setTraceHeaders({
       headers: originalArgs[6],
-      span,
-      suppressDownstream: span.shouldSuppressDownstream
+      span
     });
 
     if (deliveryCb) {
@@ -388,8 +387,8 @@ function logDeprecationKafkaAvroMessage() {
     '[Deprecation Warning] The support for kafka-avro library is deprecated and might be removed in the next major release. See https://github.com/waldophotos/kafka-avro/issues/120'
   );
 }
-function setTraceHeaders({ headers, span, suppressDownstream }) {
-  if (suppressDownstream) {
+function setTraceHeaders({ headers, span }) {
+  if (span.shouldSuppressDownstream) {
     // Suppress trace propagation to downstream services.
     return addTraceLevelSuppression(headers);
   } else {

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -153,7 +153,12 @@ function instrumentedProduce(ctx, originalProduce, originalArgs) {
 
     span.stack = tracingUtil.getStackTrace(instrumentedProduce, 1);
 
-    originalArgs[6] = setTraceHeaders({ headers: originalArgs[6], span, ignored: span.isIgnored });
+    originalArgs[6] = setTraceHeaders({
+      headers: originalArgs[6],
+      span,
+      ignored: span.isIgnored,
+      suppressed: span.isSuppressed
+    });
 
     if (deliveryCb) {
       ctx.once('delivery-report', function instanaDeliveryReportListener(err) {
@@ -384,8 +389,8 @@ function logDeprecationKafkaAvroMessage() {
     '[Deprecation Warning] The support for kafka-avro library is deprecated and might be removed in the next major release. See https://github.com/waldophotos/kafka-avro/issues/120'
   );
 }
-function setTraceHeaders({ headers, span, ignored }) {
-  if (ignored) {
+function setTraceHeaders({ headers, span, ignored, suppressed }) {
+  if (ignored && suppressed) {
     // If the span is ignored, suppress trace propagation to downstream services.
     return addTraceLevelSuppression(headers);
   } else {

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -27,7 +27,7 @@ const configNormalizers = require('./configNormalizers');
  * @property {KafkaTracingOptions} [kafka]
  * @property {boolean} [allowRootExitSpan]
  * @property {import('../tracing').IgnoreEndpoints} [ignoreEndpoints]
- * @property {boolean} [disableSupression]
+ * @property {boolean} [ignoreEndpointsDisableSuppression]
  */
 
 /**
@@ -126,7 +126,7 @@ const defaults = {
       traceCorrelation: true
     },
     ignoreEndpoints: {},
-    disableSupression: false
+    ignoreEndpointsDisableSuppression: false
   },
   secrets: {
     matcherMode: 'contains-ignore-case',
@@ -753,13 +753,13 @@ function normalizeIgnoreEndpoints(config) {
  * @param {InstanaConfig} config
  */
 function normalizeDisableSupression(config) {
-  if (process.env['INSTANA_DISABLE_SUPRESSION'] === 'true') {
+  if (process.env['INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION'] === 'true') {
     logger.info(
-      'Disabling supression as it is explicitly disabled via environment variable INSTANA_DISABLE_SUPRESSION.'
+      'Disabling supression as it is explicitly disabled via environment variable INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION.'
     );
-    config.tracing.disableSupression = true;
+    config.tracing.ignoreEndpointsDisableSuppression = true;
     return;
   }
 
-  config.tracing.disableSupression = defaults.tracing.disableSupression;
+  config.tracing.ignoreEndpointsDisableSuppression = defaults.tracing.ignoreEndpointsDisableSuppression;
 }

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -27,6 +27,7 @@ const configNormalizers = require('./configNormalizers');
  * @property {KafkaTracingOptions} [kafka]
  * @property {boolean} [allowRootExitSpan]
  * @property {import('../tracing').IgnoreEndpoints} [ignoreEndpoints]
+ * @property {boolean} [disableSupression]
  */
 
 /**
@@ -124,7 +125,8 @@ const defaults = {
     kafka: {
       traceCorrelation: true
     },
-    ignoreEndpoints: {}
+    ignoreEndpoints: {},
+    disableSupression: false
   },
   secrets: {
     matcherMode: 'contains-ignore-case',
@@ -243,6 +245,7 @@ function normalizeTracingConfig(config) {
   normalizeTracingKafka(config);
   normalizeAllowRootExitSpan(config);
   normalizeIgnoreEndpoints(config);
+  normalizeDisableSupression(config);
 }
 
 /**
@@ -744,4 +747,19 @@ function normalizeIgnoreEndpoints(config) {
     logger.debug(`Ignore endpoints have been configured: ${JSON.stringify(config.tracing.ignoreEndpoints)}`);
     return;
   }
+}
+
+/**
+ * @param {InstanaConfig} config
+ */
+function normalizeDisableSupression(config) {
+  if (process.env['INSTANA_DISABLE_SUPRESSION'] === 'true') {
+    logger.info(
+      'Disabling supression as it is explicitly disabled via environment variable INSTANA_DISABLE_SUPRESSION.'
+    );
+    config.tracing.disableSupression = true;
+    return;
+  }
+
+  config.tracing.disableSupression = defaults.tracing.disableSupression;
 }

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -755,7 +755,7 @@ function normalizeIgnoreEndpoints(config) {
 function normalizeIgnoreEndpointsDisableSuppression(config) {
   if (process.env['INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION'] === 'true') {
     logger.info(
-      'Disabling supression as it is explicitly disabled via environment variable INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION.'
+      'Disabling downstream suppression for ignoring endpoints feature as it is explicitly disabled via environment variable "INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION".'
     );
     config.tracing.ignoreEndpointsDisableSuppression = true;
     return;

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -245,7 +245,7 @@ function normalizeTracingConfig(config) {
   normalizeTracingKafka(config);
   normalizeAllowRootExitSpan(config);
   normalizeIgnoreEndpoints(config);
-  normalizeDisableSupression(config);
+  normalizeIgnoreEndpointsDisableSuppression(config);
 }
 
 /**
@@ -752,7 +752,7 @@ function normalizeIgnoreEndpoints(config) {
 /**
  * @param {InstanaConfig} config
  */
-function normalizeDisableSupression(config) {
+function normalizeIgnoreEndpointsDisableSuppression(config) {
   if (process.env['INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION'] === 'true') {
     logger.info(
       'Disabling supression as it is explicitly disabled via environment variable INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION.'

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -646,6 +646,17 @@ describe('util.normalizeConfig', () => {
       const config = normalizeConfig();
       expect(config.tracing.ignoreEndpoints).to.deep.equal({});
     });
+
+    it('should return false when INSTANA_DISABLE_SUPRESSION is not set', () => {
+      const config = normalizeConfig();
+      expect(config.tracing.disableSupression).to.deep.equal(false);
+    });
+
+    it('should return true when INSTANA_DISABLE_SUPRESSION is set', () => {
+      process.env.INSTANA_DISABLE_SUPRESSION = true;
+      const config = normalizeConfig();
+      expect(config.tracing.disableSupression).to.deep.equal(true);
+    });
   });
 
   function checkDefaults(config) {

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -647,15 +647,15 @@ describe('util.normalizeConfig', () => {
       expect(config.tracing.ignoreEndpoints).to.deep.equal({});
     });
 
-    it('should return false when INSTANA_DISABLE_SUPRESSION is not set', () => {
+    it('should return false when INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION is not set', () => {
       const config = normalizeConfig();
-      expect(config.tracing.disableSupression).to.deep.equal(false);
+      expect(config.tracing.ignoreEndpointsDisableSuppression).to.deep.equal(false);
     });
 
-    it('should return true when INSTANA_DISABLE_SUPRESSION is set', () => {
-      process.env.INSTANA_DISABLE_SUPRESSION = true;
+    it('should return true when INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION is set', () => {
+      process.env.INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION = true;
       const config = normalizeConfig();
-      expect(config.tracing.disableSupression).to.deep.equal(true);
+      expect(config.tracing.ignoreEndpointsDisableSuppression).to.deep.equal(true);
     });
   });
 


### PR DESCRIPTION
By default, suppression is enabled for ignored endpoints, preventing downstream traces from being recorded. However, in some cases, this behavior may need to be disabled. The environment variable `INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION` provides flexibility to control this suppression.

Since certain traces are already ignored, trace correlation is broken regardless. This makes suppression a configurable option without additional impact.

### Usage

To disable suppression for ignored endpoints, set the following environment variable:

```bash
export INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION=true
```

