### PR TITLE
ci(serverless): replaced AWS access key

### DIFF
--- a/packages/serverless/ci/pipeline.yaml
+++ b/packages/serverless/ci/pipeline.yaml
@@ -397,8 +397,8 @@ jobs:
                   NO_PROMPT=true \
                   CONTAINER_REGISTRY_USER=iamapikey \
                   CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
-                  AWS_ACCESS_KEY_ID=((aws-ci-manage-lambda-layers.aws_access_key_id)) \
-                  AWS_SECRET_ACCESS_KEY=((aws-ci-manage-lambda-layers.aws_secret_access_key)) \
+                  AWS_ACCESS_KEY_ID=((aws-ci-nodejs-publish-lambda-layers.aws_access_key_id)) \
+                  AWS_SECRET_ACCESS_KEY=((aws-ci-nodejs-publish-lambda-layers.aws_secret_access_key)) \
                   AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
                   AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
                   nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -438,8 +438,8 @@ jobs:
                   LAMBDA_ARCHITECTURE=arm64 \
                   CONTAINER_REGISTRY_USER=iamapikey \
                   CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
-                  AWS_ACCESS_KEY_ID=((aws-ci-manage-lambda-layers.aws_access_key_id)) \
-                  AWS_SECRET_ACCESS_KEY=((aws-ci-manage-lambda-layers.aws_secret_access_key)) \
+                  AWS_ACCESS_KEY_ID=((aws-ci-nodejs-publish-lambda-layers.aws_access_key_id)) \
+                  AWS_SECRET_ACCESS_KEY=((aws-ci-nodejs-publish-lambda-layers.aws_secret_access_key)) \
                   AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
                   AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
                   nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -479,8 +479,8 @@ jobs:
                   PUBLISH_TO_CHINA_REGIONS=true \
                   CONTAINER_REGISTRY_USER=iamapikey \
                   CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
-                  AWS_ACCESS_KEY_ID=((aws-ci-manage-lambda-layers.aws_access_key_id)) \
-                  AWS_SECRET_ACCESS_KEY=((aws-ci-manage-lambda-layers.aws_secret_access_key)) \
+                  AWS_ACCESS_KEY_ID=((aws-ci-nodejs-publish-lambda-layers.aws_access_key_id)) \
+                  AWS_SECRET_ACCESS_KEY=((aws-ci-nodejs-publish-lambda-layers.aws_secret_access_key)) \
                   AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
                   AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
                   nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh
@@ -521,8 +521,8 @@ jobs:
                   PUBLISH_TO_CHINA_REGIONS=true \
                   CONTAINER_REGISTRY_USER=iamapikey \
                   CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
-                  AWS_ACCESS_KEY_ID=((aws-ci-manage-lambda-layers.aws_access_key_id)) \
-                  AWS_SECRET_ACCESS_KEY=((aws-ci-manage-lambda-layers.aws_secret_access_key)) \
+                  AWS_ACCESS_KEY_ID=((aws-ci-nodejs-publish-lambda-layers.aws_access_key_id)) \
+                  AWS_SECRET_ACCESS_KEY=((aws-ci-nodejs-publish-lambda-layers.aws_secret_access_key)) \
                   AWS_ACCESS_KEY_ID_CHINA=((aws-ci-manage-lambda-layers-china.aws_access_key_id)) \
                   AWS_SECRET_ACCESS_KEY_CHINA=((aws-ci-manage-lambda-layers-china.aws_secret_access_key)) \
                   nodejs-repository/packages/aws-lambda/layer/bin/publish-layer.sh


### PR DESCRIPTION
- replaced access key of user "ci-manage-lambda-layers" on 410797082306
- every Team has its own access key to publish
- background: key rotation, security, decoupling
- cn key coming later