### PR TITLE
feat: added support for redis v5

### DIFF
--- a/.tekton/assets/sidecars.json
+++ b/.tekton/assets/sidecars.json
@@ -100,7 +100,7 @@
     },
     {
       "name": "redis",
-      "image": "redis:5.0.14"
+      "image": "redis:7.4.3"
     },
     {
       "name": "localstack",

--- a/.tekton/tasks/test-groups/test-ci-collector-tracing-database-task.yaml
+++ b/.tekton/tasks/test-groups/test-ci-collector-tracing-database-task.yaml
@@ -18,7 +18,7 @@ spec:
           - name: "xpack.security.enabled"
             value: "false"
     - name: redis
-      image: redis:5.0.14
+      image: redis:7.4.3
     - name: couchbase
       image: couchbase/server:7.1.4
       readinessProbe:

--- a/.tekton/tasks/test-groups/test-ci-collector-tracing-messaging-task.yaml
+++ b/.tekton/tasks/test-groups/test-ci-collector-tracing-messaging-task.yaml
@@ -52,7 +52,7 @@ spec:
           periodSeconds: 2
           timeoutSeconds: 60
     - name: redis
-      image: redis:5.0.14
+      image: redis:7.4.3
     - name: nats
       image: nats:2.9.14-linux
     - name: nats-streaming

--- a/.tekton/tasks/test-groups/test-ci-collector-tracing-misc-task.yaml
+++ b/.tekton/tasks/test-groups/test-ci-collector-tracing-misc-task.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   sidecars:
     - name: redis
-      image: redis:5.0.14
+      image: redis:7.4.3
   envFrom:
     - configMapRef:
         name: environment-properties  

--- a/currencies.json
+++ b/currencies.json
@@ -187,6 +187,17 @@
     "core": false
   },
   {
+    "name": "@redis/client",
+    "policy": "45-days",
+    "lastSupportedVersion": "",
+    "latestVersion": "",
+    "cloudNative": false,
+    "isBeta": false,
+    "ignoreUpdates": false,
+    "note": "",
+    "core": false
+  },
+  {
     "name": "amqplib",
     "policy": "45-days",
     "lastSupportedVersion": "",

--- a/docker-compose-base.yaml
+++ b/docker-compose-base.yaml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   redis:
-    image: redis:7.4
+    image: redis:7.4.3
     ports:
       - 6379:6379
 

--- a/docker-compose-base.yaml
+++ b/docker-compose-base.yaml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   redis:
-    image: redis:5.0.14
+    image: redis:7.4
     ports:
       - 6379:6379
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,7 +159,7 @@
         "proxyquire": "^2.1.3",
         "read-pkg-up": "^7.0.1",
         "recursive-copy": "^2.0.14",
-        "redis": "^5.0.0",
+        "redis": "^5.0.1",
         "redis-v3": "npm:redis@^3.1.2",
         "redis-v4": "npm:redis@^4.7.0",
         "restify": "^11.1.0",
@@ -24222,16 +24222,15 @@
       "dev": true
     },
     "node_modules/@redis/bloom": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.0.0.tgz",
-      "integrity": "sha512-YHlra6a7+brJ3Ustqa+jC68Pdnw2/wbnVLeULN0llP3gHpKxOSmiDyLwuHq5t/jFi6QUgjSprUQi2a8CieKFIA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.0.1.tgz",
+      "integrity": "sha512-F7L+rnuJvq/upKaVoEgsf8VT7g5pLQYWRqSUOV3uO4vpVtARzSKJ7CLyJjVsQS+wZVCGxsLMh8DwAIDcny1B+g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.0.0"
+        "@redis/client": "^5.0.1"
       }
     },
     "node_modules/@redis/client": {
@@ -24262,42 +24261,39 @@
       }
     },
     "node_modules/@redis/json": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.0.0.tgz",
-      "integrity": "sha512-8YFjshsvWR9dWjOiQ50TfBxfl+z1mjCae8jDnfOYN1aCvUZWJXqM1OpL56v6mWRyXwZ5C9qJJKDGmHTr4PVskQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.0.1.tgz",
+      "integrity": "sha512-t94HOTk5myfhvaHZzlUzk2hoUvH2jsjftcnMgJWuHL/pzjAJQoZDCUJzjkoXIUjWXuyJixTguaaDyOZWwqH2Kg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.0.0"
+        "@redis/client": "^5.0.1"
       }
     },
     "node_modules/@redis/search": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.0.0.tgz",
-      "integrity": "sha512-oEop/S/0NB5p7vpTTlp5X5LQO4oTomJnFEOaKhQ5xZWROLXTgEVvPSfXVNBbtr9maU2+OupxXQR63HW3MGeTUg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.0.1.tgz",
+      "integrity": "sha512-wipK6ZptY7K68B7YLVhP5I/wYCDUU+mDJMyJiUcQLuOs7/eKOBc8lTXKUSssor8QnzZSPy4A5ulcC5PZY22Zgw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.0.0"
+        "@redis/client": "^5.0.1"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.0.0.tgz",
-      "integrity": "sha512-DNsP4DH5CRfXlQDyvLJm2DltZm3kjpVKZsNTI3SPdbRxhc9i2c0NehUbM/gDECnEfG+jkNN/LUv6Em4LaLwPBQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.0.1.tgz",
+      "integrity": "sha512-k6PgbrakhnohsEWEAdQZYt3e5vSKoIzpKvgQt8//lnWLrTZx+c3ed2sj0+pKIF4FvnSeuXLo4bBWcH0Z7Urg1A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.0.0"
+        "@redis/client": "^5.0.1"
       }
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -48180,17 +48176,16 @@
       }
     },
     "node_modules/redis": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-5.0.0.tgz",
-      "integrity": "sha512-J/fzf0cYeFw5NP4aYIvv9owYOcNUsaDqF4qmwbSuaV4yKBLaIHJQIFbAKLgjn99GDXdJBbfqCRXE7+BIlkpATA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.0.1.tgz",
+      "integrity": "sha512-J8nqUjrfSq0E8NQkcHDZ4HdEQk5RMYjP3jZq02PE+ERiRxolbDNxPaTT4xh6tdrme+lJ86Goje9yMt9uzh23hQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@redis/bloom": "5.0.0",
-        "@redis/client": "5.0.0",
-        "@redis/json": "5.0.0",
-        "@redis/search": "5.0.0",
-        "@redis/time-series": "5.0.0"
+        "@redis/bloom": "5.0.1",
+        "@redis/client": "5.0.1",
+        "@redis/json": "5.0.1",
+        "@redis/search": "5.0.1",
+        "@redis/time-series": "5.0.1"
       },
       "engines": {
         "node": ">= 18"
@@ -48324,18 +48319,6 @@
       "dev": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
-      }
-    },
-    "node_modules/redis/node_modules/@redis/client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.0.0.tgz",
-      "integrity": "sha512-1MqfzOOoFBwWprigJ3S5hM+LuzaWwxyyx+74NDzCpmjKWyjjC07xkWsd5E9fr+61NUDtvUivRiyAxGiRIwJCaQ==",
-      "dev": true,
-      "dependencies": {
-        "cluster-key-slot": "1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "@opentelemetry/instrumentation": "0.50.0",
         "@opentelemetry/sdk-node": "^0.49.1",
         "@opentelemetry/sdk-trace-base": "^1.22.0",
-        "@redis/client": "^5.0.1",
         "@redis/client-v4": "npm:@redis/client@1.6.0",
         "@types/chai": "^4.3.0",
         "@types/detect-libc": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -157,7 +157,7 @@
         "proxyquire": "^2.1.3",
         "read-pkg-up": "^7.0.1",
         "recursive-copy": "^2.0.14",
-        "redis": "^4.7.0",
+        "redis": "^5.0.0",
         "redis-v3": "npm:redis@^3.1.2",
         "restify": "^11.1.0",
         "rimraf": "^3.0.2",
@@ -24219,62 +24219,68 @@
       "dev": true
     },
     "node_modules/@redis/bloom": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
-      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.0.0.tgz",
+      "integrity": "sha512-YHlra6a7+brJ3Ustqa+jC68Pdnw2/wbnVLeULN0llP3gHpKxOSmiDyLwuHq5t/jFi6QUgjSprUQi2a8CieKFIA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.0.0"
       }
     },
     "node_modules/@redis/client": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
-      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.0.0.tgz",
+      "integrity": "sha512-1MqfzOOoFBwWprigJ3S5hM+LuzaWwxyyx+74NDzCpmjKWyjjC07xkWsd5E9fr+61NUDtvUivRiyAxGiRIwJCaQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "cluster-key-slot": "1.1.2",
-        "generic-pool": "3.9.0",
-        "yallist": "4.0.0"
+        "cluster-key-slot": "1.1.2"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@redis/graph": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
-      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
-      "dev": true,
-      "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "node": ">= 18"
       }
     },
     "node_modules/@redis/json": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
-      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.0.0.tgz",
+      "integrity": "sha512-8YFjshsvWR9dWjOiQ50TfBxfl+z1mjCae8jDnfOYN1aCvUZWJXqM1OpL56v6mWRyXwZ5C9qJJKDGmHTr4PVskQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.0.0"
       }
     },
     "node_modules/@redis/search": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
-      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.0.0.tgz",
+      "integrity": "sha512-oEop/S/0NB5p7vpTTlp5X5LQO4oTomJnFEOaKhQ5xZWROLXTgEVvPSfXVNBbtr9maU2+OupxXQR63HW3MGeTUg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.0.0"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
-      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.0.0.tgz",
+      "integrity": "sha512-DNsP4DH5CRfXlQDyvLJm2DltZm3kjpVKZsNTI3SPdbRxhc9i2c0NehUbM/gDECnEfG+jkNN/LUv6Em4LaLwPBQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.0.0"
       }
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -36222,15 +36228,6 @@
         "is-property": "^1.0.2"
       }
     },
-    "node_modules/generic-pool": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
-      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/get-assigned-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
@@ -48157,17 +48154,20 @@
       }
     },
     "node_modules/redis": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
-      "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.0.0.tgz",
+      "integrity": "sha512-J/fzf0cYeFw5NP4aYIvv9owYOcNUsaDqF4qmwbSuaV4yKBLaIHJQIFbAKLgjn99GDXdJBbfqCRXE7+BIlkpATA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@redis/bloom": "1.2.0",
-        "@redis/client": "1.6.0",
-        "@redis/graph": "1.1.1",
-        "@redis/json": "1.0.7",
-        "@redis/search": "1.2.0",
-        "@redis/time-series": "1.1.0"
+        "@redis/bloom": "5.0.0",
+        "@redis/client": "5.0.0",
+        "@redis/json": "5.0.0",
+        "@redis/search": "5.0.0",
+        "@redis/time-series": "5.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/redis-commands": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,8 @@
         "@opentelemetry/instrumentation": "0.50.0",
         "@opentelemetry/sdk-node": "^0.49.1",
         "@opentelemetry/sdk-trace-base": "^1.22.0",
+        "@redis/client": "^5.0.1",
+        "@redis/client-v4": "npm:@redis/client@1.6.0",
         "@types/chai": "^4.3.0",
         "@types/detect-libc": "^1.0.0",
         "@types/event-loop-lag": "^1.0.30",
@@ -24233,16 +24235,30 @@
       }
     },
     "node_modules/@redis/client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.0.0.tgz",
-      "integrity": "sha512-1MqfzOOoFBwWprigJ3S5hM+LuzaWwxyyx+74NDzCpmjKWyjjC07xkWsd5E9fr+61NUDtvUivRiyAxGiRIwJCaQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.0.1.tgz",
+      "integrity": "sha512-k0EJvlMGEyBqUD3orKe0UMZ66fPtfwqPIr+ZSd853sXj2EyhNtPXSx+J6sENXJNgAlEBhvD+57Dwt0qTisKB0A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@redis/client-v4": {
+      "name": "@redis/client",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
+      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "dev": true,
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@redis/json": {
@@ -48308,6 +48324,18 @@
       "dev": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/redis/node_modules/@redis/client": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.0.0.tgz",
+      "integrity": "sha512-1MqfzOOoFBwWprigJ3S5hM+LuzaWwxyyx+74NDzCpmjKWyjjC07xkWsd5E9fr+61NUDtvUivRiyAxGiRIwJCaQ==",
+      "dev": true,
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,7 @@
         "recursive-copy": "^2.0.14",
         "redis": "^5.0.0",
         "redis-v3": "npm:redis@^3.1.2",
+        "redis-v4": "npm:redis@^4.7.0",
         "restify": "^11.1.0",
         "rimraf": "^3.0.2",
         "semver": "^7.5.4",
@@ -36228,6 +36229,15 @@
         "is-property": "^1.0.2"
       }
     },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/get-assigned-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
@@ -48224,6 +48234,80 @@
       "dev": true,
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/redis-v4": {
+      "name": "redis",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
+      "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
+      "dev": true,
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.0",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
+    "node_modules/redis-v4/node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "dev": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/redis-v4/node_modules/@redis/client": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
+      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "dev": true,
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/redis-v4/node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "dev": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/redis-v4/node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/redis-v4/node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "dev": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/redis-v4/node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "dev": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@opentelemetry/instrumentation": "0.50.0",
         "@opentelemetry/sdk-node": "^0.49.1",
         "@opentelemetry/sdk-trace-base": "^1.22.0",
+        "@redis/client": "^5.0.1",
         "@redis/client-v4": "npm:@redis/client@1.6.0",
         "@types/chai": "^4.3.0",
         "@types/detect-libc": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -226,6 +226,7 @@
     "recursive-copy": "^2.0.14",
     "redis": "^5.0.0",
     "redis-v3": "npm:redis@^3.1.2",
+    "redis-v4": "npm:redis@^4.7.0",
     "restify": "^11.1.0",
     "rimraf": "^3.0.2",
     "semver": "^7.5.4",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "@opentelemetry/instrumentation": "0.50.0",
     "@opentelemetry/sdk-node": "^0.49.1",
     "@opentelemetry/sdk-trace-base": "^1.22.0",
-    "@redis/client": "^5.0.1",
     "@redis/client-v4": "npm:@redis/client@1.6.0",
     "@types/chai": "^4.3.0",
     "@types/detect-libc": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@opentelemetry/instrumentation": "0.50.0",
     "@opentelemetry/sdk-node": "^0.49.1",
     "@opentelemetry/sdk-trace-base": "^1.22.0",
+    "@redis/client": "^5.0.1",
     "@redis/client-v4": "npm:@redis/client@1.6.0",
     "@types/chai": "^4.3.0",
     "@types/detect-libc": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "proxyquire": "^2.1.3",
     "read-pkg-up": "^7.0.1",
     "recursive-copy": "^2.0.14",
-    "redis": "^4.7.0",
+    "redis": "^5.0.0",
     "redis-v3": "npm:redis@^3.1.2",
     "restify": "^11.1.0",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,8 @@
     "@opentelemetry/instrumentation": "0.50.0",
     "@opentelemetry/sdk-node": "^0.49.1",
     "@opentelemetry/sdk-trace-base": "^1.22.0",
+    "@redis/client": "^5.0.1",
+    "@redis/client-v4": "npm:@redis/client@1.6.0",
     "@types/chai": "^4.3.0",
     "@types/detect-libc": "^1.0.0",
     "@types/event-loop-lag": "^1.0.30",

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "proxyquire": "^2.1.3",
     "read-pkg-up": "^7.0.1",
     "recursive-copy": "^2.0.14",
-    "redis": "^5.0.0",
+    "redis": "^5.0.1",
     "redis-v3": "npm:redis@^3.1.2",
     "redis-v4": "npm:redis@^4.7.0",
     "restify": "^11.1.0",

--- a/packages/collector/test/tracing/database/redis/allowRootExitSpanApp.js
+++ b/packages/collector/test/tracing/database/redis/allowRootExitSpanApp.js
@@ -41,7 +41,7 @@ let client;
     const result = await client.multi().set('key', 'value').get('key').exec();
     log('value:', result);
 
-    await client.quit();
+    await client.close();
   } catch (err) {
     log('Failed to connect to Redis:', err);
   }

--- a/packages/collector/test/tracing/database/redis/allowRootExitSpanApp.js
+++ b/packages/collector/test/tracing/database/redis/allowRootExitSpanApp.js
@@ -19,7 +19,8 @@ require('../../../..')({
 const redis = require(process.env.REDIS_PKG);
 const { delay } = require('@instana/core/test/test_util');
 
-const logPrefix = `Redis allowRootExitSpan App (version: ${process.env.REDIS_VERSION}, 
+const redisVersion = process.env.REDIS_VERSION;
+const logPrefix = `Redis allowRootExitSpan App (version: ${redisVersion}, 
 require: ${process.env.REDIS_PKG}):\t`;
 
 log(logPrefix);
@@ -41,7 +42,12 @@ let client;
     const result = await client.multi().set('key', 'value').get('key').exec();
     log('value:', result);
 
-    await client.close();
+    // In v5, the quit is replaced by close
+    if (redisVersion === 'latest') {
+      await client.close();
+    } else {
+      await client.quit();
+    }
   } catch (err) {
     log('Failed to connect to Redis:', err);
   }

--- a/packages/collector/test/tracing/database/redis/app.js
+++ b/packages/collector/test/tracing/database/redis/app.js
@@ -149,7 +149,7 @@ app.get('/blocking', async (req, res) => {
 
 app.get('/scan-iterator', async (req, res) => {
   if (redisVersion === 'latest') {
-    // v5: SCAN iterators return batches of keys, enabling multi-key commands like mGet
+    // v5: SCAN iterators return collection of keys, enabling multi-key commands like mGet
     // eslint-disable-next-line no-restricted-syntax
     for await (const keys of connection.scanIterator()) {
       try {

--- a/packages/collector/test/tracing/database/redis/app.js
+++ b/packages/collector/test/tracing/database/redis/app.js
@@ -149,7 +149,7 @@ app.get('/blocking', async (req, res) => {
 
 app.get('/scan-iterator', async (req, res) => {
   if (redisVersion === 'latest') {
-    // Redis v5: SCAN iterators return batches of keys, enabling multi-key commands like mGet
+    // v5: SCAN iterators return batches of keys, enabling multi-key commands like mGet
     // eslint-disable-next-line no-restricted-syntax
     for await (const keys of connection.scanIterator()) {
       try {
@@ -159,7 +159,7 @@ app.get('/scan-iterator', async (req, res) => {
       }
     }
   } else {
-    // Redis v4: SCAN iterators return individual keys
+    // v4: SCAN iterators return individual keys
     // eslint-disable-next-line no-restricted-syntax
     for await (const key of connection.scanIterator()) {
       try {

--- a/packages/collector/test/tracing/database/redis/app.js
+++ b/packages/collector/test/tracing/database/redis/app.js
@@ -25,8 +25,9 @@ const port = require('../../../test_util/app-port')();
 
 const cls = require('../../../../../core/src/tracing/cls');
 const app = express();
+const REDIS_VERSION = process.env.REDIS_VERSION;
 const logPrefix =
-  `Redis App (version: ${process.env.REDIS_VERSION}, require: ${process.env.REDIS_PKG}, ` +
+  `Redis App (version: ${REDIS_VERSION}, require: ${process.env.REDIS_PKG}, ` +
   `cluster: ${process.env.REDIS_CLUSTER}, pid: ${process.pid}):\t`;
 const agentPort = process.env.INSTANA_AGENT_PORT;
 
@@ -34,7 +35,6 @@ let connectedToRedis = false;
 let connection;
 let connection2;
 const connect = require('./connect-via');
-const REDIS_VERSION = process.env.REDIS_VERSION || 'latest';
 
 function log() {
   const args = Array.prototype.slice.call(arguments);

--- a/packages/collector/test/tracing/database/redis/connect-via/default.js
+++ b/packages/collector/test/tracing/database/redis/connect-via/default.js
@@ -7,7 +7,6 @@
 module.exports = async function (redis, log) {
   const client = redis.createClient({ url: `redis://${process.env.REDIS}` });
   const client2 = redis.createClient({ url: `redis://${process.env.REDIS_ALTERNATIVE}` });
-  let pool;
   [client, client2].forEach(c => {
     c.on('error', err => log('Redis Client Error', err));
   });
@@ -20,22 +19,8 @@ module.exports = async function (redis, log) {
   await client2.connect();
   log(`Connected to client 2 (${process.env.REDIS_ALTERNATIVE}).`);
 
-  if (process.env.REDIS_VERSION === 'latest') {
-    pool = await redis.createClientPool({
-      url: `redis://${process.env.REDIS}`,
-
-      minimum: 1,
-      maximum: 100,
-      acquireTimeout: 3000,
-      cleanupDelay: 3000
-    });
-    pool.on('error', err => console.error('Redis Client Pool Error', err));
-    await pool.connect(); // Connect the pool
-    log(`Connected to pool(${process.env.REDIS}).`);
-  }
   return {
     connection1: client,
-    connection2: client2,
-    pool1: pool
+    connection2: client2
   };
 };

--- a/packages/collector/test/tracing/database/redis/connect-via/default.js
+++ b/packages/collector/test/tracing/database/redis/connect-via/default.js
@@ -7,7 +7,7 @@
 module.exports = async function (redis, log) {
   const client = redis.createClient({ url: `redis://${process.env.REDIS}` });
   const client2 = redis.createClient({ url: `redis://${process.env.REDIS_ALTERNATIVE}` });
-
+  let pool;
   [client, client2].forEach(c => {
     c.on('error', err => log('Redis Client Error', err));
   });
@@ -20,8 +20,22 @@ module.exports = async function (redis, log) {
   await client2.connect();
   log(`Connected to client 2 (${process.env.REDIS_ALTERNATIVE}).`);
 
+  if (process.env.REDIS_VERSION === 'latest') {
+    pool = await redis.createClientPool({
+      url: `redis://${process.env.REDIS}`,
+
+      minimum: 1,
+      maximum: 100,
+      acquireTimeout: 3000,
+      cleanupDelay: 3000
+    });
+    pool.on('error', err => console.error('Redis Client Pool Error', err));
+    await pool.connect(); // Connect the pool
+    log(`Connected to pool(${process.env.REDIS}).`);
+  }
   return {
     connection1: client,
-    connection2: client2
+    connection2: client2,
+    pool1: pool
   };
 };

--- a/packages/collector/test/tracing/database/redis/connect-via/index.js
+++ b/packages/collector/test/tracing/database/redis/connect-via/index.js
@@ -8,6 +8,9 @@ module.exports = function (redis, log) {
   if (process.env.REDIS_CLUSTER === 'true') {
     return require('./cluster')(redis, log);
   }
+  if (process.env.REDIS_POOL === 'true') {
+    return require('./pool')(redis, log);
+  }
 
   return require('./default')(redis, log);
 };

--- a/packages/collector/test/tracing/database/redis/connect-via/pool.js
+++ b/packages/collector/test/tracing/database/redis/connect-via/pool.js
@@ -1,0 +1,16 @@
+/*
+ * (c) Copyright IBM Corp. 2025
+ */
+
+'use strict';
+
+module.exports = async function (redis, log) {
+  const pool = await redis.createClientPool({
+    url: `redis://${process.env.REDIS}`
+  });
+  // eslint-disable-next-line no-console
+  pool.on('error', err => console.error('Redis Client Pool Error', err));
+  await pool.connect();
+  log(`Connected to pool(${process.env.REDIS}).`);
+  return { connection1: pool };
+};

--- a/packages/collector/test/tracing/database/redis/mockVersion.js
+++ b/packages/collector/test/tracing/database/redis/mockVersion.js
@@ -15,9 +15,9 @@ let mockedModuleName;
 if (REDIS_PKG === 'redis') {
   mockedModuleName = REDIS_VERSION === 'latest' ? 'redis' : `redis-${REDIS_VERSION}`;
 } else if (REDIS_PKG === '@redis/client') {
-  // NOTE: The @redis/client package was introduced with Redis v4 (client v1).
-  // In Redis v5, the versioning of @redis/client was aligned with Redis itself,
-  // so @redis/client v5 corresponds to Redis v5.
+  // NOTE: The '@redis/client' package was introduced with Redis v4 (client v1).
+  // In Redis v5, the versioning of '@redis/client' was aligned with Redis itself,
+  // so '@redis/client' v5 corresponds to Redis v5.
   mockedModuleName = REDIS_VERSION === 'latest' ? '@redis/client' : `@redis/client-${REDIS_VERSION}`;
 }
 

--- a/packages/collector/test/tracing/database/redis/mockVersion.js
+++ b/packages/collector/test/tracing/database/redis/mockVersion.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const mock = require('@instana/core/test/test_util/mockRequire');
+const hook = require('../../../../../core/src/util/hook');
 
 const REDIS_PKG = process.env.REDIS_PKG;
 const REDIS_VERSION = process.env.REDIS_VERSION;
@@ -23,3 +24,24 @@ if (REDIS_PKG === 'redis') {
 if (mockedModuleName !== REDIS_PKG) {
   mock(REDIS_PKG, mockedModuleName);
 }
+
+const originalOnFileLoad = hook.onFileLoad;
+
+hook.onFileLoad = function onFileLoad() {
+  const source = arguments[0]?.source;
+
+  if (
+    mockedModuleName.startsWith('@redis/client') &&
+    (source === '\\/@redis\\/client\\/dist\\/lib\\/commands\\/index.js' ||
+      source === '\\/@redis\\/client\\/dist\\/lib\\/cluster\\/commands.js')
+  ) {
+    const updatedSource = source.replace('@redis\\/client', mockedModuleName);
+
+    const regex = new RegExp(updatedSource);
+    arguments[0] = regex;
+
+    return originalOnFileLoad.apply(this, arguments);
+  }
+
+  return originalOnFileLoad.apply(this, arguments);
+};

--- a/packages/collector/test/tracing/database/redis/mockVersion.js
+++ b/packages/collector/test/tracing/database/redis/mockVersion.js
@@ -6,9 +6,20 @@
 
 const mock = require('@instana/core/test/test_util/mockRequire');
 
+const REDIS_PKG = process.env.REDIS_PKG;
 const REDIS_VERSION = process.env.REDIS_VERSION;
-const REDIS_REQUIRE = process.env.REDIS_VERSION === 'latest' ? 'redis' : `redis-${REDIS_VERSION}`;
 
-if (REDIS_REQUIRE !== 'redis') {
-  mock('redis', REDIS_REQUIRE);
+let mockedModuleName;
+
+if (REDIS_PKG === 'redis') {
+  mockedModuleName = REDIS_VERSION === 'latest' ? 'redis' : `redis-${REDIS_VERSION}`;
+} else if (REDIS_PKG === '@redis/client') {
+  // NOTE: The @redis/client package was introduced with Redis v4 (client v1).
+  // In Redis v5, the versioning of @redis/client was aligned with Redis itself,
+  // so @redis/client v5 corresponds to Redis v5.
+  mockedModuleName = REDIS_VERSION === 'latest' ? '@redis/client' : `@redis/client-${REDIS_VERSION}`;
+}
+
+if (mockedModuleName !== REDIS_PKG) {
+  mock(REDIS_PKG, mockedModuleName);
 }

--- a/packages/collector/test/tracing/database/redis/test.js
+++ b/packages/collector/test/tracing/database/redis/test.js
@@ -749,7 +749,7 @@ const legacyVersion = 'v3';
               // scanIterator not available on cluster.
               if (setupType !== 'cluster') {
                 // eslint-disable-next-line mocha/no-exclusive-tests
-                it.only('must trace scan iterator usage', () =>
+                it('must trace scan iterator usage', () =>
                   controls
                     .sendRequest({
                       method: 'GET',
@@ -759,7 +759,7 @@ const legacyVersion = 'v3';
                       retry(() =>
                         agentControls.getSpans().then(spans => {
                           // eslint-disable-next-line no-console
-                          console.log('-----------------------------------', spans);
+                          console.log('-----------------------------------', JSON.stringify(spans));
                           const entrySpan = expectAtLeastOneMatching(spans, [
                             span => expect(span.n).to.equal('node.http.server'),
                             span => expect(span.data.http.method).to.equal('GET')

--- a/packages/collector/test/tracing/database/redis/test.js
+++ b/packages/collector/test/tracing/database/redis/test.js
@@ -90,7 +90,7 @@ const legacyVersion = 'v3';
             // In v5, Redis moved “Isolation Pool” into RedisClientPool.
             // see: //github.com/redis/node-redis/blob/master/docs/pool.md
             if (redisVersion === 'latest') {
-              mochaSuiteFn('When clientpool is used', function () {
+              mochaSuiteFn('When connected via clientpool', function () {
                 globalAgent.setUpCleanUpHooks();
                 let controls;
 
@@ -771,7 +771,7 @@ const legacyVersion = 'v3';
                             span => expect(span.n).to.equal('node.http.server'),
                             span => expect(span.data.http.method).to.equal('GET')
                           ]);
-                          // NOTE: Redis v5 SCAN iterators yield batches of keys, enabling multi-key commands like MGET.
+                          // NOTE: v5 SCAN iterators yield batches of keys, enabling multi-key commands like MGET.
                           // See: https://github.com/redis/node-redis/blob/master/docs/v4-to-v5.md#scan-iterators
                           const expectedSpanCount = redisVersion === 'latest' ? 1 : 4;
                           const expectedRedisCommand = redisVersion === 'latest' ? 'mGet' : 'get';
@@ -797,8 +797,8 @@ const legacyVersion = 'v3';
               }
 
               // See https://redis.js.org/#node-redis-usage-basic-example blocking commands
-              // In Redis v5, the "Isolation Pool" was introduced via RedisClientPool.
-              // Since it requires a new type of pool connection, a separate test suite  created starting from v5.
+              // In v5, the "Isolation Pool" was introduced via RedisClientPool.
+              // Since it requires a new type of pool connection, skipping the test.
               if (redisVersion !== 'latest') {
                 it('blocking', () => testBlockingCommand(controls, setupType));
               }

--- a/packages/collector/test/tracing/database/redis/test.js
+++ b/packages/collector/test/tracing/database/redis/test.js
@@ -748,7 +748,8 @@ const legacyVersion = 'v3';
 
               // scanIterator not available on cluster.
               if (setupType !== 'cluster') {
-                it('must trace scan iterator usage', () =>
+                // eslint-disable-next-line mocha/no-exclusive-tests
+                it.only('must trace scan iterator usage', () =>
                   controls
                     .sendRequest({
                       method: 'GET',
@@ -757,11 +758,13 @@ const legacyVersion = 'v3';
                     .then(() =>
                       retry(() =>
                         agentControls.getSpans().then(spans => {
+                          // eslint-disable-next-line no-console
+                          console.log('-----------------------------------', spans);
                           const entrySpan = expectAtLeastOneMatching(spans, [
                             span => expect(span.n).to.equal('node.http.server'),
                             span => expect(span.data.http.method).to.equal('GET')
                           ]);
-                          // NOTE: v5 SCAN iterators yield batches of keys, enabling multi-key commands like MGET.
+                          // NOTE: v5 SCAN iterators yield collection of keys, enabling multi-key commands like MGET.
                           // See: https://github.com/redis/node-redis/blob/master/docs/v4-to-v5.md#scan-iterators
                           const expectedSpanCount = redisVersion === 'latest' ? 1 : 4;
                           const expectedRedisCommand = redisVersion === 'latest' ? 'mGet' : 'get';

--- a/packages/collector/test/tracing/database/redis/test.js
+++ b/packages/collector/test/tracing/database/redis/test.js
@@ -88,7 +88,7 @@ const legacyVersion = 'v3';
               });
             });
             // In v5, Redis moved “Isolation Pool” into RedisClientPool.
-            // see: //github.com/redis/node-redis/blob/master/docs/pool.md
+            // see: https://github.com/redis/node-redis/blob/master/docs/pool.md
             if (redisVersion === 'latest') {
               mochaSuiteFn('When connected via clientpool', function () {
                 globalAgent.setUpCleanUpHooks();
@@ -787,8 +787,9 @@ const legacyVersion = 'v3';
               }
 
               // See https://redis.js.org/#node-redis-usage-basic-example blocking commands
-              // In v5, the "Isolation Pool" was introduced via RedisClientPool.
-              // Since it requires a new type of pool connection, skipping the test.
+              // The "Isolation Pool" was introduced via RedisClientPool in v5.
+              // This new pool type requires a different connection mechanism.
+              // As a result, this test is being skipped.
               if (redisVersion !== 'latest') {
                 it('blocking', () => testBlockingCommand(controls, setupType));
               }

--- a/packages/collector/test/tracing/database/redis/test.js
+++ b/packages/collector/test/tracing/database/redis/test.js
@@ -748,7 +748,6 @@ const legacyVersion = 'v3';
 
               // scanIterator not available on cluster.
               if (setupType !== 'cluster') {
-                // eslint-disable-next-line mocha/no-exclusive-tests
                 it('must trace scan iterator usage', () =>
                   controls
                     .sendRequest({
@@ -758,8 +757,6 @@ const legacyVersion = 'v3';
                     .then(() =>
                       retry(() =>
                         agentControls.getSpans().then(spans => {
-                          // eslint-disable-next-line no-console
-                          console.log('-----------------------------------', JSON.stringify(spans));
                           const entrySpan = expectAtLeastOneMatching(spans, [
                             span => expect(span.n).to.equal('node.http.server'),
                             span => expect(span.data.http.method).to.equal('GET')

--- a/packages/collector/test/tracing/database/redis/test.js
+++ b/packages/collector/test/tracing/database/redis/test.js
@@ -712,7 +712,7 @@ const legacyVersion = 'v3';
 
               // scanIterator not available on cluster.
               if (setupType !== 'cluster') {
-                it.skip('must trace scan iterator usage', () =>
+                it('must trace scan iterator usage', () =>
                   controls
                     .sendRequest({
                       method: 'GET',

--- a/packages/collector/test/tracing/database/redis/test.js
+++ b/packages/collector/test/tracing/database/redis/test.js
@@ -798,7 +798,7 @@ const legacyVersion = 'v3';
 
               // See https://redis.js.org/#node-redis-usage-basic-example blocking commands
               // In Redis v5, the "Isolation Pool" was introduced via RedisClientPool.
-              // Since it requires a new type of pool connection, the related tests have been moved to a separate suite starting from v5.
+              // Since it requires a new type of pool connection, a separate test suite  created starting from v5.
               if (redisVersion !== 'latest') {
                 it('blocking', () => testBlockingCommand(controls, setupType));
               }
@@ -1146,7 +1146,7 @@ const legacyVersion = 'v3';
           }
         }
 
-        function testBlockingCommand(controls, setupType) {
+        function testBlockingCommand(controls, setupTypes) {
           return controls.sendRequest({ method: 'GET', path: '/blocking' }).then(() =>
             retry(() =>
               agentControls.getSpans().then(spans => {
@@ -1165,7 +1165,7 @@ const legacyVersion = 'v3';
                   span => expect(span.async).to.not.exist,
                   span => expect(span.error).to.not.exist,
                   span => expect(span.ec).to.equal(0),
-                  span => verifyConnection(setupType, span),
+                  span => verifyConnection(setupTypes, span),
                   span => expect(span.data.redis.command).to.equal('blPop')
                 ]);
 

--- a/packages/collector/test/tracing/database/redis/test.js
+++ b/packages/collector/test/tracing/database/redis/test.js
@@ -97,10 +97,7 @@ const legacyVersion = 'v3';
                 before(async () => {
                   controls = new ProcessControls({
                     useGlobalAgent: true,
-                    appPath:
-                      redisVersion === legacyVersion
-                        ? path.join(__dirname, 'legacyApp.js')
-                        : path.join(__dirname, 'app.js'),
+                    appPath: path.join(__dirname, 'app.js'),
                     env: {
                       REDIS_VERSION: redisVersion,
                       REDIS_PKG: redisPkg,
@@ -113,13 +110,6 @@ const legacyVersion = 'v3';
 
                 beforeEach(async () => {
                   await agentControls.clearReceivedTraceData();
-                });
-
-                before(async () => {
-                  await controls.sendRequest({
-                    method: 'POST',
-                    path: '/clearkeys'
-                  });
                 });
 
                 after(async () => {

--- a/packages/core/src/tracing/instrumentation/database/redis.js
+++ b/packages/core/src/tracing/instrumentation/database/redis.js
@@ -76,12 +76,12 @@ function instrument(redis) {
 
           const wrapAddCommand = addCommandOriginalFn => {
             return function instrumentedAddCommandInstana() {
-              if (isCluster) {
-                selfMadeQueue.push(arguments[1]);
-              } else {
-                selfMadeQueue.push(arguments[0]);
-              }
-
+              // Redis Cluster Mode:
+              // v5: The command arguments are passed as the third argument (index 2)
+              // v4: The command arguments are passed as the second argument (index 1)
+              // Non-cluster mode: only one argument passed (the command)
+              const commandArg = isCluster ? arguments[2] || arguments[1] : arguments[0];
+              selfMadeQueue.push(commandArg);
               return addCommandOriginalFn.apply(this, arguments);
             };
           };

--- a/packages/core/src/tracing/instrumentation/database/redis.js
+++ b/packages/core/src/tracing/instrumentation/database/redis.js
@@ -77,8 +77,8 @@ function instrument(redis) {
           const wrapAddCommand = addCommandOriginalFn => {
             return function instrumentedAddCommandInstana() {
               // Redis Cluster Mode:
-              // v5: The command arguments are passed as the third argument (index 2)
-              // v4: The command arguments are passed as the second argument (index 1)
+              // v5: The command arguments are passed as the third argument.
+              // v4: The command arguments are passed as the second argument.
               // Non-cluster mode: only one argument passed (the command)
               const commandArg = isCluster ? arguments[2] || arguments[1] : arguments[0];
               selfMadeQueue.push(commandArg);
@@ -166,10 +166,9 @@ function instrument(redis) {
     };
 
     const instrumentPool = () => {
-      // In Redis v5, createClientPool was introduced. We check the property descriptor of `createClientPool`
-      // to determine how to instrument it, as it might be defined in different ways:
-      // - As a getter (in redis), which requires special handling.
-      // - As a regular function (@redis/client).
+      // In Redis v5, createClientPool support was added. The createClientPool defined in different ways:
+      //   1. As a getter (in redis), which requires special handling.
+      //   2. As a regular function (@redis/client).
       const poolDescriptor = Object.getOwnPropertyDescriptor(redis, 'createClientPool');
       if (poolDescriptor?.configurable) {
         if (typeof poolDescriptor.get === 'function') {

--- a/packages/core/src/tracing/instrumentation/database/redis.js
+++ b/packages/core/src/tracing/instrumentation/database/redis.js
@@ -26,11 +26,11 @@ exports.deactivate = function deactivate() {
 };
 
 exports.init = function init() {
-  // In v5, the location of the commands module has changed.
-  hook.onFileLoad(/\/@redis\/client\/dist\/lib\/commands\/index.js/, captureCommands);
   // v4 commands, "redis-commands" is outdated and no longer compatible with it
   hook.onFileLoad(/\/@redis\/client\/dist\/lib\/cluster\/commands.js/, captureCommands);
 
+  // In v5, the location of the commands module has changed.
+  hook.onFileLoad(/\/@redis\/client\/dist\/lib\/commands\/index.js/, captureCommands);
   hook.onModuleLoad('redis', instrument);
   hook.onModuleLoad('@redis/client', instrument);
 };

--- a/packages/core/src/tracing/instrumentation/database/redis.js
+++ b/packages/core/src/tracing/instrumentation/database/redis.js
@@ -179,7 +179,7 @@ function instrument(redis) {
               return creatPoolWrap(poolDescriptor.get.call(this));
             }
           });
-        } else if (typeof poolDescriptor.value === 'function') {
+        } else {
           shimmer.wrap(redis, 'createClientPool', creatPoolWrap);
         }
       }

--- a/packages/core/src/tracing/instrumentation/database/redis.js
+++ b/packages/core/src/tracing/instrumentation/database/redis.js
@@ -26,6 +26,8 @@ exports.deactivate = function deactivate() {
 };
 
 exports.init = function init() {
+  // In v5, the location of the commands module has changed.
+  hook.onFileLoad(/\/@redis\/client\/dist\/lib\/commands\/index.js/, captureCommands);
   // v4 commands, "redis-commands" is outdated and no longer compatible with it
   hook.onFileLoad(/\/@redis\/client\/dist\/lib\/cluster\/commands.js/, captureCommands);
 


### PR DESCRIPTION
### Redis v5: Changes in this PR

1. **Connection Termination**
   In Redis v5, the method `client.quit()` (or `client.QUIT`) has been deprecated and replaced by `client.close()`. 

2. **Scan Iterator Behavior**
   * **v4:** Iterators yielded individual elements.
   * **v5:** Iterators now yield entire collections.

3. **Cluster Command Signature Change**
   In Redis v5, the method `cluster.multi().addCommand()` has an updated signature.
   * The second argument is now a boolean (`isReadonly`), and the actual command array is passed as the third argument.

4. **Connection Pool**
   Redis v5 introduces a dedicated `RedisClientPool` class for managing connection pools.
   * **v4:** Pooling was handled internally by the `RedisClient` using an "Isolation Pool".
   * **v5:** Pooling responsibilities are now abstracted into a separate class.

5. **Internal File Structure Changes**
   Redis v5 introduces a new internal structure for the package, requiring updates to how we reference and mock internal modules.

6. **Package Versioning Alignment**
   The `@redis/client` package versioning now aligns with the Redis server version:
   * **v4:** `@redis/client` was versioned as 1.x.
   * **v5:** `@redis/client` is now versioned as 5.x.

### Additional Update

* The Redis Docker image has been updated to the latest version.

### Tasks

- [x] Replace client.quit() with client.close().
- [x] Update  test to support scan iterator handling.
- [x] Adjust cluster.multi().addCommand() to new signature.
- [x] Docker image update to latest
- [x] Update internal imports and mocks for new file structure.
- [x] Support RedisClientPool https://github.com/redis/node-redis/blob/master/docs/pool.md
- [x] Add support for createSentinel() https://github.com/redis/node-redis/blob/master/docs/sentinel.md : see https://github.com/instana/nodejs/pull/1737

### References

Release notes: https://github.com/redis/node-redis/releases/tag/redis%405.0.0
Migration guide: https://github.com/redis/node-redis/blob/master/docs/v4-to-v5.md

Ref: https://jsw.ibm.com/browse/INSTA-35744