### PR TITLE
fix(aws-lambda): gracefully handled non-string path values

### DIFF
--- a/packages/aws-lambda/src/triggers.js
+++ b/packages/aws-lambda/src/triggers.js
@@ -105,20 +105,30 @@ function extractHttpFromApiGatewwayProxyEvent(event, span) {
 
     span.data.http = {
       method: requestCtxHttp.method,
-      url: requestCtxHttp.path,
-      path_tpl: event.rawPath,
+      url: normalizePath(requestCtxHttp.path),
+      path_tpl: normalizePath(event.rawPath),
       params: readHttpQueryParams(event),
       header: captureHeaders(event)
     };
   } else {
     span.data.http = {
       method: event.httpMethod,
-      url: event.path,
-      path_tpl: event.resource,
+      url: normalizePath(event.path),
+      path_tpl: normalizePath(event.resource),
       params: readHttpQueryParams(event),
       header: captureHeaders(event)
     };
   }
+}
+
+//  Ensures the `path` value is always a string. The backend expects `path` to be a string,
+//  so we convert any non-string (for example, an empty object) to null.
+//  For reference, see AWS documentation on the Lambda event input format for API Gateway and Function URLs:
+//  eslint-disable-next-line max-len
+//  https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+//  https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html#urls-payloads
+function normalizePath(value) {
+  return typeof value === 'string' ? value : null;
 }
 
 function readHttpQueryParams(event) {
@@ -415,7 +425,7 @@ function extractFunctionUrlEvent(event, span) {
 
   span.data.http = {
     method: requestCtxHttp.method,
-    url: requestCtxHttp.path,
+    url: normalizePath(requestCtxHttp.path),
     params: readHttpQueryParams(event),
     header: captureHeaders(event)
   };

--- a/packages/aws-lambda/test/runtime_mock/index.js
+++ b/packages/aws-lambda/test/runtime_mock/index.js
@@ -251,7 +251,12 @@ function createContext(callback) {
   return context;
 }
 
-function createEvent(error, trigger, eventOpts = { payloadFormatVersion: '1.0' }) {
+function createEvent(error, trigger, eventOpts) {
+  eventOpts = {
+    payloadFormatVersion: '1.0',
+    ...eventOpts
+  };
+
   /* eslint-disable default-case */
   const event = { version: eventOpts.payloadFormatVersion };
 
@@ -272,8 +277,8 @@ function createEvent(error, trigger, eventOpts = { payloadFormatVersion: '1.0' }
 
       case 'api-gateway-proxy':
         if (event.version === '1.0') {
-          event.resource = '/path/to/{param1}/{param2}';
-          event.path = '/path/to/path-xxx/path-yyy';
+          event.resource = eventOpts.pathParameter ? eventOpts.pathParameter : '/path/to/{param1}/{param2}';
+          event.path = eventOpts.pathParameter ? eventOpts.pathParameter : '/path/to/path-xxx/path-yyy';
           event.httpMethod = 'POST';
           event.headers = {
             'X-Request-Header-1': 'A Header Value',
@@ -299,11 +304,11 @@ function createEvent(error, trigger, eventOpts = { payloadFormatVersion: '1.0' }
           addHttpTracingHeaders(event);
         } else {
           event.rawQueryString = 'parameter1=value1&parameter1=value2&parameter2=value';
-          event.rawPath = '/path/to/{param1}/{param2}';
+          event.rawPath = eventOpts.pathParameter ? eventOpts.pathParameter : '/path/to/{param1}/{param2}';
           event.requestContext = {
             http: {
               method: 'POST',
-              path: '/path/to/path-xxx/path-yyy'
+              path: eventOpts.pathParameter ? eventOpts.pathParameter : '/path/to/path-xxx/path-yyy'
             },
             domainName: 'xxxxxx.execute-api.region.amazonaws.com'
           };


### PR DESCRIPTION
**Issue**

When the AWS Lambda invocation event includes a `path` field with an empty object (e.g., `"path": {}`), the trace fails to appear in the Instana UI.
In contrast, if the `path` field is completely omitted, the trace is displayed as expected.

 **Fix**

Introduced a `normalizePath()` utility function to ensure that only string values are accepted for the `path` field. If the value is not a string, it is gracefully converted to `null`. This prevents invalid data types from being sent to the backend and breaking trace visibility.

**Why This Fix**

The [BE](https://github.ibm.com/instana/backend/blob/develop/forge/src/main/java/com/instana/forge/connection/serverless/aws/lambda/AwsLambdaEntrySpan.java#L170) expects the `path` value to be a string, and the AWS Lambda event input format documentation also specifies it as such. When an unexpected type is provided, it leads to broken or missing traces. This fix enforces type safety and ensures handling of such cases within the tracer.

Reference:
[AWS gateway input format](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format)

jira [INSTA-39103](https://jsw.ibm.com/browse/INSTA-39103)