### PR TITLE
build: updated mongo server to v8

### DIFF
--- a/.tekton/assets/sidecars.json
+++ b/.tekton/assets/sidecars.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "mongodb",
-      "image": "mongo:4.1.13"
+      "image": "mongo:8.0.8"
     },
     {
       "name": "mssql",

--- a/.tekton/tasks/test-groups/test-ci-collector-general-task.yaml
+++ b/.tekton/tasks/test-groups/test-ci-collector-general-task.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   sidecars:
     - name: mysql
-      image: mysql:8.0.1
+      image: mysql:8.0.26
       args:
           - "--default-authentication-plugin=mysql_native_password"
       env:

--- a/.tekton/tasks/test-groups/test-ci-collector-general-task.yaml
+++ b/.tekton/tasks/test-groups/test-ci-collector-general-task.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   sidecars:
     - name: mysql
-      image: mysql:8.0.26
+      image: mysql:8.0.1
       args:
           - "--default-authentication-plugin=mysql_native_password"
       env:

--- a/.tekton/tasks/test-groups/test-ci-collector-tracing-database-task.yaml
+++ b/.tekton/tasks/test-groups/test-ci-collector-tracing-database-task.yaml
@@ -7,7 +7,7 @@ spec:
     - name: memcached
       image: memcached:1.6.9
     - name: mongodb
-      image: mongo:4.1.13
+      image: mongo:8.0.8
     - name: elasticsearch
       image: docker.elastic.co/elasticsearch/elasticsearch:8.6.1
       env:
@@ -29,7 +29,7 @@ spec:
           periodSeconds: 2
           timeoutSeconds: 60
     - name: mysql
-      image: mysql:8.0.26
+      image: mysql:8.0.1
       args:
           - "--default-authentication-plugin=mysql_native_password"
       env:

--- a/.tekton/tasks/test-groups/test-ci-collector-tracing-database-task.yaml
+++ b/.tekton/tasks/test-groups/test-ci-collector-tracing-database-task.yaml
@@ -29,7 +29,7 @@ spec:
           periodSeconds: 2
           timeoutSeconds: 60
     - name: mysql
-      image: mysql:8.0.1
+      image: mysql:8.0.26
       args:
           - "--default-authentication-plugin=mysql_native_password"
       env:

--- a/docker-compose-base.yaml
+++ b/docker-compose-base.yaml
@@ -43,7 +43,7 @@ services:
         ipv4_address: 172.30.0.4      
 
   mongo:
-    image: mongo:4.1.13
+    image: mongo:8.0.8
     ports:
       - 27017:27017
 


### PR DESCRIPTION
https://www.mongodb.com/docs/drivers/node/current/whats-new/#std-label-version-6.16

> Deprecates support for MongoDB Server 4.0. Support will be completely removed in a future minor release.

From #1698 

Works locally. Tested manually.

I did not read through changelogs between v4 and v8. If it works, we can just merge it.
This is just a sidetask improvement.