### PR TITLE
fix: resolved MaxListenersExceededWarning in gcstats module

### DIFF
--- a/packages/shared-metrics/src/gc.js
+++ b/packages/shared-metrics/src/gc.js
@@ -131,5 +131,7 @@ exports.deactivate = function deactivate() {
   activateHasBeenCalled = false;
   hasBeenActivated = false;
 
-  gcStats.removeListener('stats', statsHandler);
+  if (gcStats && typeof gcStats.removeListener === 'function') {
+    gcStats.removeListener('stats', statsHandler);
+  }
 };

--- a/packages/shared-metrics/test/memory_leak_detector_test.js
+++ b/packages/shared-metrics/test/memory_leak_detector_test.js
@@ -1,0 +1,49 @@
+/*
+ * (c) Copyright IBM Corp. 2025
+ */
+
+'use strict';
+
+const { expect } = require('chai');
+const gcStats = require('../src/gc');
+const nativeModuleRetry = require('../src/util/nativeModuleRetry');
+const { createFakeLogger } = require('@instana/core/test/test_util');
+const config = require('@instana/core/test/config');
+
+describe('shared-metrics/memory_leak_detector', function () {
+  this.timeout(config.getTestTimeout() * 2);
+
+  before(() => {
+    process.env.NODE_NO_WARNINGS = '0';
+  });
+
+  after(() => {
+    delete process.env.NODE_NO_WARNINGS;
+  });
+
+  it('gc.js: should not throw memory leak', async () => {
+    let warningAppeared = false;
+
+    process.on('warning', () => {
+      warningAppeared = true;
+    });
+
+    nativeModuleRetry.init({
+      logger: createFakeLogger()
+    });
+    gcStats.init({ logger: createFakeLogger() });
+
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    for (let i = 0; i <= 15; i++) {
+      gcStats.activate();
+
+      // agent announce cycle calls deactivate
+      gcStats.deactivate();
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 3 * 1000));
+
+    expect(warningAppeared).to.be.false;
+  });
+});


### PR DESCRIPTION
> 2025-06-25T04:28:55.428Z,(node:21) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 stats listeners added to [EventEmitter]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit

- appears when the agent cannot be reached and the agent announce cycle deactivate the metrics component
  - connect
  - activate
  - connection problem with agent
  - deactivate
  - loop