### PR TITLE
fix: renamed tracer disabling options 

### DIFF
--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -153,9 +153,9 @@ const isInstrumentationDisabled = (cfg, instrumentationKey) => {
   const matchResult = instrumentationKey.match(/.\/instrumentation\/[^/]*\/(.*)/);
   const extractedInstrumentationName = matchResult ? matchResult[1] : instrumentationKey.match(/\/([^/]+)$/)[1];
   return (
-    cfg.tracing.disableTracers.includes(extractedInstrumentationName.toLowerCase()) ||
+    cfg.tracing.disable.includes(extractedInstrumentationName.toLowerCase()) ||
     (instrumentationModules[instrumentationKey].instrumentationName &&
-      cfg.tracing.disableTracers.includes(instrumentationModules[instrumentationKey].instrumentationName))
+      cfg.tracing.disable.includes(instrumentationModules[instrumentationKey].instrumentationName))
   );
 };
 

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -532,15 +532,15 @@ function normalizeDisableTracers(config) {
 function getDisableTracersFromEnv() {
   let disableTracersEnvVar;
 
-  if (process.env.INSTANA_DISABLE_TRACERS) {
-    disableTracersEnvVar = parseHeadersEnvVar(process.env.INSTANA_DISABLE_TRACERS);
+  if (process.env.INSTANA_TRACING_DISABLE) {
+    disableTracersEnvVar = parseHeadersEnvVar(process.env.INSTANA_TRACING_DISABLE);
   }
   // We deprecated the variable `INSTANA_DISABLED_TRACERS` and will be removed in the next major release(v5).
   else if (process.env.INSTANA_DISABLED_TRACERS) {
     disableTracersEnvVar = parseHeadersEnvVar(process.env.INSTANA_DISABLED_TRACERS);
     logger.warn(
       'The environment variable INSTANA_DISABLED_TRACERS is deprecated and will be removed in the next major release. ' +
-        'Please use INSTANA_DISABLE_TRACERS instead.'
+        'Please use INSTANA_TRACING_DISABLE instead.'
     );
   }
 

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -21,7 +21,7 @@ const configNormalizers = require('./configNormalizers');
  * @property {number} [transmissionDelay]
  * @property {number} [stackTraceLength]
  * @property {HTTPTracingOptions} [http]
- * @property {Array<string>} [disableTracers]
+ * @property {Array<string>} [disable]
  * @property {Array<string>} [disabledTracers]
  * @property {boolean} [spanBatchingEnabled]
  * @property {boolean} [disableW3cTraceCorrelation]
@@ -120,7 +120,7 @@ const defaults = {
       extraHttpHeadersToCapture: []
     },
     stackTraceLength: 10,
-    disableTracers: [],
+    disable: [],
     spanBatchingEnabled: false,
     disableW3cTraceCorrelation: false,
     kafka: {
@@ -497,36 +497,36 @@ function normalizeNumericalStackTraceLength(numericalLength) {
 function normalizeDisableTracers(config) {
   // Case 1: process in-code configuration
   // Note: We maintain backward compatibility with the deprecated 'disabledTracers' property
-  // but internally standardize on 'disableTracers'. The old property will be removed in v5.
+  // but internally standardize on 'disable'. The old property will be removed in v5.
   if (config.tracing.disabledTracers) {
     logger.warn(
       'The configuration property "tracing.disabledTracers" is deprecated and will be removed in the next major release. ' +
-        'Please use "tracing.disableTracers" instead.'
+        'Please use "tracing.disable" instead.'
     );
 
-    // Only use disabledTracers if disableTracers isn't already set
-    if (!config.tracing.disableTracers) {
-      config.tracing.disableTracers = config.tracing.disabledTracers;
+    // Only use disabledTracers if disable isn't already set
+    if (!config.tracing.disable) {
+      config.tracing.disable = config.tracing.disabledTracers;
     }
     delete config.tracing.disabledTracers;
   }
 
   // case 2: Check environment variables if available
-  if (!config.tracing.disableTracers) {
+  if (!config.tracing.disable) {
     // Check environment variables first, fall back to defaults
-    config.tracing.disableTracers = getDisableTracersFromEnv() || defaults.tracing.disableTracers;
+    config.tracing.disable = getDisableTracersFromEnv() || defaults.tracing.disable;
   }
 
-  if (!Array.isArray(config.tracing.disableTracers)) {
+  if (!Array.isArray(config.tracing.disable)) {
     logger.warn(
-      `Invalid configuration: config.tracing.disableTracers is not an array, the value will be ignored: ${JSON.stringify(
-        config.tracing.disableTracers
+      `Invalid configuration: config.tracing.disable is not an array, the value will be ignored: ${JSON.stringify(
+        config.tracing.disable
       )}`
     );
-    config.tracing.disableTracers = defaults.tracing.disableTracers;
+    config.tracing.disable = defaults.tracing.disable;
   }
 
-  config.tracing.disableTracers = config.tracing.disableTracers.map(s => s.toLowerCase()).filter(s => s.length > 0);
+  config.tracing.disable = config.tracing.disable.map(s => s.toLowerCase()).filter(s => s.length > 0);
 }
 
 function getDisableTracersFromEnv() {

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -107,9 +107,9 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
 
   describe('init', function () {
     describe('tracer deactivation', () => {
-      describe('via disableTracers config', () => {
+      describe('via disable config', () => {
         it('should deactivate specified tracers', () => {
-          initAndActivate({ tracing: { disableTracers: ['grpc', 'kafkajs', 'aws-sdk/v2'] } });
+          initAndActivate({ tracing: { disable: ['grpc', 'kafkajs', 'aws-sdk/v2'] } });
 
           // grpcJs instrumentation has not been disabled, make sure its init and activate are called
           expect(initStubGrpcJs).to.have.been.called;
@@ -153,7 +153,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
         });
 
         it('should disable aws-sdk/v3 via config', () => {
-          initAndActivate({ tracing: { disableTracers: ['aws-sdk/v3'] } });
+          initAndActivate({ tracing: { disable: ['aws-sdk/v3'] } });
 
           expect(initAwsSdkv3).not.to.have.been.called;
           expect(activateAwsSdkv3).not.to.have.been.called;
@@ -163,7 +163,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
         });
 
         it('should disable both aws-sdk versions via config', () => {
-          initAndActivate({ tracing: { disableTracers: ['aws-sdk/v3', 'aws-sdk/v2'] } });
+          initAndActivate({ tracing: { disable: ['aws-sdk/v3', 'aws-sdk/v2'] } });
 
           expect(initAwsSdkv2).not.to.have.been.called;
           expect(activateAwsSdkv2).not.to.have.been.called;
@@ -172,8 +172,8 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           expect(activateAwsSdkv3).not.to.have.been.called;
         });
 
-        it('should ignore empty disableTracers array', () => {
-          initAndActivate({ tracing: { disableTracers: [] } });
+        it('should ignore empty disable array', () => {
+          initAndActivate({ tracing: { disable: [] } });
 
           expect(initStubGrpcJs).to.have.been.called;
           expect(activateStubGrpcJs).to.have.been.called;
@@ -185,9 +185,9 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           expect(activateStubRdKafka).to.have.been.called;
         });
 
-        it('should prefer config.tracing.disableTracers over env vars', () => {
+        it('should prefer config.tracing.disable over env vars', () => {
           process.env.INSTANA_DISABLE_TRACERS = 'grpc,kafkajs';
-          initAndActivate({ tracing: { disableTracers: ['aws-sdk/v2'] } });
+          initAndActivate({ tracing: { disable: ['aws-sdk/v2'] } });
 
           expect(initAwsSdkv2).not.to.have.been.called;
           expect(activateAwsSdkv2).not.to.have.been.called;
@@ -252,11 +252,11 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           expect(activateStubKafkaJs).not.to.have.been.called;
         });
 
-        it('should prefer disableTracers over disabledTracers when both exist', () => {
+        it('should prefer disable over disabledTracers when both exist', () => {
           initAndActivate({
             tracing: {
               disabledTracers: ['grpc', 'kafkajs'],
-              disableTracers: ['aws-sdk/v2']
+              disable: ['aws-sdk/v2']
             }
           });
 

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -74,7 +74,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     initAwsSdkv2.reset();
     initAwsSdkv3.reset();
 
-    delete process.env.INSTANA_DISABLE_TRACERS;
+    delete process.env.INSTANA_TRACING_DISABLE;
     delete process.env.INSTANA_DISABLED_TRACERS;
   });
 
@@ -132,8 +132,8 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           expect(activateAwsSdkv3).to.have.been.called;
         });
 
-        it('should disable multiple tracers in INSTANA_DISABLE_TRACERS env var', () => {
-          process.env.INSTANA_DISABLE_TRACERS = 'rdkafka,kafkajs,aws-sdk/v3';
+        it('should disable multiple tracers in INSTANA_TRACING_DISABLE env var', () => {
+          process.env.INSTANA_TRACING_DISABLE = 'rdkafka,kafkajs,aws-sdk/v3';
           initAndActivate({});
 
           expect(initStubKafkaJs).to.not.have.been.called;
@@ -186,7 +186,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
         });
 
         it('should prefer config.tracing.disable over env vars', () => {
-          process.env.INSTANA_DISABLE_TRACERS = 'grpc,kafkajs';
+          process.env.INSTANA_TRACING_DISABLE = 'grpc,kafkajs';
           initAndActivate({ tracing: { disable: ['aws-sdk/v2'] } });
 
           expect(initAwsSdkv2).not.to.have.been.called;
@@ -270,8 +270,8 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           expect(activateStubKafkaJs).to.have.been.called;
         });
 
-        it('should prefer INSTANA_DISABLE_TRACERS over INSTANA_DISABLED_TRACERS', () => {
-          process.env.INSTANA_DISABLE_TRACERS = 'aws-sdk/v2';
+        it('should prefer INSTANA_TRACING_DISABLE over INSTANA_DISABLED_TRACERS', () => {
+          process.env.INSTANA_TRACING_DISABLE = 'aws-sdk/v2';
           process.env.INSTANA_DISABLED_TRACERS = 'kafkajs';
           initAndActivate({});
 

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -255,7 +255,7 @@ describe('util.normalizeConfig', () => {
 
   it('should not disable individual tracers by default', () => {
     const config = normalizeConfig();
-    expect(config.tracing.disableTracers).to.deep.equal([]);
+    expect(config.tracing.disable).to.deep.equal([]);
   });
 
   it('should disable individual tracers via disabledTracers config', () => {
@@ -265,14 +265,14 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disableTracers).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('should disable individual tracers via env var', () => {
     process.env.INSTANA_DISABLED_TRACERS = 'graphQL   , GRPC';
     const config = normalizeConfig();
     // values will be normalized to lower case
-    expect(config.tracing.disableTracers).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('config should take precedence over INSTANA_DISABLED_TRACERS when disabling individual tracers', () => {
@@ -283,51 +283,51 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disableTracers).to.deep.equal(['baz', 'fizz']);
+    expect(config.tracing.disable).to.deep.equal(['baz', 'fizz']);
   });
 
-  it('should disable individual tracers via disableTracers config', () => {
+  it('should disable individual tracers via disable config', () => {
     const config = normalizeConfig({
       tracing: {
-        disableTracers: ['graphQL', 'GRPC']
+        disable: ['graphQL', 'GRPC']
       }
     });
-    expect(config.tracing.disableTracers).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('config should take precedence over INSTANA_DISABLE_TRACERS when disabling individual tracers', () => {
     process.env.INSTANA_DISABLE_TRACERS = 'foo, bar';
     const config = normalizeConfig({
       tracing: {
-        disableTracers: ['baz', 'fizz']
+        disable: ['baz', 'fizz']
       }
     });
-    expect(config.tracing.disableTracers).to.deep.equal(['baz', 'fizz']);
+    expect(config.tracing.disable).to.deep.equal(['baz', 'fizz']);
   });
 
   it('should disable multiple tracers via env var INSTANA_DISABLE_TRACERS', () => {
     process.env.INSTANA_DISABLE_TRACERS = 'graphQL   , GRPC, http';
     const config = normalizeConfig();
-    expect(config.tracing.disableTracers).to.deep.equal(['graphql', 'grpc', 'http']);
+    expect(config.tracing.disable).to.deep.equal(['graphql', 'grpc', 'http']);
   });
 
   it('should handle single tracer via INSTANA_DISABLE_TRACERS', () => {
     process.env.INSTANA_DISABLE_TRACERS = 'console';
     const config = normalizeConfig();
-    expect(config.tracing.disableTracers).to.deep.equal(['console']);
+    expect(config.tracing.disable).to.deep.equal(['console']);
   });
 
   it('should trim whitespace from tracer names', () => {
     process.env.INSTANA_DISABLE_TRACERS = '  graphql  ,  grpc  ';
     const config = normalizeConfig();
-    expect(config.tracing.disableTracers).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('should prefer INSTANA_DISABLE_TRACERS over INSTANA_DISABLED_TRACERS', () => {
     process.env.INSTANA_DISABLE_TRACERS = 'redis';
     process.env.INSTANA_DISABLED_TRACERS = 'postgres';
     const config = normalizeConfig();
-    expect(config.tracing.disableTracers).to.deep.equal(['redis']);
+    expect(config.tracing.disable).to.deep.equal(['redis']);
   });
 
   // delete this test when we switch to opt-out
@@ -721,7 +721,7 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.transmissionDelay).to.equal(1000);
     expect(config.tracing.forceTransmissionStartingAt).to.equal(500);
     expect(config.tracing.maxBufferedSpans).to.equal(1000);
-    expect(config.tracing.disableTracers).to.deep.equal([]);
+    expect(config.tracing.disable).to.deep.equal([]);
     expect(config.tracing.http).to.be.an('object');
     expect(config.tracing.http.extraHttpHeadersToCapture).to.be.empty;
     expect(config.tracing.http.extraHttpHeadersToCapture).to.be.an('array');

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -33,7 +33,7 @@ describe('util.normalizeConfig', () => {
     delete process.env.INSTANA_PACKAGE_JSON_PATH;
     delete process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN;
     delete process.env.INSTANA_DISABLED_TRACERS;
-    delete process.env.INSTANA_DISABLE_TRACERS;
+    delete process.env.INSTANA_TRACING_DISABLE;
   }
 
   it('should apply all defaults', () => {
@@ -295,8 +295,8 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.disable).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('config should take precedence over INSTANA_DISABLE_TRACERS when disabling individual tracers', () => {
-    process.env.INSTANA_DISABLE_TRACERS = 'foo, bar';
+  it('config should take precedence over INSTANA_TRACING_DISABLE when disabling individual tracers', () => {
+    process.env.INSTANA_TRACING_DISABLE = 'foo, bar';
     const config = normalizeConfig({
       tracing: {
         disable: ['baz', 'fizz']
@@ -305,26 +305,26 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.disable).to.deep.equal(['baz', 'fizz']);
   });
 
-  it('should disable multiple tracers via env var INSTANA_DISABLE_TRACERS', () => {
-    process.env.INSTANA_DISABLE_TRACERS = 'graphQL   , GRPC, http';
+  it('should disable multiple tracers via env var INSTANA_TRACING_DISABLE', () => {
+    process.env.INSTANA_TRACING_DISABLE = 'graphQL   , GRPC, http';
     const config = normalizeConfig();
     expect(config.tracing.disable).to.deep.equal(['graphql', 'grpc', 'http']);
   });
 
-  it('should handle single tracer via INSTANA_DISABLE_TRACERS', () => {
-    process.env.INSTANA_DISABLE_TRACERS = 'console';
+  it('should handle single tracer via INSTANA_TRACING_DISABLE', () => {
+    process.env.INSTANA_TRACING_DISABLE = 'console';
     const config = normalizeConfig();
     expect(config.tracing.disable).to.deep.equal(['console']);
   });
 
   it('should trim whitespace from tracer names', () => {
-    process.env.INSTANA_DISABLE_TRACERS = '  graphql  ,  grpc  ';
+    process.env.INSTANA_TRACING_DISABLE = '  graphql  ,  grpc  ';
     const config = normalizeConfig();
     expect(config.tracing.disable).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('should prefer INSTANA_DISABLE_TRACERS over INSTANA_DISABLED_TRACERS', () => {
-    process.env.INSTANA_DISABLE_TRACERS = 'redis';
+  it('should prefer INSTANA_TRACING_DISABLE over INSTANA_DISABLED_TRACERS', () => {
+    process.env.INSTANA_TRACING_DISABLE = 'redis';
     process.env.INSTANA_DISABLED_TRACERS = 'postgres';
     const config = normalizeConfig();
     expect(config.tracing.disable).to.deep.equal(['redis']);


### PR DESCRIPTION
- Renamed env var INSTANA_DISABLED_TRACERS → INSTANA_TRACING_DISABLE.
- Renamed config option disabledTracers → disable.
- Internally aligned naming to use "disable" instead of "disabled".
- Added deprecation warning

ref: INSTA-38729