### PR TITLE
ci: updated npm installation logic in tekton pipelines

### DIFF
--- a/.tekton/tasks/install-npm-dependencies.yaml
+++ b/.tekton/tasks/install-npm-dependencies.yaml
@@ -42,8 +42,6 @@ spec:
 
         if [ -n "$(params.npm-version)" ]; then
           npm install npm@$(params.npm-version) -g
-        else
-          npm install npm -g
         fi     
 
         if [ "$(params.skip-cache)" == "true" ]; then


### PR DESCRIPTION
Previously, the logic was simple: if a specific npm-version was provided, it would install that version; otherwise, it would always install the latest npm version globally.

Now, the updated logic improves this by first checking if npm-version is provided—if yes, it installs that version. If not, it uses the npm is already available in the environment (which it usually is, since it's bundled with the Node.js image used in the tasks). .

This change helps avoid unnecessary global installations and makes better use of the preinstalled npm that comes with the Node.js base image.