### PR TITLE
fix(autoprofile): reduced package size

### DIFF
--- a/packages/autoprofile/package.json
+++ b/packages/autoprofile/package.json
@@ -62,7 +62,10 @@
   "files": [
     "src",
     "lib",
-    "prebuilds",
+    "prebuilds/linux-arm",
+    "prebuilds/linux-arm64",
+    "prebuilds/linux-x64",
+    "prebuilds/linux-s390x",
     "binding.gyp",
     "CHANGELOG.md"
   ],


### PR DESCRIPTION
- removed darwin rebuilds from production release
- there is no use case to ship them
- reduces size