### PR TITLE
chore: udpated currency bot branch name for major updates

### DIFF
--- a/.github/workflows/cleanup-branches.yaml
+++ b/.github/workflows/cleanup-branches.yaml
@@ -47,7 +47,7 @@ jobs:
 
           git fetch --prune --all
 
-          for branch in $(git branch -r | grep -E 'origin/(chore-|docs-|fix-|feat-|test-|refactor-|ci-|build-)'); do
+          for branch in $(git branch -r | grep -E 'origin/(chore-|docs-|fix-|feat-|test-|refactor-|ci-|build-|currency-bot-)'); do
             branch_name=$(echo "$branch" | sed 's|origin/||')
 
             pr_info=$(gh pr list --state merged --base main --head "$branch_name" --json mergedAt)

--- a/bin/currency/update-currencies.js
+++ b/bin/currency/update-currencies.js
@@ -100,7 +100,7 @@ currencies.forEach(currency => {
     execSync('git checkout main', { cwd });
     execSync('npm i --no-audit', { cwd });
 
-    branchName = `${BRANCH}-${currency.name.replace(/[^a-zA-Z0-9]/g, '')}`;
+    branchName = `${BRANCH}-${currency.name.replace(/[^a-zA-Z0-9]/g, '')}-${latestVersion.replace(/\./g, '')}`;
 
     try {
       execSync(`git ls-remote --exit-code --heads origin ${branchName}`, { cwd });


### PR DESCRIPTION
- added currency bot branches to cleanup list

This was the structure of branch name:
`currency-bot-major-redisclient`

From now on it will be:
`currency-bot-major-redisclient-560` where the 560 will mean that the update of the dependency is to version 5.6.0

