### PR TITLE
chore: cleaned up unwanted debug log

### DIFF
--- a/packages/collector/src/agentConnection.js
+++ b/packages/collector/src/agentConnection.js
@@ -256,8 +256,6 @@ function checkWhetherResponseForPathIsOkay(path, cb) {
 exports.sendMetrics = function sendMetrics(data, cb) {
   cb = util.atMostOnce('callback for sendMetrics', cb);
 
-  logger.debug(`Sending metrics to agent for pid ${pidStore.pid}.`);
-
   sendData(`/com.instana.plugin.nodejs.${pidStore.pid}`, data, (err, body) => {
     if (err) {
       cb(err, null);


### PR DESCRIPTION
This commit removes a redundant debug log message:
"Sending metrics to agent for pid"
which was repeatedly printed when INSTANA_DEBUG=true was enabled.

The message provided little value during debugging and unnecessarily cluttered the logs. 