### PR TITLE
chore: included prerelease version in currency report

### DIFF
--- a/bin/currency/generate-currency-report.js
+++ b/bin/currency/generate-currency-report.js
@@ -50,7 +50,11 @@ currencies = currencies.map(currency => {
       installedVersion = installedVersion.replace(/[^0-9.]/g, '');
     }
 
-    latestVersion = utils.getLatestVersion(currency.name, installedVersion);
+    latestVersion = utils.getLatestVersion({
+      pkgName: currency.name,
+      installedVersion: installedVersion,
+      isBeta: currency.isBeta
+    });
 
     if (!installedVersion) {
       installedVersion = latestVersion;

--- a/bin/currency/update-currencies.js
+++ b/bin/currency/update-currencies.js
@@ -72,7 +72,11 @@ currencies.forEach(currency => {
   }
 
   installedVersion = installedVersion.replace(/[^0-9.]/g, '');
-  const latestVersion = utils.getLatestVersion(currency.name, installedVersion);
+  const latestVersion = utils.getLatestVersion({
+    pkgName: currency.name,
+    installedVersion: installedVersion,
+    isBeta: currency.isBeta
+  });
 
   if (latestVersion === installedVersion) {
     console.log(

--- a/bin/currency/utils.js
+++ b/bin/currency/utils.js
@@ -93,7 +93,7 @@ const getHighestMajorVersion = versions => {
   return highestMajorVersion;
 };
 
-exports.getLatestVersion = (pkgName, installedVersion) => {
+exports.getLatestVersion = ({ pkgName, installedVersion, isBeta }) => {
   let latestVersion = execSync(`npm info ${pkgName} version`).toString().trim();
   const allVersions = getAllVersions(pkgName);
   const highestMajorVersion = getHighestMajorVersion(allVersions);
@@ -107,7 +107,8 @@ exports.getLatestVersion = (pkgName, installedVersion) => {
       `Detected a higher major version: ${highestMajorVersion} and this version is a prerelease: ${!!highestMajorVersionIsPrerelease}`
     );
 
-    if (!highestMajorVersionIsPrerelease) {
+    // If isBeta is true, then we allow prerelease version as latest in currency report
+    if (!highestMajorVersionIsPrerelease || isBeta) {
       latestVersion = highestMajorVersion;
     }
   }


### PR DESCRIPTION
beta flag in currencies.json will now include pre-release versions in currency report