### PR TITLE
feat: added support for disable tracing by groups

### DIFF
--- a/packages/core/src/tracing/constants.js
+++ b/packages/core/src/tracing/constants.js
@@ -83,9 +83,6 @@ exports.isIntermediateSpan = function isIntermediateSpan(span) {
   return span && span.k === exports.INTERMEDIATE;
 };
 
-// ==============================================
-// Instrumentation groups that can be disabled
-// ==============================================
 /**
  * Set of all instrumentation groups that can be disabled.
  * @type {Set<string>}

--- a/packages/core/src/tracing/constants.js
+++ b/packages/core/src/tracing/constants.js
@@ -82,3 +82,12 @@ exports.isExitSpan = function isExitSpan(span) {
 exports.isIntermediateSpan = function isIntermediateSpan(span) {
   return span && span.k === exports.INTERMEDIATE;
 };
+
+// ==============================================
+// Instrumentation groups that can be disabled
+// ==============================================
+/**
+ * Set of all instrumentation groups that can be disabled.
+ * @type {Set<string>}
+ */
+exports.DISABLABLE_INSTRUMENTATION_GROUPS = new Set(['logging', 'messaging', 'databases']);

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -290,14 +290,6 @@ exports.activate = function activate(extraConfig = {}) {
 
     if (automaticTracingEnabled) {
       instrumentations.forEach(instrumentationKey => {
-        // If instrumentation is disabled via agent config, we skip tracing using the `isActive` flag
-        // within the instrumentation logic.
-        // However, modules already shimmered (e.g., logging) remain wrapped — we don't currently unwrap them.
-        // This may lead to minor performance overhead or partial interception. Proper unwrapping via
-        // `shimmer.unwrap(...)` would need broader changes. Given the very low performance and functional
-        // impact at present, we are accepting this behavior for now.
-        //
-        // We will revisit this in the future, especially if we encounter issues with disabled instrumentations.
         if (
           !coreUtil.disableInstrumentation.isInstrumentationDisabled({
             instrumentationModules,

--- a/packages/core/src/util/configNormalizers/disable.js
+++ b/packages/core/src/util/configNormalizers/disable.js
@@ -24,7 +24,7 @@ exports.normalize = function normalize(config) {
   if (config.tracing.disabledTracers) {
     logger?.warn(
       'The configuration property "tracing.disabledTracers" is deprecated and will be removed in the next ' +
-        'major release. Please use "tracing.disable" instead.'
+        'major release. Please use "tracing.disable.libraries" instead.'
     );
     if (!config.tracing.disable) {
       config.tracing.disable = { instrumentations: config.tracing.disabledTracers };

--- a/packages/core/src/util/configNormalizers/disable.js
+++ b/packages/core/src/util/configNormalizers/disable.js
@@ -21,7 +21,7 @@ exports.init = function init(_config) {
  * Precedence order (highest to lowest):
  * 1. `tracing.disable`
  * 2. `tracing.disabledTracers` (deprecated)
- * 2. Environment variables (`INSTANA_TRACING_DISABLE*`)
+ * 3. Environment variables (`INSTANA_TRACING_DISABLE*`)
  *
  * @param {import('../../util/normalizeConfig').InstanaConfig} config
  */

--- a/packages/core/src/util/configNormalizers/disable.js
+++ b/packages/core/src/util/configNormalizers/disable.js
@@ -49,6 +49,10 @@ exports.normalize = function normalize(config) {
   if (disableConfig?.instrumentations) {
     disableConfig.instrumentations = normalizeArray(disableConfig.instrumentations);
   }
+  // Normalize groups
+  if (disableConfig?.groups) {
+    disableConfig.groups = normalizeArray(disableConfig.groups);
+  }
 
   return disableConfig || {};
 };
@@ -73,6 +77,11 @@ function getDisableFromEnv() {
   // Handle INSTANA_TRACING_DISABLE_INSTRUMENTATIONS
   if (process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS) {
     disable.instrumentations = parseEnvVar(process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS);
+  }
+
+  // Handle INSTANA_TRACING_DISABLE_GROUPS
+  if (process.env.INSTANA_TRACING_DISABLE_GROUPS) {
+    disable.groups = parseEnvVar(process.env.INSTANA_TRACING_DISABLE_GROUPS);
   }
 
   // TODO: add support for groups as well in another PR

--- a/packages/core/src/util/configNormalizers/disable.js
+++ b/packages/core/src/util/configNormalizers/disable.js
@@ -143,7 +143,7 @@ function categorizeDisableEntries(rawEntries) {
 
   rawEntries.forEach(entry => {
     if (typeof entry !== 'string') return;
-    const normalizedEntry = entry?.toLowerCase()?.trim();
+    const normalizedEntry = entry?.toLowerCase().trim();
     if (!normalizedEntry) return;
 
     // The supported groups are predefined in DISABLABLE_INSTRUMENTATION_GROUPS.

--- a/packages/core/src/util/configNormalizers/disable.js
+++ b/packages/core/src/util/configNormalizers/disable.js
@@ -24,7 +24,7 @@ exports.normalize = function normalize(config) {
   if (config.tracing.disabledTracers) {
     logger?.warn(
       'The configuration property "tracing.disabledTracers" is deprecated and will be removed in the next ' +
-        'major release. Please use "tracing.disable.libraries" instead.'
+        'major release. Please use "tracing.disable" instead.'
     );
     if (!config.tracing.disable) {
       config.tracing.disable = { instrumentations: config.tracing.disabledTracers };

--- a/packages/core/src/util/disableInstrumentation.js
+++ b/packages/core/src/util/disableInstrumentation.js
@@ -65,14 +65,6 @@ function shouldDisable(cfg, { moduleName, instrumentationName, category } = {}) 
     return false;
   }
 
-  //   // Case 1: Explicitly enabled modules (prefixed with '!') take precedence
-  //   if (moduleName) {
-  //     const isExplicitlyEnabled = disableConfig.libraries?.some(
-  //       (/** @type {string} */ lib) => typeof lib === 'string' && lib.startsWith('!') && lib.slice(1) === moduleName
-  //     );
-  //     if (isExplicitlyEnabled) return false;
-  //   }
-
   // Case 2: Check if module or instrumentation is explicitly disabled
   if (
     (moduleName && disableConfig.libraries?.includes(moduleName)) ||

--- a/packages/core/src/util/disableInstrumentation.js
+++ b/packages/core/src/util/disableInstrumentation.js
@@ -1,0 +1,122 @@
+/*
+ * (c) Copyright IBM Corp. 2025
+ */
+
+'use strict';
+
+/** @type {import('../util/normalizeConfig').InstanaConfig} */
+let config;
+
+/** @type {import('../util/normalizeConfig').AgentConfig} */
+let agentConfig;
+
+// Categories that support category-level disabling
+const DISABLABLE_CATEGORIES = new Set(['logging', 'databases', 'messaging']);
+
+/**
+ * @param {import('../util/normalizeConfig').InstanaConfig} _config
+ */
+function init(_config) {
+  config = _config;
+}
+
+/**
+ * @param {import('../util/normalizeConfig').AgentConfig} _agentConfig
+ */
+function activate(_agentConfig) {
+  agentConfig = _agentConfig;
+}
+
+/**
+ * @param {string} instrumentationPath
+ */
+function getModuleName(instrumentationPath) {
+  // Extracts the module name from the instrumentationPath.
+  // Tries to match the pattern './instrumentation/<category>/<module>' and extract the <module> part.
+  // If that pattern doesn't match (e.g., in custom instrumentation cases),
+  // it falls back to extracting the last segment of the instrumentationPath after the final '/'.
+  const matchResult = instrumentationPath.match(/.\/instrumentation\/[^/]*\/(.*)/);
+  const moduleName = matchResult ? matchResult[1] : instrumentationPath.match(/\/([^/]+)$/)[1];
+  return moduleName.toLowerCase();
+}
+
+/**
+ * Extracts category and module from an instrumentation instrumentationPath
+ * @param {string} instrumentationPath
+ * @returns {{category: string, module: string}|null}
+ */
+function getCategoryAndModule(instrumentationPath) {
+  const match = instrumentationPath.match(/\.\/instrumentation\/([^/]+)\/([^/]+)/);
+  return match ? { category: match[1], module: match[2] } : null;
+}
+
+/**
+ * @param {*} cfg
+ * @param {object} options
+ * @param {string} [options.moduleName]
+ * @param {string} [options.instrumentationName]
+ * @param {string} [options.category]
+ */
+function shouldDisable(cfg, { moduleName, instrumentationName, category } = {}) {
+  const disableConfig = cfg.tracing?.disable;
+
+  // If neither libraries nor categories are configured for disabling, tracing is enabled
+  if (!disableConfig?.libraries && !disableConfig?.categories) {
+    return false;
+  }
+
+  //   // Case 1: Explicitly enabled modules (prefixed with '!') take precedence
+  //   if (moduleName) {
+  //     const isExplicitlyEnabled = disableConfig.libraries?.some(
+  //       (/** @type {string} */ lib) => typeof lib === 'string' && lib.startsWith('!') && lib.slice(1) === moduleName
+  //     );
+  //     if (isExplicitlyEnabled) return false;
+  //   }
+
+  // Case 2: Check if module or instrumentation is explicitly disabled
+  if (
+    (moduleName && disableConfig.libraries?.includes(moduleName)) ||
+    (instrumentationName && disableConfig.libraries?.includes(instrumentationName))
+  ) {
+    return true;
+  }
+
+  // Case 3: Check if the category is marked as disabled
+  const isCategoryDisabled =
+    category && DISABLABLE_CATEGORIES.has(category) && disableConfig.categories?.includes(category);
+
+  return Boolean(isCategoryDisabled);
+}
+
+/**
+ * @param {object} params
+ * @param {Object.<string, import('../tracing/index').InstanaInstrumentedModule>} [params.instrumentationModules]
+ * @param {string} params.instrumentationKey
+ * @returns {boolean}
+ */
+function isInstrumentationDisabled({ instrumentationModules = {}, instrumentationKey }) {
+  const moduleName = getModuleName(instrumentationKey);
+  const instrumentationName = instrumentationModules[instrumentationKey]?.instrumentationName;
+  const { category } = getCategoryAndModule(instrumentationKey) || {};
+
+  const context = { moduleName, instrumentationName, category };
+
+  // Give priority to service-level config
+  if (config && shouldDisable(config, context)) {
+    return true;
+  }
+
+  // Fallback to agent-level config if not disabled above
+  // NOTE: We currently have no single config object.
+  if (agentConfig && shouldDisable(agentConfig, context)) {
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = {
+  init,
+  activate,
+  isInstrumentationDisabled
+};

--- a/packages/core/src/util/disableInstrumentation.js
+++ b/packages/core/src/util/disableInstrumentation.js
@@ -57,14 +57,14 @@ function getCategoryAndModule(instrumentationPath) {
  * @param {string} [options.group]
  */
 function shouldDisable(cfg, { moduleName, instrumentationName, group } = {}) {
-  const disableConfig = cfg.tracing?.disable;
+  const disableConfig = cfg?.tracing?.disable;
 
   // If neither instrumentations nor groups are configured for disabling, tracing is enabled
   if (!disableConfig?.instrumentations && !disableConfig?.groups) {
     return false;
   }
 
-  // Case 1: Check if module or instrumentation is explicitly disabled
+  // Case 1: Check if module or instrumentation is disabled
   if (
     (moduleName && disableConfig.instrumentations?.includes(moduleName)) ||
     (instrumentationName && disableConfig.instrumentations?.includes(instrumentationName))
@@ -72,11 +72,11 @@ function shouldDisable(cfg, { moduleName, instrumentationName, group } = {}) {
     return true;
   }
 
-  // Case 2: Check if the group is marked as disabled
-  const isCategoryDisabled =
+  // Case 2: Check if the group is disabled
+  const isGroupDisabled =
     group && DISABLABLE_INSTRUMENTATION_GROUPS.has(group) && disableConfig.groups?.includes(group);
 
-  return Boolean(isCategoryDisabled);
+  return Boolean(isGroupDisabled);
 }
 
 /**

--- a/packages/core/src/util/disableInstrumentation.js
+++ b/packages/core/src/util/disableInstrumentation.js
@@ -4,14 +4,13 @@
 
 'use strict';
 
+const { DISABLABLE_INSTRUMENTATION_GROUPS } = require('../tracing/constants');
+
 /** @type {import('../util/normalizeConfig').InstanaConfig} */
 let config;
 
 /** @type {import('../util/normalizeConfig').AgentConfig} */
 let agentConfig;
-
-// Categories that support category-level disabling
-const DISABLABLE_CATEGORIES = new Set(['logging', 'databases', 'messaging']);
 
 /**
  * @param {import('../util/normalizeConfig').InstanaConfig} _config
@@ -75,7 +74,7 @@ function shouldDisable(cfg, { moduleName, instrumentationName, category } = {}) 
 
   // Case 3: Check if the category is marked as disabled
   const isCategoryDisabled =
-    category && DISABLABLE_CATEGORIES.has(category) && disableConfig.groups?.includes(category);
+    category && DISABLABLE_INSTRUMENTATION_GROUPS.has(category) && disableConfig.groups?.includes(category);
 
   return Boolean(isCategoryDisabled);
 }

--- a/packages/core/src/util/disableInstrumentation.js
+++ b/packages/core/src/util/disableInstrumentation.js
@@ -60,22 +60,22 @@ function getCategoryAndModule(instrumentationPath) {
 function shouldDisable(cfg, { moduleName, instrumentationName, category } = {}) {
   const disableConfig = cfg.tracing?.disable;
 
-  // If neither libraries nor categories are configured for disabling, tracing is enabled
-  if (!disableConfig?.libraries && !disableConfig?.categories) {
+  // If neither instrumentations nor groups are configured for disabling, tracing is enabled
+  if (!disableConfig?.instrumentations && !disableConfig?.groups) {
     return false;
   }
 
   // Case 2: Check if module or instrumentation is explicitly disabled
   if (
-    (moduleName && disableConfig.libraries?.includes(moduleName)) ||
-    (instrumentationName && disableConfig.libraries?.includes(instrumentationName))
+    (moduleName && disableConfig.instrumentations?.includes(moduleName)) ||
+    (instrumentationName && disableConfig.instrumentations?.includes(instrumentationName))
   ) {
     return true;
   }
 
   // Case 3: Check if the category is marked as disabled
   const isCategoryDisabled =
-    category && DISABLABLE_CATEGORIES.has(category) && disableConfig.categories?.includes(category);
+    category && DISABLABLE_CATEGORIES.has(category) && disableConfig.groups?.includes(category);
 
   return Boolean(isCategoryDisabled);
 }

--- a/packages/core/src/util/index.js
+++ b/packages/core/src/util/index.js
@@ -23,6 +23,7 @@ const preloadFlags = require('./getPreloadFlags');
 const configNormalizers = require('./configNormalizers');
 const spanFilter = require('./spanFilter');
 const yamlReader = require('./yamlReader');
+const disableInstrumentation = require('./disableInstrumentation');
 
 /** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
@@ -41,12 +42,14 @@ exports.init = function init(config) {
   spanFilter.init(config);
   yamlReader.init(config);
   configNormalizers.init(config);
+  disableInstrumentation.init(config);
 };
 
 /**
  * @param {import('./normalizeConfig').AgentConfig} extraConfig
  */
 exports.activate = function activate(extraConfig) {
+  disableInstrumentation.activate(extraConfig);
   spanFilter.activate(extraConfig);
 };
 
@@ -99,3 +102,4 @@ exports.esm = esm;
 exports.configNormalizers = configNormalizers;
 exports.spanFilter = spanFilter;
 exports.yamlReader = yamlReader;
+exports.disableInstrumentation = disableInstrumentation;

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -34,6 +34,7 @@ const configNormalizers = require('./configNormalizers');
 /**
  * @typedef {Object} TracingDisableOptions
  * @property {string[]} [instrumentations]
+ * @property {string[]} [categories]
  */
 
 /**
@@ -519,7 +520,7 @@ function normalizeNumericalStackTraceLength(numericalLength) {
  */
 function normalizeDisableTracing(config) {
   const disableConfig = configNormalizers.disable.normalize(config);
-  if (disableConfig?.instrumentations?.length > 0) {
+  if (disableConfig?.instrumentations?.length || disableConfig?.categories?.length) {
     config.tracing.disable = disableConfig;
     return;
   }

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -519,7 +519,7 @@ function normalizeNumericalStackTraceLength(numericalLength) {
  */
 function normalizeDisableTracing(config) {
   const disableConfig = configNormalizers.disable.normalize(config);
-  if (disableConfig?.instrumentations?.length > 0) {
+  if (disableConfig?.libraries?.length > 0) {
     config.tracing.disable = disableConfig;
     return;
   }

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -519,7 +519,7 @@ function normalizeNumericalStackTraceLength(numericalLength) {
  */
 function normalizeDisableTracing(config) {
   const disableConfig = configNormalizers.disable.normalize(config);
-  if (disableConfig?.libraries?.length > 0) {
+  if (disableConfig?.instrumentations?.length > 0) {
     config.tracing.disable = disableConfig;
     return;
   }

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -34,7 +34,7 @@ const configNormalizers = require('./configNormalizers');
 /**
  * @typedef {Object} TracingDisableOptions
  * @property {string[]} [instrumentations]
- * @property {string[]} [categories]
+ * @property {string[]} [groups]
  */
 
 /**
@@ -520,7 +520,7 @@ function normalizeNumericalStackTraceLength(numericalLength) {
  */
 function normalizeDisableTracing(config) {
   const disableConfig = configNormalizers.disable.normalize(config);
-  if (disableConfig?.instrumentations?.length || disableConfig?.categories?.length) {
+  if (disableConfig?.instrumentations?.length || disableConfig?.groups?.length) {
     config.tracing.disable = disableConfig;
     return;
   }

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -28,6 +28,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
   this.timeout(testConfig.getTestTimeout());
 
   let tracing;
+  let util;
 
   let activateStubGrpcJs;
   let activateStubKafkaJs;
@@ -59,6 +60,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     // requiring tracing/index via proxyquire gives us a module in pristine state everytime, in particular with the
     // tracingActivated flag reset.
     tracing = proxyquire('../../src/tracing', {});
+    util = proxyquire('../../src/util', {});
   });
 
   afterEach(() => {
@@ -299,6 +301,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
       function initAndActivate(initConfig, extraConfigForActivate) {
         const logger = testUtils.createFakeLogger();
         const config = normalizeConfig(initConfig, logger);
+        util.init(config);
         tracing.init(config);
         tracing.activate(extraConfigForActivate);
       }

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -74,7 +74,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     initAwsSdkv2.reset();
     initAwsSdkv3.reset();
 
-    delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
+    delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
     // @deprecated
     delete process.env.INSTANA_DISABLED_TRACERS;
   });

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -74,7 +74,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     initAwsSdkv2.reset();
     initAwsSdkv3.reset();
 
-    delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
+    delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
     // @deprecated
     delete process.env.INSTANA_DISABLED_TRACERS;
   });

--- a/packages/core/test/util/configNormalizers/disable_test.js
+++ b/packages/core/test/util/configNormalizers/disable_test.js
@@ -99,7 +99,7 @@ describe('util.configNormalizers.disable', () => {
       expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
-    it('should support category names', () => {
+    it('should support group names', () => {
       const config = {
         tracing: {
           disable: {
@@ -112,7 +112,7 @@ describe('util.configNormalizers.disable', () => {
       expect(result.groups).to.deep.equal(['logging', 'databases']);
     });
 
-    it('should normalize category names to lowercase and trim whitespace', () => {
+    it('should normalize group names to lowercase and trim whitespace', () => {
       const config = {
         tracing: {
           disable: {
@@ -183,6 +183,28 @@ describe('util.configNormalizers.disable', () => {
 
       const result = normalize(config);
       expect(result).to.deep.equal({});
+    });
+
+    it('should handle non-string values in disable array config', () => {
+      const config = {
+        tracing: {
+          disable: ['aws-sdk', 123, null, undefined, {}, 'mongodb']
+        }
+      };
+
+      const result = normalize(config);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb']);
+    });
+
+    it('should handle non-string values in config', () => {
+      const config = {
+        tracing: {
+          disable: { instrumentations: ['aws-sdk', 123, null, undefined, {}, 'mongodb'] }
+        }
+      };
+
+      const result = normalize(config);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb']);
     });
   });
 
@@ -292,17 +314,6 @@ describe('util.configNormalizers.disable', () => {
       const result = normalize(config);
 
       expect(result).to.deep.equal({});
-    });
-
-    it('should handle non-string values in array config', () => {
-      const config = {
-        tracing: {
-          disable: ['aws-sdk', 123, null, undefined, {}, 'mongodb']
-        }
-      };
-
-      const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb']);
     });
   });
 });

--- a/packages/core/test/util/configNormalizers/disable_test.js
+++ b/packages/core/test/util/configNormalizers/disable_test.js
@@ -103,39 +103,39 @@ describe('util.configNormalizers.disable', () => {
       const config = {
         tracing: {
           disable: {
-            categories: ['logging', 'databases']
+            groups: ['logging', 'databases']
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.categories).to.deep.equal(['logging', 'databases']);
+      expect(result.groups).to.deep.equal(['logging', 'databases']);
     });
 
     it('should normalize category names to lowercase and trim whitespace', () => {
       const config = {
         tracing: {
           disable: {
-            categories: ['LOGGING', '  DATABASES  ', '', ' MESSAGING ']
+            groups: ['LOGGING', '  DATABASES  ', '', ' MESSAGING ']
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.categories).to.deep.equal(['logging', 'databases', 'messaging']);
+      expect(result.groups).to.deep.equal(['logging', 'databases', 'messaging']);
     });
 
-    it('should handle non-array "categories" input gracefully', () => {
+    it('should handle non-array "groups" input gracefully', () => {
       const config = {
         tracing: {
           disable: {
-            categories: 'logging'
+            groups: 'logging'
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.categories).to.deep.equal([]);
+      expect(result.groups).to.deep.equal([]);
     });
   });
 
@@ -158,13 +158,13 @@ describe('util.configNormalizers.disable', () => {
       expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
-    it('should parse "INSTANA_TRACING_DISABLE_CATEGORIES" correctly', () => {
-      process.env.INSTANA_TRACING_DISABLE_CATEGORIES = 'logging, databases';
+    it('should parse "INSTANA_TRACING_DISABLE_GROUPS" correctly', () => {
+      process.env.INSTANA_TRACING_DISABLE_GROUPS = 'logging, databases';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.categories).to.deep.equal(['logging', 'databases']);
+      expect(result.groups).to.deep.equal(['logging', 'databases']);
     });
 
     it('should fallback to "INSTANA_DISABLED_TRACERS"', () => {
@@ -204,12 +204,12 @@ describe('util.configNormalizers.disable', () => {
       expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
     it('should ignore empty or whitespace-only entries in environment variable', () => {
-      process.env.INSTANA_TRACING_DISABLE_CATEGORIES = 'logging,,databases, ,messaging';
+      process.env.INSTANA_TRACING_DISABLE_GROUPS = 'logging,,databases, ,messaging';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.categories).to.deep.equal(['logging', 'databases', 'messaging']);
+      expect(result.groups).to.deep.equal(['logging', 'databases', 'messaging']);
     });
   });
 });

--- a/packages/core/test/util/configNormalizers/disable_test.js
+++ b/packages/core/test/util/configNormalizers/disable_test.js
@@ -10,9 +10,9 @@ const { expect } = require('chai');
 const { normalize } = require('../../../src/util/configNormalizers/disable');
 
 function resetEnv() {
-  delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
+  delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
   delete process.env.INSTANA_DISABLED_TRACERS;
-  delete process.env.INSTANA_TRACING_DISABLE_CATEGORIES;
+  delete process.env.INSTANA_TRACING_DISABLE;
 }
 
 describe('util.configNormalizers.disable', () => {
@@ -29,11 +29,11 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result).to.deep.equal({ libraries: [] });
+      expect(result).to.deep.equal({});
       expect(config.tracing).to.exist;
     });
 
-    it('should handle deprecated "disabledTracers" to "disable.libraries"', () => {
+    it('should handle deprecated "disabledTracers" to "disable.instrumentations"', () => {
       const config = {
         tracing: {
           disabledTracers: ['AWS-SDK', 'mongodb']
@@ -43,7 +43,7 @@ describe('util.configNormalizers.disable', () => {
       const result = normalize(config);
 
       expect(result).to.deep.equal({
-        libraries: ['aws-sdk', 'mongodb']
+        instrumentations: ['aws-sdk', 'mongodb']
       });
       expect(config.tracing.disabledTracers).to.be.undefined;
     });
@@ -53,50 +53,70 @@ describe('util.configNormalizers.disable', () => {
         tracing: {
           disabledTracers: ['AWS-SDK'],
           disable: {
-            libraries: ['redis']
+            instrumentations: ['redis']
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.libraries).to.deep.equal(['redis']);
+      expect(result.instrumentations).to.deep.equal(['redis']);
     });
 
     it('should normalize library names to lowercase and trim whitespace', () => {
       const config = {
         tracing: {
           disable: {
-            libraries: ['AWS-SDK', '  MongoDB  ', '', 'Postgres']
+            instrumentations: ['AWS-SDK', '  MongoDB  ', '', 'Postgres']
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
-    it('should handle non-array "libraries" input gracefully', () => {
+    it('should handle non-array "instrumentations" input gracefully', () => {
       const config = {
         tracing: {
           disable: {
-            libraries: 'aws-sdk'
+            instrumentations: 'aws-sdk'
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.libraries).to.deep.equal([]);
+      expect(result.instrumentations).to.deep.equal([]);
+    });
+
+    it('should handle flat disable config', () => {
+      const config = {
+        tracing: {
+          disable: ['AWS-SDK', '  MongoDB  ', '', 'Postgres']
+        }
+      };
+
+      const result = normalize(config);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
   });
 
   describe('Environment Variable Handling', () => {
-    it('should parse "INSTANA_TRACING_DISABLE_LIBRARIES" correctly', () => {
-      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk, mongodb, postgres';
+    it('should parse "INSTANA_TRACING_DISABLE_INSTRUMENTATIONS" correctly', () => {
+      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk, mongodb, postgres';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+    });
+
+    it('should parse "INSTANA_TRACING_DISABLE" correctly', () => {
+      process.env.INSTANA_TRACING_DISABLE = 'aws-sdk, mongodb, postgres';
+
+      const config = {};
+      const result = normalize(config);
+
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
     it('should fallback to "INSTANA_DISABLED_TRACERS" and issue a deprecation warning', () => {
@@ -105,35 +125,35 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result.libraries).to.deep.equal(['redis', 'mysql']);
+      expect(result.instrumentations).to.deep.equal(['redis', 'mysql']);
     });
 
-    it('should prioritize "INSTANA_TRACING_DISABLE_LIBRARIES" over deprecated variable', () => {
-      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk';
+    it('should prioritize "INSTANA_TRACING_DISABLE_INSTRUMENTATIONS" over deprecated variable', () => {
+      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk';
       process.env.INSTANA_DISABLED_TRACERS = 'redis';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.libraries).to.deep.equal(['aws-sdk']);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk']);
     });
 
     it('should support semicolon-separated values in environment variable', () => {
-      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk;mongodb;postgres';
+      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk;mongodb;postgres';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
     it('should ignore empty or whitespace-only entries in environment variable', () => {
-      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk,,mongodb, ,postgres';
+      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk,,mongodb, ,postgres';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
   });
 });

--- a/packages/core/test/util/configNormalizers/disable_test.js
+++ b/packages/core/test/util/configNormalizers/disable_test.js
@@ -137,6 +137,53 @@ describe('util.configNormalizers.disable', () => {
       const result = normalize(config);
       expect(result.groups).to.deep.equal([]);
     });
+
+    it('should handle mixed array of instrumentations and groups', () => {
+      const config = {
+        tracing: {
+          disable: ['aws-sdk', 'logging', 'mongodb', 'databases']
+        }
+      };
+
+      const result = normalize(config);
+      expect(result).to.deep.equal({
+        instrumentations: ['aws-sdk', 'mongodb'],
+        groups: ['logging', 'databases']
+      });
+    });
+
+    it('should handle empty disable config object', () => {
+      const config = {
+        tracing: {
+          disable: {}
+        }
+      };
+
+      const result = normalize(config);
+      expect(result).to.deep.equal({});
+    });
+
+    it('should handle null disable config', () => {
+      const config = {
+        tracing: {
+          disable: null
+        }
+      };
+
+      const result = normalize(config);
+      expect(result).to.deep.equal({});
+    });
+
+    it('should handle undefined disable config', () => {
+      const config = {
+        tracing: {
+          disable: undefined
+        }
+      };
+
+      const result = normalize(config);
+      expect(result).to.deep.equal({});
+    });
   });
 
   describe('Environment Variable Handling', () => {
@@ -210,6 +257,52 @@ describe('util.configNormalizers.disable', () => {
       const result = normalize(config);
 
       expect(result.groups).to.deep.equal(['logging', 'databases', 'messaging']);
+    });
+
+    it('should handle mixed environment variables', () => {
+      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk,mongodb';
+      process.env.INSTANA_TRACING_DISABLE_GROUPS = 'logging,databases';
+
+      const config = {};
+      const result = normalize(config);
+
+      expect(result).to.deep.equal({
+        instrumentations: ['aws-sdk', 'mongodb'],
+        groups: ['logging', 'databases']
+      });
+    });
+
+    it('should handle INSTANA_TRACING_DISABLE with mixed groups and instrumentations', () => {
+      process.env.INSTANA_TRACING_DISABLE = 'aws-sdk,logging,mongodb,databases';
+
+      const config = {};
+      const result = normalize(config);
+
+      expect(result).to.deep.equal({
+        instrumentations: ['aws-sdk', 'mongodb'],
+        groups: ['logging', 'databases']
+      });
+    });
+
+    it('should handle empty string in environment variables', () => {
+      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = '';
+      process.env.INSTANA_TRACING_DISABLE_GROUPS = '';
+
+      const config = {};
+      const result = normalize(config);
+
+      expect(result).to.deep.equal({});
+    });
+
+    it('should handle non-string values in array config', () => {
+      const config = {
+        tracing: {
+          disable: ['aws-sdk', 123, null, undefined, {}, 'mongodb']
+        }
+      };
+
+      const result = normalize(config);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb']);
     });
   });
 });

--- a/packages/core/test/util/configNormalizers/disable_test.js
+++ b/packages/core/test/util/configNormalizers/disable_test.js
@@ -10,9 +10,9 @@ const { expect } = require('chai');
 const { normalize } = require('../../../src/util/configNormalizers/disable');
 
 function resetEnv() {
-  delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
+  delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
   delete process.env.INSTANA_DISABLED_TRACERS;
-  delete process.env.INSTANA_TRACING_DISABLE;
+  delete process.env.INSTANA_TRACING_DISABLE_CATEGORIES;
 }
 
 describe('util.configNormalizers.disable', () => {
@@ -29,11 +29,11 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result).to.deep.equal({});
+      expect(result).to.deep.equal({ libraries: [] });
       expect(config.tracing).to.exist;
     });
 
-    it('should handle deprecated "disabledTracers" to "disable.instrumentations"', () => {
+    it('should handle deprecated "disabledTracers" to "disable.libraries"', () => {
       const config = {
         tracing: {
           disabledTracers: ['AWS-SDK', 'mongodb']
@@ -43,7 +43,7 @@ describe('util.configNormalizers.disable', () => {
       const result = normalize(config);
 
       expect(result).to.deep.equal({
-        instrumentations: ['aws-sdk', 'mongodb']
+        libraries: ['aws-sdk', 'mongodb']
       });
       expect(config.tracing.disabledTracers).to.be.undefined;
     });
@@ -53,70 +53,50 @@ describe('util.configNormalizers.disable', () => {
         tracing: {
           disabledTracers: ['AWS-SDK'],
           disable: {
-            instrumentations: ['redis']
+            libraries: ['redis']
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal(['redis']);
+      expect(result.libraries).to.deep.equal(['redis']);
     });
 
     it('should normalize library names to lowercase and trim whitespace', () => {
       const config = {
         tracing: {
           disable: {
-            instrumentations: ['AWS-SDK', '  MongoDB  ', '', 'Postgres']
+            libraries: ['AWS-SDK', '  MongoDB  ', '', 'Postgres']
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
-    it('should handle non-array "instrumentations" input gracefully', () => {
+    it('should handle non-array "libraries" input gracefully', () => {
       const config = {
         tracing: {
           disable: {
-            instrumentations: 'aws-sdk'
+            libraries: 'aws-sdk'
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal([]);
-    });
-
-    it('should handle flat disable config', () => {
-      const config = {
-        tracing: {
-          disable: ['AWS-SDK', '  MongoDB  ', '', 'Postgres']
-        }
-      };
-
-      const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.libraries).to.deep.equal([]);
     });
   });
 
   describe('Environment Variable Handling', () => {
-    it('should parse "INSTANA_TRACING_DISABLE_INSTRUMENTATIONS" correctly', () => {
-      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk, mongodb, postgres';
+    it('should parse "INSTANA_TRACING_DISABLE_LIBRARIES" correctly', () => {
+      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk, mongodb, postgres';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
-    });
-
-    it('should parse "INSTANA_TRACING_DISABLE" correctly', () => {
-      process.env.INSTANA_TRACING_DISABLE = 'aws-sdk, mongodb, postgres';
-
-      const config = {};
-      const result = normalize(config);
-
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
     it('should fallback to "INSTANA_DISABLED_TRACERS" and issue a deprecation warning', () => {
@@ -125,35 +105,35 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['redis', 'mysql']);
+      expect(result.libraries).to.deep.equal(['redis', 'mysql']);
     });
 
-    it('should prioritize "INSTANA_TRACING_DISABLE_INSTRUMENTATIONS" over deprecated variable', () => {
-      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk';
+    it('should prioritize "INSTANA_TRACING_DISABLE_LIBRARIES" over deprecated variable', () => {
+      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk';
       process.env.INSTANA_DISABLED_TRACERS = 'redis';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['aws-sdk']);
+      expect(result.libraries).to.deep.equal(['aws-sdk']);
     });
 
     it('should support semicolon-separated values in environment variable', () => {
-      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk;mongodb;postgres';
+      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk;mongodb;postgres';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
     it('should ignore empty or whitespace-only entries in environment variable', () => {
-      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk,,mongodb, ,postgres';
+      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk,,mongodb, ,postgres';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
   });
 });

--- a/packages/core/test/util/disableInstrumentation_test.js
+++ b/packages/core/test/util/disableInstrumentation_test.js
@@ -272,7 +272,7 @@ describe('util.disableInstrumentation', () => {
       });
       disableInstrumentation.activate({
         tracing: {
-          disable: { instrumentations: ['!console'] }
+          disable: { instrumentations: ['console'] }
         }
       });
 

--- a/packages/core/test/util/disableInstrumentation_test.js
+++ b/packages/core/test/util/disableInstrumentation_test.js
@@ -53,7 +53,7 @@ describe('util.disableInstrumentation', () => {
     it('should disable instrumentation when exact module name matches disable list entry', () => {
       disableInstrumentation.init({
         tracing: {
-          disable: { libraries: ['console'] }
+          disable: { instrumentations: ['console'] }
         }
       });
 
@@ -67,7 +67,7 @@ describe('util.disableInstrumentation', () => {
     it('should disable instrumentation when instrumentationName matches disable list via agent config', () => {
       disableInstrumentation.activate({
         tracing: {
-          disable: { libraries: ['aws/v3'] }
+          disable: { instrumentations: ['aws/v3'] }
         }
       });
 
@@ -81,7 +81,7 @@ describe('util.disableInstrumentation', () => {
     it('should disable instrumentation when instrumentationName matches disable list', () => {
       disableInstrumentation.init({
         tracing: {
-          disable: { libraries: ['aws/v3'] }
+          disable: { instrumentations: ['aws/v3'] }
         }
       });
 
@@ -95,7 +95,7 @@ describe('util.disableInstrumentation', () => {
     it('should not disable instrumentation when neither module path nor instrumentationName matches', () => {
       disableInstrumentation.init({
         tracing: {
-          disable: { libraries: ['console'] }
+          disable: { instrumentations: ['console'] }
         }
       });
 
@@ -109,7 +109,7 @@ describe('util.disableInstrumentation', () => {
     it('should handle module paths with different levels of nesting', () => {
       disableInstrumentation.init({
         tracing: {
-          disable: { libraries: ['mongodb'] }
+          disable: { instrumentations: ['mongodb'] }
         }
       });
 
@@ -125,7 +125,7 @@ describe('util.disableInstrumentation', () => {
     it('should disable all modules within a category when category is disabled via service config', () => {
       disableInstrumentation.init({
         tracing: {
-          disable: { categories: ['logging'] }
+          disable: { groups: ['logging'] }
         }
       });
 
@@ -145,7 +145,7 @@ describe('util.disableInstrumentation', () => {
     it('should disable all modules within a category when category is disabled via agent config', () => {
       disableInstrumentation.activate({
         tracing: {
-          disable: { categories: ['logging'] }
+          disable: { groups: ['logging'] }
         }
       });
 
@@ -162,10 +162,10 @@ describe('util.disableInstrumentation', () => {
       expect(bunyanResult).to.be.true;
     });
 
-    it('should not disable modules in categories not listed in disable configuration', () => {
+    it('should not disable modules in groups not listed in disable configuration', () => {
       disableInstrumentation.init({
         tracing: {
-          disable: { categories: ['frameworks'] }
+          disable: { groups: ['frameworks'] }
         }
       });
 
@@ -187,7 +187,7 @@ describe('util.disableInstrumentation', () => {
       // this config now only coming from agent
       disableInstrumentation.init({
         tracing: {
-          disable: { categories: ['logging'], libraries: ['console'] }
+          disable: { groups: ['logging'], instrumentations: ['console'] }
         }
       });
 
@@ -207,7 +207,7 @@ describe('util.disableInstrumentation', () => {
     it('should handle unsupported category disabling', () => {
       disableInstrumentation.init({
         tracing: {
-          disable: { categories: ['frameworks', 'logging'] }
+          disable: { groups: ['frameworks', 'logging'] }
         }
       });
 
@@ -229,12 +229,12 @@ describe('util.disableInstrumentation', () => {
     it('should prioritize service configuration over agent configuration when both are present', () => {
       disableInstrumentation.init({
         tracing: {
-          disable: { libraries: ['console'] }
+          disable: { instrumentations: ['console'] }
         }
       });
       disableInstrumentation.activate({
         tracing: {
-          disable: { libraries: ['!console'] }
+          disable: { instrumentations: ['!console'] }
         }
       });
 
@@ -249,12 +249,12 @@ describe('util.disableInstrumentation', () => {
     it('should accept service configuration and agent configuration when both are present', () => {
       disableInstrumentation.init({
         tracing: {
-          disable: { libraries: ['console'] }
+          disable: { instrumentations: ['console'] }
         }
       });
       disableInstrumentation.activate({
         tracing: {
-          disable: { libraries: ['bunyan'] }
+          disable: { instrumentations: ['bunyan'] }
         }
       });
 
@@ -275,7 +275,7 @@ describe('util.disableInstrumentation', () => {
       disableInstrumentation.init({});
       disableInstrumentation.activate({
         tracing: {
-          disable: { libraries: ['console'] }
+          disable: { instrumentations: ['console'] }
         }
       });
 
@@ -290,7 +290,7 @@ describe('util.disableInstrumentation', () => {
       disableInstrumentation.init({});
       disableInstrumentation.activate({
         tracing: {
-          disable: { libraries: ['console'] }
+          disable: { instrumentations: ['console'] }
         }
       });
 
@@ -341,7 +341,7 @@ describe('util.disableInstrumentation', () => {
     it('should handle module paths that do not exist in instrumentationModules', () => {
       disableInstrumentation.init({
         tracing: {
-          disable: { libraries: ['nonexistent'] }
+          disable: { instrumentations: ['nonexistent'] }
         }
       });
 
@@ -355,7 +355,7 @@ describe('util.disableInstrumentation', () => {
     it('should handle modules without instrumentationName property', () => {
       disableInstrumentation.init({
         tracing: {
-          disable: { libraries: ['express'] }
+          disable: { instrumentations: ['express'] }
         }
       });
 

--- a/packages/core/test/util/disableInstrumentation_test.js
+++ b/packages/core/test/util/disableInstrumentation_test.js
@@ -1,0 +1,369 @@
+/*
+ * (c) Copyright IBM Corp. 2025
+ */
+
+'use strict';
+
+const { expect } = require('chai');
+const disableInstrumentation = require('../../src/util/disableInstrumentation');
+
+describe('util.disableInstrumentation', () => {
+  const testInstrumentationModules = {
+    './instrumentation/frameworks/hapi': {
+      init: () => {},
+      activate: () => {},
+      deactivate: () => {},
+      instrumentationName: 'hapi'
+    },
+    './instrumentation/frameworks/koa': {
+      init: () => {},
+      activate: () => {},
+      deactivate: () => {},
+      instrumentationName: 'koa'
+    },
+    './instrumentation/logging/bunyan': {
+      init: () => {},
+      activate: () => {},
+      deactivate: () => {},
+      instrumentationName: 'bunyan'
+    },
+    './instrumentation/frameworks/express': {
+      instrumentationName: 'express'
+    },
+    './instrumentation/databases/mongodb': {
+      instrumentationName: 'mongodb'
+    },
+    './instrumentation/cloud/aws/v3/s3': {
+      init: () => {},
+      activate: () => {},
+      deactivate: () => {},
+      instrumentationName: 'aws/v3'
+    },
+    './instrumentation/logging/console': {
+      instrumentationName: 'console'
+    }
+  };
+
+  beforeEach(() => {
+    disableInstrumentation.init({});
+    disableInstrumentation.activate({});
+  });
+
+  describe('Module name matching functionality', () => {
+    it('should disable instrumentation when exact module name matches disable list entry', () => {
+      disableInstrumentation.init({
+        tracing: {
+          disable: { libraries: ['console'] }
+        }
+      });
+
+      const result = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/console',
+        instrumentationModules: testInstrumentationModules
+      });
+      expect(result).to.be.true;
+    });
+
+    it('should disable instrumentation when instrumentationName matches disable list via agent config', () => {
+      disableInstrumentation.activate({
+        tracing: {
+          disable: { libraries: ['aws/v3'] }
+        }
+      });
+
+      const result = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/cloud/aws/v3/s3',
+        instrumentationModules: testInstrumentationModules
+      });
+      expect(result).to.be.true;
+    });
+
+    it('should disable instrumentation when instrumentationName matches disable list', () => {
+      disableInstrumentation.init({
+        tracing: {
+          disable: { libraries: ['aws/v3'] }
+        }
+      });
+
+      const result = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/cloud/aws/v3/s3',
+        instrumentationModules: testInstrumentationModules
+      });
+      expect(result).to.be.true;
+    });
+
+    it('should not disable instrumentation when neither module path nor instrumentationName matches', () => {
+      disableInstrumentation.init({
+        tracing: {
+          disable: { libraries: ['console'] }
+        }
+      });
+
+      const result = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/bunyan',
+        instrumentationModules: testInstrumentationModules
+      });
+      expect(result).to.be.false;
+    });
+
+    it('should handle module paths with different levels of nesting', () => {
+      disableInstrumentation.init({
+        tracing: {
+          disable: { libraries: ['mongodb'] }
+        }
+      });
+
+      const result = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/databases/mongodb',
+        instrumentationModules: testInstrumentationModules
+      });
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('Category-based disabling behavior', () => {
+    it('should disable all modules within a category when category is disabled via service config', () => {
+      disableInstrumentation.init({
+        tracing: {
+          disable: { categories: ['logging'] }
+        }
+      });
+
+      const consoleResult = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/console',
+        instrumentationModules: testInstrumentationModules
+      });
+      const bunyanResult = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/bunyan',
+        instrumentationModules: testInstrumentationModules
+      });
+
+      expect(consoleResult).to.be.true;
+      expect(bunyanResult).to.be.true;
+    });
+
+    it('should disable all modules within a category when category is disabled via agent config', () => {
+      disableInstrumentation.activate({
+        tracing: {
+          disable: { categories: ['logging'] }
+        }
+      });
+
+      const consoleResult = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/console',
+        instrumentationModules: testInstrumentationModules
+      });
+      const bunyanResult = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/bunyan',
+        instrumentationModules: testInstrumentationModules
+      });
+
+      expect(consoleResult).to.be.true;
+      expect(bunyanResult).to.be.true;
+    });
+
+    it('should not disable modules in categories not listed in disable configuration', () => {
+      disableInstrumentation.init({
+        tracing: {
+          disable: { categories: ['frameworks'] }
+        }
+      });
+
+      const dbResult = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/databases/mongodb',
+        instrumentationModules: testInstrumentationModules
+      });
+      const loggingResult = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/bunyan',
+        instrumentationModules: testInstrumentationModules
+      });
+
+      expect(dbResult).to.be.false;
+      expect(loggingResult).to.be.false;
+    });
+
+    it('should handle mixed category and specific module disabling', () => {
+      // e.g. when we want to disable bunyan but not console
+      // this config now only coming from agent
+      disableInstrumentation.init({
+        tracing: {
+          disable: { categories: ['logging'], libraries: ['console'] }
+        }
+      });
+
+      const bunyanesult = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/bunyan',
+        instrumentationModules: testInstrumentationModules
+      });
+      const consoleResult = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/console',
+        instrumentationModules: testInstrumentationModules
+      });
+
+      expect(bunyanesult).to.be.true;
+      expect(consoleResult).to.be.true;
+    });
+
+    it('should handle unsupported category disabling', () => {
+      disableInstrumentation.init({
+        tracing: {
+          disable: { categories: ['frameworks', 'logging'] }
+        }
+      });
+
+      const frameworkResult = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/frameworks/koa',
+        instrumentationModules: testInstrumentationModules
+      });
+      const loggingResult = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/console',
+        instrumentationModules: testInstrumentationModules
+      });
+
+      expect(frameworkResult).to.be.false;
+      expect(loggingResult).to.be.true;
+    });
+  });
+
+  describe('Configuration precedence rules', () => {
+    it('should prioritize service configuration over agent configuration when both are present', () => {
+      disableInstrumentation.init({
+        tracing: {
+          disable: { libraries: ['console'] }
+        }
+      });
+      disableInstrumentation.activate({
+        tracing: {
+          disable: { libraries: ['!console'] }
+        }
+      });
+
+      const consoleResult = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/console',
+        instrumentationModules: testInstrumentationModules
+      });
+
+      expect(consoleResult).to.be.true;
+    });
+
+    it('should accept service configuration and agent configuration when both are present', () => {
+      disableInstrumentation.init({
+        tracing: {
+          disable: { libraries: ['console'] }
+        }
+      });
+      disableInstrumentation.activate({
+        tracing: {
+          disable: { libraries: ['bunyan'] }
+        }
+      });
+
+      const consoleResult = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/console',
+        instrumentationModules: testInstrumentationModules
+      });
+      const bunyanResult = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/bunyan',
+        instrumentationModules: testInstrumentationModules
+      });
+
+      expect(consoleResult).to.be.true;
+      expect(bunyanResult).to.be.true;
+    });
+
+    it('should use agent configuration when service configuration is empty', () => {
+      disableInstrumentation.init({});
+      disableInstrumentation.activate({
+        tracing: {
+          disable: { libraries: ['console'] }
+        }
+      });
+
+      const result = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/console',
+        instrumentationModules: testInstrumentationModules
+      });
+      expect(result).to.be.true;
+    });
+
+    it('should use service configuration when agent configuration is empty', () => {
+      disableInstrumentation.init({});
+      disableInstrumentation.activate({
+        tracing: {
+          disable: { libraries: ['console'] }
+        }
+      });
+
+      const result = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/console',
+        instrumentationModules: testInstrumentationModules
+      });
+      expect(result).to.be.true;
+    });
+
+    it('should not disable any instrumentation when both configurations are empty', () => {
+      disableInstrumentation.init({});
+      disableInstrumentation.activate({});
+
+      const result = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/console',
+        instrumentationModules: testInstrumentationModules
+      });
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle empty disable list', () => {
+      disableInstrumentation.init({
+        tracing: {
+          disable: []
+        }
+      });
+
+      const result = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/console',
+        instrumentationModules: testInstrumentationModules
+      });
+      expect(result).to.be.false;
+    });
+
+    it('should handle undefined disable configuration', () => {
+      disableInstrumentation.init({});
+
+      const result = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/logging/console',
+        instrumentationModules: testInstrumentationModules
+      });
+      expect(result).to.be.false;
+    });
+
+    it('should handle module paths that do not exist in instrumentationModules', () => {
+      disableInstrumentation.init({
+        tracing: {
+          disable: { libraries: ['nonexistent'] }
+        }
+      });
+
+      const result = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/nonexistent/module',
+        instrumentationModules: testInstrumentationModules
+      });
+      expect(result).to.be.false;
+    });
+
+    it('should handle modules without instrumentationName property', () => {
+      disableInstrumentation.init({
+        tracing: {
+          disable: { libraries: ['express'] }
+        }
+      });
+
+      const result = disableInstrumentation.isInstrumentationDisabled({
+        instrumentationKey: './instrumentation/frameworks/express',
+        instrumentationModules: testInstrumentationModules
+      });
+      expect(result).to.be.true;
+    });
+  });
+});

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -20,7 +20,7 @@ describe('util.normalizeConfig', () => {
     delete process.env.INSTANA_DISABLE_AUTO_INSTR;
     delete process.env.INSTANA_DISABLE_TRACING;
     delete process.env.INSTANA_DISABLED_TRACERS;
-    delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
+    delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
     delete process.env.INSTANA_TRACE_IMMEDIATELY;
     delete process.env.INSTANA_EXTRA_HTTP_HEADERS;
     delete process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT;
@@ -275,14 +275,14 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('should disable individual instrumentations via env var', () => {
     process.env.INSTANA_DISABLED_TRACERS = 'graphQL   , GRPC';
     const config = normalizeConfig();
     // values will be normalized to lower case
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('config should take precedence over env vars when disabling individual tracers', () => {
@@ -293,60 +293,51 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['baz', 'fizz']);
   });
 
-  it('should disable individual instrumentations via disable config', () => {
+  it('should disable individual tracers via disable config', () => {
     const config = normalizeConfig({
       tracing: {
-        disable: ['graphQL', 'GRPC']
+        disable: { libraries: ['graphQL', 'GRPC'] }
       }
     });
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('should disable individual instrumentations via disable.instrumentations config', () => {
+  it('config should take precedence over INSTANA_TRACING_DISABLE_LIBRARIES when disabling individual tracers', () => {
+    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'foo, bar';
     const config = normalizeConfig({
       tracing: {
-        disable: { instrumentations: ['graphQL', 'GRPC'] }
+        disable: { libraries: ['baz', 'fizz'] }
       }
     });
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['baz', 'fizz']);
   });
 
-  it('config should take precedence over INSTANA_TRACING_DISABLE_INSTRUMENTATIONS  for config', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'foo, bar';
-    const config = normalizeConfig({
-      tracing: {
-        disable: { instrumentations: ['baz', 'fizz'] }
-      }
-    });
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
-  });
-
-  it('should disable multiple instrumentations via env var INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'graphQL   , GRPC, http';
+  it('should disable multiple tracers via env var INSTANA_TRACING_DISABLE_LIBRARIES', () => {
+    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'graphQL   , GRPC, http';
     const config = normalizeConfig();
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc', 'http']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc', 'http']);
   });
 
-  it('should handle single instrumentations via INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'console';
+  it('should handle single tracer via INSTANA_TRACING_DISABLE_LIBRARIES', () => {
+    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'console';
     const config = normalizeConfig();
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['console']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['console']);
   });
 
   it('should trim whitespace from tracer names', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = '  graphql  ,  grpc  ';
+    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = '  graphql  ,  grpc  ';
     const config = normalizeConfig();
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('should prefer INSTANA_TRACING_DISABLE_INSTRUMENTATIONS over INSTANA_DISABLED_TRACERS', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'redis';
+  it('should prefer INSTANA_TRACING_DISABLE_LIBRARIES over INSTANA_DISABLED_TRACERS', () => {
+    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'redis';
     process.env.INSTANA_DISABLED_TRACERS = 'postgres';
     const config = normalizeConfig();
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['redis']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['redis']);
   });
 
   // delete this test when we switch to opt-out

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -21,7 +21,7 @@ describe('util.normalizeConfig', () => {
     delete process.env.INSTANA_DISABLE_TRACING;
     delete process.env.INSTANA_DISABLED_TRACERS;
     delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
-    delete process.env.INSTANA_TRACING_DISABLE_CATEGORIES;
+    delete process.env.INSTANA_TRACING_DISABLE_GROUPS;
     delete process.env.INSTANA_TRACE_IMMEDIATELY;
     delete process.env.INSTANA_EXTRA_HTTP_HEADERS;
     delete process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT;
@@ -350,47 +350,47 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.disable.instrumentations).to.deep.equal(['redis']);
   });
 
-  it('should disable individual categories via disable config', () => {
+  it('should disable individual groups via disable config', () => {
     const config = normalizeConfig({
       tracing: {
-        disable: { categories: ['logging'] }
+        disable: { groups: ['logging'] }
       }
     });
-    expect(config.tracing.disable.categories).to.deep.equal(['logging']);
+    expect(config.tracing.disable.groups).to.deep.equal(['logging']);
   });
 
-  it('config should disable when env var INSTANA_TRACING_DISABLE_CATEGORIES is set', () => {
-    process.env.INSTANA_TRACING_DISABLE_CATEGORIES = 'frameworks, databases';
+  it('config should disable when env var INSTANA_TRACING_DISABLE_GROUPS is set', () => {
+    process.env.INSTANA_TRACING_DISABLE_GROUPS = 'frameworks, databases';
     const config = normalizeConfig({});
-    expect(config.tracing.disable.categories).to.deep.equal(['frameworks', 'databases']);
+    expect(config.tracing.disable.groups).to.deep.equal(['frameworks', 'databases']);
   });
 
-  it('config should take precedence over INSTANA_TRACING_DISABLE_CATEGORIES when disabling categories', () => {
-    process.env.INSTANA_TRACING_DISABLE_CATEGORIES = 'frameworks, databases';
+  it('config should take precedence over INSTANA_TRACING_DISABLE_GROUPS when disabling groups', () => {
+    process.env.INSTANA_TRACING_DISABLE_GROUPS = 'frameworks, databases';
     const config = normalizeConfig({
       tracing: {
-        disable: { categories: ['LOGGING'] }
+        disable: { groups: ['LOGGING'] }
       }
     });
-    expect(config.tracing.disable.categories).to.deep.equal(['logging']);
+    expect(config.tracing.disable.groups).to.deep.equal(['logging']);
   });
 
-  it('should disable libraries and categories when both configured', () => {
+  it('should disable instrumentations and groups when both configured', () => {
     const config = normalizeConfig({
       tracing: {
-        disable: { categories: ['LOGGING'], libraries: ['redis', 'kafka'] }
+        disable: { groups: ['LOGGING'], instrumentations: ['redis', 'kafka'] }
       }
     });
-    expect(config.tracing.disable.categories).to.deep.equal(['logging']);
-    expect(config.tracing.disable.libraries).to.deep.equal(['redis', 'kafka']);
+    expect(config.tracing.disable.groups).to.deep.equal(['logging']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['redis', 'kafka']);
   });
 
-  it('should disable libraries and categories when both configured env variables provided', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'redis';
-    process.env.INSTANA_TRACING_DISABLE_CATEGORIES = 'logging';
+  it('should disable instrumentations and groups when both configured env variables provided', () => {
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'redis';
+    process.env.INSTANA_TRACING_DISABLE_GROUPS = 'logging';
     const config = normalizeConfig();
-    expect(config.tracing.disable.libraries).to.deep.equal(['redis']);
-    expect(config.tracing.disable.categories).to.deep.equal(['logging']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['redis']);
+    expect(config.tracing.disable.groups).to.deep.equal(['logging']);
   });
 
   // delete this test when we switch to opt-out

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -20,7 +20,7 @@ describe('util.normalizeConfig', () => {
     delete process.env.INSTANA_DISABLE_AUTO_INSTR;
     delete process.env.INSTANA_DISABLE_TRACING;
     delete process.env.INSTANA_DISABLED_TRACERS;
-    delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
+    delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
     delete process.env.INSTANA_TRACE_IMMEDIATELY;
     delete process.env.INSTANA_EXTRA_HTTP_HEADERS;
     delete process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT;
@@ -275,14 +275,14 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('should disable individual instrumentations via env var', () => {
     process.env.INSTANA_DISABLED_TRACERS = 'graphQL   , GRPC';
     const config = normalizeConfig();
     // values will be normalized to lower case
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('config should take precedence over env vars when disabling individual tracers', () => {
@@ -293,51 +293,60 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disable.libraries).to.deep.equal(['baz', 'fizz']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
   });
 
-  it('should disable individual tracers via disable config', () => {
+  it('should disable individual instrumentations via disable config', () => {
     const config = normalizeConfig({
       tracing: {
-        disable: { libraries: ['graphQL', 'GRPC'] }
+        disable: ['graphQL', 'GRPC']
       }
     });
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('config should take precedence over INSTANA_TRACING_DISABLE_LIBRARIES when disabling individual tracers', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'foo, bar';
+  it('should disable individual instrumentations via disable.instrumentations config', () => {
     const config = normalizeConfig({
       tracing: {
-        disable: { libraries: ['baz', 'fizz'] }
+        disable: { instrumentations: ['graphQL', 'GRPC'] }
       }
     });
-    expect(config.tracing.disable.libraries).to.deep.equal(['baz', 'fizz']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('should disable multiple tracers via env var INSTANA_TRACING_DISABLE_LIBRARIES', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'graphQL   , GRPC, http';
-    const config = normalizeConfig();
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc', 'http']);
+  it('config should take precedence over INSTANA_TRACING_DISABLE_INSTRUMENTATIONS  for config', () => {
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'foo, bar';
+    const config = normalizeConfig({
+      tracing: {
+        disable: { instrumentations: ['baz', 'fizz'] }
+      }
+    });
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
   });
 
-  it('should handle single tracer via INSTANA_TRACING_DISABLE_LIBRARIES', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'console';
+  it('should disable multiple instrumentations via env var INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'graphQL   , GRPC, http';
     const config = normalizeConfig();
-    expect(config.tracing.disable.libraries).to.deep.equal(['console']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc', 'http']);
+  });
+
+  it('should handle single instrumentations via INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'console';
+    const config = normalizeConfig();
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['console']);
   });
 
   it('should trim whitespace from tracer names', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = '  graphql  ,  grpc  ';
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = '  graphql  ,  grpc  ';
     const config = normalizeConfig();
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('should prefer INSTANA_TRACING_DISABLE_LIBRARIES over INSTANA_DISABLED_TRACERS', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'redis';
+  it('should prefer INSTANA_TRACING_DISABLE_INSTRUMENTATIONS over INSTANA_DISABLED_TRACERS', () => {
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'redis';
     process.env.INSTANA_DISABLED_TRACERS = 'postgres';
     const config = normalizeConfig();
-    expect(config.tracing.disable.libraries).to.deep.equal(['redis']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['redis']);
   });
 
   // delete this test when we switch to opt-out

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -385,7 +385,7 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.disable.instrumentations).to.deep.equal(['redis', 'kafka']);
   });
 
-  it('should disable instrumentations and groups when both configured env variables provided', () => {
+  it('should disable instrumentations and groups when both env variables provided', () => {
     process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'redis';
     process.env.INSTANA_TRACING_DISABLE_GROUPS = 'logging';
     const config = normalizeConfig();


### PR DESCRIPTION
Previously, tracing could only be selectively disabled at the **package level**.
With this changes, tracing can now also be disabled at the **group level**.


### **New Configuration Options**

#### **1. Environment Variables**

* **Disable by group (e.g., logging):**

```bash
INSTANA_TRACING_DISABLE_GROUPS=logging
```

* **Disable specific instrumentations (e.g., console, redis):**

```bash
INSTANA_TRACING_DISABLE_INSTRUMENTATIONS=console,redis #incorporated in last PR
```

* **Disable both groups and instrumentations (flat format):**

```bash
INSTANA_TRACING_DISABLE=redis,logging
```

---

#### **2. In-Code**

To disable specific instrumentations or groups:

```javascript
require('@instana/collector')({
  tracing: {
    disable: {
      instrumentations: ['redis'],
      groups: ['logging']
    }
  }
});
```

Or using flat shorthand:

```javascript
require('@instana/collector')({
  tracing: {
    disable: ['redis', 'logging']
  }
});
```

---

### **TODO**

* [ ] Add agent-side configuration (in a separate PR) https://github.com/instana/nodejs/pull/1795
* [ ] Add support for `INSTANA_TRACING_DISABLE=true` (in a separate PR)
* [ ] Update public documentation

---

### **References**

* JIRA: [INSTA-38729](https://jsw.ibm.com/browse/INSTA-38729)
* Design Doc: [GitHub PR #344](https://github.ibm.com/instana/technical-documentation/pull/344)

