### PR TITLE
ci: added support for `npm-version` param in update-dependencies task 

### DIFF
--- a/.tekton/pipeline/currency-bot-pipeline.yaml
+++ b/.tekton/pipeline/currency-bot-pipeline.yaml
@@ -144,6 +144,8 @@ spec:
           value: "secure-properties"
         - name: node-version
           value: $(params.node-version)
+        - name: npm-version
+          value: $(params.npm-version)
         - name: type
           value: $(params.type)
       workspaces:

--- a/.tekton/tasks/update-dependencies.yaml
+++ b/.tekton/tasks/update-dependencies.yaml
@@ -62,7 +62,7 @@ spec:
           MAJOR_UPDATES_MODE=false BRANCH=currency-bot node bin/currency/update-currencies.js    
         else
           echo "Open PRs exist for branch currency-bot. Skipping patch/minor updates."
-        fi         
+        fi        
 
         echo "Running major updates..."
         MAJOR_UPDATES_MODE=true BRANCH=currency-bot-major node bin/currency/update-currencies.js

--- a/.tekton/tasks/update-dependencies.yaml
+++ b/.tekton/tasks/update-dependencies.yaml
@@ -10,6 +10,8 @@ spec:
       value: $(params.type)
     - name: node-version
       value: $(params.node-version)
+    - name: npm-version
+      value: $(params.npm-version)
   workspaces:
     - name: output
       mountPath: /artifacts
@@ -27,6 +29,10 @@ spec:
 
         ARTIFACTS_PATH="$(workspaces.output.path)"
         cd $ARTIFACTS_PATH
+
+        if [ -n "$(params.npm-version)" ]; then
+          npm install npm@$(params.npm-version) -g
+        fi  
         
         git config user.name "Instanacd PAT for GitHub Public"
         git config user.email "techuser@instana.com"
@@ -56,10 +62,6 @@ spec:
           MAJOR_UPDATES_MODE=false BRANCH=currency-bot node bin/currency/update-currencies.js    
         else
           echo "Open PRs exist for branch currency-bot. Skipping patch/minor updates."
-        fi  
-
-        if [ -n "$(params.npm-version)" ]; then
-          npm install npm@$(params.npm-version) -g
         fi         
 
         echo "Running major updates..."

--- a/.tekton/tasks/update-dependencies.yaml
+++ b/.tekton/tasks/update-dependencies.yaml
@@ -56,7 +56,11 @@ spec:
           MAJOR_UPDATES_MODE=false BRANCH=currency-bot node bin/currency/update-currencies.js    
         else
           echo "Open PRs exist for branch currency-bot. Skipping patch/minor updates."
-        fi        
+        fi  
+
+        if [ -n "$(params.npm-version)" ]; then
+          npm install npm@$(params.npm-version) -g
+        fi         
 
         echo "Running major updates..."
         MAJOR_UPDATES_MODE=true BRANCH=currency-bot-major node bin/currency/update-currencies.js

--- a/bin/currency/update-currencies.js
+++ b/bin/currency/update-currencies.js
@@ -33,6 +33,8 @@ const hasCommits = (branch, cwd) => {
   }
 };
 
+execSync('npm install npm@11', { cwd });
+
 if (!MAJOR_UPDATES_MODE) {
   console.log('Preparing patch/minor updates...');
   execSync('git checkout main', { cwd });

--- a/bin/currency/update-currencies.js
+++ b/bin/currency/update-currencies.js
@@ -33,8 +33,6 @@ const hasCommits = (branch, cwd) => {
   }
 };
 
-execSync('npm install npm@11', { cwd });
-
 if (!MAJOR_UPDATES_MODE) {
   console.log('Preparing patch/minor updates...');
   execSync('git checkout main', { cwd });


### PR DESCRIPTION
This PR addresses an issue observed during the currency update where the typeorm package changes were only reflected in the package-lock.json, while package.json remained unchanged. This inconsistency may be caused by an npm bug when dependencies are installed from a non-root directory.

To resolve this, we've upgraded to npm v11, which behaves as expected locally and includes the necessary changes in both files.

Changes:
 - Adds support for an `npm-version` parameter in the `update-dependencies` task.

 - This parameter can now be specified via the Tekton pipeline to control the npm version used during dependency updates.