### PR TITLE
fix: renamed disabledTracers to disableTracers config

### DIFF
--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -153,9 +153,9 @@ const isInstrumentationDisabled = (cfg, instrumentationKey) => {
   const matchResult = instrumentationKey.match(/.\/instrumentation\/[^/]*\/(.*)/);
   const extractedInstrumentationName = matchResult ? matchResult[1] : instrumentationKey.match(/\/([^/]+)$/)[1];
   return (
-    cfg.tracing.disabledTracers.includes(extractedInstrumentationName.toLowerCase()) ||
+    cfg.tracing.disableTracers.includes(extractedInstrumentationName.toLowerCase()) ||
     (instrumentationModules[instrumentationKey].instrumentationName &&
-      cfg.tracing.disabledTracers.includes(instrumentationModules[instrumentationKey].instrumentationName))
+      cfg.tracing.disableTracers.includes(instrumentationModules[instrumentationKey].instrumentationName))
   );
 };
 

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -498,13 +498,15 @@ function normalizeDisableTracers(config) {
   if (!config.tracing.disableTracers) {
     config.tracing.disableTracers = [];
   }
-  // case 1: use in-code configuration if available
-  // Internally use disableTracers instead of disabledTracers
+  // Case 1: process in-code configuration
+  // Note: We maintain backward compatibility with the deprecated 'disabledTracers' property
+  // but internally standardize on 'disableTracers'. The old property will be removed in v5.
   if (config.tracing.disabledTracers) {
     logger.warn(
       'The configuration property "tracing.disabledTracers" is deprecated and will be removed in the next major release. ' +
         'Please use "tracing.disableTracers" instead.'
     );
+
     if (Array.isArray(config.tracing.disabledTracers)) {
       config.tracing.disableTracers.push(...config.tracing.disabledTracers);
     } else {
@@ -542,7 +544,9 @@ function getDisableTracersFromEnv() {
 
   if (process.env.INSTANA_DISABLE_TRACERS) {
     disableTracersEnvVar = parseHeadersEnvVar(process.env.INSTANA_DISABLE_TRACERS);
-  } else if (process.env.INSTANA_DISABLED_TRACERS) {
+  }
+  // We deprecated the variable `INSTANA_DISABLED_TRACERS` and will be removed in the next major release(v5).
+  else if (process.env.INSTANA_DISABLED_TRACERS) {
     disableTracersEnvVar = parseHeadersEnvVar(process.env.INSTANA_DISABLED_TRACERS);
     logger.warn(
       'The environment variable INSTANA_DISABLED_TRACERS is deprecated and will be removed in the next major release. ' +

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -502,7 +502,7 @@ function normalizeDisableTracers(config) {
   // Internally use disableTracers instead of disabledTracers
   if (config.tracing.disabledTracers) {
     logger.warn(
-      'The configuration property "tracing.disabledTracers" is deprecated and will be removed in a future release. ' +
+      'The configuration property "tracing.disabledTracers" is deprecated and will be removed in the next major release. ' +
         'Please use "tracing.disableTracers" instead.'
     );
     if (Array.isArray(config.tracing.disabledTracers)) {

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -495,9 +495,6 @@ function normalizeNumericalStackTraceLength(numericalLength) {
  * @param {InstanaConfig} config
  */
 function normalizeDisableTracers(config) {
-  if (!config.tracing.disableTracers) {
-    config.tracing.disableTracers = [];
-  }
   // Case 1: process in-code configuration
   // Note: We maintain backward compatibility with the deprecated 'disabledTracers' property
   // but internally standardize on 'disableTracers'. The old property will be removed in v5.
@@ -507,24 +504,17 @@ function normalizeDisableTracers(config) {
         'Please use "tracing.disableTracers" instead.'
     );
 
-    if (Array.isArray(config.tracing.disabledTracers)) {
-      config.tracing.disableTracers.push(...config.tracing.disabledTracers);
-    } else {
-      logger.warn(
-        `Invalid configuration: config.tracing.disabledTracers is not an array, the value will be ignored: ${JSON.stringify(
-          config.tracing.disabledTracers
-        )}`
-      );
+    // Only use disabledTracers if disableTracers isn't already set
+    if (!config.tracing.disableTracers) {
+      config.tracing.disableTracers = config.tracing.disabledTracers;
     }
     delete config.tracing.disabledTracers;
   }
 
   // case 2: Check environment variables if available
-  if (config.tracing.disableTracers.length === 0) {
-    const disableTracersEnvVar = getDisableTracersFromEnv();
-    if (disableTracersEnvVar) {
-      config.tracing.disableTracers = disableTracersEnvVar;
-    }
+  if (!config.tracing.disableTracers) {
+    // Check environment variables first, fall back to defaults
+    config.tracing.disableTracers = getDisableTracersFromEnv() || defaults.tracing.disableTracers;
   }
 
   if (!Array.isArray(config.tracing.disableTracers)) {

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -501,6 +501,10 @@ function normalizeDisableTracers(config) {
   // case 1: use in-code configuration if available
   // Internally use disableTracers instead of disabledTracers
   if (config.tracing.disabledTracers) {
+    logger.warn(
+      'The configuration property "tracing.disabledTracers" is deprecated and will be removed in a future release. ' +
+        'Please use "tracing.disableTracers" instead.'
+    );
     if (Array.isArray(config.tracing.disabledTracers)) {
       config.tracing.disableTracers.push(...config.tracing.disabledTracers);
     } else {

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -74,6 +74,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     initAwsSdkv2.reset();
     initAwsSdkv3.reset();
 
+    delete process.env.INSTANA_DISABLE_TRACERS;
     delete process.env.INSTANA_DISABLED_TRACERS;
   });
 
@@ -105,132 +106,182 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
   });
 
   describe('init', function () {
-    it('should deactivate instrumentation via disabledTracers', () => {
-      initAndActivate({ tracing: { disabledTracers: ['grpc', 'kafkajs', 'aws-sdk/v2'] } });
+    describe('tracer deactivation', () => {
+      describe('via disableTracers config', () => {
+        it('should deactivate specified tracers', () => {
+          initAndActivate({ tracing: { disableTracers: ['grpc', 'kafkajs', 'aws-sdk/v2'] } });
 
-      // grpcJs instrumentation has not been disabled, make sure its init and activate are called
-      expect(initStubGrpcJs).to.have.been.called;
-      expect(activateStubGrpcJs).to.have.been.called;
+          // grpcJs instrumentation has not been disabled, make sure its init and activate are called
+          expect(initStubGrpcJs).to.have.been.called;
+          expect(activateStubGrpcJs).to.have.been.called;
 
-      // kafkajs has been disabled...
-      expect(initStubKafkaJs).to.not.have.been.called;
-      expect(activateStubKafkaJs).to.not.have.been.called;
+          // kafkajs has been disabled...
+          expect(initStubKafkaJs).to.not.have.been.called;
+          expect(activateStubKafkaJs).to.not.have.been.called;
 
-      // ...but rdkafka has not been disabled
-      expect(initStubRdKafka).to.have.been.called;
-      expect(activateStubRdKafka).to.have.been.called;
+          // ...but rdkafka has not been disabled
+          expect(initStubRdKafka).to.have.been.called;
+          expect(activateStubRdKafka).to.have.been.called;
 
-      // aws-sdk/v2 has been disabled (via aws-sdk/v2)
-      expect(initAwsSdkv2).not.to.have.been.called;
-      expect(activateAwsSdkv2).not.to.have.been.called;
+          // aws-sdk/v2 has been disabled (via aws-sdk/v2)
+          expect(initAwsSdkv2).not.to.have.been.called;
+          expect(activateAwsSdkv2).not.to.have.been.called;
 
-      // aws-sdk/v3 has not been disabled
-      expect(initAwsSdkv3).to.have.been.called;
-      expect(activateAwsSdkv3).to.have.been.called;
-    });
+          // aws-sdk/v3 has not been disabled
+          expect(initAwsSdkv3).to.have.been.called;
+          expect(activateAwsSdkv3).to.have.been.called;
+        });
 
-    it('should deactivate instrumentation via INSTANA_DISABLED_TRACERS environment variable', () => {
-      process.env.INSTANA_DISABLED_TRACERS = 'grpc';
-      initAndActivate({});
+        it('should disable multiple tracers in INSTANA_DISABLE_TRACERS env var', () => {
+          process.env.INSTANA_DISABLE_TRACERS = 'rdkafka,kafkajs,aws-sdk/v3';
+          initAndActivate({});
 
-      expect(activateStubGrpcJs).to.have.been.called;
-      expect(activateStubKafkaJs).to.have.been.called;
-      expect(activateStubRdKafka).to.have.been.called;
-      expect(activateAwsSdkv2).to.have.been.called;
-    });
+          expect(initStubKafkaJs).to.not.have.been.called;
+          expect(initStubRdKafka).to.not.have.been.called;
+          expect(initAwsSdkv3).not.to.have.been.called;
 
-    it('should update Kafka tracing config', () => {
-      const extraConfigFromAgent = {
-        tracing: {
-          kafka: {
-            traceCorrelation: false
-          }
-        }
-      };
-      initAndActivate({}, extraConfigFromAgent);
-      expect(activateStubKafkaJs).to.have.been.calledWith(extraConfigFromAgent);
-      expect(activateStubRdKafka).to.have.been.calledWith(extraConfigFromAgent);
-    });
+          expect(initAwsSdkv2).to.have.been.called;
+          expect(initStubGrpcJs).to.have.been.called;
+        });
 
-    it('should disable aws-sdk/v3 via config', () => {
-      initAndActivate({ tracing: { disabledTracers: ['aws-sdk/v3'] } });
+        it('should update Kafka tracing configuration', () => {
+          const kafkaConfig = { tracing: { kafka: { traceCorrelation: false } } };
+          initAndActivate({}, kafkaConfig);
 
-      // aws-sdk/v3 has been disabled (via aws-sdk/v3)
-      expect(initAwsSdkv3).not.to.have.been.called;
-      expect(activateAwsSdkv3).not.to.have.been.called;
+          expect(activateStubKafkaJs).to.have.been.calledWith(kafkaConfig);
+          expect(activateStubRdKafka).to.have.been.calledWith(kafkaConfig);
+        });
 
-      // aws-sdk/v2 has not been disabled (via aws-sdk/v2)
-      expect(initAwsSdkv2).to.have.been.called;
-      expect(activateAwsSdkv2).to.have.been.called;
-    });
+        it('should disable aws-sdk/v3 via config', () => {
+          initAndActivate({ tracing: { disableTracers: ['aws-sdk/v3'] } });
 
-    it('should disable both aws-sdk/v3 and aws-sdk/v2 via config', () => {
-      initAndActivate({ tracing: { disabledTracers: ['aws-sdk/v3', 'aws-sdk/v2'] } });
+          expect(initAwsSdkv3).not.to.have.been.called;
+          expect(activateAwsSdkv3).not.to.have.been.called;
 
-      // aws-sdk/v2 has been disabled (via aws-sdk/v2)
-      expect(initAwsSdkv2).not.to.have.been.called;
-      expect(activateAwsSdkv2).not.to.have.been.called;
+          expect(initAwsSdkv2).to.have.been.called;
+          expect(activateAwsSdkv2).to.have.been.called;
+        });
 
-      // aws-sdk/v3 has been disabled (via aws-sdk/v3)
-      expect(initAwsSdkv3).not.to.have.been.called;
-      expect(activateAwsSdkv3).not.to.have.been.called;
-    });
+        it('should disable both aws-sdk versions via config', () => {
+          initAndActivate({ tracing: { disableTracers: ['aws-sdk/v3', 'aws-sdk/v2'] } });
 
-    it('should deactivate instrumentation via disableTracers', () => {
-      initAndActivate({ tracing: { disableTracers: ['grpc', 'kafkajs', 'aws-sdk/v2'] } });
+          expect(initAwsSdkv2).not.to.have.been.called;
+          expect(activateAwsSdkv2).not.to.have.been.called;
 
-      expect(initStubGrpcJs).to.have.been.called;
-      expect(activateStubGrpcJs).to.have.been.called;
+          expect(initAwsSdkv3).not.to.have.been.called;
+          expect(activateAwsSdkv3).not.to.have.been.called;
+        });
 
-      expect(initStubKafkaJs).to.not.have.been.called;
-      expect(activateStubKafkaJs).to.not.have.been.called;
+        it('should ignore empty disableTracers array', () => {
+          initAndActivate({ tracing: { disableTracers: [] } });
 
-      expect(initStubRdKafka).to.have.been.called;
-      expect(activateStubRdKafka).to.have.been.called;
+          expect(initStubGrpcJs).to.have.been.called;
+          expect(activateStubGrpcJs).to.have.been.called;
 
-      expect(initAwsSdkv2).not.to.have.been.called;
-      expect(activateAwsSdkv2).not.to.have.been.called;
+          expect(initStubKafkaJs).to.have.been.called;
+          expect(activateStubKafkaJs).to.have.been.called;
 
-      expect(initAwsSdkv3).to.have.been.called;
-      expect(activateAwsSdkv3).to.have.been.called;
-    });
+          expect(initStubRdKafka).to.have.been.called;
+          expect(activateStubRdKafka).to.have.been.called;
+        });
 
-    it('should deactivate instrumentation via INSTANA_DISABLE_TRACERS environment variable', () => {
-      process.env.INSTANA_DISABLE_TRACERS = 'grpc';
-      initAndActivate({});
+        it('should prefer config.tracing.disableTracers over env vars', () => {
+          process.env.INSTANA_DISABLE_TRACERS = 'grpc,kafkajs';
+          initAndActivate({ tracing: { disableTracers: ['aws-sdk/v2'] } });
 
-      expect(activateStubGrpcJs).to.have.been.called;
-      expect(activateStubKafkaJs).to.have.been.called;
-      expect(activateStubRdKafka).to.have.been.called;
-      expect(activateAwsSdkv2).to.have.been.called;
-    });
+          expect(initAwsSdkv2).not.to.have.been.called;
+          expect(activateAwsSdkv2).not.to.have.been.called;
 
-    it('should disable both aws-sdk versions via INSTANA_DISABLE_TRACERS environment variable', () => {
-      process.env.INSTANA_DISABLE_TRACERS = 'aws-sdk/v2,aws-sdk/v3';
-      initAndActivate({});
+          expect(initStubGrpcJs).to.have.been.called;
+          expect(activateStubGrpcJs).to.have.been.called;
 
-      expect(initAwsSdkv2).not.to.have.been.called;
-      expect(activateAwsSdkv2).not.to.have.been.called;
+          expect(initStubKafkaJs).to.have.been.called;
+          expect(activateStubKafkaJs).to.have.been.called;
+        });
+      });
 
-      expect(initAwsSdkv3).not.to.have.been.called;
-      expect(activateAwsSdkv3).not.to.have.been.called;
-    });
+      describe('[deprecated] via disabledTracers config', () => {
+        it('should deactivate tracers', () => {
+          initAndActivate({ tracing: { disabledTracers: ['grpc', 'kafkajs', 'aws-sdk/v2'] } });
 
-    it('should handle environment variable with multiple tracers', () => {
-      process.env.INSTANA_DISABLE_TRACERS = 'rdkafka,kafkajs';
-      initAndActivate({});
+          // grpcJs instrumentation has not been disabled, make sure its init and activate are called
+          expect(initStubGrpcJs).to.have.been.called;
+          expect(activateStubGrpcJs).to.have.been.called;
 
-      expect(initStubKafkaJs).to.not.have.been.called;
-      expect(activateStubKafkaJs).to.not.have.been.called;
+          // kafkajs has been disabled...
+          expect(initStubKafkaJs).to.not.have.been.called;
+          expect(activateStubKafkaJs).to.not.have.been.called;
 
-      expect(initStubRdKafka).to.not.have.been.called;
-      expect(activateStubRdKafka).to.not.have.been.called;
+          // ...but rdkafka has not been disabled
+          expect(initStubRdKafka).to.have.been.called;
+          expect(activateStubRdKafka).to.have.been.called;
 
-      expect(initAwsSdkv2).to.have.been.called;
-      expect(activateAwsSdkv2).to.have.been.called;
+          // aws-sdk/v2 has been disabled (via aws-sdk/v2)
+          expect(initAwsSdkv2).not.to.have.been.called;
+          expect(activateAwsSdkv2).not.to.have.been.called;
 
-      expect(initAwsSdkv3).to.have.been.called;
-      expect(activateAwsSdkv3).to.have.been.called;
+          // aws-sdk/v3 has not been disabled
+          expect(initAwsSdkv3).to.have.been.called;
+          expect(activateAwsSdkv3).to.have.been.called;
+        });
+
+        it('should handle INSTANA_DISABLED_TRACERS env var', () => {
+          process.env.INSTANA_DISABLED_TRACERS = 'kafkajs';
+          initAndActivate({});
+
+          expect(initStubKafkaJs).not.to.have.been.called;
+          expect(activateStubKafkaJs).not.to.have.been.called;
+        });
+
+        it('should handle empty disabledTracers array', () => {
+          initAndActivate({ tracing: { disabledTracers: [] } });
+
+          expect(initStubGrpcJs).to.have.been.called;
+          expect(initStubKafkaJs).to.have.been.called;
+          expect(initStubRdKafka).to.have.been.called;
+        });
+
+        it('should trim whitespace in INSTANA_DISABLED_TRACERS', () => {
+          process.env.INSTANA_DISABLED_TRACERS = '  grpc  ,  kafkajs  ';
+          initAndActivate({});
+
+          expect(initStubGrpcJs).to.have.been.called;
+          expect(activateStubGrpcJs).to.have.been.called;
+
+          expect(initStubKafkaJs).not.to.have.been.called;
+          expect(activateStubKafkaJs).not.to.have.been.called;
+        });
+
+        it('should prefer disableTracers over disabledTracers when both exist', () => {
+          initAndActivate({
+            tracing: {
+              disabledTracers: ['grpc', 'kafkajs'],
+              disableTracers: ['aws-sdk/v2']
+            }
+          });
+
+          expect(initAwsSdkv2).not.to.have.been.called;
+          expect(activateAwsSdkv2).not.to.have.been.called;
+
+          expect(initStubGrpcJs).to.have.been.called;
+          expect(activateStubGrpcJs).to.have.been.called;
+
+          expect(initStubKafkaJs).to.have.been.called;
+          expect(activateStubKafkaJs).to.have.been.called;
+        });
+
+        it('should prefer INSTANA_DISABLE_TRACERS over INSTANA_DISABLED_TRACERS', () => {
+          process.env.INSTANA_DISABLE_TRACERS = 'aws-sdk/v2';
+          process.env.INSTANA_DISABLED_TRACERS = 'kafkajs';
+          initAndActivate({});
+
+          expect(initAwsSdkv2).not.to.have.been.called;
+          expect(activateAwsSdkv2).not.to.have.been.called;
+
+          expect(initStubKafkaJs).to.have.been.called;
+          expect(activateStubKafkaJs).to.have.been.called;
+        });
+      });
     });
 
     function initAndActivate(initConfig, extraConfigForActivate) {

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -258,7 +258,7 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.disableTracers).to.deep.equal([]);
   });
 
-  it('should disable individual tracers via config', () => {
+  it('should disable individual tracers via disabledTracers config', () => {
     const config = normalizeConfig({
       tracing: {
         disabledTracers: ['graphQL', 'GRPC']
@@ -275,7 +275,7 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.disableTracers).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('config should take precedence over env vars when disabling individual tracers', () => {
+  it('config should take precedence over INSTANA_DISABLED_TRACERS when disabling individual tracers', () => {
     process.env.INSTANA_DISABLED_TRACERS = 'foo, bar';
     const config = normalizeConfig({
       tracing: {
@@ -283,6 +283,25 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
+    expect(config.tracing.disableTracers).to.deep.equal(['baz', 'fizz']);
+  });
+
+  it('should disable individual tracers via disableTracers config', () => {
+    const config = normalizeConfig({
+      tracing: {
+        disableTracers: ['graphQL', 'GRPC']
+      }
+    });
+    expect(config.tracing.disableTracers).to.deep.equal(['graphql', 'grpc']);
+  });
+
+  it('config should take precedence over INSTANA_DISABLE_TRACERS when disabling individual tracers', () => {
+    process.env.INSTANA_DISABLE_TRACERS = 'foo, bar';
+    const config = normalizeConfig({
+      tracing: {
+        disableTracers: ['baz', 'fizz']
+      }
+    });
     expect(config.tracing.disableTracers).to.deep.equal(['baz', 'fizz']);
   });
 

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -16,7 +16,6 @@ describe('util.normalizeConfig', () => {
   afterEach(resetEnv);
 
   function resetEnv() {
-    delete process.env.INSTANA_DISABLED_TRACERS;
     delete process.env.INSTANA_DISABLE_AUTO_INSTR;
     delete process.env.INSTANA_DISABLE_TRACING;
     delete process.env.INSTANA_TRACE_IMMEDIATELY;
@@ -33,6 +32,8 @@ describe('util.normalizeConfig', () => {
     delete process.env.INSTANA_KAFKA_TRACE_CORRELATION;
     delete process.env.INSTANA_PACKAGE_JSON_PATH;
     delete process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN;
+    delete process.env.INSTANA_DISABLED_TRACERS;
+    delete process.env.INSTANA_DISABLE_TRACERS;
   }
 
   it('should apply all defaults', () => {
@@ -254,7 +255,7 @@ describe('util.normalizeConfig', () => {
 
   it('should not disable individual tracers by default', () => {
     const config = normalizeConfig();
-    expect(config.tracing.disabledTracers).to.deep.equal([]);
+    expect(config.tracing.disableTracers).to.deep.equal([]);
   });
 
   it('should disable individual tracers via config', () => {
@@ -264,14 +265,14 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disabledTracers).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disableTracers).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('should disable individual tracers via env var', () => {
     process.env.INSTANA_DISABLED_TRACERS = 'graphQL   , GRPC';
     const config = normalizeConfig();
     // values will be normalized to lower case
-    expect(config.tracing.disabledTracers).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disableTracers).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('config should take precedence over env vars when disabling individual tracers', () => {
@@ -282,7 +283,32 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disabledTracers).to.deep.equal(['baz', 'fizz']);
+    expect(config.tracing.disableTracers).to.deep.equal(['baz', 'fizz']);
+  });
+
+  it('should disable multiple tracers via env var INSTANA_DISABLE_TRACERS', () => {
+    process.env.INSTANA_DISABLE_TRACERS = 'graphQL   , GRPC, http';
+    const config = normalizeConfig();
+    expect(config.tracing.disableTracers).to.deep.equal(['graphql', 'grpc', 'http']);
+  });
+
+  it('should handle single tracer via INSTANA_DISABLE_TRACERS', () => {
+    process.env.INSTANA_DISABLE_TRACERS = 'console';
+    const config = normalizeConfig();
+    expect(config.tracing.disableTracers).to.deep.equal(['console']);
+  });
+
+  it('should trim whitespace from tracer names', () => {
+    process.env.INSTANA_DISABLE_TRACERS = '  graphql  ,  grpc  ';
+    const config = normalizeConfig();
+    expect(config.tracing.disableTracers).to.deep.equal(['graphql', 'grpc']);
+  });
+
+  it('should prefer INSTANA_DISABLE_TRACERS over INSTANA_DISABLED_TRACERS', () => {
+    process.env.INSTANA_DISABLE_TRACERS = 'redis';
+    process.env.INSTANA_DISABLED_TRACERS = 'postgres';
+    const config = normalizeConfig();
+    expect(config.tracing.disableTracers).to.deep.equal(['redis']);
   });
 
   // delete this test when we switch to opt-out
@@ -676,7 +702,7 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.transmissionDelay).to.equal(1000);
     expect(config.tracing.forceTransmissionStartingAt).to.equal(500);
     expect(config.tracing.maxBufferedSpans).to.equal(1000);
-    expect(config.tracing.disabledTracers).to.deep.equal([]);
+    expect(config.tracing.disableTracers).to.deep.equal([]);
     expect(config.tracing.http).to.be.an('object');
     expect(config.tracing.http.extraHttpHeadersToCapture).to.be.empty;
     expect(config.tracing.http.extraHttpHeadersToCapture).to.be.an('array');


### PR DESCRIPTION
**What this change does**

Currently, we support the environment variable `INSTANA_DISABLED_TRACERS`. With this change, we're normalizing it to `INSTANA_DISABLE_TRACERS` for consistency.

Both variants are supported for now, but a deprecation warning will be shown when `INSTANA_DISABLED_TRACERS` is used. Support for this deprecated variable will be removed in the next major release.

Internally, we use the term disable instead of disabled.