### PR TITLE
build: bumped node-rdkafka from 3.3.1 to 3.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -190,7 +190,7 @@
         "couchbase-v443": "npm:couchbase@4.4.3",
         "ibm_db": "^3.3.0",
         "kafka-avro": "^3.2.0",
-        "node-rdkafka": "^3.3.1",
+        "node-rdkafka": "^3.4.0",
         "pg-native": "^3.4.5",
         "prisma": "^6.7.0"
       }
@@ -44699,10 +44699,11 @@
       }
     },
     "node_modules/node-rdkafka": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-3.3.1.tgz",
-      "integrity": "sha512-dx4vHvt1RkoGsOVqGQBpu72WRx/7+1FyeZMB+f3frQODRlAFnUgFhK+h+dWuL9Majx0FFdgVx8VehOgJT6vGrw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-3.4.0.tgz",
+      "integrity": "sha512-jLFIsGzlAq8hHMY+c0B7e8vEZs9qs65tr95GTUqgSc95qCNE97Nk9f1kor2isXdLC3diILKqzk+oKqmRYO64MA==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "bindings": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "couchbase-v443": "npm:couchbase@4.4.3",
     "ibm_db": "^3.3.0",
     "kafka-avro": "^3.2.0",
-    "node-rdkafka": "^3.3.1",
+    "node-rdkafka": "^3.4.0",
     "pg-native": "^3.4.5",
     "prisma": "^6.7.0"
   },

--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -317,7 +317,6 @@ class ProcessControls {
       requestOpts.ca = cert;
 
       let response;
-
       const result = await fetch(requestOpts.url, requestOpts);
       const contentType = result.headers.get('content-type');
 

--- a/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
@@ -28,8 +28,9 @@ const isStream = process.env.RDKAFKA_CONSUMER_AS_STREAM === 'true';
 const app = express();
 
 const topic = 'rdkafka-topic';
+let consumerReady = false;
 
-function getConsumer() {
+function setupConsumer() {
   /** @type {Kafka.KafkaConsumer | Kafka.ConsumerStream} */
   let _consumer;
 
@@ -49,8 +50,13 @@ function getConsumer() {
       }
     );
 
-    _consumer.on('error', err => {
+    _consumer.consumer.on('error', err => {
       log('Consumer stream error:', err);
+    });
+
+    _consumer.consumer.on('ready', () => {
+      log('Consumer stream ready.');
+      consumerReady = true;
     });
 
     if (process.env.RDKAFKA_CONSUMER_ERROR && process.env.RDKAFKA_CONSUMER_ERROR === 'streamErrorReceiver') {
@@ -71,7 +77,7 @@ function getConsumer() {
     }
 
     _consumer.on('data', async data => {
-      log('Got stream message');
+      log('Got stream message', data);
 
       const span = instana.currentSpan();
       span.disableAutoEnd();
@@ -93,13 +99,14 @@ function getConsumer() {
     });
   } else {
     _consumer = new Kafka.KafkaConsumer(consumerOptions);
-
     _consumer.connect();
 
     _consumer
       .on('ready', () => {
-        log('Consumer Ready.');
+        log('Consumer Standard Ready.');
+        consumerReady = true;
 
+        log('Subscribing to topic', topic);
         _consumer.subscribe([topic]);
 
         // Consume from the rdkafka-topic. This is what determines
@@ -115,7 +122,7 @@ function getConsumer() {
         // }, 100);
       })
       .on('data', async data => {
-        log('Got standard message');
+        log('Got standard message', data);
 
         const span = instana.currentSpan();
         span.disableAutoEnd();
@@ -139,10 +146,10 @@ function getConsumer() {
   return _consumer;
 }
 
-const consumer = getConsumer();
+setupConsumer();
 
 app.get('/', (_req, res) => {
-  if (consumer.read || (consumer.isConnected && consumer.isConnected())) {
+  if (consumerReady) {
     res.send('ok');
   } else {
     res.status(500).send('rdkafka Consumer is not ready yet.');

--- a/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
@@ -34,7 +34,7 @@ function getConsumer() {
   let _consumer;
 
   const consumerOptions = {
-    'metadata.broker.list': '127.0.0.1:9092',
+    'metadata.broker.list': process.env.KAFKA,
     'group.id': uuid()
   };
 
@@ -98,7 +98,7 @@ function getConsumer() {
 
     _consumer
       .on('ready', () => {
-        log('Standard Ready.');
+        log('Consumer Ready.');
 
         _consumer.subscribe([topic]);
 

--- a/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
@@ -95,7 +95,9 @@ function getProducer(isStream = false) {
 
     // We must either call .poll() manually after sending messages or set the producer to poll on an interval.
     // Without this, we do not get delivery events and the queue will eventually fill up.
-    // TODO: 3.4.0 broke the delivery report. We have disabled the test for now.
+    // TODO: 3.4.0 introduces some bugs
+    // https://github.com/Blizzard/node-rdkafka/issues/1128
+    // https://github.com/Blizzard/node-rdkafka/issues/1123#issuecomment-2855329479
     if (enableDeliveryCb) {
       _producer.setPollInterval(100);
     }

--- a/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
@@ -100,7 +100,7 @@ function getProducer() {
 
     // We must either call .poll() manually after sending messages or set the producer to poll on an interval.
     // Without this, we do not get delivery events and the queue will eventually fill up.
-    // TODO: 3.4.0 introduces some bugs
+    // TODO: Critical performance problems since 3.4.0
     // https://github.com/Blizzard/node-rdkafka/issues/1128
     // https://github.com/Blizzard/node-rdkafka/issues/1123#issuecomment-2855329479
     if (enableDeliveryCb) {

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -36,8 +36,7 @@ const { verifyHttpRootEntry, verifyHttpExit } = require('@instana/core/test/test
 // TODO: 3.4.0 introduces some bugs
 // https://github.com/Blizzard/node-rdkafka/issues/1128
 // https://github.com/Blizzard/node-rdkafka/issues/1123#issuecomment-2855329479
-// const producerEnableDeliveryCbOptions = ['true', 'false'];
-const producerEnableDeliveryCbOptions = ['false'];
+const producerEnableDeliveryCbOptions = ['true', 'false'];
 const producerApiMethods = ['standard', 'stream'];
 const consumerApiMethods = ['standard', 'stream'];
 const objectModeMethods = ['true', 'false'];

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -50,6 +50,9 @@ const SINGLE_TEST_PROPS = {
 };
 
 const retryTime = 1000;
+const retryTimeUntil = Date.now() + 20000;
+const checkStartedEvery = 3000;
+const checkStaredUntil = Date.now() + 60000;
 const topic = 'rdkafka-topic';
 
 const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
@@ -101,8 +104,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
                       }
                     });
 
-                    await consumerControls.startAndWaitForAgentConnection(3000, new Date() + 60000);
-                    await producerControls.startAndWaitForAgentConnection(3000, new Date() + 60000);
+                    await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+                    await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
                   });
 
                   beforeEach(async () => {
@@ -198,7 +201,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         );
       },
       retryTime,
-      Date.now() + 20000
+      retryTimeUntil
     );
   }
 
@@ -306,7 +309,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
   }
 
   describe('tracing enabled, header format string', function () {
-    this.timeout(config.getTestTimeout() * 2);
+    this.timeout(config.getTestTimeout() * 10);
     let producerControls;
     let consumerControls;
 
@@ -320,8 +323,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         useGlobalAgent: true
       });
 
-      await producerControls.startAndWaitForAgentConnection();
-      await consumerControls.startAndWaitForAgentConnection();
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
     });
 
     beforeEach(async () => {
@@ -345,15 +348,19 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         path: apiPath
       });
 
-      await retry(async () => {
-        await verifyResponseAndMessage(response, consumerControls);
-        const spans = await agentControls.getSpans();
-        const httpEntry = verifyHttpRootEntry({ spans, apiPath, pid: String(producerControls.getPid()) });
-        const kafkaExit = verifyRdKafkaExit(producerControls, spans, httpEntry, null, false);
-        verifyHttpExit({ spans, parent: httpEntry, pid: String(producerControls.getPid()) });
-        const kafkaEntry = verifyRdKafkaEntry(consumerControls, spans, kafkaExit, null, false);
-        verifyHttpExit({ spans, parent: kafkaEntry, pid: String(consumerControls.getPid()) });
-      });
+      await retry(
+        async () => {
+          await verifyResponseAndMessage(response, consumerControls);
+          const spans = await agentControls.getSpans();
+          const httpEntry = verifyHttpRootEntry({ spans, apiPath, pid: String(producerControls.getPid()) });
+          const kafkaExit = verifyRdKafkaExit(producerControls, spans, httpEntry, null, false);
+          verifyHttpExit({ spans, parent: httpEntry, pid: String(producerControls.getPid()) });
+          const kafkaEntry = verifyRdKafkaEntry(consumerControls, spans, kafkaExit, null, false);
+          verifyHttpExit({ spans, parent: kafkaEntry, pid: String(consumerControls.getPid()) });
+        },
+        retryTime,
+        retryTimeUntil
+      );
     });
   });
 
@@ -376,8 +383,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         agentControls: customAgentControls
       });
 
-      await producerControls.startAndWaitForAgentConnection();
-      await consumerControls.startAndWaitForAgentConnection();
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
     });
 
     beforeEach(async () => {
@@ -402,15 +409,19 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         path: apiPath
       });
 
-      await retry(async () => {
-        await verifyResponseAndMessage(response, consumerControls);
-        const spans = await customAgentControls.getSpans();
-        const httpEntry = verifyHttpRootEntry({ spans, apiPath, pid: String(producerControls.getPid()) });
-        const kafkaExit = verifyRdKafkaExit(producerControls, spans, httpEntry, null, false);
-        verifyHttpExit({ spans, parent: httpEntry, pid: String(producerControls.getPid()) });
-        const kafkaEntry = verifyRdKafkaEntry(consumerControls, spans, kafkaExit, null, false);
-        verifyHttpExit({ spans, parent: kafkaEntry, pid: String(consumerControls.getPid()) });
-      });
+      await retry(
+        async () => {
+          await verifyResponseAndMessage(response, consumerControls);
+          const spans = await customAgentControls.getSpans();
+          const httpEntry = verifyHttpRootEntry({ spans, apiPath, pid: String(producerControls.getPid()) });
+          const kafkaExit = verifyRdKafkaExit(producerControls, spans, httpEntry, null, false);
+          verifyHttpExit({ spans, parent: httpEntry, pid: String(producerControls.getPid()) });
+          const kafkaEntry = verifyRdKafkaEntry(consumerControls, spans, kafkaExit, null, false);
+          verifyHttpExit({ spans, parent: kafkaEntry, pid: String(consumerControls.getPid()) });
+        },
+        retryTime,
+        retryTimeUntil
+      );
     });
   });
 
@@ -433,8 +444,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         useGlobalAgent: true
       });
 
-      await producerControls.startAndWaitForAgentConnection();
-      await consumerControls.startAndWaitForAgentConnection();
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
     });
 
     beforeEach(async () => {
@@ -458,15 +469,19 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         path: apiPath
       });
 
-      await retry(async () => {
-        await verifyResponseAndMessage(response, consumerControls);
-        const spans = await agentControls.getSpans();
-        const httpEntry = verifyHttpRootEntry({ spans, apiPath, pid: String(producerControls.getPid()) });
-        verifyRdKafkaExit(producerControls, spans, httpEntry, null, false);
-        verifyHttpExit({ spans, parent: httpEntry, pid: String(producerControls.getPid()) });
-        const kafkaEntry = verifyRdKafkaEntry(consumerControls, spans, null, null, false);
-        verifyHttpExit({ spans, parent: kafkaEntry, pid: String(consumerControls.getPid()) });
-      });
+      await retry(
+        async () => {
+          await verifyResponseAndMessage(response, consumerControls);
+          const spans = await agentControls.getSpans();
+          const httpEntry = verifyHttpRootEntry({ spans, apiPath, pid: String(producerControls.getPid()) });
+          verifyRdKafkaExit(producerControls, spans, httpEntry, null, false);
+          verifyHttpExit({ spans, parent: httpEntry, pid: String(producerControls.getPid()) });
+          const kafkaEntry = verifyRdKafkaEntry(consumerControls, spans, null, null, false);
+          verifyHttpExit({ spans, parent: kafkaEntry, pid: String(consumerControls.getPid()) });
+        },
+        retryTime,
+        retryTimeUntil
+      );
     });
   });
 
@@ -491,8 +506,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         agentControls: customAgentControls
       });
 
-      await producerControls.startAndWaitForAgentConnection();
-      await consumerControls.startAndWaitForAgentConnection();
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
     });
 
     beforeEach(async () => {
@@ -517,15 +532,19 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         path: apiPath
       });
 
-      await retry(async () => {
-        await verifyResponseAndMessage(response, consumerControls);
-        const spans = await customAgentControls.getSpans();
-        const httpEntry = verifyHttpRootEntry({ spans, apiPath, pid: String(producerControls.getPid()) });
-        verifyRdKafkaExit(producerControls, spans, httpEntry, null, false);
-        verifyHttpExit({ spans, parent: httpEntry, pid: String(producerControls.getPid()) });
-        const kafkaEntry = verifyRdKafkaEntry(consumerControls, spans, null, null, false);
-        verifyHttpExit({ spans, parent: kafkaEntry, pid: String(consumerControls.getPid()) });
-      });
+      await retry(
+        async () => {
+          await verifyResponseAndMessage(response, consumerControls);
+          const spans = await customAgentControls.getSpans();
+          const httpEntry = verifyHttpRootEntry({ spans, apiPath, pid: String(producerControls.getPid()) });
+          verifyRdKafkaExit(producerControls, spans, httpEntry, null, false);
+          verifyHttpExit({ spans, parent: httpEntry, pid: String(producerControls.getPid()) });
+          const kafkaEntry = verifyRdKafkaEntry(consumerControls, spans, null, null, false);
+          verifyHttpExit({ spans, parent: kafkaEntry, pid: String(consumerControls.getPid()) });
+        },
+        retryTime,
+        retryTimeUntil
+      );
     });
   });
 
@@ -543,7 +562,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           RDKAFKA_PRODUCER_DELIVERY_CB: 'false'
         }
       });
-      await producerControls.startAndWaitForAgentConnection();
+
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
     });
 
     beforeEach(async () => {
@@ -571,7 +591,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           }
         });
 
-        await consumerControls.startAndWaitForAgentConnection();
+        await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
       });
 
       beforeEach(async () => {
@@ -592,7 +612,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           path: '/produce/standard'
         });
 
-        return retry(() => verifyResponseAndMessage(response, consumerControls), retryTime)
+        return retry(() => verifyResponseAndMessage(response, consumerControls), retryTime, retryTimeUntil)
           .then(() => delay(1000))
           .then(() => agentControls.getSpans())
           .then(spans => {
@@ -615,7 +635,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           RDKAFKA_PRODUCER_DELIVERY_CB: 'false'
         }
       });
-      await producerControls.startAndWaitForAgentConnection();
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
     });
 
     beforeEach(async () => {
@@ -642,7 +662,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           }
         });
 
-        await receiverControls.startAndWaitForAgentConnection();
+        await receiverControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
       });
 
       beforeEach(async () => {
@@ -664,9 +684,13 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           suppressTracing: true
         });
 
-        return retry(() => {
-          verifyResponseAndMessage(response, receiverControls);
-        }, retryTime)
+        return retry(
+          () => {
+            verifyResponseAndMessage(response, receiverControls);
+          },
+          retryTime,
+          retryTimeUntil
+        )
           .then(() => delay(1000))
           .then(() => agentControls.getSpans())
           .then(spans => {
@@ -701,8 +725,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
             agentControls: customAgentControls
           });
 
-          await producerControls.startAndWaitForAgentConnection();
-          await consumerControls.startAndWaitForAgentConnection();
+          await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+          await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
         });
 
         beforeEach(async () => {
@@ -727,24 +751,28 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
             path: apiPath
           });
 
-          await retry(async () => {
-            await verifyResponseAndMessage(response, consumerControls);
-            const spans = await customAgentControls.getSpans();
-            // 1 x http server
-            // 1 x http client
-            expect(spans.length).to.equal(2);
+          await retry(
+            async () => {
+              await verifyResponseAndMessage(response, consumerControls);
+              const spans = await customAgentControls.getSpans();
+              // 1 x http server
+              // 1 x http client
+              expect(spans.length).to.equal(2);
 
-            const spanNames = spans.map(span => span.n);
-            // Flow: HTTP
-            //       ├── Kafka Produce (ignored)
-            //       │      └── Kafka Consume → HTTP (ignored)
-            //       └── HTTP exit (traced)
-            expect(spanNames).to.include('node.http.server');
-            expect(spanNames).to.include('node.http.client');
+              const spanNames = spans.map(span => span.n);
+              // Flow: HTTP
+              //       ├── Kafka Produce (ignored)
+              //       │      └── Kafka Consume → HTTP (ignored)
+              //       └── HTTP exit (traced)
+              expect(spanNames).to.include('node.http.server');
+              expect(spanNames).to.include('node.http.client');
 
-            // Since Kafka produce is ignored, both the produce operation and all downstream calls are also ignored.
-            expect(spanNames).to.not.include('kafka');
-          });
+              // Since Kafka produce is ignored, both the produce operation and all downstream calls are also ignored.
+              expect(spanNames).to.not.include('kafka');
+            },
+            retryTime,
+            retryTimeUntil
+          );
         });
       });
     });
@@ -767,8 +795,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           agentControls: customAgentControls
         });
 
-        await producerControls.startAndWaitForAgentConnection();
-        await consumerControls.startAndWaitForAgentConnection();
+        await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+        await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
       });
 
       beforeEach(async () => {
@@ -793,26 +821,30 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           path: apiPath
         });
 
-        await retry(async () => {
-          await verifyResponseAndMessage(response, consumerControls);
-          const spans = await customAgentControls.getSpans();
-          expect(spans.length).to.equal(3);
+        await retry(
+          async () => {
+            await verifyResponseAndMessage(response, consumerControls);
+            const spans = await customAgentControls.getSpans();
+            expect(spans.length).to.equal(3);
 
-          // Flow: HTTP
-          //       ├── Kafka Produce (traced)
-          //       │      └── Kafka Consume → HTTP (ignored)
-          //       └── HTTP exit (traced)
-          // Kafka send will still be present, but since Kafka consume is ignored, the consume operation
-          // and all subsequent downstream calls will also be ignored.
-          const spanNames = spans.map(span => span.n);
-          expect(spanNames).to.include('node.http.server');
-          expect(spanNames).to.include('node.http.client');
-          expect(spanNames).to.include('kafka');
+            // Flow: HTTP
+            //       ├── Kafka Produce (traced)
+            //       │      └── Kafka Consume → HTTP (ignored)
+            //       └── HTTP exit (traced)
+            // Kafka send will still be present, but since Kafka consume is ignored, the consume operation
+            // and all subsequent downstream calls will also be ignored.
+            const spanNames = spans.map(span => span.n);
+            expect(spanNames).to.include('node.http.server');
+            expect(spanNames).to.include('node.http.client');
+            expect(spanNames).to.include('kafka');
 
-          // Kafka send exists but consume is ignored
-          expect(spans.some(span => span.n === 'kafka' && span.data.kafka?.access === 'send')).to.be.true;
-          expect(spans.some(span => span.n === 'kafka' && span.data.kafka?.access === 'consume')).to.be.false;
-        });
+            // Kafka send exists but consume is ignored
+            expect(spans.some(span => span.n === 'kafka' && span.data.kafka?.access === 'send')).to.be.true;
+            expect(spans.some(span => span.n === 'kafka' && span.data.kafka?.access === 'consume')).to.be.false;
+          },
+          retryTime,
+          retryTimeUntil
+        );
       });
     });
   });

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -33,7 +33,9 @@ const globalAgent = require('../../../globalAgent');
 const { AgentStubControls } = require('../../../apps/agentStubControls');
 const { verifyHttpRootEntry, verifyHttpExit } = require('@instana/core/test/test_util/common_verifications');
 
-// TODO: 3.4.0 broke the delivery callback
+// TODO: 3.4.0 introduces some bugs
+// https://github.com/Blizzard/node-rdkafka/issues/1128
+// https://github.com/Blizzard/node-rdkafka/issues/1123#issuecomment-2855329479
 // const producerEnableDeliveryCbOptions = ['true', 'false'];
 const producerEnableDeliveryCbOptions = ['false'];
 const producerApiMethods = ['standard', 'stream'];
@@ -50,9 +52,9 @@ const SINGLE_TEST_PROPS = {
 };
 
 const retryTime = 1000;
-const retryTimeUntil = Date.now() + 20000;
+const retryTimeUntil = () => Date.now() + 20000;
 const checkStartedEvery = 3000;
-const checkStartedUntil = Date.now() + 60000;
+const checkStartedUntil = () => Date.now() + 60000;
 const topic = 'rdkafka-topic';
 
 const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
@@ -104,8 +106,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
                       }
                     });
 
-                    await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
-                    await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+                    await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
+                    await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
                   });
 
                   beforeEach(async () => {
@@ -323,8 +325,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         useGlobalAgent: true
       });
 
-      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
-      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
+      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
     });
 
     beforeEach(async () => {
@@ -383,8 +385,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         agentControls: customAgentControls
       });
 
-      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
-      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
+      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
     });
 
     beforeEach(async () => {
@@ -444,8 +446,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         useGlobalAgent: true
       });
 
-      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
-      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
+      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
     });
 
     beforeEach(async () => {
@@ -506,8 +508,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         agentControls: customAgentControls
       });
 
-      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
-      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
+      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
     });
 
     beforeEach(async () => {
@@ -563,7 +565,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         }
       });
 
-      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
     });
 
     beforeEach(async () => {
@@ -591,7 +593,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           }
         });
 
-        await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+        await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
       });
 
       beforeEach(async () => {
@@ -635,7 +637,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           RDKAFKA_PRODUCER_DELIVERY_CB: 'false'
         }
       });
-      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
     });
 
     beforeEach(async () => {
@@ -662,7 +664,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           }
         });
 
-        await receiverControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+        await receiverControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
       });
 
       beforeEach(async () => {
@@ -725,8 +727,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
             agentControls: customAgentControls
           });
 
-          await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
-          await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+          await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
+          await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
         });
 
         beforeEach(async () => {
@@ -795,8 +797,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           agentControls: customAgentControls
         });
 
-        await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
-        await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+        await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
+        await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil());
       });
 
       beforeEach(async () => {

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -52,7 +52,7 @@ const SINGLE_TEST_PROPS = {
 const retryTime = 1000;
 const retryTimeUntil = Date.now() + 20000;
 const checkStartedEvery = 3000;
-const checkStaredUntil = Date.now() + 60000;
+const checkStartedUntil = Date.now() + 60000;
 const topic = 'rdkafka-topic';
 
 const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
@@ -104,8 +104,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
                       }
                     });
 
-                    await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
-                    await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+                    await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+                    await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
                   });
 
                   beforeEach(async () => {
@@ -323,8 +323,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         useGlobalAgent: true
       });
 
-      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
-      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
     });
 
     beforeEach(async () => {
@@ -383,8 +383,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         agentControls: customAgentControls
       });
 
-      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
-      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
     });
 
     beforeEach(async () => {
@@ -444,8 +444,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         useGlobalAgent: true
       });
 
-      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
-      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
     });
 
     beforeEach(async () => {
@@ -506,8 +506,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         agentControls: customAgentControls
       });
 
-      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
-      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+      await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
     });
 
     beforeEach(async () => {
@@ -563,7 +563,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
         }
       });
 
-      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
     });
 
     beforeEach(async () => {
@@ -591,7 +591,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           }
         });
 
-        await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+        await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
       });
 
       beforeEach(async () => {
@@ -635,7 +635,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           RDKAFKA_PRODUCER_DELIVERY_CB: 'false'
         }
       });
-      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+      await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
     });
 
     beforeEach(async () => {
@@ -662,7 +662,7 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           }
         });
 
-        await receiverControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+        await receiverControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
       });
 
       beforeEach(async () => {
@@ -725,8 +725,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
             agentControls: customAgentControls
           });
 
-          await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
-          await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+          await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+          await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
         });
 
         beforeEach(async () => {
@@ -795,8 +795,8 @@ mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
           agentControls: customAgentControls
         });
 
-        await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
-        await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStaredUntil);
+        await producerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
+        await consumerControls.startAndWaitForAgentConnection(checkStartedEvery, checkStartedUntil);
       });
 
       beforeEach(async () => {

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -163,6 +163,7 @@ function instrumentedProduce(ctx, originalProduce, originalArgs) {
       // https://github.com/Blizzard/node-rdkafka/issues/1128
       // https://github.com/Blizzard/node-rdkafka/issues/1123#issuecomment-2855329479
       ctx.once('delivery-report', function instanaDeliveryReportListener(err) {
+        console.log('yeah delivery report');
         span.d = Date.now() - span.ts;
 
         if (err) {

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -159,7 +159,7 @@ function instrumentedProduce(ctx, originalProduce, originalArgs) {
     });
 
     if (deliveryCb) {
-      // TODO: 3.4.0 introduced some bugs
+      // TODO: Critical performance problems since 3.4.0
       // https://github.com/Blizzard/node-rdkafka/issues/1128
       // https://github.com/Blizzard/node-rdkafka/issues/1123#issuecomment-2855329479
       ctx.once('delivery-report', function instanaDeliveryReportListener(err) {

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -163,7 +163,6 @@ function instrumentedProduce(ctx, originalProduce, originalArgs) {
       // https://github.com/Blizzard/node-rdkafka/issues/1128
       // https://github.com/Blizzard/node-rdkafka/issues/1123#issuecomment-2855329479
       ctx.once('delivery-report', function instanaDeliveryReportListener(err) {
-        console.log('yeah delivery report');
         span.d = Date.now() - span.ts;
 
         if (err) {

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -159,6 +159,9 @@ function instrumentedProduce(ctx, originalProduce, originalArgs) {
     });
 
     if (deliveryCb) {
+      // TODO: 3.4.0 introduced some bugs
+      // https://github.com/Blizzard/node-rdkafka/issues/1128
+      // https://github.com/Blizzard/node-rdkafka/issues/1123#issuecomment-2855329479
       ctx.once('delivery-report', function instanaDeliveryReportListener(err) {
         span.d = Date.now() - span.ts;
 


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-35944

The reason why the tests where failing is a combination of node-rdkafka being slow and the tests and apps where not able to handle the slowness.

I saw locally some flaky tests, but I ran the CI tests are couple of times without any issues.
If the test becomes flaky on CI, we can e.g. remove running the delivery report test.

- [x] raise issue for node-rdkafka (super slow connection / operations + delivery report)
  - [x] https://github.com/Blizzard/node-rdkafka/issues/1128
  - [x] https://github.com/Blizzard/node-rdkafka/issues/1123#issuecomment-2855329479
- [x] raise JIRA to update Kafka from 2.x (EOL) to 3.x (https://jsw.ibm.com/browse/INSTA-36044)
- [x] make tests green with 3.4.0