### PR TITLE
feat: added support for disabling config from agent

### DIFF
--- a/packages/collector/src/announceCycle/unannounced.js
+++ b/packages/collector/src/announceCycle/unannounced.js
@@ -44,6 +44,7 @@ const maxRetryDelay = 60 * 1000; // one minute
  * @property {KafkaTracingConfig} [kafka]
  * @property {import('@instana/core/src/tracing').IgnoreEndpoints} [ignore-endpoints]
  * @property {boolean} [span-batching-enabled]
+ * @property {Object} [disable]
  */
 
 /**
@@ -119,6 +120,7 @@ function applyAgentConfiguration(agentResponse) {
   applyKafkaTracingConfiguration(agentResponse);
   applySpanBatchingConfiguration(agentResponse);
   applyIgnoreEndpointsConfiguration(agentResponse);
+  applyDisableConfiguration(agentResponse);
 }
 
 /**
@@ -237,6 +239,21 @@ function applyIgnoreEndpointsConfiguration(agentResponse) {
   agentOpts.config.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.normalizeConfig(ignoreEndpointsConfig);
 }
 
+/**
+ * The incoming agent configuration include  `disable` object that include
+ * which instrumentation/categories should be disabled. For example: { logging: true, console: false }
+ * This will be normalized into an array of strings, such as: ['logging', '!console']
+ * For more details on the design, refer to:https://github.ibm.com/instana/technical-documentation/pull/344
+ *
+ * @param {AgentAnnounceResponse} agentResponse
+ */
+function applyDisableConfiguration(agentResponse) {
+  const disablingConfig = agentResponse?.tracing?.disable;
+  if (!disablingConfig) return;
+
+  ensureNestedObjectExists(agentOpts.config, ['tracing', 'disable']);
+  agentOpts.config.tracing.disable = configNormalizers.disable.normalize({ tracing: { disable: disablingConfig } });
+}
 module.exports = {
   init,
 

--- a/packages/collector/src/announceCycle/unannounced.js
+++ b/packages/collector/src/announceCycle/unannounced.js
@@ -44,7 +44,7 @@ const maxRetryDelay = 60 * 1000; // one minute
  * @property {KafkaTracingConfig} [kafka]
  * @property {import('@instana/core/src/tracing').IgnoreEndpoints} [ignore-endpoints]
  * @property {boolean} [span-batching-enabled]
- * @property {Object} [disable]
+ * @property {import('@instana/core/src/tracing').Disable} [disable]
  */
 
 /**

--- a/packages/collector/src/announceCycle/unannounced.js
+++ b/packages/collector/src/announceCycle/unannounced.js
@@ -252,7 +252,9 @@ function applyDisableConfiguration(agentResponse) {
   if (!disablingConfig) return;
 
   ensureNestedObjectExists(agentOpts.config, ['tracing', 'disable']);
-  agentOpts.config.tracing.disable = configNormalizers.disable.normalize({ tracing: { disable: disablingConfig } });
+  agentOpts.config.tracing.disable = configNormalizers.disable.normalizeExternalConfig({
+    tracing: { disable: disablingConfig }
+  });
 }
 module.exports = {
   init,

--- a/packages/collector/test/apps/agentStub.js
+++ b/packages/collector/test/apps/agentStub.js
@@ -44,6 +44,7 @@ const kafkaTraceCorrelation = process.env.KAFKA_TRACE_CORRELATION
   ? process.env.KAFKA_TRACE_CORRELATION === 'true'
   : null;
 const ignoreEndpoints = process.env.IGNORE_ENDPOINTS && JSON.parse(process.env.IGNORE_ENDPOINTS);
+const disable = process.env.AGENT_DISABLE_TRACING && JSON.parse(process.env.AGENT_DISABLE_TRACING);
 
 let discoveries = {};
 let rejectAnnounceAttempts = 0;
@@ -92,7 +93,7 @@ app.put('/com.instana.plugin.nodejs.discovery', (req, res) => {
     }
   };
 
-  if (kafkaTraceCorrelation != null || extraHeaders.length > 0 || enableSpanBatching || ignoreEndpoints) {
+  if (kafkaTraceCorrelation != null || extraHeaders.length > 0 || enableSpanBatching || ignoreEndpoints || disable) {
     response.tracing = {};
 
     if (extraHeaders.length > 0) {
@@ -111,6 +112,9 @@ app.put('/com.instana.plugin.nodejs.discovery', (req, res) => {
     }
     if (ignoreEndpoints) {
       response.tracing['ignore-endpoints'] = ignoreEndpoints;
+    }
+    if (disable) {
+      response.tracing.disable = disable;
     }
   }
   res.send(response);

--- a/packages/collector/test/apps/agentStubControls.js
+++ b/packages/collector/test/apps/agentStubControls.js
@@ -49,6 +49,10 @@ class AgentStubControls {
       env.IGNORE_ENDPOINTS = JSON.stringify(opts.ignoreEndpoints);
     }
 
+    if (opts.disable) {
+      env.AGENT_DISABLE_TRACING = JSON.stringify(opts.disable);
+    }
+
     this.agentStub = spawn('node', [path.join(__dirname, 'agentStub.js')], {
       stdio: config.getAppStdio(),
       env

--- a/packages/collector/test/tracing/logging/console/test.js
+++ b/packages/collector/test/tracing/logging/console/test.js
@@ -131,7 +131,7 @@ mochaSuiteFn('tracing/logging/console', function () {
       ));
   });
 
-  describe('when logging instrumentation is disabled', () => {
+  describe('when logging is disabled', () => {
     describe('through environment variables', () => {
       let envVarControls;
 
@@ -254,7 +254,7 @@ mochaSuiteFn('tracing/logging/console', function () {
     });
 
     describe('through agent configuration', () => {
-      describe('when logging category is disabled', () => {
+      describe('when logging group is disabled', () => {
         const { AgentStubControls } = require('../../../apps/agentStubControls');
         let customAgentControls;
         let agentConfigControls;

--- a/packages/collector/test/tracing/logging/console/test.js
+++ b/packages/collector/test/tracing/logging/console/test.js
@@ -131,6 +131,223 @@ mochaSuiteFn('tracing/logging/console', function () {
       ));
   });
 
+  describe('when logging instrumentation is disabled', () => {
+    describe('through environment variables', () => {
+      let envVarControls;
+
+      describe('using INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
+        before(async () => {
+          envVarControls = new ProcessControls({
+            useGlobalAgent: true,
+            dirname: __dirname,
+            env: {
+              INSTANA_TRACING_DISABLE_INSTRUMENTATIONS: ['console']
+            }
+          });
+          await envVarControls.startAndWaitForAgentConnection();
+        });
+
+        after(async () => {
+          await envVarControls.stop();
+        });
+
+        it('should not trace console.warn calls', async () => {
+          await envVarControls.sendRequest({ path: '/warn' });
+
+          await testUtils.retry(async () => {
+            const spans = await agentControls.getSpans();
+            const httpEntrySpan = verifyHttpRootEntry({
+              spans,
+              apiPath: '/warn',
+              pid: String(envVarControls.getPid())
+            });
+
+            verifyHttpExit({
+              spans,
+              parent: httpEntrySpan,
+              pid: String(envVarControls.getPid())
+            });
+
+            const consoleLogSpans = testUtils.getSpansByName(spans, 'log.console');
+            expect(consoleLogSpans).to.be.empty;
+          });
+        });
+      });
+
+      describe('using INSTANA_TRACING_DISABLE_GROUPS', () => {
+        before(async () => {
+          envVarControls = new ProcessControls({
+            useGlobalAgent: true,
+            dirname: __dirname,
+            env: {
+              INSTANA_TRACING_DISABLE_GROUPS: ['LOGGING']
+            }
+          });
+          await envVarControls.startAndWaitForAgentConnection();
+        });
+
+        after(async () => {
+          await envVarControls.stop();
+        });
+
+        it('should not trace console.warn calls', async () => {
+          await envVarControls.sendRequest({ path: '/warn' });
+
+          await testUtils.retry(async () => {
+            const spans = await agentControls.getSpans();
+            const httpEntrySpan = verifyHttpRootEntry({
+              spans,
+              apiPath: '/warn',
+              pid: String(envVarControls.getPid())
+            });
+
+            verifyHttpExit({
+              spans,
+              parent: httpEntrySpan,
+              pid: String(envVarControls.getPid())
+            });
+
+            const consoleLogSpans = testUtils.getSpansByName(spans, 'log.console');
+            expect(consoleLogSpans).to.be.empty;
+          });
+        });
+      });
+
+      describe('using INSTANA_TRACING_DISABLE with value "logging"', () => {
+        before(async () => {
+          envVarControls = new ProcessControls({
+            useGlobalAgent: true,
+            dirname: __dirname,
+            env: {
+              INSTANA_TRACING_DISABLE: ['logging']
+            }
+          });
+          await envVarControls.startAndWaitForAgentConnection();
+        });
+
+        after(async () => {
+          await envVarControls.stop();
+        });
+
+        it('should not trace console.warn calls', async () => {
+          await envVarControls.sendRequest({ path: '/warn' });
+
+          await testUtils.retry(async () => {
+            const spans = await agentControls.getSpans();
+            const httpEntrySpan = verifyHttpRootEntry({
+              spans,
+              apiPath: '/warn',
+              pid: String(envVarControls.getPid())
+            });
+
+            verifyHttpExit({
+              spans,
+              parent: httpEntrySpan,
+              pid: String(envVarControls.getPid())
+            });
+
+            const consoleLogSpans = testUtils.getSpansByName(spans, 'log.console');
+            expect(consoleLogSpans).to.be.empty;
+          });
+        });
+      });
+    });
+
+    describe('through agent configuration', () => {
+      describe('when logging category is disabled', () => {
+        const { AgentStubControls } = require('../../../apps/agentStubControls');
+        let customAgentControls;
+        let agentConfigControls;
+
+        before(async () => {
+          customAgentControls = new AgentStubControls();
+          await customAgentControls.startAgent({
+            disable: { logging: true }
+          });
+
+          agentConfigControls = new ProcessControls({
+            agentControls: customAgentControls,
+            dirname: __dirname
+          });
+          await agentConfigControls.startAndWaitForAgentConnection();
+        });
+
+        after(async () => {
+          await agentConfigControls.stop();
+          await customAgentControls.stopAgent();
+        });
+
+        it('should not trace console.warn calls', async () => {
+          await agentConfigControls.sendRequest({ path: '/warn' });
+
+          await testUtils.retry(async () => {
+            const spans = await customAgentControls.getSpans();
+            const httpEntrySpan = verifyHttpRootEntry({
+              spans,
+              apiPath: '/warn',
+              pid: String(agentConfigControls.getPid())
+            });
+
+            verifyHttpExit({
+              spans,
+              parent: httpEntrySpan,
+              pid: String(agentConfigControls.getPid())
+            });
+
+            const consoleLogSpans = testUtils.getSpansByName(spans, 'log.console');
+            expect(consoleLogSpans).to.be.empty;
+          });
+        });
+      });
+
+      describe('when logging is disabled but console is explicitly enabled', () => {
+        const { AgentStubControls } = require('../../../apps/agentStubControls');
+        let customAgentControls;
+        let agentConfigControls;
+
+        before(async () => {
+          customAgentControls = new AgentStubControls();
+          await customAgentControls.startAgent({
+            disable: { logging: true, console: false }
+          });
+
+          agentConfigControls = new ProcessControls({
+            agentControls: customAgentControls,
+            dirname: __dirname
+          });
+          await agentConfigControls.startAndWaitForAgentConnection();
+        });
+
+        after(async () => {
+          await agentConfigControls.stop();
+          await customAgentControls.stopAgent();
+        });
+
+        it('should trace console.warn calls', async () => {
+          await agentConfigControls.sendRequest({ path: '/warn' });
+
+          await testUtils.retry(async () => {
+            const spans = await customAgentControls.getSpans();
+            const httpEntrySpan = verifyHttpRootEntry({
+              spans,
+              apiPath: '/warn',
+              pid: String(agentConfigControls.getPid())
+            });
+
+            verifyHttpExit({
+              spans,
+              parent: httpEntrySpan,
+              pid: String(agentConfigControls.getPid())
+            });
+
+            const consoleLogSpans = testUtils.getSpansByName(spans, 'log.console');
+            expect(consoleLogSpans.length).to.equal(1);
+          });
+        });
+      });
+    });
+  });
+
   function runAndDoNotTrace(url) {
     return controls.sendRequest({ path: `/${url}` }).then(() =>
       testUtils.retry(() =>

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -290,6 +290,14 @@ exports.activate = function activate(extraConfig = {}) {
 
     if (automaticTracingEnabled) {
       instrumentations.forEach(instrumentationKey => {
+        // If instrumentation is disabled via agent config, we skip tracing using the `isActive` flag
+        // within the instrumentation logic.
+        // However, modules already shimmered (e.g., logging) remain wrapped — we don't currently unwrap them.
+        // This may lead to minor performance overhead or partial interception. Proper unwrapping via
+        // `shimmer.unwrap(...)` would need broader changes. Given the very low performance and functional
+        // impact at present, we are accepting this behavior for now.
+        //
+        // We will revisit this in the future, especially if we encounter issues with disabled instrumentations.
         if (
           !coreUtil.disableInstrumentation.isInstrumentationDisabled({
             instrumentationModules,

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -129,6 +129,16 @@ if (customInstrumentations.length > 0) {
  * @property {string[]} [connections]
  */
 
+/**
+ * @typedef {TracingDisableOptions} Disable
+ */
+
+/**
+ * @typedef {Object} TracingDisableOptions
+ * @property {string[]} [instrumentations]
+ * @property {string[]} [groups]
+ */
+
 /** @type {Array.<InstanaInstrumentedModule>} */
 let additionalInstrumentationModules = [];
 /** @type {Object.<string, InstanaInstrumentedModule>} */

--- a/packages/core/src/util/configNormalizers/disable.js
+++ b/packages/core/src/util/configNormalizers/disable.js
@@ -111,9 +111,6 @@ function getDisableFromEnv() {
  * @returns {string[]}
  */
 function parseEnvVar(envVarValue) {
-  if (typeof envVarValue !== 'string') {
-    return [];
-  }
   return envVarValue
     .split(/[;,]/)
     .map(item => item.trim().toLowerCase())

--- a/packages/core/src/util/configNormalizers/disable.js
+++ b/packages/core/src/util/configNormalizers/disable.js
@@ -111,6 +111,9 @@ function getDisableFromEnv() {
  * @returns {string[]}
  */
 function parseEnvVar(envVarValue) {
+  if (typeof envVarValue !== 'string') {
+    return [];
+  }
   return envVarValue
     .split(/[;,]/)
     .map(item => item.trim().toLowerCase())

--- a/packages/core/src/util/configNormalizers/disable.js
+++ b/packages/core/src/util/configNormalizers/disable.js
@@ -63,7 +63,7 @@ exports.normalize = function normalize(config) {
     return disableConfig || {};
   } catch (error) {
     // Fallback to an empty disable config on error
-    logger?.warn('Error while normalizing tracing.disable config.', error);
+    logger?.warn(`Error while normalizing tracing.disable config: ${error?.message} ${error?.stack}`);
     return {};
   }
 };
@@ -78,8 +78,8 @@ exports.normalizeExternalConfig = function normalizeExternalConfig(config) {
       const flattenedEntries = flattenDisableConfigs(config.tracing.disable);
       return categorizeDisableEntries(flattenedEntries);
     }
-  } catch (err) {
-    logger?.warn('Error while normalizing external tracing.disable config.', err);
+  } catch (error) {
+    logger?.warn(`Error while normalizing external tracing.disable config: ${error?.message} ${error?.stack}`);
   }
 
   return {};

--- a/packages/core/src/util/configNormalizers/disable.js
+++ b/packages/core/src/util/configNormalizers/disable.js
@@ -63,7 +63,7 @@ exports.normalize = function normalize(config) {
     return disableConfig || {};
   } catch (error) {
     // Fallback to an empty disable config on error
-    logger?.warn(`Error while normalizing tracing.disable config: ${error?.message} ${error?.stack}`);
+    logger?.debug(`Error while normalizing tracing.disable config: ${error?.message} ${error?.stack}`);
     return {};
   }
 };
@@ -79,7 +79,7 @@ exports.normalizeExternalConfig = function normalizeExternalConfig(config) {
       return categorizeDisableEntries(flattenedEntries);
     }
   } catch (error) {
-    logger?.warn(`Error while normalizing external tracing.disable config: ${error?.message} ${error?.stack}`);
+    logger?.debug(`Error while normalizing external tracing.disable config: ${error?.message} ${error?.stack}`);
   }
 
   return {};

--- a/packages/core/src/util/configNormalizers/disable.js
+++ b/packages/core/src/util/configNormalizers/disable.js
@@ -40,8 +40,6 @@ exports.normalize = function normalize(config) {
       delete config.tracing.disabledTracers;
     }
 
-    let disableConfig = config.tracing.disable;
-
     // Fallback to environment variables if `disable` is not configured
     const disableConfig = config.tracing?.disable || getDisableFromEnv();
     if (!disableConfig) {

--- a/packages/core/src/util/disableInstrumentation.js
+++ b/packages/core/src/util/disableInstrumentation.js
@@ -64,7 +64,15 @@ function shouldDisable(cfg, { moduleName, instrumentationName, group } = {}) {
     return false;
   }
 
-  // Case 1: Check if module or instrumentation is disabled
+  // Case 1: Check if module or instrumentation is explicitly enabled
+  if (moduleName) {
+    const isExplicitlyEnabled = disableConfig.instrumentations?.some(
+      (/** @type {string} */ lib) => typeof lib === 'string' && lib.startsWith('!') && lib.slice(1) === moduleName
+    );
+    if (isExplicitlyEnabled) return false;
+  }
+
+  // Case 2: Check if module or instrumentation is explicitly disabled
   if (
     (moduleName && disableConfig.instrumentations?.includes(moduleName)) ||
     (instrumentationName && disableConfig.instrumentations?.includes(instrumentationName))
@@ -72,11 +80,20 @@ function shouldDisable(cfg, { moduleName, instrumentationName, group } = {}) {
     return true;
   }
 
-  // Case 2: Check if the group is disabled
-  const isGroupDisabled =
-    group && DISABLABLE_INSTRUMENTATION_GROUPS.has(group) && disableConfig.groups?.includes(group);
+  // Case 3: Disable the group if it's explicitly enabled,
+  // (e.g., logging: false overrides logging: true at group level)
+  if (group && DISABLABLE_INSTRUMENTATION_GROUPS.has(group)) {
+    const isGroupExplicitlyEnabled = disableConfig.groups?.some(
+      (/** @type {string} */ grp) => typeof grp === 'string' && grp.startsWith('!') && grp.slice(1) === group
+    );
+    if (isGroupExplicitlyEnabled) return false;
 
-  return Boolean(isGroupDisabled);
+    if (disableConfig.groups?.includes(group)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**

--- a/packages/core/src/util/disableInstrumentation.js
+++ b/packages/core/src/util/disableInstrumentation.js
@@ -72,7 +72,7 @@ function shouldDisable(cfg, { moduleName, instrumentationName, group } = {}) {
     if (isExplicitlyEnabled) return false;
   }
 
-  // Case 2: Check if module or instrumentation is explicitly disabled
+  // Case 2: Check if module or instrumentation is disabled
   if (
     (moduleName && disableConfig.instrumentations?.includes(moduleName)) ||
     (instrumentationName && disableConfig.instrumentations?.includes(instrumentationName))
@@ -80,9 +80,10 @@ function shouldDisable(cfg, { moduleName, instrumentationName, group } = {}) {
     return true;
   }
 
-  // Case 3: Disable the group if it's explicitly enabled,
-  // (e.g., logging: false overrides logging: true at group level)
+  // Case 3: Group disabling
   if (group && DISABLABLE_INSTRUMENTATION_GROUPS.has(group)) {
+    // Check if group is explicitly enabled (rare case)
+    // (e.g., logging: false overrides logging: true at group level)
     const isGroupExplicitlyEnabled = disableConfig.groups?.some(
       (/** @type {string} */ grp) => typeof grp === 'string' && grp.startsWith('!') && grp.slice(1) === group
     );

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -88,6 +88,7 @@ const allowedSecretMatchers = ['equals', 'equals-ignore-case', 'contains', 'cont
  * @property {AgentTracingKafkaConfig} [kafka]
  * @property {boolean|string} [spanBatchingEnabled]
  * @property {import('../tracing').IgnoreEndpoints} [ignoreEndpoints]
+ * @property {TracingDisableOptions} [disable]
  */
 
 /**

--- a/packages/core/src/util/normalizeConfig.js
+++ b/packages/core/src/util/normalizeConfig.js
@@ -21,7 +21,7 @@ const configNormalizers = require('./configNormalizers');
  * @property {number} [transmissionDelay]
  * @property {number} [stackTraceLength]
  * @property {HTTPTracingOptions} [http]
- * @property {TracingDisableOptions} [disable]
+ * @property {import('../tracing').Disable} [disable]
  * @property {Array<string>} [disabledTracers]
  * @property {boolean} [spanBatchingEnabled]
  * @property {boolean} [disableW3cTraceCorrelation]
@@ -29,12 +29,6 @@ const configNormalizers = require('./configNormalizers');
  * @property {boolean} [allowRootExitSpan]
  * @property {import('../tracing').IgnoreEndpoints} [ignoreEndpoints]
  * @property {boolean} [ignoreEndpointsDisableSuppression]
- */
-
-/**
- * @typedef {Object} TracingDisableOptions
- * @property {string[]} [instrumentations]
- * @property {string[]} [groups]
  */
 
 /**
@@ -88,7 +82,7 @@ const allowedSecretMatchers = ['equals', 'equals-ignore-case', 'contains', 'cont
  * @property {AgentTracingKafkaConfig} [kafka]
  * @property {boolean|string} [spanBatchingEnabled]
  * @property {import('../tracing').IgnoreEndpoints} [ignoreEndpoints]
- * @property {TracingDisableOptions} [disable]
+ * @property {import('../tracing').Disable} [disable]
  */
 
 /**

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -76,7 +76,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     initAwsSdkv2.reset();
     initAwsSdkv3.reset();
 
-    delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
+    delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
     // @deprecated
     delete process.env.INSTANA_DISABLED_TRACERS;
   });

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -76,7 +76,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     initAwsSdkv2.reset();
     initAwsSdkv3.reset();
 
-    delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
+    delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
     // @deprecated
     delete process.env.INSTANA_DISABLED_TRACERS;
   });

--- a/packages/core/test/util/configNormalizers/disable_test.js
+++ b/packages/core/test/util/configNormalizers/disable_test.js
@@ -10,9 +10,9 @@ const { expect } = require('chai');
 const { normalize } = require('../../../src/util/configNormalizers/disable');
 
 function resetEnv() {
-  delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
+  delete process.env.INSTANA_TRACING_DISABLE_LIBRARIES;
   delete process.env.INSTANA_DISABLED_TRACERS;
-  delete process.env.INSTANA_TRACING_DISABLE;
+  delete process.env.INSTANA_TRACING_DISABLE_CATEGORIES;
 }
 
 describe('util.configNormalizers.disable', () => {
@@ -29,11 +29,11 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result).to.deep.equal({});
+      expect(result).to.deep.equal({ libraries: [] });
       expect(config.tracing).to.exist;
     });
 
-    it('should handle deprecated "disabledTracers" to "disable.instrumentations"', () => {
+    it('should handle deprecated "disabledTracers" to "disable.libraries"', () => {
       const config = {
         tracing: {
           disabledTracers: ['AWS-SDK', 'mongodb']
@@ -43,7 +43,7 @@ describe('util.configNormalizers.disable', () => {
       const result = normalize(config);
 
       expect(result).to.deep.equal({
-        instrumentations: ['aws-sdk', 'mongodb']
+        libraries: ['aws-sdk', 'mongodb']
       });
       expect(config.tracing.disabledTracers).to.be.undefined;
     });
@@ -53,50 +53,39 @@ describe('util.configNormalizers.disable', () => {
         tracing: {
           disabledTracers: ['AWS-SDK'],
           disable: {
-            instrumentations: ['redis']
+            libraries: ['redis']
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal(['redis']);
+      expect(result.libraries).to.deep.equal(['redis']);
     });
 
     it('should normalize library names to lowercase and trim whitespace', () => {
       const config = {
         tracing: {
           disable: {
-            instrumentations: ['AWS-SDK', '  MongoDB  ', '', 'Postgres']
+            libraries: ['AWS-SDK', '  MongoDB  ', '', 'Postgres']
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
-    it('should handle non-array "instrumentations" input gracefully', () => {
+    it('should handle non-array "libraries" input gracefully', () => {
       const config = {
         tracing: {
           disable: {
-            instrumentations: 'aws-sdk'
+            libraries: 'aws-sdk'
           }
         }
       };
 
       const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal([]);
-    });
-
-    it('should handle flat disable config', () => {
-      const config = {
-        tracing: {
-          disable: ['AWS-SDK', '  MongoDB  ', '', 'Postgres']
-        }
-      };
-
-      const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.libraries).to.deep.equal([]);
     });
 
     it('should support group names', () => {
@@ -209,22 +198,13 @@ describe('util.configNormalizers.disable', () => {
   });
 
   describe('Environment Variable Handling', () => {
-    it('should parse "INSTANA_TRACING_DISABLE_INSTRUMENTATIONS" correctly', () => {
-      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk, mongodb, postgres';
+    it('should parse "INSTANA_TRACING_DISABLE_LIBRARIES" correctly', () => {
+      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk, mongodb, postgres';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
-    });
-
-    it('should parse "INSTANA_TRACING_DISABLE" correctly', () => {
-      process.env.INSTANA_TRACING_DISABLE = 'aws-sdk, mongodb, postgres';
-
-      const config = {};
-      const result = normalize(config);
-
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
     it('should parse "INSTANA_TRACING_DISABLE_GROUPS" correctly', () => {
@@ -242,35 +222,35 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['redis', 'mysql']);
+      expect(result.libraries).to.deep.equal(['redis', 'mysql']);
     });
 
-    it('should prioritize "INSTANA_TRACING_DISABLE_INSTRUMENTATIONS" over deprecated variable', () => {
-      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk';
+    it('should prioritize "INSTANA_TRACING_DISABLE_LIBRARIES" over deprecated variable', () => {
+      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk';
       process.env.INSTANA_DISABLED_TRACERS = 'redis';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['aws-sdk']);
+      expect(result.libraries).to.deep.equal(['aws-sdk']);
     });
 
     it('should support semicolon-separated values in environment variable', () => {
-      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk;mongodb;postgres';
+      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk;mongodb;postgres';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
 
     it('should ignore empty or whitespace-only entries in environment variable', () => {
-      process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk,,mongodb, ,postgres';
+      process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'aws-sdk,,mongodb, ,postgres';
 
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.libraries).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
     });
     it('should ignore empty or whitespace-only entries in environment variable', () => {
       process.env.INSTANA_TRACING_DISABLE_GROUPS = 'logging,,databases, ,messaging';

--- a/packages/core/test/util/configNormalizers/disable_test.js
+++ b/packages/core/test/util/configNormalizers/disable_test.js
@@ -7,7 +7,7 @@
 const { describe, it, beforeEach, afterEach } = require('mocha');
 const { expect } = require('chai');
 
-const { normalize } = require('../../../src/util/configNormalizers/disable');
+const { normalize, normalizeExternalConfig } = require('../../../src/util/configNormalizers/disable');
 
 function resetEnv() {
   delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
@@ -327,7 +327,7 @@ describe('util.configNormalizers.disable', () => {
         }
       };
 
-      const result = normalize(config);
+      const result = normalizeExternalConfig(config);
       expect(result.instrumentations).to.deep.equal(['redis', 'console']);
     });
 
@@ -341,25 +341,26 @@ describe('util.configNormalizers.disable', () => {
         }
       };
 
-      const result = normalize(config);
+      const result = normalizeExternalConfig(config);
       expect(result.groups).to.include('messaging');
       expect(result.instrumentations).to.include('kafka');
     });
 
-    it('should handle config with true values', () => {
+    it('should handle config with true/false values', () => {
       const config = {
         tracing: {
           disable: {
             logging: true,
             redis: true,
-            console: false
+            console: false,
+            databases: false
           }
         }
       };
 
-      const result = normalize(config);
+      const result = normalizeExternalConfig(config);
       expect(result.instrumentations).to.deep.equal(['redis', '!console']);
-      expect(result.groups).to.include('logging');
+      expect(result.groups).to.include('logging', '!databases');
     });
 
     it('should handle if all entries set to false', () => {
@@ -372,7 +373,7 @@ describe('util.configNormalizers.disable', () => {
         }
       };
 
-      const result = normalize(config);
+      const result = normalizeExternalConfig(config);
       expect(result.instrumentations).to.deep.equal(['!redis', '!pg']);
     });
 
@@ -387,7 +388,7 @@ describe('util.configNormalizers.disable', () => {
         }
       };
 
-      const result = normalize(config);
+      const result = normalizeExternalConfig(config);
       expect(result.instrumentations).to.deep.equal(['redis']);
     });
   });

--- a/packages/core/test/util/configNormalizers/disable_test.js
+++ b/packages/core/test/util/configNormalizers/disable_test.js
@@ -316,4 +316,79 @@ describe('util.configNormalizers.disable', () => {
       expect(result).to.deep.equal({});
     });
   });
+  describe('config from agent', () => {
+    it('should handle config with true values', () => {
+      const config = {
+        tracing: {
+          disable: {
+            redis: true,
+            console: true
+          }
+        }
+      };
+
+      const result = normalize(config);
+      expect(result.instrumentations).to.deep.equal(['redis', 'console']);
+    });
+
+    it('should categorize known groups from object entries', () => {
+      const config = {
+        tracing: {
+          disable: {
+            messaging: true,
+            kafka: true
+          }
+        }
+      };
+
+      const result = normalize(config);
+      expect(result.groups).to.include('messaging');
+      expect(result.instrumentations).to.include('kafka');
+    });
+
+    it('should handle config with true values', () => {
+      const config = {
+        tracing: {
+          disable: {
+            logging: true,
+            redis: true,
+            console: false
+          }
+        }
+      };
+
+      const result = normalize(config);
+      expect(result.instrumentations).to.deep.equal(['redis', '!console']);
+      expect(result.groups).to.include('logging');
+    });
+
+    it('should handle if all entries set to false', () => {
+      const config = {
+        tracing: {
+          disable: {
+            redis: false,
+            pg: false
+          }
+        }
+      };
+
+      const result = normalize(config);
+      expect(result.instrumentations).to.deep.equal(['!redis', '!pg']);
+    });
+
+    it('should ignore non-boolean values in object config', () => {
+      const config = {
+        tracing: {
+          disable: {
+            redis: true,
+            pg: 'nope',
+            mysql: null
+          }
+        }
+      };
+
+      const result = normalize(config);
+      expect(result.instrumentations).to.deep.equal(['redis']);
+    });
+  });
 });

--- a/packages/core/test/util/disableInstrumentation_test.js
+++ b/packages/core/test/util/disableInstrumentation_test.js
@@ -344,7 +344,7 @@ describe('util.disableInstrumentation', () => {
       expect(bunyanResult).to.be.false;
     });
 
-    it('should precedence enable over disable for groups', () => {
+    it('should priotize enable config over disable config in case of groups', () => {
       disableInstrumentation.init({
         tracing: {
           disable: { groups: ['logging', '!logging'] }

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -19,7 +19,6 @@ describe('util.normalizeConfig', () => {
     delete process.env.INSTANA_DISABLED_TRACERS;
     delete process.env.INSTANA_DISABLE_AUTO_INSTR;
     delete process.env.INSTANA_DISABLE_TRACING;
-    delete process.env.INSTANA_DISABLED_TRACERS;
     delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
     delete process.env.INSTANA_TRACING_DISABLE_GROUPS;
     delete process.env.INSTANA_TRACE_IMMEDIATELY;
@@ -276,14 +275,14 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('should disable individual instrumentations via env var', () => {
     process.env.INSTANA_DISABLED_TRACERS = 'graphQL   , GRPC';
     const config = normalizeConfig();
     // values will be normalized to lower case
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('config should take precedence over env vars when disabling individual tracers', () => {
@@ -294,51 +293,60 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disable.libraries).to.deep.equal(['baz', 'fizz']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
   });
 
-  it('should disable individual tracers via disable config', () => {
+  it('should disable individual instrumentations via disable config', () => {
     const config = normalizeConfig({
       tracing: {
-        disable: { libraries: ['graphQL', 'GRPC'] }
+        disable: ['graphQL', 'GRPC']
       }
     });
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('config should take precedence over INSTANA_TRACING_DISABLE_LIBRARIES when disabling individual tracers', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'foo, bar';
+  it('should disable individual instrumentations via disable.instrumentations config', () => {
     const config = normalizeConfig({
       tracing: {
-        disable: { libraries: ['baz', 'fizz'] }
+        disable: { instrumentations: ['graphQL', 'GRPC'] }
       }
     });
-    expect(config.tracing.disable.libraries).to.deep.equal(['baz', 'fizz']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('should disable multiple tracers via env var INSTANA_TRACING_DISABLE_LIBRARIES', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'graphQL   , GRPC, http';
-    const config = normalizeConfig();
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc', 'http']);
+  it('config should take precedence over INSTANA_TRACING_DISABLE_INSTRUMENTATIONS  for config', () => {
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'foo, bar';
+    const config = normalizeConfig({
+      tracing: {
+        disable: { instrumentations: ['baz', 'fizz'] }
+      }
+    });
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
   });
 
-  it('should handle single tracer via INSTANA_TRACING_DISABLE_LIBRARIES', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'console';
+  it('should disable multiple instrumentations via env var INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'graphQL   , GRPC, http';
     const config = normalizeConfig();
-    expect(config.tracing.disable.libraries).to.deep.equal(['console']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc', 'http']);
+  });
+
+  it('should handle single instrumentations via INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'console';
+    const config = normalizeConfig();
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['console']);
   });
 
   it('should trim whitespace from tracer names', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = '  graphql  ,  grpc  ';
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = '  graphql  ,  grpc  ';
     const config = normalizeConfig();
-    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('should prefer INSTANA_TRACING_DISABLE_LIBRARIES over INSTANA_DISABLED_TRACERS', () => {
-    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'redis';
+  it('should prefer INSTANA_TRACING_DISABLE_INSTRUMENTATIONS over INSTANA_DISABLED_TRACERS', () => {
+    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'redis';
     process.env.INSTANA_DISABLED_TRACERS = 'postgres';
     const config = normalizeConfig();
-    expect(config.tracing.disable.libraries).to.deep.equal(['redis']);
+    expect(config.tracing.disable.instrumentations).to.deep.equal(['redis']);
   });
 
   it('should disable individual groups via disable config', () => {

--- a/packages/core/test/util/normalizeConfig_test.js
+++ b/packages/core/test/util/normalizeConfig_test.js
@@ -276,14 +276,14 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('should disable individual instrumentations via env var', () => {
     process.env.INSTANA_DISABLED_TRACERS = 'graphQL   , GRPC';
     const config = normalizeConfig();
     // values will be normalized to lower case
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
   });
 
   it('config should take precedence over env vars when disabling individual tracers', () => {
@@ -294,60 +294,51 @@ describe('util.normalizeConfig', () => {
       }
     });
     // values will be normalized to lower case
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['baz', 'fizz']);
   });
 
-  it('should disable individual instrumentations via disable config', () => {
+  it('should disable individual tracers via disable config', () => {
     const config = normalizeConfig({
       tracing: {
-        disable: ['graphQL', 'GRPC']
+        disable: { libraries: ['graphQL', 'GRPC'] }
       }
     });
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('should disable individual instrumentations via disable.instrumentations config', () => {
+  it('config should take precedence over INSTANA_TRACING_DISABLE_LIBRARIES when disabling individual tracers', () => {
+    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'foo, bar';
     const config = normalizeConfig({
       tracing: {
-        disable: { instrumentations: ['graphQL', 'GRPC'] }
+        disable: { libraries: ['baz', 'fizz'] }
       }
     });
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['baz', 'fizz']);
   });
 
-  it('config should take precedence over INSTANA_TRACING_DISABLE_INSTRUMENTATIONS  for config', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'foo, bar';
-    const config = normalizeConfig({
-      tracing: {
-        disable: { instrumentations: ['baz', 'fizz'] }
-      }
-    });
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
-  });
-
-  it('should disable multiple instrumentations via env var INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'graphQL   , GRPC, http';
+  it('should disable multiple tracers via env var INSTANA_TRACING_DISABLE_LIBRARIES', () => {
+    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'graphQL   , GRPC, http';
     const config = normalizeConfig();
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc', 'http']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc', 'http']);
   });
 
-  it('should handle single instrumentations via INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'console';
+  it('should handle single tracer via INSTANA_TRACING_DISABLE_LIBRARIES', () => {
+    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'console';
     const config = normalizeConfig();
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['console']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['console']);
   });
 
   it('should trim whitespace from tracer names', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = '  graphql  ,  grpc  ';
+    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = '  graphql  ,  grpc  ';
     const config = normalizeConfig();
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['graphql', 'grpc']);
   });
 
-  it('should prefer INSTANA_TRACING_DISABLE_INSTRUMENTATIONS over INSTANA_DISABLED_TRACERS', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'redis';
+  it('should prefer INSTANA_TRACING_DISABLE_LIBRARIES over INSTANA_DISABLED_TRACERS', () => {
+    process.env.INSTANA_TRACING_DISABLE_LIBRARIES = 'redis';
     process.env.INSTANA_DISABLED_TRACERS = 'postgres';
     const config = normalizeConfig();
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['redis']);
+    expect(config.tracing.disable.libraries).to.deep.equal(['redis']);
   });
 
   it('should disable individual groups via disable config', () => {


### PR DESCRIPTION
Added support for disabling instrumentations and groups via the agent configuration.

#### Agent Config (YAML):

Example agent's `configuration.yaml` file:

```yaml
tracing:
  disable:
    redis: true         # disable redis
    console: false      # enable console
    logging: true       # disable logging grp
```

####  Internally Normalized As:

```js
tracing.disable = {
  instrumentations: ['redis', '!console'],
  groups: ['logging']
}
```

#### Internal Notes:

* When a package or group is explicitly enabled (false in config), we internally normalize it as a negated entry using ! (e.g., !console).
* Instrumentation level disables take precedence over group enables.
* Group disables apply to all matching instrumentations unless explicitly enabled.

Ref: https://github.ibm.com/instana/technical-documentation/pull/344/files


