### PR TITLE
build: bumped redis v5.0.1 to v5.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,7 +159,7 @@
         "proxyquire": "^2.1.3",
         "read-pkg-up": "^7.0.1",
         "recursive-copy": "^2.0.14",
-        "redis": "^5.0.1",
+        "redis": "^5.1.0",
         "redis-v3": "npm:redis@^3.1.2",
         "redis-v4": "npm:redis@^4.7.0",
         "restify": "^11.1.0",
@@ -24222,15 +24222,16 @@
       "dev": true
     },
     "node_modules/@redis/bloom": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.0.1.tgz",
-      "integrity": "sha512-F7L+rnuJvq/upKaVoEgsf8VT7g5pLQYWRqSUOV3uO4vpVtARzSKJ7CLyJjVsQS+wZVCGxsLMh8DwAIDcny1B+g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.1.0.tgz",
+      "integrity": "sha512-Gp5RWvVKbvItMU2sd848yhY/BnigToz8H4PYcvlBBSP5cQ3lVP1LMh5Kx2CYBNzCdDabVicwBKNvaoLBqPNqIg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.0.1"
+        "@redis/client": "^5.1.0"
       }
     },
     "node_modules/@redis/client": {
@@ -24261,39 +24262,42 @@
       }
     },
     "node_modules/@redis/json": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.0.1.tgz",
-      "integrity": "sha512-t94HOTk5myfhvaHZzlUzk2hoUvH2jsjftcnMgJWuHL/pzjAJQoZDCUJzjkoXIUjWXuyJixTguaaDyOZWwqH2Kg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.1.0.tgz",
+      "integrity": "sha512-laXZt1Rlimk3py5ZoABBnd4xn/8dWbLUWGvVS7avgMhdczS+eWtXpElilJbFpc+7ZpVlol4vaSGFuR8ThDcTFw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.0.1"
+        "@redis/client": "^5.1.0"
       }
     },
     "node_modules/@redis/search": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.0.1.tgz",
-      "integrity": "sha512-wipK6ZptY7K68B7YLVhP5I/wYCDUU+mDJMyJiUcQLuOs7/eKOBc8lTXKUSssor8QnzZSPy4A5ulcC5PZY22Zgw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.1.0.tgz",
+      "integrity": "sha512-afQYMeIdWGNPjr84GxxgJVkolxMW3BBrlNOwhRHPdzbdGh0rTUPjOJpGHBig34ostHX6AhZ6QwqceU1zLluDEg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.0.1"
+        "@redis/client": "^5.1.0"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.0.1.tgz",
-      "integrity": "sha512-k6PgbrakhnohsEWEAdQZYt3e5vSKoIzpKvgQt8//lnWLrTZx+c3ed2sj0+pKIF4FvnSeuXLo4bBWcH0Z7Urg1A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.1.0.tgz",
+      "integrity": "sha512-BjKndLXREPeb4ZtxrI6z1bz2FbzBj7LnWyyevNk6Wd7VRWQ3W10LSvJAJwguPD62mSqpTPhy0lMPqFJwo0gS7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.0.1"
+        "@redis/client": "^5.1.0"
       }
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -48176,16 +48180,17 @@
       }
     },
     "node_modules/redis": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-5.0.1.tgz",
-      "integrity": "sha512-J8nqUjrfSq0E8NQkcHDZ4HdEQk5RMYjP3jZq02PE+ERiRxolbDNxPaTT4xh6tdrme+lJ86Goje9yMt9uzh23hQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.1.0.tgz",
+      "integrity": "sha512-5G5k9sYo5H5L0kd7UETiJZFTkIClH31fSmaEk2eU8E7mrmF0J1t6RqmFXOCJmSRlNd3QyvDUK/AWL9psbKaN0Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@redis/bloom": "5.0.1",
-        "@redis/client": "5.0.1",
-        "@redis/json": "5.0.1",
-        "@redis/search": "5.0.1",
-        "@redis/time-series": "5.0.1"
+        "@redis/bloom": "5.1.0",
+        "@redis/client": "5.1.0",
+        "@redis/json": "5.1.0",
+        "@redis/search": "5.1.0",
+        "@redis/time-series": "5.1.0"
       },
       "engines": {
         "node": ">= 18"
@@ -48319,19 +48324,6 @@
       "dev": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
-      }
-    },
-    "node_modules/redis/node_modules/@redis/client": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.0.1.tgz",
-      "integrity": "sha512-k0EJvlMGEyBqUD3orKe0UMZ66fPtfwqPIr+ZSd853sXj2EyhNtPXSx+J6sENXJNgAlEBhvD+57Dwt0qTisKB0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cluster-key-slot": "1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/reflect-metadata": {
@@ -53459,6 +53451,83 @@
         "@instana/autoprofile": "4.15.0"
       }
     },
+    "packages/collector/node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "packages/collector/node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/collector/node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "packages/collector/node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "packages/collector/node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "packages/collector/node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "packages/collector/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -53620,6 +53689,26 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/collector/node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "packages/collector/node_modules/semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@opentelemetry/instrumentation": "0.50.0",
         "@opentelemetry/sdk-node": "^0.49.1",
         "@opentelemetry/sdk-trace-base": "^1.22.0",
-        "@redis/client": "^5.0.1",
+        "@redis/client": "^5.1.0",
         "@redis/client-v4": "npm:@redis/client@1.6.0",
         "@types/chai": "^4.3.0",
         "@types/detect-libc": "^1.0.0",
@@ -24234,10 +24234,11 @@
       }
     },
     "node_modules/@redis/client": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.0.1.tgz",
-      "integrity": "sha512-k0EJvlMGEyBqUD3orKe0UMZ66fPtfwqPIr+ZSd853sXj2EyhNtPXSx+J6sENXJNgAlEBhvD+57Dwt0qTisKB0A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.1.0.tgz",
+      "integrity": "sha512-FMD35y2KgCWTBLOfF0MhwDSaIVcu5mOUuTV9Kw3JOWHMgON3+ulht31cjTB/gph0BfD1vzUvCeROeRaf/d+35w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -48318,6 +48319,19 @@
       "dev": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/redis/node_modules/@redis/client": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.0.1.tgz",
+      "integrity": "sha512-k0EJvlMGEyBqUD3orKe0UMZ66fPtfwqPIr+ZSd853sXj2EyhNtPXSx+J6sENXJNgAlEBhvD+57Dwt0qTisKB0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "proxyquire": "^2.1.3",
     "read-pkg-up": "^7.0.1",
     "recursive-copy": "^2.0.14",
-    "redis": "^5.0.1",
+    "redis": "^5.1.0",
     "redis-v3": "npm:redis@^3.1.2",
     "redis-v4": "npm:redis@^4.7.0",
     "restify": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@opentelemetry/instrumentation": "0.50.0",
     "@opentelemetry/sdk-node": "^0.49.1",
     "@opentelemetry/sdk-trace-base": "^1.22.0",
-    "@redis/client": "^5.0.1",
+    "@redis/client": "^5.1.0",
     "@redis/client-v4": "npm:@redis/client@1.6.0",
     "@types/chai": "^4.3.0",
     "@types/detect-libc": "^1.0.0",

--- a/packages/collector/test/tracing/database/redis/mockVersion.js
+++ b/packages/collector/test/tracing/database/redis/mockVersion.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+const path = require('path');
 const mock = require('@instana/core/test/test_util/mockRequire');
 const hook = require('../../../../../core/src/util/hook');
 
@@ -21,9 +22,12 @@ if (REDIS_PKG === 'redis') {
   mockedModuleName = REDIS_VERSION === 'latest' ? '@redis/client' : `@redis/client-${REDIS_VERSION}`;
 }
 
-if (mockedModuleName !== REDIS_PKG) {
-  mock(REDIS_PKG, mockedModuleName);
-}
+// The 'redis' package is also installed in the collector package due to the typeorm dependency.
+// To ensure we override the default resolution (which would load 'redis' from the collector's node_modules),
+// we explicitly point to the root-level node_modules.
+const nodeModulesPath = path.resolve(__dirname, '../../../../../../node_modules');
+const mockModuleFullPath = path.join(nodeModulesPath, mockedModuleName);
+mock(REDIS_PKG, mockModuleFullPath);
 
 const originalOnFileLoad = hook.onFileLoad;
 


### PR DESCRIPTION
This PR updates Redis from version 5.0.1 to 5.1.0.

As part of this update, Redis was also installed in the collector package because it's a dependency of TypeORM, which requires v4. While the root package uses Redis v5 by default, during test execution, the module was being resolved from collector/node_modules instead of the root. To address this, the mock logic was updated to ensure Redis is loaded from the root.

Additionally, tests for all setup types related to rootExitSpan are now enabled. Previously, they were not being executed for all setups.

Planning to merge this as three separate commits:

1. Two for build-related updates.
2. One for test logic fixes.