### PR TITLE
ci: updated tasks to respect task splitting logic in the coverage pipeline

### DIFF
--- a/.tekton/tasks/test-groups/autoprofile-task.yaml
+++ b/.tekton/tasks/test-groups/autoprofile-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:autoprofile" --report_dir="autoprofile"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:autoprofile" --report_dir="autoprofile"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/autoprofile-task.yaml
+++ b/.tekton/tasks/test-groups/autoprofile-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:autoprofile" --report_dir="autoprofile"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:autoprofile" --report_dir="autoprofile"
+            else
+               npm run coverage-ci --npm_command="test:ci:autoprofile" --report_dir="autoprofile"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/aws-fargate-task.yaml
+++ b/.tekton/tasks/test-groups/aws-fargate-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:aws-fargate" --report_dir="aws-fargate"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:aws-fargate" --report_dir="aws-fargate"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/aws-fargate-task.yaml
+++ b/.tekton/tasks/test-groups/aws-fargate-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:aws-fargate" --report_dir="aws-fargate"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:aws-fargate" --report_dir="aws-fargate"
+            else
+               npm run coverage-ci --npm_command="test:ci:aws-fargate" --report_dir="aws-fargate"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/aws-lambda-split-2-task.yaml
+++ b/.tekton/tasks/test-groups/aws-lambda-split-2-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-2"
+            if [[ 5 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-2"
+            else
+               npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-2"
+            fi
           else
             if [[ 5 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci" --stream --scope="@instana/aws-lambda"

--- a/.tekton/tasks/test-groups/aws-lambda-split-2-task.yaml
+++ b/.tekton/tasks/test-groups/aws-lambda-split-2-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-2"
+            CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-2"
           else
             if [[ 5 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci" --stream --scope="@instana/aws-lambda"

--- a/.tekton/tasks/test-groups/aws-lambda-split-3-task.yaml
+++ b/.tekton/tasks/test-groups/aws-lambda-split-3-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-3"
+            if [[ 5 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-3"
+            else
+               npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-3"
+            fi
           else
             if [[ 5 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=3 npx lerna run "test:ci" --stream --scope="@instana/aws-lambda"

--- a/.tekton/tasks/test-groups/aws-lambda-split-3-task.yaml
+++ b/.tekton/tasks/test-groups/aws-lambda-split-3-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-3"
+            CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-3"
           else
             if [[ 5 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=3 npx lerna run "test:ci" --stream --scope="@instana/aws-lambda"

--- a/.tekton/tasks/test-groups/aws-lambda-split-4-task.yaml
+++ b/.tekton/tasks/test-groups/aws-lambda-split-4-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-4"
+            CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=4 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-4"
           else
             if [[ 5 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=4 npx lerna run "test:ci" --stream --scope="@instana/aws-lambda"

--- a/.tekton/tasks/test-groups/aws-lambda-split-4-task.yaml
+++ b/.tekton/tasks/test-groups/aws-lambda-split-4-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=4 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-4"
+            if [[ 5 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=4 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-4"
+            else
+               npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-4"
+            fi
           else
             if [[ 5 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=4 npx lerna run "test:ci" --stream --scope="@instana/aws-lambda"

--- a/.tekton/tasks/test-groups/aws-lambda-split-5-task.yaml
+++ b/.tekton/tasks/test-groups/aws-lambda-split-5-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-5"
+            CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=5 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-5"
           else
             if [[ 5 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=5 npx lerna run "test:ci" --stream --scope="@instana/aws-lambda"

--- a/.tekton/tasks/test-groups/aws-lambda-split-5-task.yaml
+++ b/.tekton/tasks/test-groups/aws-lambda-split-5-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=5 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-5"
+            if [[ 5 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=5 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-5"
+            else
+               npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda-split-5"
+            fi
           else
             if [[ 5 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=5 npx lerna run "test:ci" --stream --scope="@instana/aws-lambda"

--- a/.tekton/tasks/test-groups/aws-lambda-task.yaml
+++ b/.tekton/tasks/test-groups/aws-lambda-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda"
+            CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda"
           else
             if [[ 5 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci" --stream --scope="@instana/aws-lambda"

--- a/.tekton/tasks/test-groups/aws-lambda-task.yaml
+++ b/.tekton/tasks/test-groups/aws-lambda-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda"
+            if [[ 5 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda"
+            else
+               npm run coverage-ci --npm_command="test:ci:aws-lambda" --report_dir="aws-lambda"
+            fi
           else
             if [[ 5 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci" --stream --scope="@instana/aws-lambda"

--- a/.tekton/tasks/test-groups/azure-container-services-task.yaml
+++ b/.tekton/tasks/test-groups/azure-container-services-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:azure-container-services" --report_dir="azure-container-services"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:azure-container-services" --report_dir="azure-container-services"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/azure-container-services-task.yaml
+++ b/.tekton/tasks/test-groups/azure-container-services-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:azure-container-services" --report_dir="azure-container-services"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:azure-container-services" --report_dir="azure-container-services"
+            else
+               npm run coverage-ci --npm_command="test:ci:azure-container-services" --report_dir="azure-container-services"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-general-task.yaml
+++ b/.tekton/tasks/test-groups/collector-general-task.yaml
@@ -139,7 +139,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:general" --report_dir="collector-general"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:general" --report_dir="collector-general"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-general-task.yaml
+++ b/.tekton/tasks/test-groups/collector-general-task.yaml
@@ -139,7 +139,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:general" --report_dir="collector-general"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:general" --report_dir="collector-general"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:general" --report_dir="collector-general"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v2-split-2-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v2-split-2-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2-split-2"
+            if [[ 3 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2-split-2"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2-split-2"
+            fi
           else
             if [[ 3 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci:tracing:cloud:aws:v2" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v2-split-2-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v2-split-2-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2-split-2"
+            CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2-split-2"
           else
             if [[ 3 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci:tracing:cloud:aws:v2" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v2-split-3-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v2-split-3-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2-split-3"
+            CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2-split-3"
           else
             if [[ 3 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=3 npx lerna run "test:ci:tracing:cloud:aws:v2" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v2-split-3-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v2-split-3-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2-split-3"
+            if [[ 3 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2-split-3"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2-split-3"
+            fi
           else
             if [[ 3 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=3 npx lerna run "test:ci:tracing:cloud:aws:v2" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v2-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v2-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2"
+            CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2"
           else
             if [[ 3 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci:tracing:cloud:aws:v2" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v2-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v2-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2"
+            if [[ 3 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v2" --report_dir="collector-tracing-cloud-aws-v2"
+            fi
           else
             if [[ 3 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci:tracing:cloud:aws:v2" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v3-split-2-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v3-split-2-task.yaml
@@ -117,7 +117,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3-split-2"
+            CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3-split-2"
           else
             if [[ 3 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci:tracing:cloud:aws:v3" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v3-split-2-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v3-split-2-task.yaml
@@ -117,7 +117,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3-split-2"
+            if [[ 3 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3-split-2"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3-split-2"
+            fi
           else
             if [[ 3 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci:tracing:cloud:aws:v3" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v3-split-3-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v3-split-3-task.yaml
@@ -117,7 +117,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3-split-3"
+            CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3-split-3"
           else
             if [[ 3 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=3 npx lerna run "test:ci:tracing:cloud:aws:v3" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v3-split-3-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v3-split-3-task.yaml
@@ -117,7 +117,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3-split-3"
+            if [[ 3 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3-split-3"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3-split-3"
+            fi
           else
             if [[ 3 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=3 npx lerna run "test:ci:tracing:cloud:aws:v3" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v3-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v3-task.yaml
@@ -117,7 +117,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3"
+            if [[ 3 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3"
+            fi
           else
             if [[ 3 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci:tracing:cloud:aws:v3" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v3-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-aws-v3-task.yaml
@@ -117,7 +117,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3"
+            CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:aws:v3" --report_dir="collector-tracing-cloud-aws-v3"
           else
             if [[ 3 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=3 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci:tracing:cloud:aws:v3" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-azure-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-azure-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:azure" --report_dir="collector-tracing-cloud-azure"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:azure" --report_dir="collector-tracing-cloud-azure"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:azure" --report_dir="collector-tracing-cloud-azure"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-azure-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-azure-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:azure" --report_dir="collector-tracing-cloud-azure"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:azure" --report_dir="collector-tracing-cloud-azure"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-gcp-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-gcp-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:gcp" --report_dir="collector-tracing-cloud-gcp"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:gcp" --report_dir="collector-tracing-cloud-gcp"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-tracing-cloud-gcp-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-cloud-gcp-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:gcp" --report_dir="collector-tracing-cloud-gcp"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:gcp" --report_dir="collector-tracing-cloud-gcp"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:cloud:gcp" --report_dir="collector-tracing-cloud-gcp"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-10-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-10-task.yaml
@@ -210,7 +210,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=10 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-10"
+            if [[ 10 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=10 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-10"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-10"
+            fi
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=10 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-10-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-10-task.yaml
@@ -210,7 +210,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-10"
+            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=10 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-10"
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=10 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-2-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-2-task.yaml
@@ -210,7 +210,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-2"
+            if [[ 10 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-2"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-2"
+            fi
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-2-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-2-task.yaml
@@ -210,7 +210,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-2"
+            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-2"
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-3-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-3-task.yaml
@@ -210,7 +210,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-3"
+            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-3"
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=3 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-3-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-3-task.yaml
@@ -210,7 +210,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-3"
+            if [[ 10 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-3"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-3"
+            fi
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=3 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-4-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-4-task.yaml
@@ -210,7 +210,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=4 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-4"
+            if [[ 10 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=4 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-4"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-4"
+            fi
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=4 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-4-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-4-task.yaml
@@ -210,7 +210,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-4"
+            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=4 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-4"
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=4 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-5-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-5-task.yaml
@@ -210,7 +210,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-5"
+            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=5 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-5"
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=5 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-5-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-5-task.yaml
@@ -210,7 +210,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=5 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-5"
+            if [[ 10 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=5 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-5"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-5"
+            fi
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=5 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-6-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-6-task.yaml
@@ -210,7 +210,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=6 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-6"
+            if [[ 10 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=6 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-6"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-6"
+            fi
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=6 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-6-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-6-task.yaml
@@ -210,7 +210,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-6"
+            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=6 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-6"
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=6 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-7-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-7-task.yaml
@@ -210,7 +210,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-7"
+            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=7 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-7"
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=7 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-7-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-7-task.yaml
@@ -210,7 +210,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=7 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-7"
+            if [[ 10 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=7 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-7"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-7"
+            fi
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=7 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-8-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-8-task.yaml
@@ -210,7 +210,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-8"
+            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=8 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-8"
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=8 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-8-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-8-task.yaml
@@ -210,7 +210,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=8 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-8"
+            if [[ 10 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=8 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-8"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-8"
+            fi
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=8 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-9-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-9-task.yaml
@@ -210,7 +210,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-9"
+            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=9 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-9"
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=9 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-split-9-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-split-9-task.yaml
@@ -210,7 +210,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=9 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-9"
+            if [[ 10 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=9 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-9"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database-split-9"
+            fi
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=9 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-task.yaml
@@ -210,7 +210,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database"
+            if [[ 10 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database"
+            fi
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-database-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-database-task.yaml
@@ -210,7 +210,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database"
+            CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:database" --report_dir="collector-tracing-database"
           else
             if [[ 10 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=10 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci:tracing:database" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-frameworks-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-frameworks-task.yaml
@@ -133,7 +133,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:frameworks" --report_dir="collector-tracing-frameworks"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:frameworks" --report_dir="collector-tracing-frameworks"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:frameworks" --report_dir="collector-tracing-frameworks"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-tracing-frameworks-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-frameworks-task.yaml
@@ -133,7 +133,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:frameworks" --report_dir="collector-tracing-frameworks"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:frameworks" --report_dir="collector-tracing-frameworks"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-tracing-general-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-general-task.yaml
@@ -133,7 +133,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:general" --report_dir="collector-tracing-general"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:general" --report_dir="collector-tracing-general"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-tracing-general-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-general-task.yaml
@@ -133,7 +133,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:general" --report_dir="collector-tracing-general"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:general" --report_dir="collector-tracing-general"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:general" --report_dir="collector-tracing-general"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-tracing-logging-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-logging-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:logging" --report_dir="collector-tracing-logging"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:logging" --report_dir="collector-tracing-logging"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-tracing-logging-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-logging-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:logging" --report_dir="collector-tracing-logging"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:logging" --report_dir="collector-tracing-logging"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:logging" --report_dir="collector-tracing-logging"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-tracing-messaging-split-2-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-messaging-split-2-task.yaml
@@ -209,7 +209,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-2"
+            if [[ 4 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-2"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-2"
+            fi
           else
             if [[ 4 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-messaging-split-2-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-messaging-split-2-task.yaml
@@ -209,7 +209,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-2"
+            CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-2"
           else
             if [[ 4 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-messaging-split-3-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-messaging-split-3-task.yaml
@@ -209,7 +209,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-3"
+            CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-3"
           else
             if [[ 4 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=3 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-messaging-split-3-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-messaging-split-3-task.yaml
@@ -209,7 +209,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-3"
+            if [[ 4 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-3"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-3"
+            fi
           else
             if [[ 4 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=3 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-messaging-split-4-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-messaging-split-4-task.yaml
@@ -209,7 +209,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-4"
+            CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=4 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-4"
           else
             if [[ 4 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=4 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-messaging-split-4-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-messaging-split-4-task.yaml
@@ -209,7 +209,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=4 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-4"
+            if [[ 4 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=4 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-4"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-4"
+            fi
           else
             if [[ 4 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=4 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-messaging-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-messaging-task.yaml
@@ -209,7 +209,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging"
+            CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging"
           else
             if [[ 4 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-messaging-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-messaging-task.yaml
@@ -209,7 +209,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging"
+            if [[ 4 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging"
+            fi
           else
             if [[ 4 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-misc-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-misc-task.yaml
@@ -117,7 +117,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:misc" --report_dir="collector-tracing-misc"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:misc" --report_dir="collector-tracing-misc"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:misc" --report_dir="collector-tracing-misc"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-tracing-misc-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-misc-task.yaml
@@ -117,7 +117,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:misc" --report_dir="collector-tracing-misc"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:misc" --report_dir="collector-tracing-misc"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/collector-tracing-protocols-split-2-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-protocols-split-2-task.yaml
@@ -123,7 +123,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=2 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:protocols" --report_dir="collector-tracing-protocols-split-2"
+            if [[ 2 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=2 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:protocols" --report_dir="collector-tracing-protocols-split-2"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:protocols" --report_dir="collector-tracing-protocols-split-2"
+            fi
           else
             if [[ 2 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=2 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci:tracing:protocols" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-protocols-split-2-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-protocols-split-2-task.yaml
@@ -123,7 +123,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:protocols" --report_dir="collector-tracing-protocols-split-2"
+            CI_TEST_SPLIT=2 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:protocols" --report_dir="collector-tracing-protocols-split-2"
           else
             if [[ 2 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=2 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci:tracing:protocols" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-protocols-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-protocols-task.yaml
@@ -123,7 +123,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:collector:tracing:protocols" --report_dir="collector-tracing-protocols"
+            CI_TEST_SPLIT=2 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:protocols" --report_dir="collector-tracing-protocols"
           else
             if [[ 2 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=2 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci:tracing:protocols" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/collector-tracing-protocols-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-protocols-task.yaml
@@ -123,7 +123,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=2 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:protocols" --report_dir="collector-tracing-protocols"
+            if [[ 2 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=2 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:protocols" --report_dir="collector-tracing-protocols"
+            else
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:protocols" --report_dir="collector-tracing-protocols"
+            fi
           else
             if [[ 2 =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=2 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci:tracing:protocols" --stream --scope="@instana/collector"

--- a/.tekton/tasks/test-groups/core-task.yaml
+++ b/.tekton/tasks/test-groups/core-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:core" --report_dir="core"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:core" --report_dir="core"
+            else
+               npm run coverage-ci --npm_command="test:ci:core" --report_dir="core"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/core-task.yaml
+++ b/.tekton/tasks/test-groups/core-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:core" --report_dir="core"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:core" --report_dir="core"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/google-cloud-run-task.yaml
+++ b/.tekton/tasks/test-groups/google-cloud-run-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:google-cloud-run" --report_dir="google-cloud-run"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:google-cloud-run" --report_dir="google-cloud-run"
+            else
+               npm run coverage-ci --npm_command="test:ci:google-cloud-run" --report_dir="google-cloud-run"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/google-cloud-run-task.yaml
+++ b/.tekton/tasks/test-groups/google-cloud-run-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:google-cloud-run" --report_dir="google-cloud-run"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:google-cloud-run" --report_dir="google-cloud-run"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/metrics-util-task.yaml
+++ b/.tekton/tasks/test-groups/metrics-util-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:metrics-util" --report_dir="metrics-util"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:metrics-util" --report_dir="metrics-util"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/metrics-util-task.yaml
+++ b/.tekton/tasks/test-groups/metrics-util-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:metrics-util" --report_dir="metrics-util"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:metrics-util" --report_dir="metrics-util"
+            else
+               npm run coverage-ci --npm_command="test:ci:metrics-util" --report_dir="metrics-util"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/opentelemetry-exporter-task.yaml
+++ b/.tekton/tasks/test-groups/opentelemetry-exporter-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:opentelemetry-exporter" --report_dir="opentelemetry-exporter"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:opentelemetry-exporter" --report_dir="opentelemetry-exporter"
+            else
+               npm run coverage-ci --npm_command="test:ci:opentelemetry-exporter" --report_dir="opentelemetry-exporter"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/opentelemetry-exporter-task.yaml
+++ b/.tekton/tasks/test-groups/opentelemetry-exporter-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:opentelemetry-exporter" --report_dir="opentelemetry-exporter"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:opentelemetry-exporter" --report_dir="opentelemetry-exporter"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/opentelemetry-sampler-task.yaml
+++ b/.tekton/tasks/test-groups/opentelemetry-sampler-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:opentelemetry-sampler" --report_dir="opentelemetry-sampler"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:opentelemetry-sampler" --report_dir="opentelemetry-sampler"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/opentelemetry-sampler-task.yaml
+++ b/.tekton/tasks/test-groups/opentelemetry-sampler-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:opentelemetry-sampler" --report_dir="opentelemetry-sampler"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:opentelemetry-sampler" --report_dir="opentelemetry-sampler"
+            else
+               npm run coverage-ci --npm_command="test:ci:opentelemetry-sampler" --report_dir="opentelemetry-sampler"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/serverless-collector-task.yaml
+++ b/.tekton/tasks/test-groups/serverless-collector-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:serverless-collector" --report_dir="serverless-collector"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:serverless-collector" --report_dir="serverless-collector"
+            else
+               npm run coverage-ci --npm_command="test:ci:serverless-collector" --report_dir="serverless-collector"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/serverless-collector-task.yaml
+++ b/.tekton/tasks/test-groups/serverless-collector-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:serverless-collector" --report_dir="serverless-collector"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:serverless-collector" --report_dir="serverless-collector"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/serverless-task.yaml
+++ b/.tekton/tasks/test-groups/serverless-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:serverless" --report_dir="serverless"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:serverless" --report_dir="serverless"
+            else
+               npm run coverage-ci --npm_command="test:ci:serverless" --report_dir="serverless"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/serverless-task.yaml
+++ b/.tekton/tasks/test-groups/serverless-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:serverless" --report_dir="serverless"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:serverless" --report_dir="serverless"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/shared-metrics-task.yaml
+++ b/.tekton/tasks/test-groups/shared-metrics-task.yaml
@@ -114,7 +114,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="test:ci:shared-metrics" --report_dir="shared-metrics"
+            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:shared-metrics" --report_dir="shared-metrics"
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/tasks/test-groups/shared-metrics-task.yaml
+++ b/.tekton/tasks/test-groups/shared-metrics-task.yaml
@@ -114,7 +114,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:shared-metrics" --report_dir="shared-metrics"
+            if [[ false =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:shared-metrics" --report_dir="shared-metrics"
+            else
+               npm run coverage-ci --npm_command="test:ci:shared-metrics" --report_dir="shared-metrics"
+            fi
           else
             if [[ false =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT=false CI_TEST_SPLIT_CURRENT=1 npx lerna run "false" --stream --scope="false"

--- a/.tekton/templates/test-task.yaml.template
+++ b/.tekton/templates/test-task.yaml.template
@@ -124,7 +124,11 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            CI_TEST_SPLIT={{split}} CI_TEST_SPLIT_CURRENT={{splitNumber}} npm run coverage-ci --npm_command="{{groupName}}" --report_dir="{{sanitizedGroupName}}"
+            if [[ {{split}} =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT={{split}} CI_TEST_SPLIT_CURRENT={{splitNumber}} npm run coverage-ci --npm_command="{{groupName}}" --report_dir="{{sanitizedGroupName}}"
+            else
+               npm run coverage-ci --npm_command="{{groupName}}" --report_dir="{{sanitizedGroupName}}"
+            fi
           else
             if [[ {{split}} =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT={{split}} CI_TEST_SPLIT_CURRENT={{splitNumber}} npx lerna run "{{subname}}" --stream --scope="{{scope}}"

--- a/.tekton/templates/test-task.yaml.template
+++ b/.tekton/templates/test-task.yaml.template
@@ -124,7 +124,7 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            npm run coverage-ci --npm_command="{{groupName}}" --report_dir="{{sanitizedGroupName}}"
+            CI_TEST_SPLIT={{split}} CI_TEST_SPLIT_CURRENT={{splitNumber}} npm run coverage-ci --npm_command="{{groupName}}" --report_dir="{{sanitizedGroupName}}"
           else
             if [[ {{split}} =~ ^[0-9]+$ ]]; then
               CI_TEST_SPLIT={{split}} CI_TEST_SPLIT_CURRENT={{splitNumber}} npx lerna run "{{subname}}" --stream --scope="{{scope}}"


### PR DESCRIPTION
without this setting, the split tasks for coverage don’t function correctly. The different split tasks end up running the same set of tests, which leads to span assertion issues and longer execution times