### PR TITLE
build: removed event-loop-stats and gcstats from dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34562,9 +34562,9 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/event-loop-stats/-/event-loop-stats-1.4.1.tgz",
       "integrity": "sha512-Wzohoz1JrQOBjt/shh5Z3/8Ti6SVoGl5nyX952Vcp5N56QVOtjPuJsQa+dEhsDJHu4QAFz45ePXRFq01skb9xA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "nan": "^2.14.0"
       },
@@ -36590,9 +36590,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gcstats.js/-/gcstats.js-1.0.0.tgz",
       "integrity": "sha512-gY4x4gWpZtXwIot2js62z4xNNZd+skNzfr4zpK5lVvDqZcqWKP/LhMKKi1Q/VFszJgqPz8ZQpO/OG4SHRgiTng==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "nan": "^2.0.5"
       }
@@ -57041,9 +57041,7 @@
         "tar": "^6.2.1"
       },
       "devDependencies": {
-        "@types/tar": "^6.1.6",
-        "event-loop-stats": "1.4.1",
-        "gcstats.js": "1.0.0"
+        "@types/tar": "^6.1.6"
       },
       "optionalDependencies": {
         "event-loop-stats": "1.4.1",

--- a/packages/shared-metrics/package.json
+++ b/packages/shared-metrics/package.json
@@ -66,9 +66,7 @@
     "tar": "^6.2.1"
   },
   "devDependencies": {
-    "@types/tar": "^6.1.6",
-    "event-loop-stats": "1.4.1",
-    "gcstats.js": "1.0.0"
+    "@types/tar": "^6.1.6"
   },
   "optionalDependencies": {
     "event-loop-stats": "1.4.1",


### PR DESCRIPTION
In the prerelease pipeline, the npm install step failed for multiple reasons. One reason is the failure to install event-loop-stats and gcstats.

The reason is that the C++ builds are never available for rc candidates and are also usually never immediately available when a new release comes out.
The c++ libraries need to first ship the support for the next node version.
We have decided to revert the changes we made in
https://github.com/instana/nodejs/commit/a2fcb0ffe17a468ace5150f97a3839b507b2348f
https://github.com/instana/nodejs/commit/605da7bb9d0a8ce1363a0988a9c03c3c474ebdbd
and to wait till the builds are randomly failing again to search for a better long-term solution

Step by step, resolving each issue resolved in https://github.com/instana/nodejs/pull/1419 to see the action in pipeline