### PR TITLE
chore: added knex support in currencies.json

### DIFF
--- a/currencies.json
+++ b/currencies.json
@@ -407,6 +407,17 @@
     "core": false
   },
   {
+    "name": "knex",
+    "policy": "45-days",
+    "lastSupportedVersion": "",
+    "latestVersion": "",
+    "cloudNative": false,
+    "isBeta": false,
+    "ignoreUpdates": true,
+    "note": "",
+    "core": false
+  },
+  {
     "name": "koa",
     "policy": "45-days",
     "lastSupportedVersion": "",


### PR DESCRIPTION
We offer built-in support for [Knex](https://knexjs.org/guide/), a SQL query builder for Node.js that supports multiple databases, including PostgreSQL, MySQL, CockroachDB, MSSQL, and SQLite3.  

The `currencies.json` file has been updated to reflect Knex support.  

Previously, we had a test for Knex but removed it. See [Commit](https://github.com/instana/nodejs/pull/884/commits/de4556361f1c74d14c70d74fa2251a753adb8a0a)
ref INSTA-24797.