### PR TITLE
chore: fixed npm uninstall usages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,11 +185,8 @@ The following sections describe how to manage dependencies in practice.
 
 ### Removing A Package Dependency
 
-`npm uninstall -D ${dependency-name}`: Removes a dev dependency from the root package.
-`npm uninstall ${dependency-name} -w packages/collector`: Removes a production dependency from the package `@instana/collector`. This is equivalent to `cd packages/collector; npm uninstall ${dependency-name}`.
-`npm uninstall -D ${dependency-name} -w packages/collector`: Removes a dev dependency from the package `@instana/collector`. This is equivalent to `cd packages/collector; npm uninstall -D ${dependency-name}`.
-
-Note: `npm uninstall -D` command is removed from npm v7. see: https://docs.npmjs.com/cli/v11/commands/npm-uninstall
+`npm uninstall ${dependency-name}`: Removes a dependency from the root package.
+`npm uninstall ${dependency-name} -w packages/collector`: Removes a dependency from the package `@instana/collector`. This is equivalent to `cd packages/collector; npm uninstall ${dependency-name}`.
 
 ### Updating A Single Version In A `package.json` File
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,8 @@ The following sections describe how to manage dependencies in practice.
 `npm uninstall ${dependency-name} -w packages/collector`: Removes a production dependency from the package `@instana/collector`. This is equivalent to `cd packages/collector; npm uninstall ${dependency-name}`.
 `npm uninstall -D ${dependency-name} -w packages/collector`: Removes a dev dependency from the package `@instana/collector`. This is equivalent to `cd packages/collector; npm uninstall -D ${dependency-name}`.
 
+Note: `npm uninstall -D` command is removed from npm v7. see: https://docs.npmjs.com/cli/v11/commands/npm-uninstall
+
 ### Updating A Single Version In A `package.json` File
 
 `npm install ${dependency-name}@${version}`: Updates a specific production dependency on the root.

--- a/packages/aws-lambda/lambdas/bin/create-zip-util
+++ b/packages/aws-lambda/lambdas/bin/create-zip-util
@@ -30,10 +30,10 @@ function createZip {
       #   "instana-aws-lambda-auto-wrap": "file:../../instana-aws-lambda-auto-wrap.tgz"
       # }
       # ...then those need to be removed:
-      npm uninstall --production -S @instana/core
-      npm uninstall --production -S @instana/aws-lambda
-      npm uninstall --production -S @instana/serverless
-      npm uninstall --production -S instana-aws-lambda-auto-wrap
+      npm uninstall -S @instana/core
+      npm uninstall -S @instana/aws-lambda
+      npm uninstall -S @instana/serverless
+      npm uninstall -S instana-aws-lambda-auto-wrap
 
     elif [[ "${BUILD_LAMBDAS_WITH}" == "local" ]]; then
       # The lambda's package.json might or might not already have a dependency to the local tar files:
@@ -63,9 +63,9 @@ function createZip {
       #   "@instana/aws-lambda": "file:../../instana-aws-lambda.tgz"
       # }
       # this needs to be removed and then we install the latest published package from npm
-      npm uninstall --production -S @instana/core
-      npm uninstall --production -S @instana/aws-lambda
-      npm uninstall --production -S @instana/serverless
+      npm uninstall -S @instana/core
+      npm uninstall -S @instana/aws-lambda
+      npm uninstall -S @instana/serverless
       npm install --production -S @instana/core
       npm install --production -S @instana/aws-lambda
       npm install --production -S @instana/serverless


### PR DESCRIPTION
`npm uninstall -D` command is removed from npm v7 and above. 
Also `npm uninstall` with `--production` falg is also not valid anymore

see: https://docs.npmjs.com/cli/v11/commands/npm-uninstall