### PR TITLE
chore: added dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" 
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "production"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns: ["*"]


### PR DESCRIPTION
refs [INSTA-38933](https://jsw.ibm.com/browse/INSTA-38933)

The current logic enables Dependabot and does the following:

- Creates a single PR for all packages when there are minor or patch updates
- Creates individual PRs for each package with major updates

This behavior aligns with the current PR logic used by our currency bot.

You can see a sample PR structure here: https://github.com/abhilash-sivan/nodejs/pulls