### PR TITLE
ci: udpate npm install step for prerelease pipeline

### DIFF
--- a/.tekton/listeners/node-pre-release.yaml
+++ b/.tekton/listeners/node-pre-release.yaml
@@ -29,8 +29,8 @@ spec:
     - name: pipeline-ref
       value: "default-pipeline"
     - name: skip-cache
-      value: $(params.skip-cache)   
-      default: ""
+      value: "true"  
+      default: "true"
     - name: prerelease
       value: "true"
       default: ""

--- a/.tekton/tasks/install-npm-dependencies.yaml
+++ b/.tekton/tasks/install-npm-dependencies.yaml
@@ -36,20 +36,15 @@ spec:
         ARTIFACTS_PATH="$(workspaces.output.path)"
         cd $ARTIFACTS_PATH
 
+        if [ "$(params.prerelease)" == "true" ]; then
+          source bin/install-prerelease.sh 
+        fi
+
         if [ -n "$(params.npm-version)" ]; then
           npm install npm@$(params.npm-version) -g
         else
           npm install npm -g
         fi     
-
-        if [ "$(params.prerelease)" == "true" ]; then
-          echo "Installing dependencies for prerelease..."
-
-          source bin/install-prerelease.sh 
-
-          npm install --loglevel verbose          
-          exit 0
-        fi
 
         if [ "$(params.skip-cache)" == "true" ]; then
           echo "Skipping npm cache..."


### PR DESCRIPTION
In the CI, npm install step for prerelease pipeline was giving a false positive.
Updated the logic and order for resolving this issue