### PR TITLE
chore: exclude markdown files from prettier formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 *.yml
 *.yaml
+*.md


### PR DESCRIPTION
We don't want the formatter for markdown files, as formatting can alter the intended structure or layout.