### PR TITLE
ci: updated aws Lambda base image to node:20

### DIFF
--- a/packages/aws-lambda/layer/Dockerfile
+++ b/packages/aws-lambda/layer/Dockerfile
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. and contributors 2021
 
-FROM public.ecr.aws/lambda/nodejs:16
+FROM public.ecr.aws/lambda/nodejs:22
 
 WORKDIR /opt
 COPY tmp/ .

--- a/packages/aws-lambda/layer/Dockerfile
+++ b/packages/aws-lambda/layer/Dockerfile
@@ -1,7 +1,8 @@
 # (c) Copyright IBM Corp. 2021
 # (c) Copyright Instana Inc. and contributors 2021
 
-FROM public.ecr.aws/lambda/nodejs:22
+ARG NODEJS_VERSION
+FROM public.ecr.aws/lambda/nodejs:${NODEJS_VERSION}
 
 WORKDIR /opt
 COPY tmp/ .


### PR DESCRIPTION
We already dropped support for Node.js 16 aws lambda runtime in the last major release, we missed to update the dockerfile.

Updated the base image in the Dockerfile to public.ecr.aws/lambda/nodejs:22 to align with the latest Node.js version for AWS Lambda.