### PR TITLE
chore: bump express version in currency report to v5

### DIFF
--- a/bin/currency/generate-currency-report.js
+++ b/bin/currency/generate-currency-report.js
@@ -30,7 +30,7 @@ currencies = currencies.map(currency => {
   console.log('\n###############################################');
   console.log(`Checking ${currency.name}...`);
 
-  let installedVersion = utils.getRootDependencyVersion(currency.name);
+  let installedVersion = currency.lastSupportedVersion || utils.getRootDependencyVersion(currency.name);
   let latestVersion;
   let upToDate;
   let latestVersionPublishedAt = 'N/A';
@@ -50,7 +50,7 @@ currencies = currencies.map(currency => {
       installedVersion = installedVersion.replace(/[^0-9.]/g, '');
     }
 
-    latestVersion = utils.getLatestVersion(currency.name, installedVersion);
+    latestVersion = currency.latestVersion || utils.getLatestVersion(currency.name, installedVersion);
 
     if (!installedVersion) {
       installedVersion = latestVersion;

--- a/currencies.json
+++ b/currencies.json
@@ -233,10 +233,10 @@
   {
     "name": "express",
     "policy": "45-days",
-    "lastSupportedVersion": "",
-    "latestVersion": "",
+    "lastSupportedVersion": "5.0.1",
+    "latestVersion": "5.0.1",
     "cloudNative": false,
-    "isBeta": false,
+    "isBeta": true,
     "ignoreUpdates": false,
     "note": "",
     "core": false


### PR DESCRIPTION
This PR bumps the latest supported version in currency report to v5.0.1 statically.
We need to keep an eye on [Express releases](https://www.npmjs.com/package/express?activeTab=versions) to keep this updated until v5 becomes `latest` in NPM.

This static change will ensure that we get the minor updates for v4(latest) in timely manner but the currency report will point to the latest major version