### PR TITLE
fix(collector): optimized flushing spans before application dies

### DIFF
--- a/packages/aws-lambda/test/many_data/test.js
+++ b/packages/aws-lambda/test/many_data/test.js
@@ -235,7 +235,8 @@ describe('aws-lambda: many data', function () {
           INSTANA_NUMBER_OF_ITERATIONS: 100,
           // TODO: This is currently off by default.
           INSTANA_FORCE_TRANSMISSION_STARTING_AT: 10,
-          INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS: 100
+          // Send out 100ms after initialization.
+          INSTANA_TRACING_TRANSMISSION_DELAY: 100
         }
       });
 

--- a/packages/collector/src/agentConnection.js
+++ b/packages/collector/src/agentConnection.js
@@ -256,6 +256,8 @@ function checkWhetherResponseForPathIsOkay(path, cb) {
 exports.sendMetrics = function sendMetrics(data, cb) {
   cb = util.atMostOnce('callback for sendMetrics', cb);
 
+  logger.debug(`Sending metrics to agent for pid ${pidStore.pid}.`);
+
   sendData(`/com.instana.plugin.nodejs.${pidStore.pid}`, data, (err, body) => {
     if (err) {
       cb(err, null);

--- a/packages/collector/src/metrics/transmissionCycle.js
+++ b/packages/collector/src/metrics/transmissionCycle.js
@@ -82,6 +82,10 @@ exports.activate = function activate(_metrics, _downstreamConnection, _onSuccess
 
   transmissionsSinceLastFullDataEmit = 0;
   sendMetrics();
+
+  process.once('beforeExit', () => {
+    clearTimeout(transmissionTimeoutHandle);
+  });
 };
 
 function sendMetrics() {

--- a/packages/collector/src/metrics/transmissionCycle.js
+++ b/packages/collector/src/metrics/transmissionCycle.js
@@ -82,10 +82,6 @@ exports.activate = function activate(_metrics, _downstreamConnection, _onSuccess
 
   transmissionsSinceLastFullDataEmit = 0;
   sendMetrics();
-
-  process.once('beforeExit', () => {
-    clearTimeout(transmissionTimeoutHandle);
-  });
 };
 
 function sendMetrics() {

--- a/packages/collector/test/apps/expressControls.js
+++ b/packages/collector/test/apps/expressControls.js
@@ -36,7 +36,6 @@ exports.start = function start(opts = {}, retryTime = null) {
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
   }
 
-  env.INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS = 0;
   env.INSTANA_RETRY_AGENT_CONNECTION_IN_MS = 100;
   env.INSTANA_LOG_LEVEL = 'warn';
 

--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -143,7 +143,6 @@ class ProcessControls {
         INSTANA_LOG_LEVEL: 'warn',
         INSTANA_DISABLE_TRACING: !this.tracingEnabled,
         INSTANA_FORCE_TRANSMISSION_STARTING_AT: '1',
-        INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS: opts.minimalDelay != null ? opts.minimalDelay : 0,
         INSTANA_FULL_METRICS_INTERNAL_IN_S: 1,
         INSTANA_FIRE_MONITORING_EVENT_DURATION_IN_MS: 500,
         INSTANA_RETRY_AGENT_CONNECTION_IN_MS: 500,

--- a/packages/collector/test/tracing/common/test.js
+++ b/packages/collector/test/tracing/common/test.js
@@ -41,7 +41,9 @@ mochaSuiteFn('tracing/common', function () {
           controls = new ProcessControls({
             useGlobalAgent: true,
             dirname: __dirname,
-            minimalDelay: 6000
+            env: {
+              INSTANA_TRACING_TRANSMISSION_DELAY: '6000'
+            }
           });
         } else {
           controls = new ProcessControls({

--- a/packages/collector/test/tracing/sdk/allowRootExitSpans/app_default.js
+++ b/packages/collector/test/tracing/sdk/allowRootExitSpans/app_default.js
@@ -12,7 +12,8 @@ process.on('SIGTERM', () => {
 
 require('../../../../src')({
   tracing: {
-    allowRootExitSpan: true
+    allowRootExitSpan: true,
+    useOpentelemetry: false
   }
 });
 

--- a/packages/collector/test/tracing/sdk/allowRootExitSpans/app_with_entry.js
+++ b/packages/collector/test/tracing/sdk/allowRootExitSpans/app_with_entry.js
@@ -12,7 +12,8 @@ process.on('SIGTERM', () => {
 
 const instana = require('../../../../src')({
   tracing: {
-    allowRootExitSpan: true
+    allowRootExitSpan: true,
+    useOpentelemetry: false
   }
 });
 const { delay } = require('../../../../../core/test/test_util');

--- a/packages/collector/test/tracing/sdk/allowRootExitSpans/test.js
+++ b/packages/collector/test/tracing/sdk/allowRootExitSpans/test.js
@@ -16,10 +16,11 @@ const constants = require('@instana/core').tracing.constants;
 
 const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 
-// ATTENTION: starting the short living worker will already send out the span!
-//            beforeEach will kick in afterwards and reset the spans! Do not use beforeEach!
+// ATTENTION: starting the short living worker will immediately send out the span!
+//            beforeEach will kick in AFTERWARDS and reset the spans! Do not use beforeEach!
 // ATTENTION: the apps are dying directly and any timer in our tracer won't get triggered anymore
-//            because the process is already dead and we are making use of `unref`.
+//            because the process is already dead and we are making use of `unref`. Therefor
+//            spans would not get flushed out without `beforeExit` native event.
 mochaSuiteFn('tracing/sdk/rootExitSpans', function () {
   this.timeout(config.getTestTimeout());
 

--- a/packages/collector/test/tracing/sdk/allowRootExitSpans/test.js
+++ b/packages/collector/test/tracing/sdk/allowRootExitSpans/test.js
@@ -18,6 +18,8 @@ const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : descri
 
 // ATTENTION: starting the short living worker will already send out the span!
 //            beforeEach will kick in afterwards and reset the spans! Do not use beforeEach!
+// ATTENTION: the apps are dying directly and any timer in our tracer won't get triggered anymore
+//            because the process is already dead and we are making use of `unref`.
 mochaSuiteFn('tracing/sdk/rootExitSpans', function () {
   this.timeout(config.getTestTimeout());
 
@@ -50,7 +52,7 @@ mochaSuiteFn('tracing/sdk/rootExitSpans', function () {
 
         const entrySpan = expectEntrySpan(appControls, spans);
         expectExitSpan(appControls, entrySpan, spans);
-      });
+      }, 1000);
     });
   });
 
@@ -74,7 +76,7 @@ mochaSuiteFn('tracing/sdk/rootExitSpans', function () {
         const spans = await agentControls.getSpans();
         expect(spans.length).to.equal(1);
         assertSingleExitSpan(spans);
-      });
+      }, 1000);
     });
   });
 

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -19,11 +19,8 @@ let downstreamConnection = null;
 let isActive = false;
 /** @type {number} */
 let activatedAt = null;
-
-const minDelayBeforeSendingSpans = 1000;
-
 /** @type {number} */
-let initialDelayBeforeSendingSpans;
+let minDelayBeforeSendingSpans = 1000;
 /** @type {number} */
 let transmissionDelay;
 /** @type {number} */
@@ -92,7 +89,7 @@ exports.init = function init(config, _downstreamConnection) {
   forceTransmissionStartingAt = config.tracing.forceTransmissionStartingAt;
   transmissionDelay = config.tracing.transmissionDelay;
   batchingEnabled = config.tracing.spanBatchingEnabled;
-  initialDelayBeforeSendingSpans = Math.max(transmissionDelay, minDelayBeforeSendingSpans);
+  minDelayBeforeSendingSpans = Math.max(transmissionDelay, minDelayBeforeSendingSpans);
   isFaaS = false;
   transmitImmediate = false;
 
@@ -100,6 +97,7 @@ exports.init = function init(config, _downstreamConnection) {
     preActivationCleanupIntervalHandle = setInterval(() => {
       removeSpansIfNecessary();
     }, transmissionDelay);
+
     preActivationCleanupIntervalHandle.unref();
   }
 };
@@ -145,7 +143,7 @@ exports.activate = function activate(extraConfig) {
   //       Spans are collected during the agent cycle -  we flush them here and assume we
   //       are connected to the agent.
   if (!isFaaS) {
-    transmissionTimeoutHandle = setTimeout(transmitSpans, initialDelayBeforeSendingSpans);
+    transmissionTimeoutHandle = setTimeout(transmitSpans, minDelayBeforeSendingSpans);
     transmissionTimeoutHandle.unref();
   }
 

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -148,6 +148,8 @@ exports.activate = function activate(extraConfig) {
     clearInterval(preActivationCleanupIntervalHandle);
   }
 
+  // NOTE: Faas (currently only Lambda) sends a bundle of spans at the end of the handler execution.
+  //       We don't have to worry about not flushing the spans.
   if (!isFaaS) {
     process.once('beforeExit', async () => {
       transmitSpans();

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -142,15 +142,10 @@ exports.activate = function activate(extraConfig) {
   if (!isFaaS) {
     transmissionTimeoutHandle = setTimeout(transmitSpans, transmissionDelay);
     transmissionTimeoutHandle.unref();
-  }
 
-  if (preActivationCleanupIntervalHandle) {
-    clearInterval(preActivationCleanupIntervalHandle);
-  }
-
-  // NOTE: Faas (currently only Lambda) sends a bundle of spans at the end of the handler execution.
-  //       We don't have to worry about not flushing the spans.
-  if (!isFaaS) {
+    // CASE: Flushing spans before process exits.
+    // NOTE: Faas (currently only Lambda) sends a bundle of spans at the end of the handler execution.
+    //       We don't have to worry about not flushing the spans.
     process.once('beforeExit', async () => {
       transmitSpans();
 
@@ -161,6 +156,10 @@ exports.activate = function activate(extraConfig) {
         }, 500);
       });
     });
+  }
+
+  if (preActivationCleanupIntervalHandle) {
+    clearInterval(preActivationCleanupIntervalHandle);
   }
 };
 

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -156,7 +156,7 @@ exports.activate = function activate(extraConfig) {
         setTimeout(() => {
           clearTimeout(transmissionTimeoutHandle);
           resolve();
-        }, 1000);
+        }, 500);
       });
     });
   }

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -211,7 +211,6 @@ exports.addSpan = function (span) {
       addToBucket(span);
     }
 
-    console.log(forceTransmissionStartingAt, transmissionDelay, activatedAt);
     // NOTE: we send out spans directly if the number of spans reaches > 500 [default] and if the min delay is reached.
     if (spans.length >= forceTransmissionStartingAt && Date.now() - transmissionDelay > activatedAt) {
       transmitSpans();

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -374,12 +374,29 @@ function normalizeActivateImmediately(config) {
 function normalizeTracingTransmission(config) {
   config.tracing.maxBufferedSpans = config.tracing.maxBufferedSpans || defaults.tracing.maxBufferedSpans;
 
-  config.tracing.transmissionDelay = normalizeSingleValue(
-    config.tracing.transmissionDelay,
-    defaults.tracing.transmissionDelay,
-    'config.tracing.transmissionDelay',
-    'INSTANA_TRACING_TRANSMISSION_DELAY'
-  );
+  if (process.env['INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS']) {
+    logger.warn(
+      'The environment variable INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS is deprecated and will be removed in the next major release. ' +
+        'Please use INSTANA_TRACING_TRANSMISSION_DELAY instead.'
+    );
+
+    config.tracing.transmissionDelay = parseInt(process.env['INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS'], 10);
+
+    if (isNaN(config.tracing.transmissionDelay)) {
+      logger.warn(
+        `The value of INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS is not a number. Falling back to the default value ${defaults.tracing.transmissionDelay}.`
+      );
+
+      config.tracing.transmissionDelay = defaults.tracing.transmissionDelay;
+    }
+  } else {
+    config.tracing.transmissionDelay = normalizeSingleValue(
+      config.tracing.transmissionDelay,
+      defaults.tracing.transmissionDelay,
+      'config.tracing.transmissionDelay',
+      'INSTANA_TRACING_TRANSMISSION_DELAY'
+    );
+  }
 
   config.tracing.forceTransmissionStartingAt = normalizeSingleValue(
     config.tracing.forceTransmissionStartingAt,

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -374,6 +374,14 @@ function normalizeActivateImmediately(config) {
 function normalizeTracingTransmission(config) {
   config.tracing.maxBufferedSpans = config.tracing.maxBufferedSpans || defaults.tracing.maxBufferedSpans;
 
+  config.tracing.transmissionDelay = normalizeSingleValue(
+    config.tracing.transmissionDelay,
+    defaults.tracing.transmissionDelay,
+    'config.tracing.transmissionDelay',
+    'INSTANA_TRACING_TRANSMISSION_DELAY'
+  );
+
+  // DEPRECATED! This was never documented, but we shared it with a customer.
   if (process.env['INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS']) {
     logger.warn(
       'The environment variable INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS is deprecated and will be removed in the next major release. ' +
@@ -389,13 +397,6 @@ function normalizeTracingTransmission(config) {
 
       config.tracing.transmissionDelay = defaults.tracing.transmissionDelay;
     }
-  } else {
-    config.tracing.transmissionDelay = normalizeSingleValue(
-      config.tracing.transmissionDelay,
-      defaults.tracing.transmissionDelay,
-      'config.tracing.transmissionDelay',
-      'INSTANA_TRACING_TRANSMISSION_DELAY'
-    );
   }
 
   config.tracing.forceTransmissionStartingAt = normalizeSingleValue(

--- a/packages/serverless/test/backend_stub/index.js
+++ b/packages/serverless/test/backend_stub/index.js
@@ -61,7 +61,7 @@ app.post('/serverless/bundle', acceptBundle);
 
 function acceptBundle(req, res) {
   logger.info('POST /serverless/bundle');
-  logger.debug(req.body);
+  logger.debug(`Received ${req.body.spans.length}`);
 
   receivedData.rawBundles.push(req.body);
   if (unresponsive) {


### PR DESCRIPTION
- the span buffer was not flushing before the app dies
- especially visable for worker apps
- the bug in our root exit span worker app was **hidden** because the `minDelayBeforeSendingSpans` was suppressed to 0
- the test fails when you remove the minDelayBeforeSendingSpans
- discovered while working on #1315 
