### PR TITLE
chore: fixed npm install failure for autorpofile in prerelease pipelines

### DIFF
--- a/packages/autoprofile/package.json
+++ b/packages/autoprofile/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "audit": "npm audit --omit=dev",
     "node_modules:exists": "mkdir -p node_modules",
-    "install": "node-gyp-build",
+    "install": "node-gyp-build || true",
     "test": "mocha $npm_config_watch --config=test/.mocharc.js --require test/hooks.js --sort $(find test -iname '*test.js' -not -path '*node_modules*')",
     "test:debug": "WITH_STDOUT=true npm run test",
     "test:ci": "echo \"******* Files to be tested:\n $CI_AUTOPROFILE_TEST_FILES\" && if [ -z \"${CI_AUTOPROFILE_TEST_FILES}\" ]; then echo \"No test files have been assigned to this CircleCI executor.\"; else mocha --config=test/.mocharc.js --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json --require test/hooks.js --sort ${CI_AUTOPROFILE_TEST_FILES}; fi",


### PR DESCRIPTION
Skipping the installation of autoprofile if it fails because this is an optional dependency and it keeps failing on prerelease pipeline because of the native c++ modules incompatibility