### PR TITLE
ci: migrated from gcr.io to icr.io for dind-nodejs-aws-jq-image

### DIFF
--- a/packages/serverless/ci/pipeline.yaml
+++ b/packages/serverless/ci/pipeline.yaml
@@ -26,10 +26,10 @@ resources:
     type: registry-image
     icon: docker
     source:
-      repository: gcr.io/k8s-brewery/instana/concourse-dind-nodejs-aws-jq
+      repository: us.icr.io/instana-tracer-nodejs/concourse-dind-nodejs-aws-jq
       tag: latest
-      username: _json_key
-      password: ((team-nodejs-gcp-service-account-json))
+      username: iamapikey
+      password: ((team-nodejs-ibm-cloud-icr-api-key))
 
   - name: instana-aws-fargate-npm-package
     type: npm-resource


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-32692

