### PR TITLE
fix: deprecate disabled tracer config

### DIFF
--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -155,14 +155,14 @@ const isInstrumentationDisabled = (cfg, instrumentationKey) => {
   const extractedInstrumentationName = matchResult ? matchResult[1] : instrumentationKey.match(/\/([^/]+)$/)[1];
 
   const disable = cfg.tracing?.disable;
-  if (!disable?.libraries) {
+  if (!disable?.instrumentations) {
     return false;
   }
 
   return (
-    disable.libraries.includes(extractedInstrumentationName.toLowerCase()) ||
+    disable.instrumentations.includes(extractedInstrumentationName.toLowerCase()) ||
     (instrumentationModules[instrumentationKey].instrumentationName &&
-      disable.libraries.includes(instrumentationModules[instrumentationKey].instrumentationName))
+      disable.instrumentations.includes(instrumentationModules[instrumentationKey].instrumentationName))
   );
 };
 

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -153,10 +153,16 @@ const isInstrumentationDisabled = (cfg, instrumentationKey) => {
   // This is primarily implemented to handle customInstrumentation cases.
   const matchResult = instrumentationKey.match(/.\/instrumentation\/[^/]*\/(.*)/);
   const extractedInstrumentationName = matchResult ? matchResult[1] : instrumentationKey.match(/\/([^/]+)$/)[1];
+
+  const disable = cfg.tracing?.disable;
+  if (!disable?.libraries) {
+    return false;
+  }
+
   return (
-    cfg.tracing.disabledTracers.includes(extractedInstrumentationName.toLowerCase()) ||
+    disable.libraries.includes(extractedInstrumentationName.toLowerCase()) ||
     (instrumentationModules[instrumentationKey].instrumentationName &&
-      cfg.tracing.disabledTracers.includes(instrumentationModules[instrumentationKey].instrumentationName))
+      disable.libraries.includes(instrumentationModules[instrumentationKey].instrumentationName))
   );
 };
 

--- a/packages/core/src/util/configNormalizers/disable.js
+++ b/packages/core/src/util/configNormalizers/disable.js
@@ -1,0 +1,88 @@
+/*
+ * (c) Copyright IBM Corp. 2025
+ */
+
+'use strict';
+
+/** @type {import('../../core').GenericLogger} */
+let logger;
+
+/**
+ * @param {import('../../util/normalizeConfig').InstanaConfig} _config
+ */
+exports.init = function init(_config) {
+  logger = _config.logger;
+};
+
+/**
+ *
+ * @param {import('../../util/normalizeConfig').InstanaConfig} config
+ */
+exports.normalize = function normalize(config) {
+  if (!config?.tracing) config.tracing = {};
+
+  // Handle deprecated `disabledTracers` property
+  if (config.tracing.disabledTracers) {
+    logger?.warn(
+      'The configuration property "tracing.disabledTracers" is deprecated and will be removed in the next ' +
+        'major release. Please use "tracing.disable" with "libraries" instead.'
+    );
+
+    if (!config.tracing.disable) {
+      config.tracing.disable = { libraries: config.tracing.disabledTracers };
+    }
+
+    delete config.tracing.disabledTracers;
+  }
+
+  // Populate `tracing.disable` if not already set, using environment variables
+  if (!config.tracing.disable) {
+    config.tracing.disable = getDisableFromEnv();
+  }
+
+  // Normalize the disable configuration
+  const disableConfig = config.tracing.disable || {};
+  disableConfig.libraries = normalizeArray(disableConfig.libraries);
+  // categories are not yet supported, but can be added in the future
+  return disableConfig;
+};
+
+function getDisableFromEnv() {
+  const disable = {};
+
+  // Fallback to deprecated variable if defined
+  if (process.env.INSTANA_DISABLED_TRACERS) {
+    logger?.warn(
+      'The environment variable "INSTANA_DISABLED_TRACERS" is deprecated and will be removed in the next ' +
+        'major release. Use "INSTANA_TRACING_DISABLE_LIBRARIES" instead.'
+    );
+    disable.libraries = normalizeArray(parseHeadersEnvVar(process.env.INSTANA_DISABLED_TRACERS));
+  }
+  if (process.env.INSTANA_TRACING_DISABLE_LIBRARIES) {
+    disable.libraries = normalizeArray(parseHeadersEnvVar(process.env.INSTANA_TRACING_DISABLE_LIBRARIES));
+  }
+
+  // Future support: parse disable categories from env if available
+
+  return Object.keys(disable).length > 0 ? disable : null;
+}
+
+/**
+ * @param {string} envVarValue
+ * @returns {string[]}
+ */
+function parseHeadersEnvVar(envVarValue) {
+  return envVarValue
+    .split(/[;,]/)
+    .map(header => header.trim())
+    .filter(header => header !== '');
+}
+
+/**
+ * @param {any[]} arr
+ * @returns {string[]}
+ */
+function normalizeArray(arr) {
+  if (!Array.isArray(arr)) return [];
+  return arr.map(s => s.toLowerCase()?.trim()).filter(Boolean);
+}

--- a/packages/core/src/util/configNormalizers/disable.js
+++ b/packages/core/src/util/configNormalizers/disable.js
@@ -25,7 +25,7 @@ exports.normalize = function normalize(config) {
   if (config.tracing.disabledTracers) {
     logger?.warn(
       'The configuration property "tracing.disabledTracers" is deprecated and will be removed in the next ' +
-        'major release. Please use "tracing.disable" with "libraries" instead.'
+        'major release. Please use "tracing.disable.libraries" instead.'
     );
 
     if (!config.tracing.disable) {

--- a/packages/core/src/util/configNormalizers/index.js
+++ b/packages/core/src/util/configNormalizers/index.js
@@ -4,12 +4,16 @@
 
 'use strict';
 
+const disable = require('./disable');
 const ignoreEndpoints = require('./ignoreEndpoints');
 
 /**
  * @param {import('../../util/normalizeConfig').InstanaConfig} config
  */
 exports.init = function init(config) {
+  disable.init(config);
   ignoreEndpoints.init(config);
 };
+
+exports.disable = disable;
 exports.ignoreEndpoints = ignoreEndpoints;

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -33,7 +33,7 @@ const configNormalizers = require('./configNormalizers');
 
 /**
  * @typedef {Object} TracingDisableOptions
- * @property {string[]} [libraries]
+ * @property {string[]} [instrumentations]
  */
 
 /**
@@ -519,7 +519,7 @@ function normalizeNumericalStackTraceLength(numericalLength) {
  */
 function normalizeDisableTracing(config) {
   const disableConfig = configNormalizers.disable.normalize(config);
-  if (disableConfig?.libraries?.length > 0) {
+  if (disableConfig?.instrumentations?.length > 0) {
     config.tracing.disable = disableConfig;
     return;
   }

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -21,6 +21,7 @@ const configNormalizers = require('./configNormalizers');
  * @property {number} [transmissionDelay]
  * @property {number} [stackTraceLength]
  * @property {HTTPTracingOptions} [http]
+ * @property {TracingDisableOptions} [disable]
  * @property {Array<string>} [disabledTracers]
  * @property {boolean} [spanBatchingEnabled]
  * @property {boolean} [disableW3cTraceCorrelation]
@@ -28,6 +29,11 @@ const configNormalizers = require('./configNormalizers');
  * @property {boolean} [allowRootExitSpan]
  * @property {import('../tracing').IgnoreEndpoints} [ignoreEndpoints]
  * @property {boolean} [ignoreEndpointsDisableSuppression]
+ */
+
+/**
+ * @typedef {Object} TracingDisableOptions
+ * @property {string[]} [libraries]
  */
 
 /**
@@ -119,7 +125,7 @@ const defaults = {
       extraHttpHeadersToCapture: []
     },
     stackTraceLength: 10,
-    disabledTracers: [],
+    disable: {},
     spanBatchingEnabled: false,
     disableW3cTraceCorrelation: false,
     kafka: {
@@ -239,7 +245,7 @@ function normalizeTracingConfig(config) {
   normalizeTracingTransmission(config);
   normalizeTracingHttp(config);
   normalizeTracingStackTraceLength(config);
-  normalizeDisabledTracers(config);
+  normalizeDisableTracers(config);
   normalizeSpanBatchingEnabled(config);
   normalizeDisableW3cTraceCorrelation(config);
   normalizeTracingKafka(config);
@@ -511,37 +517,13 @@ function normalizeNumericalStackTraceLength(numericalLength) {
 /**
  * @param {InstanaConfig} config
  */
-function normalizeDisabledTracers(config) {
-  if (
-    config.tracing.disabledTracers == null &&
-    process.env['INSTANA_DISABLED_TRACERS'] &&
-    process.env['INSTANA_DISABLED_TRACERS'].trim().length >= 0
-  ) {
-    config.tracing.disabledTracers = process.env['INSTANA_DISABLED_TRACERS']
-      .split(',')
-      .map(key => key.trim().toLowerCase())
-      .filter(key => key.length >= 0);
-  }
-
-  if (!config.tracing.disabledTracers) {
-    config.tracing.disabledTracers = defaults.tracing.disabledTracers;
-  }
-
-  if (!Array.isArray(config.tracing.disabledTracers)) {
-    logger.warn(
-      `Invalid configuration: config.tracing.disabledTracers is not an array, the value will be ignored: ${JSON.stringify(
-        config.tracing.disabledTracers
-      )}`
-    );
-    config.tracing.disabledTracers = defaults.tracing.disabledTracers;
+function normalizeDisableTracers(config) {
+  const disableConfig = configNormalizers.disable.normalize(config);
+  if (disableConfig.libraries && disableConfig.libraries.length > 0) {
+    config.tracing.disable = configNormalizers.disable.normalize(config);
     return;
   }
-
-  config.tracing.disabledTracers = config.tracing.disabledTracers.map(
-    (
-      s // We'll check for matches in an case-insensitive fashion
-    ) => s.toLowerCase()
-  );
+  config.tracing.disable = defaults.tracing.disable;
 }
 
 /**

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -245,7 +245,7 @@ function normalizeTracingConfig(config) {
   normalizeTracingTransmission(config);
   normalizeTracingHttp(config);
   normalizeTracingStackTraceLength(config);
-  normalizeDisableTracers(config);
+  normalizeDisableTracing(config);
   normalizeSpanBatchingEnabled(config);
   normalizeDisableW3cTraceCorrelation(config);
   normalizeTracingKafka(config);
@@ -517,10 +517,10 @@ function normalizeNumericalStackTraceLength(numericalLength) {
 /**
  * @param {InstanaConfig} config
  */
-function normalizeDisableTracers(config) {
+function normalizeDisableTracing(config) {
   const disableConfig = configNormalizers.disable.normalize(config);
-  if (disableConfig.libraries && disableConfig.libraries.length > 0) {
-    config.tracing.disable = configNormalizers.disable.normalize(config);
+  if (disableConfig?.libraries?.length > 0) {
+    config.tracing.disable = disableConfig;
     return;
   }
   config.tracing.disable = defaults.tracing.disable;

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -74,6 +74,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     initAwsSdkv2.reset();
     initAwsSdkv3.reset();
 
+    delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
     delete process.env.INSTANA_DISABLED_TRACERS;
   });
 
@@ -105,81 +106,201 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
   });
 
   describe('init', function () {
-    it('deactivate instrumentation via config', () => {
-      initAndActivate({ tracing: { disabledTracers: ['grpc', 'kafkajs', 'aws-sdk/v2'] } });
+    describe('tracer deactivation', () => {
+      describe('via disable config', () => {
+        it('should deactivate specified tracers', () => {
+          initAndActivate({ tracing: { disable: { libraries: ['grpc', 'kafkajs', 'aws-sdk/v2'] } } });
 
-      // grpcJs instrumentation has not been disabled, make sure its init and activate are called
-      expect(initStubGrpcJs).to.have.been.called;
-      expect(activateStubGrpcJs).to.have.been.called;
+          // grpcJs instrumentation has not been disabled, make sure its init and activate are called
+          expect(initStubGrpcJs).to.have.been.called;
+          expect(activateStubGrpcJs).to.have.been.called;
 
-      // kafkajs has been disabled...
-      expect(initStubKafkaJs).to.not.have.been.called;
-      expect(activateStubKafkaJs).to.not.have.been.called;
+          // kafkajs has been disabled...
+          expect(initStubKafkaJs).to.not.have.been.called;
+          expect(activateStubKafkaJs).to.not.have.been.called;
 
-      // ...but rdkafka has not been disabled
-      expect(initStubRdKafka).to.have.been.called;
-      expect(activateStubRdKafka).to.have.been.called;
+          // ...but rdkafka has not been disabled
+          expect(initStubRdKafka).to.have.been.called;
+          expect(activateStubRdKafka).to.have.been.called;
 
-      // aws-sdk/v2 has been disabled (via aws-sdk/v2)
-      expect(initAwsSdkv2).not.to.have.been.called;
-      expect(activateAwsSdkv2).not.to.have.been.called;
+          // aws-sdk/v2 has been disabled (via aws-sdk/v2)
+          expect(initAwsSdkv2).not.to.have.been.called;
+          expect(activateAwsSdkv2).not.to.have.been.called;
 
-      // aws-sdk/v3 has not been disabled
-      expect(initAwsSdkv3).to.have.been.called;
-      expect(activateAwsSdkv3).to.have.been.called;
+          // aws-sdk/v3 has not been disabled
+          expect(initAwsSdkv3).to.have.been.called;
+          expect(activateAwsSdkv3).to.have.been.called;
+        });
+
+        it('should disable multiple tracers in INSTANA_TRACING_DISABLE_LIBRARIES env var', () => {
+          process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'rdkafka,kafkajs,aws-sdk/v3';
+          initAndActivate({});
+
+          expect(activateStubGrpcJs).to.have.been.called;
+          expect(activateStubKafkaJs).to.have.been.called;
+          expect(activateStubRdKafka).to.have.been.called;
+          expect(activateAwsSdkv2).to.have.been.called;
+        });
+
+        it('update Kafka tracing config', () => {
+          const extraConfigFromAgent = {
+            tracing: {
+              kafka: {
+                traceCorrelation: false
+              }
+            }
+          };
+          initAndActivate({}, extraConfigFromAgent);
+          expect(activateStubKafkaJs).to.have.been.calledWith(extraConfigFromAgent);
+          expect(activateStubRdKafka).to.have.been.calledWith(extraConfigFromAgent);
+        });
+
+        it('disable aws-sdk/v3', () => {
+          initAndActivate({ tracing: { disabledTracers: ['aws-sdk/v3'] } });
+
+          // aws-sdk/v3 has been disabled (via aws-sdk/v3)
+          expect(initAwsSdkv3).not.to.have.been.called;
+          expect(activateAwsSdkv3).not.to.have.been.called;
+
+          it('should disable aws-sdk/v3 via config', () => {
+            initAndActivate({ tracing: { disable: { libraries: ['aws-sdk/v3'] } } });
+
+            // aws-sdk/v2 has been disabled (via aws-sdk/v2)
+            expect(initAwsSdkv2).not.to.have.been.called;
+            expect(activateAwsSdkv2).not.to.have.been.called;
+
+            expect(initAwsSdkv2).to.have.been.called;
+            expect(activateAwsSdkv2).to.have.been.called;
+          });
+
+          it('should disable both aws-sdk versions via config', () => {
+            initAndActivate({ tracing: { disable: { libraries: ['aws-sdk/v3', 'aws-sdk/v2'] } } });
+
+            expect(initAwsSdkv2).not.to.have.been.called;
+            expect(activateAwsSdkv2).not.to.have.been.called;
+
+            expect(initAwsSdkv3).not.to.have.been.called;
+            expect(activateAwsSdkv3).not.to.have.been.called;
+          });
+
+          it('should ignore empty disable array', () => {
+            initAndActivate({ tracing: { disable: [] } });
+
+            expect(initStubGrpcJs).to.have.been.called;
+            expect(activateStubGrpcJs).to.have.been.called;
+
+            expect(initStubKafkaJs).to.have.been.called;
+            expect(activateStubKafkaJs).to.have.been.called;
+
+            expect(initStubRdKafka).to.have.been.called;
+            expect(activateStubRdKafka).to.have.been.called;
+          });
+
+          it('should prefer config.tracing.disable over env vars', () => {
+            process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'grpc,kafkajs';
+            initAndActivate({ tracing: { disable: { libraries: ['aws-sdk/v2'] } } });
+
+            expect(initAwsSdkv2).not.to.have.been.called;
+            expect(activateAwsSdkv2).not.to.have.been.called;
+
+            expect(initStubGrpcJs).to.have.been.called;
+            expect(activateStubGrpcJs).to.have.been.called;
+
+            expect(initStubKafkaJs).to.have.been.called;
+            expect(activateStubKafkaJs).to.have.been.called;
+          });
+        });
+
+        describe('[deprecated] via disabledTracers config', () => {
+          it('should deactivate tracers', () => {
+            initAndActivate({ tracing: { disabledTracers: ['grpc', 'kafkajs', 'aws-sdk/v2'] } });
+
+            // grpcJs instrumentation has not been disabled, make sure its init and activate are called
+            expect(initStubGrpcJs).to.have.been.called;
+            expect(activateStubGrpcJs).to.have.been.called;
+
+            // kafkajs has been disabled...
+            expect(initStubKafkaJs).to.not.have.been.called;
+            expect(activateStubKafkaJs).to.not.have.been.called;
+
+            // ...but rdkafka has not been disabled
+            expect(initStubRdKafka).to.have.been.called;
+            expect(activateStubRdKafka).to.have.been.called;
+
+            // aws-sdk/v2 has been disabled (via aws-sdk/v2)
+            expect(initAwsSdkv2).not.to.have.been.called;
+            expect(activateAwsSdkv2).not.to.have.been.called;
+
+            // aws-sdk/v3 has not been disabled
+            expect(initAwsSdkv3).to.have.been.called;
+            expect(activateAwsSdkv3).to.have.been.called;
+          });
+
+          it('should handle INSTANA_DISABLED_TRACERS env var', () => {
+            process.env.INSTANA_DISABLED_TRACERS = 'kafkajs';
+            initAndActivate({});
+
+            expect(initStubKafkaJs).not.to.have.been.called;
+            expect(activateStubKafkaJs).not.to.have.been.called;
+          });
+
+          it('should handle empty disabledTracers array', () => {
+            initAndActivate({ tracing: { disabledTracers: [] } });
+
+            expect(initStubGrpcJs).to.have.been.called;
+            expect(initStubKafkaJs).to.have.been.called;
+            expect(initStubRdKafka).to.have.been.called;
+          });
+
+          it('should trim whitespace in INSTANA_DISABLED_TRACERS', () => {
+            process.env.INSTANA_DISABLED_TRACERS = '  grpc  ,  kafkajs  ';
+            initAndActivate({});
+
+            expect(initStubGrpcJs).to.have.been.called;
+            expect(activateStubGrpcJs).to.have.been.called;
+
+            expect(initStubKafkaJs).not.to.have.been.called;
+            expect(activateStubKafkaJs).not.to.have.been.called;
+          });
+
+          it('should prefer disable over disabledTracers when both exist', () => {
+            initAndActivate({
+              tracing: {
+                disabledTracers: ['grpc', 'kafkajs'],
+                disable: { libraries: ['aws-sdk/v2'] }
+              }
+            });
+
+            expect(initAwsSdkv2).not.to.have.been.called;
+            expect(activateAwsSdkv2).not.to.have.been.called;
+
+            expect(initStubGrpcJs).to.have.been.called;
+            expect(activateStubGrpcJs).to.have.been.called;
+
+            expect(initStubKafkaJs).to.have.been.called;
+            expect(activateStubKafkaJs).to.have.been.called;
+          });
+
+          it('should prefer INSTANA_TRACING_DISABLE_LIBRARIES over INSTANA_DISABLED_TRACERS', () => {
+            process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk/v2';
+            process.env.INSTANA_DISABLED_TRACERS = 'kafkajs';
+            initAndActivate({});
+
+            expect(initAwsSdkv2).not.to.have.been.called;
+            expect(activateAwsSdkv2).not.to.have.been.called;
+
+            expect(initStubKafkaJs).to.have.been.called;
+            expect(activateStubKafkaJs).to.have.been.called;
+          });
+        });
+      });
+
+      function initAndActivate(initConfig, extraConfigForActivate) {
+        const logger = testUtils.createFakeLogger();
+        const config = normalizeConfig(initConfig, logger);
+        tracing.init(config);
+        tracing.activate(extraConfigForActivate);
+      }
     });
-
-    it('deactivate instrumentation via env', () => {
-      process.env.INSTANA_DISABLED_TRACERS = 'grpc';
-      initAndActivate({});
-
-      expect(activateStubGrpcJs).to.have.been.called;
-      expect(activateStubKafkaJs).to.have.been.called;
-      expect(activateStubRdKafka).to.have.been.called;
-      expect(activateAwsSdkv2).to.have.been.called;
-    });
-
-    it('update Kafka tracing config', () => {
-      const extraConfigFromAgent = {
-        tracing: {
-          kafka: {
-            traceCorrelation: false
-          }
-        }
-      };
-      initAndActivate({}, extraConfigFromAgent);
-      expect(activateStubKafkaJs).to.have.been.calledWith(extraConfigFromAgent);
-      expect(activateStubRdKafka).to.have.been.calledWith(extraConfigFromAgent);
-    });
-
-    it('disable aws-sdk/v3', () => {
-      initAndActivate({ tracing: { disabledTracers: ['aws-sdk/v3'] } });
-
-      // aws-sdk/v3 has been disabled (via aws-sdk/v3)
-      expect(initAwsSdkv3).not.to.have.been.called;
-      expect(activateAwsSdkv3).not.to.have.been.called;
-
-      // aws-sdk/v2 has not been disabled (via aws-sdk/v2)
-      expect(initAwsSdkv2).to.have.been.called;
-      expect(activateAwsSdkv2).to.have.been.called;
-    });
-    it('disable aws-sdk/v3 and aws-sdk/v2', () => {
-      initAndActivate({ tracing: { disabledTracers: ['aws-sdk/v3', 'aws-sdk/v2'] } });
-
-      // aws-sdk/v2 has been disabled (via aws-sdk/v2)
-      expect(initAwsSdkv2).not.to.have.been.called;
-      expect(activateAwsSdkv2).not.to.have.been.called;
-
-      // aws-sdk/v3 has been disabled (via aws-sdk/v3)
-      expect(initAwsSdkv3).not.to.have.been.called;
-      expect(activateAwsSdkv3).not.to.have.been.called;
-    });
-
-    function initAndActivate(initConfig, extraConfigForActivate) {
-      const logger = testUtils.createFakeLogger();
-      const config = normalizeConfig(initConfig, logger);
-      tracing.init(config);
-      tracing.activate(extraConfigForActivate);
-    }
   });
 });

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -74,7 +74,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     initAwsSdkv2.reset();
     initAwsSdkv3.reset();
 
-    delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
+    delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
     // @deprecated
     delete process.env.INSTANA_DISABLED_TRACERS;
   });
@@ -110,7 +110,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     describe('tracer deactivation', () => {
       describe('via disable config', () => {
         it('should deactivate specified tracers', () => {
-          initAndActivate({ tracing: { disable: { libraries: ['grpc', 'kafkajs', 'aws-sdk/v2'] } } });
+          initAndActivate({ tracing: { disable: { instrumentations: ['grpc', 'kafkajs', 'aws-sdk/v2'] } } });
 
           // grpcJs instrumentation has not been disabled, make sure its init and activate are called
           expect(initStubGrpcJs).to.have.been.called;
@@ -133,8 +133,8 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           expect(activateAwsSdkv3).to.have.been.called;
         });
 
-        it('should disable multiple tracers in INSTANA_TRACING_DISABLE_LIBRARIES env var', () => {
-          process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'rdkafka,kafkajs,aws-sdk/v3';
+        it('should disable multiple tracers in INSTANA_TRACING_DISABLE_INSTRUMENTATIONS env var', () => {
+          process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'rdkafka,kafkajs,aws-sdk/v3';
           initAndActivate({});
 
           expect(activateStubGrpcJs).to.have.been.called;
@@ -164,7 +164,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           expect(activateAwsSdkv3).not.to.have.been.called;
 
           it('should disable aws-sdk/v3 via config', () => {
-            initAndActivate({ tracing: { disable: { libraries: ['aws-sdk/v3'] } } });
+            initAndActivate({ tracing: { disable: { instrumentations: ['aws-sdk/v3'] } } });
 
             // aws-sdk/v2 has been disabled (via aws-sdk/v2)
             expect(initAwsSdkv2).not.to.have.been.called;
@@ -175,7 +175,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           });
 
           it('should disable both aws-sdk versions via config', () => {
-            initAndActivate({ tracing: { disable: { libraries: ['aws-sdk/v3', 'aws-sdk/v2'] } } });
+            initAndActivate({ tracing: { disable: { instrumentations: ['aws-sdk/v3', 'aws-sdk/v2'] } } });
 
             expect(initAwsSdkv2).not.to.have.been.called;
             expect(activateAwsSdkv2).not.to.have.been.called;
@@ -198,8 +198,8 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           });
 
           it('should prefer config.tracing.disable over env vars', () => {
-            process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'grpc,kafkajs';
-            initAndActivate({ tracing: { disable: { libraries: ['aws-sdk/v2'] } } });
+            process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'grpc,kafkajs';
+            initAndActivate({ tracing: { disable: { instrumentations: ['aws-sdk/v2'] } } });
 
             expect(initAwsSdkv2).not.to.have.been.called;
             expect(activateAwsSdkv2).not.to.have.been.called;
@@ -268,7 +268,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
             initAndActivate({
               tracing: {
                 disabledTracers: ['grpc', 'kafkajs'],
-                disable: { libraries: ['aws-sdk/v2'] }
+                disable: { instrumentations: ['aws-sdk/v2'] }
               }
             });
 
@@ -282,8 +282,8 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
             expect(activateStubKafkaJs).to.have.been.called;
           });
 
-          it('should prefer INSTANA_TRACING_DISABLE_LIBRARIES over INSTANA_DISABLED_TRACERS', () => {
-            process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk/v2';
+          it('should prefer INSTANA_TRACING_DISABLE_INSTRUMENTATIONS over INSTANA_DISABLED_TRACERS', () => {
+            process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk/v2';
             process.env.INSTANA_DISABLED_TRACERS = 'kafkajs';
             initAndActivate({});
 

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -137,8 +137,8 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           initAndActivate({});
 
           expect(activateStubGrpcJs).to.have.been.called;
-          expect(activateStubKafkaJs).to.have.been.called;
-          expect(activateStubRdKafka).to.have.been.called;
+          expect(activateStubKafkaJs).not.to.have.been.called;
+          expect(activateStubRdKafka).not.to.have.been.called;
           expect(activateAwsSdkv2).to.have.been.called;
         });
 

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -75,6 +75,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     initAwsSdkv3.reset();
 
     delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
+    // @deprecated
     delete process.env.INSTANA_DISABLED_TRACERS;
   });
 

--- a/packages/core/test/util/configNormalizers/disable_test.js
+++ b/packages/core/test/util/configNormalizers/disable_test.js
@@ -10,9 +10,9 @@ const { expect } = require('chai');
 const { normalize } = require('../../../src/util/configNormalizers/disable');
 
 function resetEnv() {
-  delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
+  delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
   delete process.env.INSTANA_DISABLED_TRACERS;
-  delete process.env.INSTANA_TRACING_DISABLE_CATEGORIES;
+  delete process.env.INSTANA_TRACING_DISABLE;
 }
 
 describe('util.configNormalizers.disable', () => {
@@ -29,11 +29,11 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result).to.deep.equal({ libraries: [] });
+      expect(result).to.deep.equal({});
       expect(config.tracing).to.exist;
     });
 
-    it('should handle deprecated "disabledTracers" to "disable.libraries"', () => {
+    it('should handle deprecated "disabledTracers" to "disable.instrumentations"', () => {
       const config = {
         tracing: {
           disabledTracers: ['AWS-SDK', 'mongodb']
@@ -43,7 +43,7 @@ describe('util.configNormalizers.disable', () => {
       const result = normalize(config);
 
       expect(result).to.deep.equal({
-        libraries: ['aws-sdk', 'mongodb']
+        instrumentations: ['aws-sdk', 'mongodb']
       });
       expect(config.tracing.disabledTracers).to.be.undefined;
     });
@@ -53,50 +53,70 @@ describe('util.configNormalizers.disable', () => {
         tracing: {
           disabledTracers: ['AWS-SDK'],
           disable: {
-            libraries: ['redis']
+            instrumentations: ['redis']
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.libraries).to.deep.equal(['redis']);
+      expect(result.instrumentations).to.deep.equal(['redis']);
     });
 
     it('should normalize library names to lowercase and trim whitespace', () => {
       const config = {
         tracing: {
           disable: {
-            libraries: ['AWS-SDK', '  MongoDB  ', '', 'Postgres']
+            instrumentations: ['AWS-SDK', '  MongoDB  ', '', 'Postgres']
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
-    it('should handle non-array "libraries" input gracefully', () => {
+    it('should handle non-array "instrumentations" input gracefully', () => {
       const config = {
         tracing: {
           disable: {
-            libraries: 'aws-sdk'
+            instrumentations: 'aws-sdk'
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.libraries).to.deep.equal([]);
+      expect(result.instrumentations).to.deep.equal([]);
+    });
+
+    it('should handle flat disable config', () => {
+      const config = {
+        tracing: {
+          disable: ['AWS-SDK', '  MongoDB  ', '', 'Postgres']
+        }
+      };
+
+      const result = normalize(config);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
   });
 
   describe('Environment Variable Handling', () => {
-    it('should parse "INSTANA_TRACING_DISABLE_LIBRARIES" correctly', () => {
-      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk, mongodb, postgres';
+    it('should parse "INSTANA_TRACING_DISABLE_INSTRUMENTATIONS" correctly', () => {
+      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk, mongodb, postgres';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+    });
+
+    it('should parse "INSTANA_TRACING_DISABLE" correctly', () => {
+      process.env.INSTANA_TRACING_DISABLE = 'aws-sdk, mongodb, postgres';
+
+      const config = {};
+      const result = normalize(config);
+
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
     it('should fallback to "INSTANA_DISABLED_TRACERS" and issue a deprecation warning', () => {
@@ -105,35 +125,35 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result.libraries).to.deep.equal(['redis', 'mysql']);
+      expect(result.instrumentations).to.deep.equal(['redis', 'mysql']);
     });
 
-    it('should prioritize "INSTANA_TRACING_DISABLE_LIBRARIES" over deprecated variable', () => {
-      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk';
+    it('should prioritize "INSTANA_TRACING_DISABLE_INSTRUMENTATIONS" over deprecated variable', () => {
+      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk';
       process.env.INSTANA_DISABLED_TRACERS = 'redis';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.libraries).to.deep.equal(['aws-sdk']);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk']);
     });
 
     it('should support semicolon-separated values in environment variable', () => {
-      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk;mongodb;postgres';
+      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk;mongodb;postgres';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
     it('should ignore empty or whitespace-only entries in environment variable', () => {
-      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk,,mongodb, ,postgres';
+      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk,,mongodb, ,postgres';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
   });
 });

--- a/packages/core/test/util/configNormalizers/disable_test.js
+++ b/packages/core/test/util/configNormalizers/disable_test.js
@@ -1,0 +1,139 @@
+/*
+ * (c) Copyright IBM Corp. 2025
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('mocha');
+const { expect } = require('chai');
+
+const { normalize } = require('../../../src/util/configNormalizers/disable');
+
+function resetEnv() {
+  delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
+  delete process.env.INSTANA_DISABLED_TRACERS;
+  delete process.env.INSTANA_TRACING_DISABLE_CATEGORIES;
+}
+
+describe('util.configNormalizers.disable', () => {
+  beforeEach(() => {
+    resetEnv();
+  });
+
+  afterEach(() => {
+    resetEnv();
+  });
+
+  describe('normalize()', () => {
+    it('should handle empty config', () => {
+      const config = {};
+      const result = normalize(config);
+
+      expect(result).to.deep.equal({ libraries: [] });
+      expect(config.tracing).to.exist;
+    });
+
+    it('should handle deprecated "disabledTracers" to "disable.libraries"', () => {
+      const config = {
+        tracing: {
+          disabledTracers: ['AWS-SDK', 'mongodb']
+        }
+      };
+
+      const result = normalize(config);
+
+      expect(result).to.deep.equal({
+        libraries: ['aws-sdk', 'mongodb']
+      });
+      expect(config.tracing.disabledTracers).to.be.undefined;
+    });
+
+    it('should prioritize "disable" when both "disabledTracers" and "disable" properties are defined', () => {
+      const config = {
+        tracing: {
+          disabledTracers: ['AWS-SDK'],
+          disable: {
+            libraries: ['redis']
+          }
+        }
+      };
+
+      const result = normalize(config);
+      expect(result.libraries).to.deep.equal(['redis']);
+    });
+
+    it('should normalize library names to lowercase and trim whitespace', () => {
+      const config = {
+        tracing: {
+          disable: {
+            libraries: ['AWS-SDK', '  MongoDB  ', '', 'Postgres']
+          }
+        }
+      };
+
+      const result = normalize(config);
+      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+    });
+
+    it('should handle non-array "libraries" input gracefully', () => {
+      const config = {
+        tracing: {
+          disable: {
+            libraries: 'aws-sdk'
+          }
+        }
+      };
+
+      const result = normalize(config);
+      expect(result.libraries).to.deep.equal([]);
+    });
+  });
+
+  describe('Environment Variable Handling', () => {
+    it('should parse "INSTANA_TRACING_DISABLE_LIBRARIES" correctly', () => {
+      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk, mongodb, postgres';
+
+      const config = {};
+      const result = normalize(config);
+
+      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+    });
+
+    it('should fallback to "INSTANA_DISABLED_TRACERS" and issue a deprecation warning', () => {
+      process.env.INSTANA_DISABLED_TRACERS = 'redis, mysql';
+
+      const config = {};
+      const result = normalize(config);
+
+      expect(result.libraries).to.deep.equal(['redis', 'mysql']);
+    });
+
+    it('should prioritize "INSTANA_TRACING_DISABLE_LIBRARIES" over deprecated variable', () => {
+      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk';
+      process.env.INSTANA_DISABLED_TRACERS = 'redis';
+
+      const config = {};
+      const result = normalize(config);
+
+      expect(result.libraries).to.deep.equal(['aws-sdk']);
+    });
+
+    it('should support semicolon-separated values in environment variable', () => {
+      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk;mongodb;postgres';
+
+      const config = {};
+      const result = normalize(config);
+
+      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+    });
+
+    it('should ignore empty or whitespace-only entries in environment variable', () => {
+      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk,,mongodb, ,postgres';
+
+      const config = {};
+      const result = normalize(config);
+
+      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+    });
+  });
+});

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -20,7 +20,7 @@ describe('util.normalizeConfig', () => {
     delete process.env.INSTANA_DISABLE_AUTO_INSTR;
     delete process.env.INSTANA_DISABLE_TRACING;
     delete process.env.INSTANA_DISABLED_TRACERS;
-    delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
+    delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
     delete process.env.INSTANA_TRACE_IMMEDIATELY;
     delete process.env.INSTANA_EXTRA_HTTP_HEADERS;
     delete process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT;
@@ -263,26 +263,26 @@ describe('util.normalizeConfig', () => {
     expect(config.tracing.stackTraceLength).to.equal(3);
   });
 
-  it('should not disable individual tracers by default', () => {
+  it('should not disable individual instrumentations by default', () => {
     const config = normalizeConfig();
     expect(config.tracing.disable).to.deep.equal({});
   });
 
-  it('should disable individual tracers via config', () => {
+  it('should disable individual instrumentations via config', () => {
     const config = normalizeConfig({
       tracing: {
         disabledTracers: ['graphQL', 'GRPC']
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('should disable individual tracers via env var', () => {
+  it('should disable individual instrumentations via env var', () => {
     process.env.INSTANA_DISABLED_TRACERS = 'graphQL   , GRPC';
     const config = normalizeConfig();
     // values will be normalized to lower case
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('config should take precedence over env vars when disabling individual tracers', () => {
@@ -293,51 +293,60 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disable.libraries).to.deep.equal(['baz', 'fizz']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
   });
 
-  it('should disable individual tracers via disable config', () => {
+  it('should disable individual instrumentations via disable config', () => {
     const config = normalizeConfig({
       tracing: {
-        disable: { libraries: ['graphQL', 'GRPC'] }
+        disable: ['graphQL', 'GRPC']
       }
     });
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('config should take precedence over INSTANA_TRACING_DISABLE_LIBRARIES when disabling individual tracers', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'foo, bar';
+  it('should disable individual instrumentations via disable.instrumentations config', () => {
     const config = normalizeConfig({
       tracing: {
-        disable: { libraries: ['baz', 'fizz'] }
+        disable: { instrumentations: ['graphQL', 'GRPC'] }
       }
     });
-    expect(config.tracing.disable.libraries).to.deep.equal(['baz', 'fizz']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('should disable multiple tracers via env var INSTANA_TRACING_DISABLE_LIBRARIES', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'graphQL   , GRPC, http';
-    const config = normalizeConfig();
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc', 'http']);
+  it('config should take precedence over INSTANA_TRACING_DISABLE_INSTRUMENTATIONS  for config', () => {
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'foo, bar';
+    const config = normalizeConfig({
+      tracing: {
+        disable: { instrumentations: ['baz', 'fizz'] }
+      }
+    });
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
   });
 
-  it('should handle single tracer via INSTANA_TRACING_DISABLE_LIBRARIES', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'console';
+  it('should disable multiple instrumentations via env var INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'graphQL   , GRPC, http';
     const config = normalizeConfig();
-    expect(config.tracing.disable.libraries).to.deep.equal(['console']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc', 'http']);
+  });
+
+  it('should handle single instrumentations via INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'console';
+    const config = normalizeConfig();
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['console']);
   });
 
   it('should trim whitespace from tracer names', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = '  graphql  ,  grpc  ';
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = '  graphql  ,  grpc  ';
     const config = normalizeConfig();
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('should prefer INSTANA_TRACING_DISABLE_LIBRARIES over INSTANA_DISABLED_TRACERS', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'redis';
+  it('should prefer INSTANA_TRACING_DISABLE_INSTRUMENTATIONS over INSTANA_DISABLED_TRACERS', () => {
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'redis';
     process.env.INSTANA_DISABLED_TRACERS = 'postgres';
     const config = normalizeConfig();
-    expect(config.tracing.disable.libraries).to.deep.equal(['redis']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['redis']);
   });
 
   // delete this test when we switch to opt-out


### PR DESCRIPTION
### **What Has Changed**

#### 1. **Renamed: Disable Specific Libraries**

The environment variable used to disable specific instrumentation targets:

```bash
INSTANA_DISABLED_TRACERS=[]
```

has been **renamed** to:

```bash
INSTANA_TRACING_DISABLE=[]
```
Also added support for `INSTANA_TRACING_DISABLE_INSTRUMENTATIONS`


This name more accurately reflects its purpose—disabling specific **libraries** (e.g., Redis, MongoDB).

The finalized name, `INSTANA_TRACING_DISABLE_INSTRUMENTATIONS`, provides a clearer and more structured naming convention moving forward.

> **Coming soon:** We plan to introduce `INSTANA_TRACING_DISABLE_GROUPS` to support grouped categories.

---

#### 2. **Updated: In-Code Tracing Configuration**

In-code configuration for disabling tracing has also been updated.

**Deprecated:**

```js
require('@instana/collector')({
  tracing: { disabledTracers: ['redis'] }
});
```

**Recommended:**
flat

```js
require('@instana/collector')({
  tracing: {
    disable:  ['redis']
  }
});
```
for only for packages:

```js
require('@instana/collector')({
  tracing: {
    disable: {
      instrumentations: ['redis']
    }
  }
});
```
---

#### 2. **Priority order**

env variable:

`INSTANA_TRACING_DISABLE_INSTRUMENTATIONS >>> INSTANA_TRACING_DISABLE >>>INSTANA_DISABLED_TRACERS(deprecated)`

`tracing.disable.instrumentations >>> tracing.disable =[] > >>tracing.disabledTracers`
