### PR TITLE
fix: resolved "Cannot read properties of undefined (reading 'debug')"

### DIFF
--- a/packages/core/src/tracing/cls.js
+++ b/packages/core/src/tracing/cls.js
@@ -44,7 +44,7 @@ const ns = hooked.createNamespace('instana.collector');
 
 /**
  * @param {import('../util/normalizeConfig').InstanaConfig} config
- * @param {import('../../../collector/src/pidStore')} _processIdentityProvider
+ * @param {import('../../../collector/src/pidStore')} [_processIdentityProvider]
  */
 function init(config, _processIdentityProvider) {
   logger = config.logger;

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -193,7 +193,7 @@ exports.preInit = function preInit(preliminaryConfig) {
   spanHandle.init(preliminaryConfig);
   shimmer.init(preliminaryConfig);
   cls.init(preliminaryConfig);
-  sdk.init(config, cls);
+  sdk.init(preliminaryConfig, cls);
 
   initInstrumenations(preliminaryConfig);
 };

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -172,6 +172,18 @@ exports.registerAdditionalInstrumentations = function registerAdditionalInstrume
  * @param {import('../util/normalizeConfig').InstanaConfig} preliminaryConfig
  */
 exports.preInit = function preInit(preliminaryConfig) {
+  /**
+   * CASE: On e.g. Fargate the `preInit` function is called as early as possible
+   * and if one of our modules (shimmer, cls, spanHandle etc.) e.g. logs a warning
+   * the logger module needs to be initialized and injected.
+   *
+   * `preInit` has a limited functionality e.g. we do not activate the instrumentations.
+   * `preInit` only monkey patches the libraries as early as possible.
+   */
+  spanHandle.init(preliminaryConfig);
+  shimmer.init(preliminaryConfig);
+  cls.init(preliminaryConfig);
+
   initInstrumenations(preliminaryConfig);
 };
 

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -173,16 +173,27 @@ exports.registerAdditionalInstrumentations = function registerAdditionalInstrume
  */
 exports.preInit = function preInit(preliminaryConfig) {
   /**
-   * CASE: On e.g. Fargate the `preInit` function is called as early as possible
-   * and if one of our modules (shimmer, cls, spanHandle etc.) e.g. logs a warning
-   * the logger module needs to be initialized and injected.
+   * On e.g. Fargate the `preInit` function is called as early as possible
+   * and all our modules (shimmer, cls, sdk etc.) need to be initialized.
+   * Imagine on of these modules logs a warning. The logger module needs to be
+   * injected to be able to log anything.
    *
    * `preInit` has a limited functionality e.g. we do not activate the instrumentations.
-   * `preInit` only monkey patches the libraries as early as possible.
+   *  That means, any span creation would get skipped.
+   *
+   * `preInit` only monkey patches the libraries as early as possible to be able to start
+   * tracing as soon as the data to `init` the core package is fully available.
+   *
+   * The time between `preInit` and `init` is usually very short, but e.g. on Fargate
+   * it can take a bit of time because we are doing an async request to the meta API.
+   *
+   * Another possible use case is, that its theoretically possible that the customer
+   * can already start using the SDK although we are not fully initialized.
    */
   spanHandle.init(preliminaryConfig);
   shimmer.init(preliminaryConfig);
   cls.init(preliminaryConfig);
+  sdk.init(config, cls);
 
   initInstrumenations(preliminaryConfig);
 };

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -87,10 +87,20 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
       const config = normalizeConfig({}, logger);
       tracing.preInit(config);
 
-      // Just proof that the `init` method of one instrumentation has been called yet,
-      // but not the `activate` method. We don't care which one.
       expect(initStubGrpcJs).to.have.been.called;
       expect(activateStubGrpcJs).to.not.have.been.called;
+
+      expect(initStubKafkaJs).to.have.been.called;
+      expect(activateStubKafkaJs).to.not.have.been.called;
+
+      expect(initStubRdKafka).to.have.been.called;
+      expect(activateStubRdKafka).to.not.have.been.called;
+
+      expect(initAwsSdkv2).to.have.been.called;
+      expect(activateAwsSdkv2).to.not.have.been.called;
+
+      expect(initAwsSdkv3).to.have.been.called;
+      expect(activateAwsSdkv3).to.not.have.been.called;
     });
   });
 


### PR DESCRIPTION
refs #1701

On e.g. AWS Fargate the `preInit` fn is called as early as possible to init the instrumentations.
If **one** instrumentation (any) had a method which was already wrapped, we unwrap it and log a warning. This code would have been executed:
https://github.com/instana/nodejs/blob/v4.11.0/packages/core/src/tracing/shimmer.js#L51-L59

But the logger for `preInit` case was always undefined. This PR fixes it.
This fix is not just for Fargate.