### PR TITLE
test: fixed sns random test failure

### DIFF
--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sns/test_definition.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sns/test_definition.js
@@ -48,6 +48,7 @@ function start(version) {
   let appControls;
 
   before(async () => {
+    // TODO: move into the app.js file
     const queue = await utils.createQueue(queueName);
     const topic = await utils.createTopic(topicName);
 
@@ -58,6 +59,11 @@ function start(version) {
   });
 
   after(async () => {
+    // CASE: queue was not created in before hook
+    if (!queueUrl) {
+      return;
+    }
+
     await utils.removeQueue(queueUrl);
   });
 
@@ -84,7 +90,7 @@ function start(version) {
         });
 
         await receiverControls.startAndWaitForAgentConnection();
-        await appControls.startAndWaitForAgentConnection();
+        await appControls.startAndWaitForAgentConnection(5000, Date.now() + 10000);
       });
 
       beforeEach(async () => {

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sns/utils.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sns/utils.js
@@ -8,12 +8,28 @@ const uuid = require('uuid');
 const semver = require('semver');
 const awsSdk3 = require('@aws-sdk/client-sqs');
 const sns = require('@aws-sdk/client-sns');
-const { StandardRetryStrategy } = require('@aws-sdk/util-retry');
+const { StandardRetryStrategy } = require('@aws-sdk/middleware-retry');
 
-const maxAttempts = 5;
-const retryStrategy = new StandardRetryStrategy(async () => maxAttempts);
+const maxAttempts = 6;
 
-const sqs = new awsSdk3.SQS({ region: 'us-east-2', endpoint: process.env.LOCALSTACK_AWS, retryStrategy });
+const customRetryStrategy = new StandardRetryStrategy(async () => maxAttempts, {
+  retryDecider: err => {
+    // eslint-disable-next-line no-console
+    console.log('Not connected to LocalStack, retrying...', err.code);
+    return true;
+  },
+  delayDecider: () => 5000
+});
+
+const sqs = new awsSdk3.SQS({
+  credentials: {
+    accessKeyId: 'test',
+    secretAccessKey: 'test'
+  },
+  region: 'us-east-2',
+  endpoint: process.env.LOCALSTACK_AWS,
+  retryStrategy: customRetryStrategy
+});
 
 const clientOpts = {
   credentials: {
@@ -22,7 +38,7 @@ const clientOpts = {
   },
   endpoint: process.env.LOCALSTACK_AWS,
   region: 'us-east-2',
-  retryStrategy
+  retryStrategy: customRetryStrategy
 };
 
 const snsClient = new sns.SNSClient(clientOpts);

--- a/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/receiver.js
+++ b/packages/collector/test/tracing/cloud/aws-sdk/v3/sqs/receiver.js
@@ -47,12 +47,31 @@ const awsRegion = 'us-east-2';
 let sqs;
 let sqsv2;
 
+// CASE: sns uses this receiver as well and forwards localstack endpoint
 if (process.env.AWS_ENDPOINT) {
-  sqs = new awsSdk3.SQSClient({ region: awsRegion, endpoint: process.env.AWS_ENDPOINT });
-  sqsv2 = new awsSdk3.SQS({ region: awsRegion, endpoint: process.env.AWS_ENDPOINT });
+  sqs = new awsSdk3.SQSClient({
+    region: awsRegion,
+    endpoint: process.env.AWS_ENDPOINT,
+    credentials: {
+      accessKeyId: 'test',
+      secretAccessKey: 'test'
+    }
+  });
+  sqsv2 = new awsSdk3.SQS({
+    region: awsRegion,
+    endpoint: process.env.AWS_ENDPOINT,
+    credentials: {
+      accessKeyId: 'test',
+      secretAccessKey: 'test'
+    }
+  });
 } else {
-  sqs = new awsSdk3.SQSClient({ region: awsRegion });
-  sqsv2 = new awsSdk3.SQS({ region: awsRegion });
+  sqs = new awsSdk3.SQSClient({
+    region: awsRegion
+  });
+  sqsv2 = new awsSdk3.SQS({
+    region: awsRegion
+  });
 }
 // Keep the default value above 5, as tests can fail if not all messages are fetched.
 let sqsPollDelay = 7;


### PR DESCRIPTION
- retries for connection refused did not work

> @instana/collector:   tracing/cloud/aws-sdk/v3/sns
@instana/collector:     1) "before all" hook in "tracing/cloud/aws-sdk/v3/sns"
@instana/collector: ##### Test failed: Error: connect ECONNREFUSED 127.0.0.1:4566
@instana/collector: ##### Error stack: Error: connect ECONNREFUSED 127.0.0.1:4566
@instana/collector:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16)
@instana/collector: npm error Lifecycle script `test:ci:tracing:cloud:aws:v3` failed with error: