### PR TITLE
chore: updated ecmaVersion to 2022

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,9 +18,8 @@ module.exports = {
   },
 
   parserOptions: {
-    // https://node.green/#ES2020
-    // Min version is 14, ES2020 looks appropiate.
-    ecmaVersion: 2020,
+    // https://node.green/#ES2022
+    ecmaVersion: 2022,
     sourceType: 'script'
   },
 

--- a/misc/jscodeshift-transforms/.eslintrc.js
+++ b/misc/jscodeshift-transforms/.eslintrc.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'module'
   }
 };

--- a/packages/aws-lambda-auto-wrap/esm/.eslintrc.js
+++ b/packages/aws-lambda-auto-wrap/esm/.eslintrc.js
@@ -7,7 +7,7 @@
 module.exports = {
   extends: '../../../.eslintrc.js',
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: 'script'
   }
 };


### PR DESCRIPTION
- otherwise we cannot use modern syntax
- we support +v18
- https://node.green/#ES2022

For example we cannot use class arrow functions. It throws an eslint error.

```js
warn = () => blubb()
```