### PR TITLE
chore: handled manual test interruption gracefully

### DIFF
--- a/packages/collector/test/test_util/portfinder.js
+++ b/packages/collector/test/test_util/portfinder.js
@@ -147,6 +147,12 @@ module.exports = function findPort(minPort) {
 
     ports[port] = port;
   } catch (err) {
+    // If the test is manually interrupted, exit gracefully.
+    if (err.signal === 'SIGINT') {
+      // eslint-disable-next-line no-console
+      console.log('Test interrupted manually (SIGINT). Skipping port search.');
+      return null;
+    }
     // eslint-disable-next-line no-console
     console.log('Error when looking for port', err);
     return findPort();


### PR DESCRIPTION
Avoids unnecessary retries or error logs when tests are manually interrupted (SIGINT), allowing for a clean and silent exit during local development.

Previously, interrupting a test run (e.g., via Ctrl+C) would cause the portfinder to throw an error when continue attempting to find a port.