### PR TITLE
chore: corrected the days behind calculation for currency reports

### DIFF
--- a/bin/currency/utils.js
+++ b/bin/currency/utils.js
@@ -122,7 +122,7 @@ exports.getLatestVersion = ({ pkgName, installedVersion, isBeta }) => {
 };
 
 function filterStableReleases(releaseList) {
-  const unstableReleaseKeyWords = ['alpha', 'beta', 'canary', 'dev', 'experimental', 'rc'];
+  const unstableReleaseKeyWords = ['alpha', 'beta', 'canary', 'dev', 'experimental', 'next', 'rc'];
 
   return Object.fromEntries(
     Object.entries(releaseList).filter(


### PR DESCRIPTION
The Redis "days behind" calculation was inaccurate because it did account for versions like 5.0.0-next.6 and 5.0.0-next.7. However, these are pre-release versions and were not tagged as part of the unstable releases. As a result, they were mistakenly included in the calculation. This has now been corrected by adding the next tag to the list of unstable release keywords.