### PR TITLE
ci: updated sonar scan command in coverage task

### DIFF
--- a/.tekton/tasks/tasks-results.yaml
+++ b/.tekton/tasks/tasks-results.yaml
@@ -45,9 +45,6 @@ spec:
           echo "Running ESLint..."
           npx eslint packages/ -f json -o eslint-report.json || true
 
-          echo "Installing SonarCloud scanner..."
-          npm install -g @sonar/scan
-
           echo "Running SonarCloud analysis..."
-          sonar
+          npx @sonar/scan
         fi


### PR DESCRIPTION
We're using npx so we don't have to install the Sonar scanner globally. This makes the script simpler and more reliable, especially when running in tekton CI pipelines.

https://github.com/SonarSource/sonar-scanner-npm?tab=readme-ov-file#getting-started