### PR TITLE
chore: fixed relative path resolution in tekton pipeline generation script

### DIFF
--- a/.tekton/generate-default-pipeline.js
+++ b/.tekton/generate-default-pipeline.js
@@ -5,8 +5,13 @@
 'use strict';
 
 const fs = require('fs');
-let templateContent = fs.readFileSync('./templates/default-pipeline.yaml.template', 'utf-8');
-const taskTemplateContent = fs.readFileSync('./templates/default-pipeline-test-task.yaml.template', 'utf-8');
+const path = require('path');
+
+let templateContent = fs.readFileSync(path.join(__dirname, 'templates/default-pipeline.yaml.template'), 'utf-8');
+const taskTemplateContent = fs.readFileSync(
+  path.join(__dirname, 'templates/default-pipeline-test-task.yaml.template'),
+  'utf-8'
+);
 
 const files = fs.readdirSync('./tasks/test-groups');
 const names = files.map(f => f.replace('-task.yaml', ''));
@@ -20,7 +25,7 @@ names.forEach(name => {
 
 templateContent = templateContent.replace('{{test-tasks}}', content);
 
-const location = './pipeline/default-pipeline.yaml';
+const location = path.join(__dirname, 'pipeline', 'default-pipeline.yaml');
 
 if (fs.existsSync(location)) {
   fs.unlinkSync(location);

--- a/.tekton/generate-test-files.js
+++ b/.tekton/generate-test-files.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 
 const groups = {
   'test:ci:collector:general': {
@@ -116,8 +117,8 @@ const groups = {
 const sidecars = require('./assets/sidecars.json');
 
 for (const [groupName, { sidecars: groupSidecars, condition }] of Object.entries(groups)) {
-  const templateContent = fs.readFileSync('./templates/test-task.yaml.template', 'utf-8');
-  const sidecarTemplate = fs.readFileSync('./templates/sidecar.yaml.template', 'utf-8');
+  const templateContent = fs.readFileSync(path.join(__dirname, 'templates/test-task.yaml.template'), 'utf-8');
+  const sidecarTemplate = fs.readFileSync(path.join(__dirname, 'templates/sidecar.yaml.template'), 'utf-8');
   const sanitizedGroupName = groupName.replace(/:/g, '-');
 
   const groupSidecarDetails = groupSidecars
@@ -227,7 +228,7 @@ for (const [groupName, { sidecars: groupSidecars, condition }] of Object.entries
     .join('\n');
 
   const fileName = `${sanitizedGroupName}-task.yaml`;
-  const location = `./tasks/test-groups/${fileName}`;
+  const location = path.join(__dirname,  'tasks', 'test-groups', fileName);
 
   if (fs.existsSync(location)) {
     fs.unlinkSync(location);


### PR DESCRIPTION
When running `generate-test-files.js` or `generate-default-pipeline.js` from a different working directory, the scripts failed to locate their template files or write the generated pipeline to the intended location.
This PR updates all filesystem references to use `path.join(__dirname, …)` ensuring the scripts work correctly no matter where they’re called.
