### PR TITLE
test: updated the zookeeper image version in docker-compose

### DIFF
--- a/.tekton/assets/sidecars.json
+++ b/.tekton/assets/sidecars.json
@@ -35,7 +35,7 @@
     },
     {
       "name": "zookeeper",
-      "image": "zookeeper:3.9.2",
+      "image": "zookeeper:3.9.1",
       "readinessProbe": {
         "tcpSocket": {
           "port": 2181

--- a/.tekton/tasks/test-groups/test-ci-collector-tracing-messaging-task.yaml
+++ b/.tekton/tasks/test-groups/test-ci-collector-tracing-messaging-task.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   sidecars:
     - name: zookeeper
-      image: zookeeper:3.9.2
+      image: zookeeper:3.9.1
       readinessProbe:
           tcpSocket:
             port: 2181 

--- a/docker-compose-base.yaml
+++ b/docker-compose-base.yaml
@@ -74,7 +74,10 @@ services:
       xpack.security.enabled: 'false'
 
   zookeeper:
-    image: zookeeper:3.9.2
+    # The latest Zookeeper image is not functioning properly on ARM64.
+    # For local testing, stick to the fixed version until the issue is resolved.
+    # TODO: INSTA-32550.
+    image: zookeeper:3.9.1
     platform: linux/amd64
     ports:
       - 2181:2181


### PR DESCRIPTION
With the current  latest Zookeeper version, I'm unable to run the Kafka tests locally in arm64.

 As a temporary workaround, I  downgraded the version,  creates a [card](https://jsw.ibm.com/browse/INSTA-32550) to replace the image in the future.