### PR TITLE
ci: fix currency bot npm install if node modules are corrupted

### DIFF
--- a/bin/currency/update-currencies.js
+++ b/bin/currency/update-currencies.js
@@ -36,7 +36,7 @@ const hasCommits = (branch, cwd) => {
 if (!MAJOR_UPDATES_MODE) {
   console.log('Preparing patch/minor updates...');
   execSync('git checkout main', { cwd });
-  execSync('npm i --no-audit', { cwd });
+  execSync('npm ci --no-audit', { cwd });
 
   if (BRANCH !== 'main') {
     execSync(`git checkout -b ${branchName}`, { cwd });
@@ -98,7 +98,7 @@ currencies.forEach(currency => {
 
     console.log(`Major update available for ${currency.name}.`);
     execSync('git checkout main', { cwd });
-    execSync('npm i --no-audit', { cwd });
+    execSync('npm ci --no-audit', { cwd });
 
     branchName = `${BRANCH}-${currency.name.replace(/[^a-zA-Z0-9]/g, '')}`;
 


### PR DESCRIPTION
**context:**
The currency pipeline was broken while running `npm i --no-audit` step in the update currencies script. It failed for node 20.19 (our latest default dev version) due to a corrupted node modules issue.
 
see error:
>  
>  npm error code ENOTEMPTY
> npm error syscall rename
> npm error path /artifacts/node_modules/acorn-node/node_modules/acorn
> npm error dest /artifacts/node_modules/acorn-node/node_modules/.acorn-HmByUYsm
> npm error errno -39
> npm error ENOTEMPTY: directory not empty, rename '/artifacts/node_modules/acorn-node/node_modules/acorn' -> '/artifacts/node_modules/acorn-node/node_modules/.acorn-HmByUYsm'

errored pipeline: [pl-main-currency-bot-20.19](https://cloud.ibm.com/devops/pipelines/tekton/c2cd6a8d-ea5a-47b0-913e-cd172d63833f/runs/a0b6d4ae-e61c-4aec-b270-f19d134df6cd?env_id=ibm:yp:eu-de)

**solution:**

Running a clean install fixes the node_modules corruption issue:

see pipeline: [pl-chore-fix-currency-bot-currency-bot-20.19](https://cloud.ibm.com/devops/pipelines/tekton/c2cd6a8d-ea5a-47b0-913e-cd172d63833f/runs/965f8a3c-f29b-4161-a405-7c9a1460acdc?env_id=ibm:yp:eu-de)