### PR TITLE
test: ensured test controls are properly stopped

### DIFF
--- a/packages/collector/test/tracing/protocols/http/client/test.js
+++ b/packages/collector/test/tracing/protocols/http/client/test.js
@@ -53,6 +53,10 @@ mochaSuiteFn('tracing/http client', function () {
       await sdkControls.start(null, null, true);
     });
 
+    after(async () => {
+      await sdkControls.stop();
+    });
+
     it('should not trace example.com exit span without entry span', async () => {
       await delay(2500);
 
@@ -110,6 +114,14 @@ mochaSuiteFn('tracing/http client', function () {
       await agentControls.start(null, null, true);
     });
 
+    beforeEach(async () => {
+      await agentControls.clearReceivedTraceData();
+    });
+
+    after(async () => {
+      await agentControls.stop();
+    });
+
     it('should trace exit span without entry span if INSTANA_ALLOW_ROOT_EXIT_SPAN is true', async () => {
       await delay(2500);
 
@@ -137,6 +149,14 @@ mochaSuiteFn('tracing/http client', function () {
       });
 
       await agentControls.start(null, null, true);
+    });
+
+    beforeEach(async () => {
+      await agentControls.clearReceivedTraceData();
+    });
+
+    after(async () => {
+      await agentControls.stop();
     });
 
     it('should not trace exit span without entry span if INSTANA_ALLOW_ROOT_EXIT_SPAN is false', async () => {

--- a/packages/collector/test/tracing/protocols/http/client/test.js
+++ b/packages/collector/test/tracing/protocols/http/client/test.js
@@ -100,10 +100,10 @@ mochaSuiteFn('tracing/http client', function () {
   // When INSTANA_ALLOW_ROOT_EXIT_SPAN is set to TRUE via environment variable
   // it should track the exit spans without parent
   describe('Allow Root Exit Span Case 1', function () {
-    let agentControls;
+    let controls;
 
     before(async () => {
-      agentControls = new ProcessControls({
+      controls = new ProcessControls({
         appPath: path.join(__dirname, 'allowRootExitSpanApp'),
         useGlobalAgent: true,
         env: {
@@ -111,11 +111,11 @@ mochaSuiteFn('tracing/http client', function () {
         }
       });
 
-      await agentControls.start(null, null, true);
+      await controls.start(null, null, true);
     });
 
     after(async () => {
-      await agentControls.stop();
+      await controls.stop();
     });
 
     it('should trace exit span without entry span if INSTANA_ALLOW_ROOT_EXIT_SPAN is true', async () => {
@@ -133,10 +133,10 @@ mochaSuiteFn('tracing/http client', function () {
   // When INSTANA_ALLOW_ROOT_EXIT_SPAN is set to FALSE via environment variable
   // it should not track the exit spans without parent
   describe('Allow Root Exit Span Case 2', function () {
-    let agentControls;
+    let controls;
 
     before(async () => {
-      agentControls = new ProcessControls({
+      controls = new ProcessControls({
         appPath: path.join(__dirname, 'allowRootExitSpanApp'),
         useGlobalAgent: true,
         env: {
@@ -144,11 +144,11 @@ mochaSuiteFn('tracing/http client', function () {
         }
       });
 
-      await agentControls.start(null, null, true);
+      await controls.start(null, null, true);
     });
 
     after(async () => {
-      await agentControls.stop();
+      await controls.stop();
     });
 
     it('should not trace exit span without entry span if INSTANA_ALLOW_ROOT_EXIT_SPAN is false', async () => {

--- a/packages/collector/test/tracing/protocols/http/client/test.js
+++ b/packages/collector/test/tracing/protocols/http/client/test.js
@@ -114,10 +114,6 @@ mochaSuiteFn('tracing/http client', function () {
       await agentControls.start(null, null, true);
     });
 
-    beforeEach(async () => {
-      await agentControls.clearReceivedTraceData();
-    });
-
     after(async () => {
       await agentControls.stop();
     });
@@ -149,10 +145,6 @@ mochaSuiteFn('tracing/http client', function () {
       });
 
       await agentControls.start(null, null, true);
-    });
-
-    beforeEach(async () => {
-      await agentControls.clearReceivedTraceData();
     });
 
     after(async () => {

--- a/packages/collector/test/tracing/protocols/http/native_fetch/test.js
+++ b/packages/collector/test/tracing/protocols/http/native_fetch/test.js
@@ -519,10 +519,10 @@ mochaSuiteFn('tracing/native fetch', function () {
   // When INSTANA_ALLOW_ROOT_EXIT_SPAN is set to TRUE via environment variable
   // it should track the exit spans without parent
   describe('Allow Root Exit Span Case 1', function () {
-    let agentControls;
+    let controls;
 
     before(async () => {
-      agentControls = new ProcessControls({
+      controls = new ProcessControls({
         appPath: path.join(__dirname, 'allowRootExitSpanApp'),
         useGlobalAgent: true,
         env: {
@@ -530,15 +530,15 @@ mochaSuiteFn('tracing/native fetch', function () {
         }
       });
 
-      await agentControls.start(null, null, true);
+      await controls.start(null, null, true);
     });
 
     after(async () => {
-      await agentControls.stop();
+      await controls.stop();
     });
 
     it('should trace exit span without entry span if INSTANA_ALLOW_ROOT_EXIT_SPAN is true', async () => {
-      await delay(2500);
+      await delay(500);
 
       await retry(async () => {
         const spans = await globalAgent.instance.getSpans();
@@ -553,10 +553,10 @@ mochaSuiteFn('tracing/native fetch', function () {
   // When INSTANA_ALLOW_ROOT_EXIT_SPAN is set to FALSE via environment variable
   // it should not track the exit spans without parent
   describe('Allow Root Exit Span Case 2', function () {
-    let agentControls;
+    let controls;
 
     before(async () => {
-      agentControls = new ProcessControls({
+      controls = new ProcessControls({
         appPath: path.join(__dirname, 'allowRootExitSpanApp'),
         useGlobalAgent: true,
         env: {
@@ -564,11 +564,11 @@ mochaSuiteFn('tracing/native fetch', function () {
         }
       });
 
-      await agentControls.start(null, null, true);
+      await controls.start(null, null, true);
     });
 
     after(async () => {
-      await agentControls.stop();
+      await controls.stop();
     });
 
     it('should not trace exit span without entry span if INSTANA_ALLOW_ROOT_EXIT_SPAN is false', async () => {

--- a/packages/collector/test/tracing/protocols/http/native_fetch/test.js
+++ b/packages/collector/test/tracing/protocols/http/native_fetch/test.js
@@ -533,6 +533,14 @@ mochaSuiteFn('tracing/native fetch', function () {
       await agentControls.start(null, null, true);
     });
 
+    beforeEach(async () => {
+      await agentControls.clearReceivedTraceData();
+    });
+
+    after(async () => {
+      await agentControls.stop();
+    });
+
     it('should trace exit span without entry span if INSTANA_ALLOW_ROOT_EXIT_SPAN is true', async () => {
       await delay(2500);
 
@@ -561,6 +569,14 @@ mochaSuiteFn('tracing/native fetch', function () {
       });
 
       await agentControls.start(null, null, true);
+    });
+
+    beforeEach(async () => {
+      await agentControls.clearReceivedTraceData();
+    });
+
+    after(async () => {
+      await agentControls.stop();
     });
 
     it('should not trace exit span without entry span if INSTANA_ALLOW_ROOT_EXIT_SPAN is false', async () => {

--- a/packages/collector/test/tracing/protocols/http/native_fetch/test.js
+++ b/packages/collector/test/tracing/protocols/http/native_fetch/test.js
@@ -533,10 +533,6 @@ mochaSuiteFn('tracing/native fetch', function () {
       await agentControls.start(null, null, true);
     });
 
-    beforeEach(async () => {
-      await agentControls.clearReceivedTraceData();
-    });
-
     after(async () => {
       await agentControls.stop();
     });
@@ -569,10 +565,6 @@ mochaSuiteFn('tracing/native fetch', function () {
       });
 
       await agentControls.start(null, null, true);
-    });
-
-    beforeEach(async () => {
-      await agentControls.clearReceivedTraceData();
     });
 
     after(async () => {


### PR DESCRIPTION
Previously, some tests did not stop their associated test controls, which led to controls remained active even after the tests completed.

Applies to the "Allow Root Exit" test cases
