### PR TITLE
fix(aws-lambda): resolved TypeError when memory is too low

### DIFF
--- a/packages/aws-lambda/test/using_api/test.js
+++ b/packages/aws-lambda/test/using_api/test.js
@@ -30,6 +30,9 @@ function prelude(opts) {
   if (opts.instanaEndpointUrlMissing) {
     env.INSTANA_ENDPOINT_URL = '';
   }
+  if (opts.instanaAgentKeyMissing) {
+    env.INSTANA_AGENT_KEY = '';
+  }
   if (opts.instanaAgentKey) {
     env.INSTANA_AGENT_KEY = opts.instanaAgentKey;
   }
@@ -350,6 +353,41 @@ describe('Using the API', function () {
     });
 
     it('must ignore the missing URL gracefully', () => {
+      return verify(control, false, false);
+    });
+  });
+
+  describe('when INSTANA_AGENT_KEY is missing', function () {
+    // - INSTANA_AGENT_KEY is missing
+    // - INSTANA_ENDPOINT_URL is configured
+    const env = prelude.bind(this)({
+      handlerDefinitionPath,
+      instanaAgentKeyMissing: true
+    });
+
+    let control;
+
+    before(async () => {
+      control = new Control({
+        faasRuntimePath: path.join(__dirname, '../runtime_mock'),
+        handlerDefinitionPath: handlerDefinitionPath,
+        startBackend: true,
+        env
+      });
+
+      await control.start();
+    });
+
+    beforeEach(async () => {
+      await control.reset();
+      await control.resetBackendSpansAndMetrics();
+    });
+
+    after(async () => {
+      await control.stop();
+    });
+
+    it('must not expect spans or metrics', () => {
       return verify(control, false, false);
     });
   });

--- a/packages/serverless/src/logger.js
+++ b/packages/serverless/src/logger.js
@@ -62,45 +62,15 @@ class InstanaServerlessLogger {
     return minLevel === DEBUG_LEVEL;
   }
 
-  info() {
-    if (!this.logger.info) {
-      return;
-    }
+  warn = (...args) => this.logger?.warn?.(...args);
 
-    this.logger.info.apply(this.logger, arguments);
-  }
+  error = (...args) => this.logger?.error?.(...args);
 
-  warn() {
-    if (!this.logger.warn) {
-      return;
-    }
+  info = (...args) => this.logger?.info?.(...args);
 
-    this.logger.warn.apply(this.logger, arguments);
-  }
+  debug = (...args) => this.logger?.debug?.(...args);
 
-  error() {
-    if (!this.logger.error) {
-      return;
-    }
-
-    this.logger.error.apply(this.logger, arguments);
-  }
-
-  debug() {
-    if (!this.logger.debug) {
-      return;
-    }
-
-    this.logger.debug.apply(this.logger, arguments);
-  }
-
-  trace() {
-    if (!this.logger.trace) {
-      return;
-    }
-
-    this.logger.trace.apply(this.logger, arguments);
-  }
+  trace = (...args) => this.logger?.trace?.(...args);
 }
 
 exports.init = function init(config = {}) {


### PR DESCRIPTION
```{
  "errorType": "TypeError",
  "errorMessage": "Cannot read properties of undefined (reading 'logger')",
  "trace": [
    "TypeError: Cannot read properties of undefined (reading 'logger')",
    "    at warn (/opt/nodejs/node_modules/@instana/serverless/src/logger.js:74:15)",
    "    at shouldUseLambdaExtension (/opt/nodejs/node_modules/@instana/aws-lambda/src/wrapper.js:383:7)",
    "    at init (/opt/nodejs/node_modules/@instana/aws-lambda/src/wrapper.js:259:30)",
    "    at shimmedHandler (/opt/nodejs/node_modules/@instana/aws-lambda/src/wrapper.js:71:26)",
    "    at handler1 (/opt/nodejs/node_modules/@instana/aws-lambda/src/wrapper.js:52:16)",
    "    at Runtime.instanaAutowrapHandler [as handler] (/opt/nodejs/node_modules/instana-aws-lambda-auto-wrap-esm/index.js:24:10)"
  ]
}