### PR TITLE
feat: added support for @apollo/server v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
       "devDependencies": {
         "@apollo/gateway": "^2.11.2",
         "@apollo/server": "^5.0.0",
+        "@apollo/server-v4": "npm:@apollo/server@4.12.2",
         "@apollo/subgraph": "^2.11.2",
+        "@as-integrations/express5": "^1.1.2",
         "@aws-sdk/client-cloudwatch-logs": "^3.696.0",
         "@aws-sdk/client-dynamodb": "^3.846.0",
         "@aws-sdk/client-dynamodb-v3": "npm:@aws-sdk/client-dynamodb@3.20.0",
@@ -426,6 +428,362 @@
         "graphql": "14.x || 15.x || 16.x"
       }
     },
+    "node_modules/@apollo/server-v4": {
+      "name": "@apollo/server",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.12.2.tgz",
+      "integrity": "sha512-jKRlf+sBMMdKYrjMoiWKne42Eb6paBfDOr08KJnUaeaiyWFj+/040FjVPQI7YGLfdwnYIsl1NUUqS2UdgezJDg==",
+      "deprecated": "Apollo Server v4 is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/cache-control-types": "^1.0.3",
+        "@apollo/server-gateway-interface": "^1.1.1",
+        "@apollo/usage-reporting-protobuf": "^4.1.1",
+        "@apollo/utils.createhash": "^2.0.2",
+        "@apollo/utils.fetcher": "^2.0.0",
+        "@apollo/utils.isnodelike": "^2.0.0",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
+        "@apollo/utils.logger": "^2.0.0",
+        "@apollo/utils.usagereporting": "^2.1.0",
+        "@apollo/utils.withrequired": "^2.0.0",
+        "@graphql-tools/schema": "^9.0.0",
+        "@types/express": "^4.17.13",
+        "@types/express-serve-static-core": "^4.17.30",
+        "@types/node-fetch": "^2.6.1",
+        "async-retry": "^1.2.1",
+        "cors": "^2.8.5",
+        "express": "^4.21.1",
+        "loglevel": "^1.6.8",
+        "lru-cache": "^7.10.1",
+        "negotiator": "^0.6.3",
+        "node-abort-controller": "^3.1.1",
+        "node-fetch": "^2.6.7",
+        "uuid": "^9.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.6.0"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/@apollo/utils.withrequired": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-2.0.1.tgz",
+      "integrity": "sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/@graphql-tools/merge": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
+      "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^9.2.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/@graphql-tools/schema": {
+      "version": "9.0.19",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
+      "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/merge": "^8.4.1",
+        "@graphql-tools/utils": "^9.2.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/@graphql-tools/utils": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@apollo/server-v4/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@apollo/server-v4/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@apollo/server-v4/node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@apollo/server-v4/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@apollo/server-v4/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@apollo/server-v4/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/@apollo/server/node_modules/@apollo/server-gateway-interface": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-2.0.0.tgz",
@@ -454,18 +812,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.dropunuseddefinitions": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-2.0.1.tgz",
-      "integrity": "sha512-EsPIBqsSt2BwDsv8Wu76LK5R1KtsVkNoO4b0M5aK0hx+dGg9xJXuqlr7Fo34Dl+y83jmzn+UvEW+t1/GP2melA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
       }
     },
     "node_modules/@apollo/server/node_modules/@apollo/utils.fetcher": {
@@ -510,77 +856,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.printwithreducedwhitespace": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-2.0.1.tgz",
-      "integrity": "sha512-9M4LUXV/fQBh8vZWlLvb/HyyhjJ77/I5ZKu+NBWV/BmYGyRmoEP9EVAy7LCVoY3t8BDcyCAGfxJaLFCSuQkPUg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.removealiases": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-2.0.1.tgz",
-      "integrity": "sha512-0joRc2HBO4u594Op1nev+mUF6yRnxoUH64xw8x3bX7n8QBDYdeYgY4tF0vJReTy+zdn2xv6fMsquATSgC722FA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.sortast": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-2.0.1.tgz",
-      "integrity": "sha512-eciIavsWpJ09za1pn37wpsCGrQNXUhM0TktnZmHwO+Zy9O4fu/WdB4+5BvVhFiZYOXvfjzJUcc+hsIV8RUOtMw==",
-      "dev": true,
-      "dependencies": {
-        "lodash.sortby": "^4.7.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.stripsensitiveliterals": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-2.0.1.tgz",
-      "integrity": "sha512-QJs7HtzXS/JIPMKWimFnUMK7VjkGQTzqD9bKD1h3iuPAqLsxd0mUNVbkYOPTsDhUKgcvUOfOqOJWYohAKMvcSA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.usagereporting": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-2.1.0.tgz",
-      "integrity": "sha512-LPSlBrn+S17oBy5eWkrRSGb98sWmnEzo3DPTZgp8IQc8sJe0prDgDuppGq4NeQlpoqEHz0hQeYHAOA0Z3aQsxQ==",
-      "dev": true,
-      "dependencies": {
-        "@apollo/usage-reporting-protobuf": "^4.1.0",
-        "@apollo/utils.dropunuseddefinitions": "^2.0.1",
-        "@apollo/utils.printwithreducedwhitespace": "^2.0.1",
-        "@apollo/utils.removealiases": "2.0.1",
-        "@apollo/utils.sortast": "^2.0.1",
-        "@apollo/utils.stripsensitiveliterals": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
       }
     },
     "node_modules/@apollo/server/node_modules/body-parser": {
@@ -813,6 +1088,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/@apollo/utils.dropunuseddefinitions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-2.0.1.tgz",
+      "integrity": "sha512-EsPIBqsSt2BwDsv8Wu76LK5R1KtsVkNoO4b0M5aK0hx+dGg9xJXuqlr7Fo34Dl+y83jmzn+UvEW+t1/GP2melA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
     "node_modules/@apollo/utils.fetcher": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-2.0.1.tgz",
@@ -865,6 +1153,82 @@
         "node": ">=14"
       }
     },
+    "node_modules/@apollo/utils.printwithreducedwhitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-2.0.1.tgz",
+      "integrity": "sha512-9M4LUXV/fQBh8vZWlLvb/HyyhjJ77/I5ZKu+NBWV/BmYGyRmoEP9EVAy7LCVoY3t8BDcyCAGfxJaLFCSuQkPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.removealiases": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-2.0.1.tgz",
+      "integrity": "sha512-0joRc2HBO4u594Op1nev+mUF6yRnxoUH64xw8x3bX7n8QBDYdeYgY4tF0vJReTy+zdn2xv6fMsquATSgC722FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.sortast": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-2.0.1.tgz",
+      "integrity": "sha512-eciIavsWpJ09za1pn37wpsCGrQNXUhM0TktnZmHwO+Zy9O4fu/WdB4+5BvVhFiZYOXvfjzJUcc+hsIV8RUOtMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.stripsensitiveliterals": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-2.0.1.tgz",
+      "integrity": "sha512-QJs7HtzXS/JIPMKWimFnUMK7VjkGQTzqD9bKD1h3iuPAqLsxd0mUNVbkYOPTsDhUKgcvUOfOqOJWYohAKMvcSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.usagereporting": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-2.1.0.tgz",
+      "integrity": "sha512-LPSlBrn+S17oBy5eWkrRSGb98sWmnEzo3DPTZgp8IQc8sJe0prDgDuppGq4NeQlpoqEHz0hQeYHAOA0Z3aQsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/usage-reporting-protobuf": "^4.1.0",
+        "@apollo/utils.dropunuseddefinitions": "^2.0.1",
+        "@apollo/utils.printwithreducedwhitespace": "^2.0.1",
+        "@apollo/utils.removealiases": "2.0.1",
+        "@apollo/utils.sortast": "^2.0.1",
+        "@apollo/utils.stripsensitiveliterals": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
     "node_modules/@apollo/utils.withrequired": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-3.0.0.tgz",
@@ -873,6 +1237,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@as-integrations/express5": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@as-integrations/express5/-/express5-1.1.2.tgz",
+      "integrity": "sha512-BxfwtcWNf2CELDkuPQxi5Zl3WqY/dQVJYafeCBOGoFQjv5M0fjhxmAFZ9vKx/5YKKNeok4UY6PkFbHzmQrdxIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@apollo/server": "^4.0.0 || ^5.0.0",
+        "express": "^5.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -53564,6 +53942,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/value-or-promise": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,9 @@
   "devDependencies": {
     "@apollo/gateway": "^2.11.2",
     "@apollo/server": "^5.0.0",
+    "@apollo/server-v4": "npm:@apollo/server@4.12.2",
     "@apollo/subgraph": "^2.11.2",
+    "@as-integrations/express5": "^1.1.2",
     "@aws-sdk/client-cloudwatch-logs": "^3.696.0",
     "@aws-sdk/client-dynamodb": "^3.846.0",
     "@aws-sdk/client-dynamodb-v3": "npm:@aws-sdk/client-dynamodb@3.20.0",

--- a/packages/collector/test/tracing/protocols/apollo_subgraph/gateway.js
+++ b/packages/collector/test/tracing/protocols/apollo_subgraph/gateway.js
@@ -16,11 +16,21 @@ require('../../../..')();
 
 const { ApolloServer } = require('@apollo/server');
 const { ApolloGateway, IntrospectAndCompose } = require('@apollo/gateway');
-const { expressMiddleware } = require('@apollo/server/express4');
 const bodyParser = require('body-parser');
 const express = require('express');
 const http = require('http');
 const morgan = require('morgan');
+
+// In Apollo Server v5, use @as-integrations/express5; otherwise, fall back to the built-in v4 middleware.
+const apolloServerVersion = process.env.APOLLO_SERVER_VERSION || 'latest';
+
+let expressMiddleware;
+
+if (apolloServerVersion === 'latest') {
+  ({ expressMiddleware } = require('@as-integrations/express5'));
+} else {
+  ({ expressMiddleware } = require('@apollo/server-v4/express4'));
+}
 
 const accountsPort = process.env.SERVICE_PORT_ACCOUNTS;
 const inventoryPort = process.env.SERVICE_PORT_INVENTORY;

--- a/packages/collector/test/tracing/protocols/apollo_subgraph/services/accounts/index.js
+++ b/packages/collector/test/tracing/protocols/apollo_subgraph/services/accounts/index.js
@@ -16,12 +16,21 @@ require('../../../../../..')();
 
 const { ApolloServer } = require('@apollo/server');
 const { buildSubgraphSchema } = require('@apollo/subgraph');
-const { expressMiddleware } = require('@apollo/server/express4');
 const bodyParser = require('body-parser');
 const express = require('express');
 const http = require('http');
 const morgan = require('morgan');
 const { gql } = require('graphql-tag');
+
+// In Apollo Server v5, use @as-integrations/express5; otherwise, fall back to the built-in v4 middleware.
+const apolloServerVersion = process.env.APOLLO_SERVER_VERSION || 'latest';
+let expressMiddleware;
+
+if (apolloServerVersion === 'latest') {
+  ({ expressMiddleware } = require('@as-integrations/express5'));
+} else {
+  ({ expressMiddleware } = require('@apollo/server-v4/express4'));
+}
 
 const port = require('../../../../../test_util/app-port')();
 const app = express();

--- a/packages/collector/test/tracing/protocols/apollo_subgraph/services/inventory/index.js
+++ b/packages/collector/test/tracing/protocols/apollo_subgraph/services/inventory/index.js
@@ -15,13 +15,23 @@ require('@instana/core/test/test_util/loadExpressV4');
 require('../../../../../..')();
 
 const { ApolloServer } = require('@apollo/server');
-const { expressMiddleware } = require('@apollo/server/express4');
 const { buildSubgraphSchema } = require('@apollo/subgraph');
 const bodyParser = require('body-parser');
 const express = require('express');
 const http = require('http');
 const morgan = require('morgan');
 const { gql } = require('graphql-tag');
+
+// In Apollo Server v5, use @as-integrations/express5; otherwise, fall back to the built-in v4 middleware.
+const apolloServerVersion = process.env.APOLLO_SERVER_VERSION || 'latest';
+
+let expressMiddleware;
+
+if (apolloServerVersion === 'latest') {
+  ({ expressMiddleware } = require('@as-integrations/express5'));
+} else {
+  ({ expressMiddleware } = require('@apollo/server-v4/express4'));
+}
 
 const port = require('../../../../../test_util/app-port')();
 const app = express();
@@ -30,7 +40,6 @@ const logPrefix = `Inventory Service (${process.pid}):\t`;
 if (process.env.WITH_STDOUT) {
   app.use(morgan(`${logPrefix}:method :url :status`));
 }
-
 app.use(bodyParser.json());
 
 const typeDefs = gql`

--- a/packages/collector/test/tracing/protocols/apollo_subgraph/services/products/index.js
+++ b/packages/collector/test/tracing/protocols/apollo_subgraph/services/products/index.js
@@ -15,13 +15,23 @@ require('@instana/core/test/test_util/loadExpressV4');
 require('../../../../../..')();
 
 const { ApolloServer } = require('@apollo/server');
-const { expressMiddleware } = require('@apollo/server/express4');
 const { buildSubgraphSchema } = require('@apollo/subgraph');
 const bodyParser = require('body-parser');
 const express = require('express');
 const http = require('http');
 const morgan = require('morgan');
 const { gql } = require('graphql-tag');
+
+// In Apollo Server v5, use @as-integrations/express5; otherwise, fall back to the built-in v4 middleware.
+const apolloServerVersion = process.env.APOLLO_SERVER_VERSION || 'latest';
+
+let expressMiddleware;
+
+if (apolloServerVersion === 'latest') {
+  ({ expressMiddleware } = require('@as-integrations/express5'));
+} else {
+  ({ expressMiddleware } = require('@apollo/server-v4/express4'));
+}
 
 const port = require('../../../../../test_util/app-port')();
 const app = express();

--- a/packages/collector/test/tracing/protocols/apollo_subgraph/services/reviews/index.js
+++ b/packages/collector/test/tracing/protocols/apollo_subgraph/services/reviews/index.js
@@ -10,12 +10,22 @@ require('../../../../../..')();
 
 const { ApolloServer } = require('@apollo/server');
 const { buildSubgraphSchema } = require('@apollo/subgraph');
-const { expressMiddleware } = require('@apollo/server/express4');
 const bodyParser = require('body-parser');
 const express = require('express');
 const http = require('http');
 const morgan = require('morgan');
 const { gql } = require('graphql-tag');
+
+// In Apollo Server v5, use @as-integrations/express5; otherwise, fall back to the built-in v4 middleware.
+const apolloServerVersion = process.env.APOLLO_SERVER_VERSION || 'latest';
+
+let expressMiddleware;
+
+if (apolloServerVersion === 'latest') {
+  ({ expressMiddleware } = require('@as-integrations/express5'));
+} else {
+  ({ expressMiddleware } = require('@apollo/server-v4/express4'));
+}
 
 const port = require('../../../../../test_util/app-port')();
 const app = express();

--- a/packages/collector/test/tracing/protocols/apollo_subgraph/test.js
+++ b/packages/collector/test/tracing/protocols/apollo_subgraph/test.js
@@ -16,312 +16,337 @@ const globalAgent = require('../../../globalAgent');
 
 const agentControls = globalAgent.instance;
 
-const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
+['latest', 'v4'].forEach(version => {
+  let mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 
-mochaSuiteFn('tracing gateway with apollo-subgraph', function () {
-  this.timeout(config.getTestTimeout() * 5);
-  globalAgent.setUpCleanUpHooks();
+  // Apollo Server 5 supports Node.js v20.0.0 and later.
+  if (version === 'latest' && process.versions.node < '20.0.0') {
+    mochaSuiteFn = describe.skip;
+  }
+  mochaSuiteFn(`tracing gateway with apollo-subgraph, using @apollo-server ${version}`, function () {
+    this.timeout(config.getTestTimeout() * 5);
+    globalAgent.setUpCleanUpHooks();
 
-  [true, false].forEach(withError => {
-    describe(`queries (with error: ${withError})`, function () {
-      let accountServiceControls;
-      let inventoryServiceControls;
-      let productsServiceControls;
-      let reviewsServiceControls;
-      let gatewayControls;
-      let clientControls;
+    [true, false].forEach(withError => {
+      describe(`queries (with error: ${withError})`, function () {
+        let accountServiceControls;
+        let inventoryServiceControls;
+        let productsServiceControls;
+        let reviewsServiceControls;
+        let gatewayControls;
+        let clientControls;
 
-      before(async () => {
-        accountServiceControls = new ProcessControls({
-          appPath: path.join(__dirname, 'services', 'accounts'),
-          useGlobalAgent: true
+        before(async () => {
+          accountServiceControls = new ProcessControls({
+            appPath: path.join(__dirname, 'services', 'accounts'),
+            useGlobalAgent: true,
+            env: {
+              APOLLO_SERVER_VERSION: version
+            }
+          });
+          inventoryServiceControls = new ProcessControls({
+            appPath: path.join(__dirname, 'services', 'inventory'),
+            useGlobalAgent: true,
+            env: {
+              APOLLO_SERVER_VERSION: version
+            }
+          });
+          productsServiceControls = new ProcessControls({
+            appPath: path.join(__dirname, 'services', 'products'),
+            useGlobalAgent: true,
+            env: {
+              APOLLO_SERVER_VERSION: version
+            }
+          });
+          reviewsServiceControls = new ProcessControls({
+            appPath: path.join(__dirname, 'services', 'reviews'),
+            useGlobalAgent: true,
+            env: {
+              APOLLO_SERVER_VERSION: version
+            }
+          });
+          gatewayControls = new ProcessControls({
+            appPath: path.join(__dirname, 'gateway'),
+            useGlobalAgent: true,
+            env: {
+              SERVICE_PORT_ACCOUNTS: accountServiceControls.getPort(),
+              SERVICE_PORT_INVENTORY: inventoryServiceControls.getPort(),
+              SERVICE_PORT_PRODUCTS: productsServiceControls.getPort(),
+              SERVICE_PORT_REVIEWS: reviewsServiceControls.getPort(),
+              APOLLO_SERVER_VERSION: version
+            }
+          });
+          clientControls = new ProcessControls({
+            appPath: path.join(__dirname, 'client'),
+            useGlobalAgent: true,
+            env: {
+              SERVER_PORT: gatewayControls.getPort(),
+              APOLLO_SERVER_VERSION: version
+            }
+          });
+
+          await accountServiceControls.startAndWaitForAgentConnection();
+          await inventoryServiceControls.startAndWaitForAgentConnection();
+          await productsServiceControls.startAndWaitForAgentConnection();
+          await reviewsServiceControls.startAndWaitForAgentConnection();
+          await gatewayControls.startAndWaitForAgentConnection();
+          await clientControls.startAndWaitForAgentConnection();
         });
-        inventoryServiceControls = new ProcessControls({
-          appPath: path.join(__dirname, 'services', 'inventory'),
-          useGlobalAgent: true
-        });
-        productsServiceControls = new ProcessControls({
-          appPath: path.join(__dirname, 'services', 'products'),
-          useGlobalAgent: true
-        });
-        reviewsServiceControls = new ProcessControls({
-          appPath: path.join(__dirname, 'services', 'reviews'),
-          useGlobalAgent: true
-        });
-        gatewayControls = new ProcessControls({
-          appPath: path.join(__dirname, 'gateway'),
-          useGlobalAgent: true,
-          env: {
-            SERVICE_PORT_ACCOUNTS: accountServiceControls.getPort(),
-            SERVICE_PORT_INVENTORY: inventoryServiceControls.getPort(),
-            SERVICE_PORT_PRODUCTS: productsServiceControls.getPort(),
-            SERVICE_PORT_REVIEWS: reviewsServiceControls.getPort()
-          }
-        });
-        clientControls = new ProcessControls({
-          appPath: path.join(__dirname, 'client'),
-          useGlobalAgent: true,
-          env: {
-            SERVER_PORT: gatewayControls.getPort()
-          }
+
+        beforeEach(async () => {
+          await agentControls.clearReceivedTraceData();
         });
 
-        await accountServiceControls.startAndWaitForAgentConnection();
-        await inventoryServiceControls.startAndWaitForAgentConnection();
-        await productsServiceControls.startAndWaitForAgentConnection();
-        await reviewsServiceControls.startAndWaitForAgentConnection();
-        await gatewayControls.startAndWaitForAgentConnection();
-        await clientControls.startAndWaitForAgentConnection();
-      });
+        after(async () => {
+          await accountServiceControls.stop();
+          await inventoryServiceControls.stop();
+          await productsServiceControls.stop();
+          await reviewsServiceControls.stop();
+          await gatewayControls.stop();
+          await clientControls.stop();
+        });
 
-      beforeEach(async () => {
-        await agentControls.clearReceivedTraceData();
-      });
+        it(`must trace a query (with error: ${withError})`, () => {
+          const queryParams = withError ? 'withError=yes' : null;
+          const url = queryParams ? `/query?${queryParams}` : '/query';
 
-      after(async () => {
-        await accountServiceControls.stop();
-        await inventoryServiceControls.stop();
-        await productsServiceControls.stop();
-        await reviewsServiceControls.stop();
-        await gatewayControls.stop();
-        await clientControls.stop();
-      });
+          return clientControls
+            .sendRequest({
+              method: 'POST',
+              path: url
+            })
+            .then(response => {
+              verifyQueryResponse(response, { withError });
 
-      it(`must trace a query (with error: ${withError})`, () => {
-        const queryParams = withError ? 'withError=yes' : null;
-        const url = queryParams ? `/query?${queryParams}` : '/query';
-
-        return clientControls
-          .sendRequest({
-            method: 'POST',
-            path: url
-          })
-          .then(response => {
-            verifyQueryResponse(response, { withError });
-
-            return testUtils.retry(() => {
-              return agentControls.getSpans().then(spans => {
-                if (withError) {
-                  expect(spans.length).to.equal(5);
-                } else {
-                  expect(spans.length).to.equal(11);
-                }
-                return verifySpansForQuery(
-                  {
-                    gatewayControls,
-                    clientControls,
-                    inventoryServiceControls,
-                    accountServiceControls,
-                    reviewsServiceControls,
-                    productsServiceControls
-                  },
-                  { withError },
-                  spans
-                );
+              return testUtils.retry(() => {
+                return agentControls.getSpans().then(spans => {
+                  if (withError) {
+                    expect(spans.length).to.equal(5);
+                  } else {
+                    expect(spans.length).to.equal(11);
+                  }
+                  return verifySpansForQuery(
+                    {
+                      gatewayControls,
+                      clientControls,
+                      inventoryServiceControls,
+                      accountServiceControls,
+                      reviewsServiceControls,
+                      productsServiceControls
+                    },
+                    { withError },
+                    spans
+                  );
+                });
               });
             });
-          });
+        });
       });
     });
   });
+
+  function verifyQueryResponse(response, testConfig) {
+    const { withError } = testConfig;
+    expect(response).to.be.an('object');
+
+    if (withError) {
+      expect(response.errors).to.have.lengthOf(1);
+    } else {
+      const { data } = response;
+      expect(data).to.be.an('object');
+      const { me } = data;
+      expect(me)
+        .to.be.an('object')
+        .that.deep.includes({
+          username: '@ada',
+          reviews: [
+            { body: 'Love it!', product: { name: 'Table', upc: '1', inStock: true } },
+            { body: 'Too expensive.', product: { name: 'Couch', upc: '2', inStock: false } }
+          ]
+        });
+    }
+  }
+
+  function verifySpansForQuery(allControls, testConfig, spans) {
+    const {
+      gatewayControls,
+      reviewsServiceControls,
+      productsServiceControls,
+      clientControls,
+      inventoryServiceControls,
+      accountServiceControls
+    } = allControls;
+
+    const { withError } = testConfig;
+    const httpEntryInClientApp = verifyHttpEntry(clientControls, spans);
+    const httpExitFromClientApp = verifyHttpExit(
+      httpEntryInClientApp,
+      clientControls,
+      gatewayControls.getPort(),
+      spans
+    );
+    const graphQLQueryEntryInGateway = verifyGraphQLGatewayEntry(httpExitFromClientApp, allControls, testConfig, spans);
+
+    // The gateway sends a GraphQL request to each service, thus there There are four HTTP exits from the
+    // gateway and four corresponding GraphQL entries - one for each service involved.
+    const httpExitFromGatewayToAccounts = verifyHttpExit(
+      graphQLQueryEntryInGateway,
+      gatewayControls,
+      accountServiceControls.getPort(),
+      spans
+    );
+
+    verifyGraphQLAccountEntry(httpExitFromGatewayToAccounts, allControls, testConfig, spans);
+
+    // In the error test we throw an error in the accounts service. The gateway then aborts processing this GraphQL
+    // query and never talks to the other services. Thus, the remaining GraphQL communication only happens in the
+    // non-error test case.
+    if (!withError) {
+      const httpExitFromGatewayToInventory = verifyHttpExit(
+        graphQLQueryEntryInGateway,
+        gatewayControls,
+        inventoryServiceControls.getPort(),
+        spans
+      );
+      verifyGraphQLInventoryEntry(httpExitFromGatewayToInventory, allControls, testConfig, spans);
+
+      const httpExitFromGatewayToProducts = verifyHttpExit(
+        graphQLQueryEntryInGateway,
+        gatewayControls,
+        productsServiceControls.getPort(),
+        spans
+      );
+      verifyGraphQLProductsEntry(httpExitFromGatewayToProducts, allControls, testConfig, spans);
+
+      const httpExitFromGatewayToReviews = verifyHttpExit(
+        graphQLQueryEntryInGateway,
+        gatewayControls,
+        reviewsServiceControls.getPort(),
+        spans
+      );
+      verifyGraphQLReviewsEntry(httpExitFromGatewayToReviews, allControls, testConfig, spans);
+    }
+
+    // Verify there are no unexpected extraneous GraphQL spans:
+    const allGraphQLSpans = spans
+      .filter(s => s.n === 'graphql.server')
+      .filter(s => !['GetServiceDefinition', 'IntrospectionQuery'].includes(s.data.graphql.operationName))
+      .map(s => ({
+        n: s.n,
+        t: s.t,
+        s: s.s,
+        p: s.p,
+        k: s.k,
+        f: s.f,
+        ec: s.ec,
+        error: s.error,
+        data: s.data
+      }));
+    const expectedGraphQLSpans = withError ? 1 : 4;
+    if (allGraphQLSpans.length !== expectedGraphQLSpans) {
+      // eslint-disable-next-line no-console
+      allGraphQLSpans.forEach(s => console.log(JSON.stringify(s, null, 2)));
+    }
+    expect(allGraphQLSpans).to.have.lengthOf(expectedGraphQLSpans);
+  }
+
+  function verifyHttpEntry(source, spans) {
+    return testUtils.expectAtLeastOneMatching(spans, [
+      span => expect(span.n).to.equal('node.http.server'),
+      span => expect(span.k).to.equal(constants.ENTRY),
+      span => expect(span.p).to.not.exist,
+      span => expect(span.f.e).to.equal(String(source.getPid())),
+      span => expect(span.data.http.method).to.equal('POST'),
+      span => expect(span.data.http.url).to.equal('/query')
+    ]);
+  }
+
+  function verifyHttpExit(parentSpan, source, targetPort, spans) {
+    return testUtils.expectAtLeastOneMatching(spans, [
+      span => expect(span.n).to.equal('node.http.client'),
+      span => expect(span.k).to.equal(constants.EXIT),
+      span => expect(span.t).to.equal(parentSpan.t),
+      span => expect(span.f.e).to.equal(String(source.getPid())),
+      span => expect(span.data.http.url).to.match(new RegExp(`${targetPort}/graphql`)),
+      span => expect(span.data.http.method).to.equal('POST')
+    ]);
+  }
+
+  function verifyGraphQLGatewayEntry(parentSpan, allControls, testConfig, spans) {
+    const { gatewayControls } = allControls;
+    const entrySpans = spans.filter(span => span.k === 1 && span.n === 'graphql.server');
+    return testUtils.expectAtLeastOneMatching(entrySpans, span => {
+      verifyGraphQLQueryEntry(span, parentSpan, gatewayControls, testConfig);
+      // excludes 'GetServiceDefinition' or 'IntrospectionQuery' queries
+      expect(span.data.graphql.operationName).to.not.exist;
+      expect(span.data.graphql.fields.me).to.deep.equal(['__typename', 'id', 'username']);
+      expect(span.data.graphql.args.me).to.deep.equal(['withError']);
+    });
+  }
+
+  function verifyGraphQLAccountEntry(parentSpan, allControls, testConfig, spans) {
+    const { accountServiceControls } = allControls;
+    return testUtils.expectAtLeastOneMatching(spans, span => {
+      verifyGraphQLQueryEntry(span, parentSpan, accountServiceControls, testConfig);
+      // excludes 'GetServiceDefinition' or 'IntrospectionQuery' queries
+      expect(span.data.graphql.operationName).to.not.exist;
+      expect(span.data.graphql.fields.me).to.deep.equal(['__typename', 'id', 'username']);
+      expect(span.data.graphql.args.me).to.deep.equal(['withError']);
+    });
+  }
+
+  function verifyGraphQLInventoryEntry(parentSpan, allControls, testConfig, spans) {
+    const { inventoryServiceControls } = allControls;
+    return testUtils.expectAtLeastOneMatching(spans, span => {
+      verifyGraphQLQueryEntry(span, parentSpan, inventoryServiceControls, testConfig);
+      // excludes 'GetServiceDefinition' or 'IntrospectionQuery' queries
+      expect(span.data.graphql.operationName).to.not.exist;
+      expect(span.data.graphql.fields._entities).to.deep.equal([]);
+      expect(span.data.graphql.args._entities).to.deep.equal(['representations']);
+    });
+  }
+
+  function verifyGraphQLProductsEntry(parentSpan, allControls, testConfig, spans) {
+    const { productsServiceControls } = allControls;
+    return testUtils.expectAtLeastOneMatching(spans, span => {
+      verifyGraphQLQueryEntry(span, parentSpan, productsServiceControls, testConfig);
+      // excludes 'GetServiceDefinition' or 'IntrospectionQuery' queries
+      expect(span.data.graphql.operationName).to.not.exist;
+      expect(span.data.graphql.fields._entities).to.deep.equal([]);
+      expect(span.data.graphql.args._entities).to.deep.equal(['representations']);
+    });
+  }
+
+  function verifyGraphQLReviewsEntry(parentSpan, allControls, testConfig, spans) {
+    const { reviewsServiceControls } = allControls;
+    return testUtils.expectAtLeastOneMatching(spans, span => {
+      verifyGraphQLQueryEntry(span, parentSpan, reviewsServiceControls, testConfig);
+      // excludes 'GetServiceDefinition' or 'IntrospectionQuery' queries
+      expect(span.data.graphql.operationName).to.not.exist;
+      expect(span.data.graphql.fields._entities).to.deep.equal([]);
+      expect(span.data.graphql.args._entities).to.deep.equal(['representations']);
+    });
+  }
+
+  function verifyGraphQLQueryEntry(span, parentSpan, source, testConfig) {
+    const { withError } = testConfig;
+    expect(span.n).to.equal('graphql.server');
+    expect(span.k).to.equal(constants.ENTRY);
+    expect(span.t).to.equal(parentSpan.t);
+    expect(span.ts).to.be.a('number');
+    expect(span.d).to.be.a('number');
+    expect(span.stack).to.be.an('array');
+    expect(span.data.graphql).to.exist;
+    expect(span.data.graphql.operationType).to.equal('query');
+
+    if (withError) {
+      expect(span.ec).to.equal(1);
+      expect(span.error).to.not.exist;
+      expect(span.data.graphql.errors).to.equal('Deliberately throwing an error in account service.');
+    } else {
+      expect(span.ec).to.equal(0);
+      expect(span.error).to.not.exist;
+      expect(span.data.graphql.errors).to.not.exist;
+    }
+  }
 });
-
-function verifyQueryResponse(response, testConfig) {
-  const { withError } = testConfig;
-  expect(response).to.be.an('object');
-
-  if (withError) {
-    expect(response.errors).to.have.lengthOf(1);
-  } else {
-    const { data } = response;
-    expect(data).to.be.an('object');
-    const { me } = data;
-    expect(me)
-      .to.be.an('object')
-      .that.deep.includes({
-        username: '@ada',
-        reviews: [
-          { body: 'Love it!', product: { name: 'Table', upc: '1', inStock: true } },
-          { body: 'Too expensive.', product: { name: 'Couch', upc: '2', inStock: false } }
-        ]
-      });
-  }
-}
-
-function verifySpansForQuery(allControls, testConfig, spans) {
-  const {
-    gatewayControls,
-    reviewsServiceControls,
-    productsServiceControls,
-    clientControls,
-    inventoryServiceControls,
-    accountServiceControls
-  } = allControls;
-
-  const { withError } = testConfig;
-  const httpEntryInClientApp = verifyHttpEntry(clientControls, spans);
-  const httpExitFromClientApp = verifyHttpExit(httpEntryInClientApp, clientControls, gatewayControls.getPort(), spans);
-  const graphQLQueryEntryInGateway = verifyGraphQLGatewayEntry(httpExitFromClientApp, allControls, testConfig, spans);
-
-  // The gateway sends a GraphQL request to each service, thus there There are four HTTP exits from the gateway and four
-  // corresponding GraphQL entries - one for each service involved.
-  const httpExitFromGatewayToAccounts = verifyHttpExit(
-    graphQLQueryEntryInGateway,
-    gatewayControls,
-    accountServiceControls.getPort(),
-    spans
-  );
-
-  verifyGraphQLAccountEntry(httpExitFromGatewayToAccounts, allControls, testConfig, spans);
-
-  // In the error test we throw an error in the accounts service. The gateway then aborts processing this GraphQL
-  // query and never talks to the other services. Thus, the remaining GraphQL communication only happens in the
-  // non-error test case.
-  if (!withError) {
-    const httpExitFromGatewayToInventory = verifyHttpExit(
-      graphQLQueryEntryInGateway,
-      gatewayControls,
-      inventoryServiceControls.getPort(),
-      spans
-    );
-    verifyGraphQLInventoryEntry(httpExitFromGatewayToInventory, allControls, testConfig, spans);
-
-    const httpExitFromGatewayToProducts = verifyHttpExit(
-      graphQLQueryEntryInGateway,
-      gatewayControls,
-      productsServiceControls.getPort(),
-      spans
-    );
-    verifyGraphQLProductsEntry(httpExitFromGatewayToProducts, allControls, testConfig, spans);
-
-    const httpExitFromGatewayToReviews = verifyHttpExit(
-      graphQLQueryEntryInGateway,
-      gatewayControls,
-      reviewsServiceControls.getPort(),
-      spans
-    );
-    verifyGraphQLReviewsEntry(httpExitFromGatewayToReviews, allControls, testConfig, spans);
-  }
-
-  // Verify there are no unexpected extraneous GraphQL spans:
-  const allGraphQLSpans = spans
-    .filter(s => s.n === 'graphql.server')
-    .filter(s => !['GetServiceDefinition', 'IntrospectionQuery'].includes(s.data.graphql.operationName))
-    .map(s => ({
-      n: s.n,
-      t: s.t,
-      s: s.s,
-      p: s.p,
-      k: s.k,
-      f: s.f,
-      ec: s.ec,
-      error: s.error,
-      data: s.data
-    }));
-  const expectedGraphQLSpans = withError ? 1 : 4;
-  if (allGraphQLSpans.length !== expectedGraphQLSpans) {
-    // eslint-disable-next-line no-console
-    allGraphQLSpans.forEach(s => console.log(JSON.stringify(s, null, 2)));
-  }
-  expect(allGraphQLSpans).to.have.lengthOf(expectedGraphQLSpans);
-}
-
-function verifyHttpEntry(source, spans) {
-  return testUtils.expectAtLeastOneMatching(spans, [
-    span => expect(span.n).to.equal('node.http.server'),
-    span => expect(span.k).to.equal(constants.ENTRY),
-    span => expect(span.p).to.not.exist,
-    span => expect(span.f.e).to.equal(String(source.getPid())),
-    span => expect(span.data.http.method).to.equal('POST'),
-    span => expect(span.data.http.url).to.equal('/query')
-  ]);
-}
-
-function verifyHttpExit(parentSpan, source, targetPort, spans) {
-  return testUtils.expectAtLeastOneMatching(spans, [
-    span => expect(span.n).to.equal('node.http.client'),
-    span => expect(span.k).to.equal(constants.EXIT),
-    span => expect(span.t).to.equal(parentSpan.t),
-    span => expect(span.f.e).to.equal(String(source.getPid())),
-    span => expect(span.data.http.url).to.match(new RegExp(`${targetPort}/graphql`)),
-    span => expect(span.data.http.method).to.equal('POST')
-  ]);
-}
-
-function verifyGraphQLGatewayEntry(parentSpan, allControls, testConfig, spans) {
-  const { gatewayControls } = allControls;
-  const entrySpans = spans.filter(span => span.k === 1 && span.n === 'graphql.server');
-  return testUtils.expectAtLeastOneMatching(entrySpans, span => {
-    verifyGraphQLQueryEntry(span, parentSpan, gatewayControls, testConfig);
-    // excludes 'GetServiceDefinition' or 'IntrospectionQuery' queries
-    expect(span.data.graphql.operationName).to.not.exist;
-    expect(span.data.graphql.fields.me).to.deep.equal(['__typename', 'id', 'username']);
-    expect(span.data.graphql.args.me).to.deep.equal(['withError']);
-  });
-}
-
-function verifyGraphQLAccountEntry(parentSpan, allControls, testConfig, spans) {
-  const { accountServiceControls } = allControls;
-  return testUtils.expectAtLeastOneMatching(spans, span => {
-    verifyGraphQLQueryEntry(span, parentSpan, accountServiceControls, testConfig);
-    // excludes 'GetServiceDefinition' or 'IntrospectionQuery' queries
-    expect(span.data.graphql.operationName).to.not.exist;
-    expect(span.data.graphql.fields.me).to.deep.equal(['__typename', 'id', 'username']);
-    expect(span.data.graphql.args.me).to.deep.equal(['withError']);
-  });
-}
-
-function verifyGraphQLInventoryEntry(parentSpan, allControls, testConfig, spans) {
-  const { inventoryServiceControls } = allControls;
-  return testUtils.expectAtLeastOneMatching(spans, span => {
-    verifyGraphQLQueryEntry(span, parentSpan, inventoryServiceControls, testConfig);
-    // excludes 'GetServiceDefinition' or 'IntrospectionQuery' queries
-    expect(span.data.graphql.operationName).to.not.exist;
-    expect(span.data.graphql.fields._entities).to.deep.equal([]);
-    expect(span.data.graphql.args._entities).to.deep.equal(['representations']);
-  });
-}
-
-function verifyGraphQLProductsEntry(parentSpan, allControls, testConfig, spans) {
-  const { productsServiceControls } = allControls;
-  return testUtils.expectAtLeastOneMatching(spans, span => {
-    verifyGraphQLQueryEntry(span, parentSpan, productsServiceControls, testConfig);
-    // excludes 'GetServiceDefinition' or 'IntrospectionQuery' queries
-    expect(span.data.graphql.operationName).to.not.exist;
-    expect(span.data.graphql.fields._entities).to.deep.equal([]);
-    expect(span.data.graphql.args._entities).to.deep.equal(['representations']);
-  });
-}
-
-function verifyGraphQLReviewsEntry(parentSpan, allControls, testConfig, spans) {
-  const { reviewsServiceControls } = allControls;
-  return testUtils.expectAtLeastOneMatching(spans, span => {
-    verifyGraphQLQueryEntry(span, parentSpan, reviewsServiceControls, testConfig);
-    // excludes 'GetServiceDefinition' or 'IntrospectionQuery' queries
-    expect(span.data.graphql.operationName).to.not.exist;
-    expect(span.data.graphql.fields._entities).to.deep.equal([]);
-    expect(span.data.graphql.args._entities).to.deep.equal(['representations']);
-  });
-}
-
-function verifyGraphQLQueryEntry(span, parentSpan, source, testConfig) {
-  const { withError } = testConfig;
-  expect(span.n).to.equal('graphql.server');
-  expect(span.k).to.equal(constants.ENTRY);
-  expect(span.t).to.equal(parentSpan.t);
-  expect(span.ts).to.be.a('number');
-  expect(span.d).to.be.a('number');
-  expect(span.stack).to.be.an('array');
-  expect(span.data.graphql).to.exist;
-  expect(span.data.graphql.operationType).to.equal('query');
-
-  if (withError) {
-    expect(span.ec).to.equal(1);
-    expect(span.error).to.not.exist;
-    expect(span.data.graphql.errors).to.equal('Deliberately throwing an error in account service.');
-  } else {
-    expect(span.ec).to.equal(0);
-    expect(span.error).to.not.exist;
-    expect(span.data.graphql.errors).to.not.exist;
-  }
-}

--- a/packages/collector/test/tracing/protocols/graphql/apolloServer.js
+++ b/packages/collector/test/tracing/protocols/graphql/apolloServer.js
@@ -21,7 +21,17 @@ const express = require('express');
 const morgan = require('morgan');
 const { WebSocketServer } = require('ws');
 const { useServer } = require('graphql-ws/use/ws');
-const { expressMiddleware } = require('@apollo/server/express4');
+
+// In Apollo Server v5, use @as-integrations/express5; otherwise, fall back to the built-in v4 middleware.
+const apolloServerVersion = process.env.APOLLO_SERVER_VERSION || 'latest';
+
+let expressMiddleware;
+
+if (apolloServerVersion === 'latest') {
+  ({ expressMiddleware } = require('@as-integrations/express5'));
+} else {
+  ({ expressMiddleware } = require('@apollo/server-v4/express4'));
+}
 
 const { schema, pubsub, pinoLogger } = require('./schema')();
 const data = require('./data');


### PR DESCRIPTION
**Main Updates**

- Skipped tests for Apollo Server on Node.js versions < 20, since Apollo Server 5 requires Node.js v20+.
- Ensured usage of graphql@^16.11.0, as Apollo Server 5 drops support for older GraphQL versions.
- Updated Express integration:
  - Apollo Server 5 now using @as-integrations/express5.
  - Apollo Server 4 uses the built-in @apollo/server/express4.


**Reference**

https://www.apollographql.com/docs/apollo-server/migration
https://github.com/apollographql/apollo-server/releases/tag/%40apollo%2Fserver%405.0.0

ref https://jsw.ibm.com/browse/INSTA-46663