### PR TITLE
fix: added eol event for Node v18, v21 and v23

### DIFF
--- a/packages/collector/src/util/eol.js
+++ b/packages/collector/src/util/eol.js
@@ -14,5 +14,5 @@ const { satisfies } = require('semver');
  * @returns {boolean}
  */
 exports.isNodeVersionEOL = function () {
-  return satisfies(process.versions.node, '<18 || 19');
+  return satisfies(process.versions.node, '<20 || 21 || 23');
 };

--- a/packages/collector/test/util/isNodeVersionEOL_test.js
+++ b/packages/collector/test/util/isNodeVersionEOL_test.js
@@ -35,6 +35,7 @@ describe('util/eol', () => {
   runEolTest('14.13.3');
   runEolTest('15.16.17');
   runEolTest('17.0.0');
+  runEolTest('21.0.3');
 
   function runEolTest(version) {
     it(`EOL should be detected when the Node.js version is EOL (${version})`, () => {


### PR DESCRIPTION
updated eol logic and events to treat node <20, 21.x, and 23.x as eol

Node.js versions below 20, as well as versions 21.x and 23.x, have reached end-of-life.
this update ensures the node.js collector triggers eol events for these versions to inform users of security and support risks.

reference: https://nodejs.org/en/about/previous-releases

- node 18: eol on mar 27, 2025
- node 21: eol since apr 10, 2024
- node 23: eol since may 14, 2025

