### PR TITLE
fix: renamed tracing disable env variables and improve in-code configuration support

### DIFF
--- a/packages/aws-lambda/test/integration_test/test_definition.js
+++ b/packages/aws-lambda/test/integration_test/test_definition.js
@@ -58,7 +58,7 @@ function prelude(opts) {
     env.INSTANA_ENDPOINT_URL = '';
   }
   if (opts.instanaTracingDisabled) {
-    env.INSTANA_DISABLE_TRACING = 'true';
+    env.INSTANA_TRACING_DISABLE = 'true';
   }
   if (opts.instanaAgentKey) {
     env.INSTANA_AGENT_KEY = opts.instanaAgentKey;
@@ -1032,7 +1032,43 @@ function registerTests(handlerDefinitionPath, reduced) {
     });
   });
 
-  describeOrSkipIfReduced()('when INSTANA_DISABLE_TRACING is set', function () {
+  describeOrSkipIfReduced()('when INSTANA_TRACING_DISABLE is set', function () {
+    // - INSTANA_ENDPOINT_URL is missing
+    // - lambda function ends with success
+    const env = prelude.bind(this)({
+      handlerDefinitionPath,
+      instanaAgentKey,
+      instanaTracingDisabled: true
+    });
+
+    let control;
+
+    before(async () => {
+      control = new Control({
+        faasRuntimePath: path.join(__dirname, '../runtime_mock'),
+        handlerDefinitionPath,
+        startBackend: true,
+        env
+      });
+
+      await control.start();
+    });
+
+    beforeEach(async () => {
+      await control.reset();
+      await control.resetBackendSpansAndMetrics();
+    });
+
+    after(async () => {
+      await control.stop();
+    });
+
+    it('expect no tracing data', () => {
+      return verify(control, { error: false, expectMetrics: false, expectSpans: false });
+    });
+  });
+
+  describeOrSkipIfReduced()('when deprecated INSTANA_DISABLE_TRACING is set', function () {
     // - INSTANA_ENDPOINT_URL is missing
     // - lambda function ends with success
     const env = prelude.bind(this)({

--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -141,7 +141,7 @@ class ProcessControls {
         APP_PORT: this.port,
         INSTANA_AGENT_PORT: agentPort,
         INSTANA_LOG_LEVEL: 'warn',
-        INSTANA_DISABLE_TRACING: !this.tracingEnabled,
+        INSTANA_TRACING_DISABLE: !this.tracingEnabled,
         INSTANA_FORCE_TRANSMISSION_STARTING_AT: '1',
         INSTANA_FULL_METRICS_INTERNAL_IN_S: 1,
         INSTANA_FIRE_MONITORING_EVENT_DURATION_IN_MS: 500,

--- a/packages/collector/test/tracing/databases/mongodb/app.mjs
+++ b/packages/collector/test/tracing/databases/mongodb/app.mjs
@@ -15,7 +15,7 @@ const isLegacy = process.env.MONGODB_VERSION === 'v4';
 const agentPort = process.env.INSTANA_AGENT_PORT;
 
 process.env.INSTANA_LOG_LEVEL = 'warn';
-process.env.INSTANA_DISABLE_TRACING = process.env.TRACING_ENABLED !== 'false';
+process.env.INSTANA_TRACING_DISABLE = process.env.TRACING_ENABLED !== 'false';
 process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT = 1;
 
 import MongoClient from 'mongodb';

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -153,11 +153,15 @@ const isInstrumentationDisabled = (cfg, instrumentationKey) => {
   // This is primarily implemented to handle customInstrumentation cases.
   const matchResult = instrumentationKey.match(/.\/instrumentation\/[^/]*\/(.*)/);
   const extractedInstrumentationName = matchResult ? matchResult[1] : instrumentationKey.match(/\/([^/]+)$/)[1];
-  return (
-    cfg.tracing.disable.includes(extractedInstrumentationName.toLowerCase()) ||
-    (instrumentationModules[instrumentationKey].instrumentationName &&
-      cfg.tracing.disable.includes(instrumentationModules[instrumentationKey].instrumentationName))
-  );
+  if (Array.isArray(cfg.tracing.disable)) {
+    return (
+      cfg.tracing.disable.includes(extractedInstrumentationName.toLowerCase()) ||
+      (instrumentationModules[instrumentationKey].instrumentationName &&
+        cfg.tracing.disable.includes(instrumentationModules[instrumentationKey].instrumentationName))
+    );
+  }
+
+  return false;
 };
 
 /**

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -261,8 +261,16 @@ function normalizeTracingEnabled(config) {
   if (config.tracing.enabled === true) {
     return;
   }
-  if (process.env['INSTANA_DISABLE_TRACING'] === 'true') {
+  if (process.env['INSTANA_TRACING_DISABLE'] === 'true') {
     logger.info('Not enabling tracing as it is explicitly disabled via environment variable INSTANA_DISABLE_TRACING.');
+    config.tracing.enabled = false;
+    return;
+  } else if (process.env['INSTANA_DISABLE_TRACING'] === 'true') {
+    logger.info('Not enabling tracing as it is explicitly disabled via environment variable INSTANA_DISABLE_TRACING.');
+    logger.warn(
+      'The environment variable INSTANA_DISABLE_TRACING is deprecated and will be removed in the next major release. ' +
+        'Please use INSTANA_TRACING_DISABLE instead.'
+    );
     config.tracing.enabled = false;
     return;
   }
@@ -550,15 +558,15 @@ function normalizeDisableTracers(config) {
 function getDisableTracersFromEnv() {
   let disableTracersEnvVar;
 
-  if (process.env.INSTANA_TRACING_DISABLE) {
-    disableTracersEnvVar = parseHeadersEnvVar(process.env.INSTANA_TRACING_DISABLE);
+  if (process.env.INSTANA_TRACING_DISABLE_ENTITIES) {
+    disableTracersEnvVar = parseHeadersEnvVar(process.env.INSTANA_TRACING_DISABLE_ENTITIES);
   }
   // We deprecated the variable `INSTANA_DISABLED_TRACERS` and will be removed in the next major release(v5).
   else if (process.env.INSTANA_DISABLED_TRACERS) {
     disableTracersEnvVar = parseHeadersEnvVar(process.env.INSTANA_DISABLED_TRACERS);
     logger.warn(
       'The environment variable INSTANA_DISABLED_TRACERS is deprecated and will be removed in the next major release. ' +
-        'Please use INSTANA_TRACING_DISABLE instead.'
+        'Please use INSTANA_TRACING_DISABLE_ENTITIES instead.'
     );
   }
 

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -74,7 +74,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     initAwsSdkv2.reset();
     initAwsSdkv3.reset();
 
-    delete process.env.INSTANA_TRACING_DISABLE;
+    delete process.env.INSTANA_TRACING_DISABLE_ENTITIES;
     delete process.env.INSTANA_DISABLED_TRACERS;
   });
 
@@ -132,8 +132,8 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           expect(activateAwsSdkv3).to.have.been.called;
         });
 
-        it('should disable multiple tracers in INSTANA_TRACING_DISABLE env var', () => {
-          process.env.INSTANA_TRACING_DISABLE = 'rdkafka,kafkajs,aws-sdk/v3';
+        it('should disable multiple tracers in INSTANA_TRACING_DISABLE_ENTITIES env var', () => {
+          process.env.INSTANA_TRACING_DISABLE_ENTITIES = 'rdkafka,kafkajs,aws-sdk/v3';
           initAndActivate({});
 
           expect(initStubKafkaJs).to.not.have.been.called;
@@ -186,7 +186,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
         });
 
         it('should prefer config.tracing.disable over env vars', () => {
-          process.env.INSTANA_TRACING_DISABLE = 'grpc,kafkajs';
+          process.env.INSTANA_TRACING_DISABLE_ENTITIES = 'grpc,kafkajs';
           initAndActivate({ tracing: { disable: ['aws-sdk/v2'] } });
 
           expect(initAwsSdkv2).not.to.have.been.called;
@@ -270,8 +270,8 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           expect(activateStubKafkaJs).to.have.been.called;
         });
 
-        it('should prefer INSTANA_TRACING_DISABLE over INSTANA_DISABLED_TRACERS', () => {
-          process.env.INSTANA_TRACING_DISABLE = 'aws-sdk/v2';
+        it('should prefer INSTANA_TRACING_DISABLE_ENTITIES over INSTANA_DISABLED_TRACERS', () => {
+          process.env.INSTANA_TRACING_DISABLE_ENTITIES = 'aws-sdk/v2';
           process.env.INSTANA_DISABLED_TRACERS = 'kafkajs';
           initAndActivate({});
 

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -18,7 +18,9 @@ describe('util.normalizeConfig', () => {
   function resetEnv() {
     delete process.env.INSTANA_DISABLE_AUTO_INSTR;
     delete process.env.INSTANA_DISABLE_TRACING;
+    delete process.env.INSTANA_DISABLED_TRACERS;
     delete process.env.INSTANA_TRACING_DISABLE;
+    delete process.env.INSTANA_TRACING_DISABLE_ENTITIES;
     delete process.env.INSTANA_TRACE_IMMEDIATELY;
     delete process.env.INSTANA_EXTRA_HTTP_HEADERS;
     delete process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT;
@@ -33,8 +35,6 @@ describe('util.normalizeConfig', () => {
     delete process.env.INSTANA_KAFKA_TRACE_CORRELATION;
     delete process.env.INSTANA_PACKAGE_JSON_PATH;
     delete process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN;
-    delete process.env.INSTANA_DISABLED_TRACERS;
-    delete process.env.INSTANA_TRACING_DISABLE_ENTITIES;
   }
 
   it('should apply all defaults', () => {
@@ -90,7 +90,13 @@ describe('util.normalizeConfig', () => {
     expect(config.metrics.timeBetweenHealthcheckCalls).to.equal(9876);
   });
 
-  it('should disable tracing', () => {
+  it('should disable tracing with enabled: false', () => {
+    const config = normalizeConfig({ tracing: { enabled: false } });
+    expect(config.tracing.enabled).to.be.false;
+    expect(config.tracing.automaticTracingEnabled).to.be.false;
+  });
+
+  it('should disable tracing with disable: true', () => {
     const config = normalizeConfig({ tracing: { enabled: false } });
     expect(config.tracing.enabled).to.be.false;
     expect(config.tracing.automaticTracingEnabled).to.be.false;

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -18,6 +18,7 @@ describe('util.normalizeConfig', () => {
   function resetEnv() {
     delete process.env.INSTANA_DISABLE_AUTO_INSTR;
     delete process.env.INSTANA_DISABLE_TRACING;
+    delete process.env.INSTANA_TRACING_DISABLE;
     delete process.env.INSTANA_TRACE_IMMEDIATELY;
     delete process.env.INSTANA_EXTRA_HTTP_HEADERS;
     delete process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT;
@@ -33,7 +34,7 @@ describe('util.normalizeConfig', () => {
     delete process.env.INSTANA_PACKAGE_JSON_PATH;
     delete process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN;
     delete process.env.INSTANA_DISABLED_TRACERS;
-    delete process.env.INSTANA_TRACING_DISABLE;
+    delete process.env.INSTANA_TRACING_DISABLE_ENTITIES;
   }
 
   it('should apply all defaults', () => {
@@ -95,8 +96,15 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.automaticTracingEnabled).to.be.false;
   });
 
-  it('should disable tracing via INSTANA_DISABLE_TRACING', () => {
+  it('should disable tracing via depreacted INSTANA_DISABLE_TRACING', () => {
     process.env.INSTANA_DISABLE_TRACING = true;
+    const config = normalizeConfig();
+    expect(config.tracing.enabled).to.be.false;
+    expect(config.tracing.automaticTracingEnabled).to.be.false;
+  });
+
+  it('should disable tracing via INSTANA_TRACING_DISABLE', () => {
+    process.env.INSTANA_TRACING_DISABLE = true;
     const config = normalizeConfig();
     expect(config.tracing.enabled).to.be.false;
     expect(config.tracing.automaticTracingEnabled).to.be.false;
@@ -295,8 +303,8 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.disable).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('config should take precedence over INSTANA_TRACING_DISABLE when disabling individual tracers', () => {
-    process.env.INSTANA_TRACING_DISABLE = 'foo, bar';
+  it('config should take precedence over INSTANA_TRACING_DISABLE_ENTITIES when disabling individual tracers', () => {
+    process.env.INSTANA_TRACING_DISABLE_ENTITIES = 'foo, bar';
     const config = normalizeConfig({
       tracing: {
         disable: ['baz', 'fizz']
@@ -305,26 +313,26 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.disable).to.deep.equal(['baz', 'fizz']);
   });
 
-  it('should disable multiple tracers via env var INSTANA_TRACING_DISABLE', () => {
-    process.env.INSTANA_TRACING_DISABLE = 'graphQL   , GRPC, http';
+  it('should disable multiple tracers via env var INSTANA_TRACING_DISABLE_ENTITIES', () => {
+    process.env.INSTANA_TRACING_DISABLE_ENTITIES = 'graphQL   , GRPC, http';
     const config = normalizeConfig();
     expect(config.tracing.disable).to.deep.equal(['graphql', 'grpc', 'http']);
   });
 
-  it('should handle single tracer via INSTANA_TRACING_DISABLE', () => {
-    process.env.INSTANA_TRACING_DISABLE = 'console';
+  it('should handle single tracer via INSTANA_TRACING_DISABLE_ENTITIES', () => {
+    process.env.INSTANA_TRACING_DISABLE_ENTITIES = 'console';
     const config = normalizeConfig();
     expect(config.tracing.disable).to.deep.equal(['console']);
   });
 
   it('should trim whitespace from tracer names', () => {
-    process.env.INSTANA_TRACING_DISABLE = '  graphql  ,  grpc  ';
+    process.env.INSTANA_TRACING_DISABLE_ENTITIES = '  graphql  ,  grpc  ';
     const config = normalizeConfig();
     expect(config.tracing.disable).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('should prefer INSTANA_TRACING_DISABLE over INSTANA_DISABLED_TRACERS', () => {
-    process.env.INSTANA_TRACING_DISABLE = 'redis';
+  it('should prefer INSTANA_TRACING_DISABLE_ENTITIES over INSTANA_DISABLED_TRACERS', () => {
+    process.env.INSTANA_TRACING_DISABLE_ENTITIES = 'redis';
     process.env.INSTANA_DISABLED_TRACERS = 'postgres';
     const config = normalizeConfig();
     expect(config.tracing.disable).to.deep.equal(['redis']);


### PR DESCRIPTION
### **What Changed**

#### 1. **Disabling All Tracing**

Previously, full tracing could be disabled using the following environment variable:

```bash
INSTANA_DISABLE_TRACING=true
```

This has now been **renamed** to:

```bash
INSTANA_TRACING_DISABLE=true
```

This update aligns with the new configuration structure outlined in the tracer specification. 

Please note that this change currently applies only to the **Node.js tracer** and is not yet adopted by other language tracers.


Task

- [ ] Need to update the public doc

---

#### 2. **Disabling Specific Entities (Packages or Categories)**

The previous environment variable:

```bash
INSTANA_TRACING_DISABLE=[]
```

has been **renamed** to:

```bash
INSTANA_TRACING_DISABLE_ENTITIES=[]
```

The updated name more accurately reflects its function, enabling the specification of individual **packages or tracing categories** to be disabled.

For background: this configuration initially started as `INSTANA_DISABLED_TRACERS`, which was later [[renamed](https://github.com/instana/nodejs/pull/1776)](https://github.com/instana/nodejs/pull/1776) to `INSTANA_TRACING_DISABLE`, although that version was never officially released. 

The finalized `INSTANA_TRACING_DISABLE_ENTITIES` now provides a clearer and more consistent naming convention going forward.

Task

- [ ] Need to update the public doc

---

#### 3. **Disabling Tracing via Code (Packages or Categories)**

You can now configure tracing in code using either a boolean or a list of entities:

```js
require('@instana/collector')({ tracing: { disable: true } });
```

```js
require('@instana/collector')({ tracing: { disable: [] } });
```

This in-code configuration accepts:

* A boolean (`true`) to disable all tracing
* An array (`[]`) to selectively disable specific packages or categories

Currently, the way to[ disable all tracing in code via]([url](https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-collector-configuration#tracing)):

```js
require('@instana/collector')({ tracing: { enabled: false } });
```
That method still works for backward compatibility, but the new disable option offers better alignment with the tracer specification and greater flexibility.
