### PR TITLE
chore: removed gcr.io usage for test images

### DIFF
--- a/packages/google-cloud-run/images/README.md
+++ b/packages/google-cloud-run/images/README.md
@@ -6,9 +6,9 @@ This folder contains code to build and test the container image that is used by 
 There are three types of container images, each in their own sub folder:
 
 * `inspector`: A simple Node.js application that inspects its surrounding. It will print environment variables and query the Cloud Run metadata server, and print the resulting HTTP responses. When running this in a Google Cloud Run service, it gives valuable insight into what a live Google Cloud Run application has available. This has mostly historic value as `@instana/google-cloud-run` is pretty feature complete. However, it could become useful again if new Google Cloud Run runtime versions behave differently or make metadata available in a different way.
-* `instana-google-cloud-run`: This is the production base image that we provide to customers to monitor Node.js Google Cloud Run services. The production image is published to `icr.io` (the public IBM Container Registry). This happens on our CI system, see `packages/serverless/ci/pipeline.yaml`. The [CI pipeline](https://ci.instana.io/teams/nodejs/pipelines/serverless-in-process-collectors:main/jobs/google-cloud-run-nodejs-container-image-layer) uses the Dockerfile and package.json file in that folder, but not the build scripts `build.sh` or `build-and-push.sh`. These scripts are used to build variants of this image locally and to push them to a Google Cloud container registry, which is very usefull for testing. Available scripts:
+* `instana-google-cloud-run`: This is the production base image that we provide to customers to monitor Node.js Google Cloud Run services. The production image is published to `icr.io` (the public IBM Container Registry). This happens on our CI system, see `packages/serverless/ci/pipeline.yaml`. The [CI pipeline](https://ci.instana.io/teams/nodejs/pipelines/serverless-in-process-collectors:main/jobs/google-cloud-run-nodejs-container-image-layer) uses the Dockerfile and package.json file in that folder, but not the build scripts `build.sh` or `build-and-push.sh`. These scripts are used to build variants of this image locally and to push them to a Google Cloud Artifact registry, which is very usefull for testing. Available scripts:
     * `instana-google-cloud-run/build.sh` builds the Instana Node.js Google Cloud Run base image, either from your local sources or from an already published npm package.
-    * `instana-google-cloud-run/build-and-push.sh` builds the Instana Node.js Google Cloud Run base image and pushes it to a container image registry of your choice (usually our internal Google Cloud container registry).
+    * `instana-google-cloud-run/build-and-push.sh` builds the Instana Node.js Google Cloud Run base image and pushes it to a container image registry of your choice.
     * Both scripts each have documentation, explaining their purpose and the parameters they accept.
 * `test-images`: The scripts in this folder can build various versions of a simple test application that uses the base image from `instana-google-cloud-run`. Such an image basically represents a customer's application/Google Cloud Run service using our Node.js Google Cloud Run monitoring setup. Available scripts:
     * `test-images/build.sh`: Builds the test application image.
@@ -23,9 +23,10 @@ How-To for Common Use Cases
 
 - Copy `instana-google-cloud-run/.env.template` to `instana-google-cloud-run/.env`. Usually, no modification is necessary.
 - Copy `test-images/.env.template` to `test-images/.env`. Just for building and pushing the test images, no modification is necessary. If you want to run the test images locally and report to an Instana environment, you need to configure a few things, which are documented in the `.env.template` file.
-- You need to be authenticated with the Google Cloud platform. Please refer to the [Google Cloud documentation](https://cloud.google.com/container-registry/docs/advanced-authentication) for details.
 
-**NOTE:** For the Google Cloud container registry, you do not need to create repositories ahead of time. When you push a container image with a name that does not exist yet, the repository is created automatically.
+- Depending what you would like to achieve, you need to:
+  - be authenticated against IBM Cloud to push BASE test images for icr.io (preferred)
+  - be authenticated against Google Cloud platform to push images with test applications
 
 ### Test the Current Release
 
@@ -57,17 +58,17 @@ instana-google-cloud-run/build-and-push.sh npm next
 
 Instead of running `instana-google-cloud-run/build-and-push.sh`, you can also only run `instana-google-cloud-run/build.sh` if you are not interested in pushing the image to a registry or if you want to verify it can be built correctly first.
 
-With the default settings (default Google Cloud container registry) you would find the image here: <https://console.cloud.google.com/gcr/images/k8s-brewery/global/cloud-run/nodejs?project=k8s-brewery>
+With the default settings (default Google Cloud Artifact registry) you would find the image here: <https://console.cloud.google/artifacts/docker/k8s-brewery/europe-west10/eu-west-tracers?csesidx=54336053&inv=1&invt=AbzTvg&project=k8s-brewery>
 
 Once the Instana Node.js Google Cloud Run base image with the release candidate has been created, you can create a test application image with it:
 
 ```
 # Remember to provide an .env file in test-images, too.
 
-test-images/build-and-push.sh gcr 18 standard next
+test-images/build-and-push.sh internal-icr 18 standard next
 ```
 
-The first parameter (`gcr`) specifies from where to fetch the Instana Node.js Google Cloud Run base image (in this case, from the Google Cloud container registry instead of icr.io). The second parameter (`18`) specifies the Node.js version. The third parameter determines the Linux distribution to use (`standard` means Debian here). The last parameter, `next` refers to the Docker tag that has been applied to the Instana Node.js Google Cloud Run base image earlier, when building and pushing it. The tag `next` has been applied because that was the npm dist-tag that has been used. If you used a different dist-tag, you need to use that as the Docker tag here as well.
+The first parameter (`gcr`) specifies from where to fetch the Instana Node.js Google Cloud Run base image (in this case, from the Google Cloud Artifact registry instead of icr.io). The second parameter (`18`) specifies the Node.js version. The third parameter determines the Linux distribution to use (`standard` means Debian here). The last parameter, `next` refers to the Docker tag that has been applied to the Instana Node.js Google Cloud Run base image earlier, when building and pushing it. The tag `next` has been applied because that was the npm dist-tag that has been used. If you used a different dist-tag, you need to use that as the Docker tag here as well.
 
 Finally, use the [Google Cloud web UI](https://console.cloud.google.com/run?project=k8s-brewery) to include that image in a Google Cloud Run service and run it (see below).
 

--- a/packages/google-cloud-run/images/instana-google-cloud-run/.env.template
+++ b/packages/google-cloud-run/images/instana-google-cloud-run/.env.template
@@ -1,2 +1,2 @@
-image_tag_prefix=instana-google-cloud-run-nodejs
-gcr_repository=gcr.io/k8s-brewery/cloud-run/nodejs
+image_tag_prefix=google-cloud-run-nodejs-test-base-image
+gcr_repository=us.icr.io/instana-tracer-nodejs

--- a/packages/google-cloud-run/images/test-images/.env.template
+++ b/packages/google-cloud-run/images/test-images/.env.template
@@ -1,7 +1,7 @@
 # Options required to build and push images:
-image_tag_prefix=cloud-run-nodejs-test
-gcr_repository=gcr.io/k8s-brewery/cloud-run/nodejs
-container_name_prefix=cloud-run-nodejs-test-container
+gcr_repository=europe-west10-docker.pkg.dev/k8s-brewery/eu-west-tracers/nodejs
+image_tag_prefix=cloud-run-nodejs-test-app
+container_name_prefix=cloud-run-nodejs-test-app
 
 # Options required to run the image as a container locally in a simulated environment:
 instana_log_level=info

--- a/packages/google-cloud-run/images/test-images/build-and-push.sh
+++ b/packages/google-cloud-run/images/test-images/build-and-push.sh
@@ -7,7 +7,7 @@
 
 # This script builds and pushes a test image that can be used as a Google Cloud Run service. You can either the Instanan Node.js
 # Google Cloud Run base image from one of various sources (published production image, image from your local Docker registry,
-# image from an GCR registry with pre-release images).
+# base test image from our internal ICR registry).
 
 # ##############
 # # Parameters #

--- a/packages/google-cloud-run/images/test-images/build-and-run.sh
+++ b/packages/google-cloud-run/images/test-images/build-and-run.sh
@@ -6,8 +6,8 @@
 #######################################
 
 # This script builds and runs a test image locally. You can either the Instanan Node.js Google Cloud Run
-# base image from one of various sources (published production image, image from your local Docker registry,
-# image from an GCR registry with pre-release images). To run test images locally, you will also want to start the
+# base image from one of various sources (published production image, image from your local Docker registry or
+# base test image from our internal ICR registry). To run test images locally, you will also want to start the
 # metadata server emulation via
 #
 #   node packages/google-cloud-run/test/metadata_mock

--- a/packages/google-cloud-run/images/test-images/build.sh
+++ b/packages/google-cloud-run/images/test-images/build.sh
@@ -8,7 +8,7 @@
 
 # This script builds a test image that can be used as a Google Cloud Run service. You can either use the Instana
 # Node.js Google Cloud Run base image from one of various sources (published production image, image from your local
-# Docker registry, image from a GCR registry with pre-release images). You would usually not call this script
+# Docker registry or test base image from internal ICR registry). You would usually not call this script
 # directly but either use ./build-and-push.sh to directly push the built image to a registry to use it in an actual
 # Cloud Run service or use ./build-and-run.sh to run it locally in a simulated Cloud Run environment.
 
@@ -18,11 +18,8 @@
 #
 # $1: Instana Layer Mode, aka which Docker base image layer to use. One of:
 #     - released      -> use an official production image from the public IBM container registry (icr.io)
-#     - authenticated -> use an official production image from Instana's own registry (containers.instana.io);
-#                        these are the very same images that are available from icr.io, but containers.instana.io
-#                        requires authentication. See https://www.ibm.com/docs/en/obi/current?topic=agents-monitoring-google-cloud-run#getting-the-nodejs-layer-from-containersinstanaio
 #     - local         -> use a local Docker base image
-#     - gcr           -> use an image from the GCR registry with test base images
+#     - internal-icr  -> use a test base image from the internal ICR registry
 # $2: Node.js version. One of:
 #     - 20
 #     - 18
@@ -36,7 +33,7 @@
 #       it to our pre-release Google Cloud container registry with the tag "next" by doing
 #       packages/google-cloud-run/images/instana-google-cloud-run/build.sh npm next
 #       then using that pre-release base image here by specifying "next" for $4 as
-#       well -> packages/google-cloud-run/images/test-images/build.sh gcr 18 standard next
+#       well -> packages/google-cloud-run/images/test-images/build.sh internal-icr 18 standard next
 
 set -eo pipefail
 

--- a/packages/google-cloud-run/images/test-images/utils
+++ b/packages/google-cloud-run/images/test-images/utils
@@ -1,17 +1,17 @@
 function normalizeArgs {
   local instanaLayerMode=$1
+
+  # production base image: icr.io/instana/google-cloud-run-nodejs
+  # test base image: us.icr.io/instana-tracer-nodejs/google-cloud-run-nodejs-test-base-image
   if [[ -z "${instanaLayerMode-}" || $instanaLayerMode = released ]]; then
     instana_layer_without_tag=icr.io/instana/google-cloud-run-nodejs
     INSTANA_LAYER_MODE=released
-  elif [[ $instanaLayerMode = authenticated ]]; then
-    instana_layer_without_tag=containers.instana.io/instana/release/gcp/run/nodejs
-    INSTANA_LAYER_MODE=authenticated
   elif [[ $instanaLayerMode = local ]]; then
     instana_layer_without_tag=instana-google-cloud-run-nodejs-local
     INSTANA_LAYER_MODE=local
-  elif [[ $instanaLayerMode = gcr ]]; then
-    instana_layer_without_tag=gcr.io/k8s-brewery/cloud-run/nodejs/instana-google-cloud-run-nodejs
-    INSTANA_LAYER_MODE=gcr
+  elif [[ $instanaLayerMode = internal-icr ]]; then
+    instana_layer_without_tag=us.icr.io/instana-tracer-nodejs/google-cloud-run-nodejs-test-base-image
+    INSTANA_LAYER_MODE=internal-icr
   else
     echo "Unknown option for Instana layer: $instanaLayerMode"
     exit 1


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-34297

- gcr.io got shutdown (CR)
- we could theoretically use a migrated gcr.io domain, but that creates confusion in the future
- we now use a real AR registry when testing images on GC (test apps)
- we still need to keep gcr to test customer use cases
- for base images we only use icr