### PR TITLE
test: cleanup opentelemetry tedious test

### DIFF
--- a/packages/collector/test/tracing/opentelemetry/test.js
+++ b/packages/collector/test/tracing/opentelemetry/test.js
@@ -6,7 +6,6 @@
 
 const expect = require('chai').expect;
 const path = require('path');
-const semver = require('semver');
 const supportedVersion = require('@instana/core').tracing.supportedVersion;
 const constants = require('@instana/core').tracing.constants;
 const config = require('../../../../core/test/config');
@@ -504,8 +503,7 @@ mochaSuiteFn('opentelemetry/instrumentations', function () {
         ));
   });
 
-  const runTedious = semver.gte(process.versions.node, '18.17.0') ? describe : describe.skip;
-  runTedious('tedious', function () {
+  describe('tedious', function () {
     describe('opentelemetry is enabled', function () {
       globalAgent.setUpCleanUpHooks();
       const agentControls = globalAgent.instance;


### PR DESCRIPTION
Since our minimum supported node version is 18, we don't need to explicitly check for the condition in tedious tests.