### PR TITLE
feat: added support for ignoring http entry calls

### DIFF
--- a/packages/collector/test/tracing/protocols/http/client/clientApp.js
+++ b/packages/collector/test/tracing/protocols/http/client/clientApp.js
@@ -12,7 +12,7 @@ process.on('SIGTERM', () => {
 });
 require('@instana/core/test/test_util/loadExpressV4');
 
-require('../../../../..')();
+const instana = require('../../../../..')();
 const agentPort = process.env.INSTANA_AGENT_PORT;
 
 const AWS = require('aws-sdk');
@@ -306,6 +306,15 @@ app.post('/upload-s3', (req, res) => {
 });
 app.get('/matrix-params/:params', (req, res) => {
   res.sendStatus(200);
+});
+
+app.get('/current-span', (req, res) => {
+  const span = instana.currentSpan();
+  const currentSpan = {
+    spanConstructorName: span.span?.constructor?.name,
+    span: span.span
+  };
+  res.status(200).json(currentSpan);
 });
 
 app.get('/downstream-call', (req, res) => {

--- a/packages/collector/test/tracing/protocols/http/client/files/tracing.yaml
+++ b/packages/collector/test/tracing/protocols/http/client/files/tracing.yaml
@@ -1,0 +1,5 @@
+tracing:
+  ignore-endpoints:
+    http:  
+    - methods: ["*"]  
+      endpoints: ["/get-url-only", "/downstream-call"]  

--- a/packages/collector/test/tracing/protocols/http/client/test.js
+++ b/packages/collector/test/tracing/protocols/http/client/test.js
@@ -149,10 +149,70 @@ mochaSuiteFn('tracing/http client', function () {
     });
   });
 
-  describe('ignore-endpoints - test', function () {
-    this.timeout(10000);
+  describe('ignore-endpoints', function () {
+    describe('when endpoints are configured to be ignored (with agent config)', function () {
+      let serverControls;
+      let clientControls;
+      const { AgentStubControls } = require('../../../../apps/agentStubControls');
+      const customAgentControls = new AgentStubControls();
 
-    describe('when endpoints are configured to be ignored (normal flow)', function () {
+      before(async () => {
+        await customAgentControls.startAgent({
+          ignoreEndpoints: {
+            http: [
+              {
+                methods: ['get'],
+                endpoints: ['/get-url-only', '/downstream-call']
+              }
+            ]
+          }
+        });
+
+        serverControls = new ProcessControls({
+          agentControls: customAgentControls,
+          appPath: path.join(__dirname, 'serverApp'),
+          appUsesHttps: false
+        });
+
+        clientControls = new ProcessControls({
+          appPath: path.join(__dirname, 'clientApp'),
+          agentControls: customAgentControls,
+          appUsesHttps: false,
+          env: {
+            SERVER_PORT: serverControls.getPort()
+          }
+        });
+
+        await serverControls.startAndWaitForAgentConnection();
+        await clientControls.startAndWaitForAgentConnection();
+      });
+
+      after(() => Promise.all([serverControls.stop(), clientControls.stop(), customAgentControls.stopAgent()]));
+
+      beforeEach(() => customAgentControls.clearReceivedTraceData());
+
+      afterEach(() => Promise.all([serverControls.clearIpcMessages(), clientControls.clearIpcMessages()]));
+
+      it('should not trace HTTP calls as per ignore config', async () => {
+        await clientControls.sendRequest({ method: 'GET', path: '/get-url-only' });
+
+        await retry(async () => {
+          const spans = await customAgentControls.getSpans();
+          expect(spans).to.have.length(0);
+        });
+      });
+
+      it('should not trace downstream calls', async () => {
+        await clientControls.sendRequest({ method: 'GET', path: '/downstream-call' });
+
+        await retry(async () => {
+          const spans = await customAgentControls.getSpans();
+          expect(spans).to.have.length(0);
+        });
+      });
+    });
+
+    describe('when endpoints are configured to be ignored via INSTANA_IGNORE_ENDPOINTS_PATH', function () {
       let serverControls;
       let clientControls;
 
@@ -169,7 +229,7 @@ mochaSuiteFn('tracing/http client', function () {
           appUsesHttps: false,
           env: {
             SERVER_PORT: serverControls.getPort(),
-            INSTANA_IGNORE_ENDPOINTS: 'http:get'
+            INSTANA_IGNORE_ENDPOINTS_PATH: path.join(__dirname, 'files', 'tracing.yaml')
           }
         });
 
@@ -198,6 +258,56 @@ mochaSuiteFn('tracing/http client', function () {
         await retry(async () => {
           const spans = await globalAgent.instance.getSpans();
           expect(spans).to.have.length(0);
+        });
+      });
+    });
+    describe('when downstream suppression is disabled via INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION', function () {
+      let serverControls;
+      let clientControls;
+
+      before(async () => {
+        serverControls = new ProcessControls({
+          appPath: path.join(__dirname, 'serverApp'),
+          useGlobalAgent: true,
+          appUsesHttps: false
+        });
+
+        clientControls = new ProcessControls({
+          appPath: path.join(__dirname, 'clientApp'),
+          useGlobalAgent: true,
+          appUsesHttps: false,
+          env: {
+            SERVER_PORT: serverControls.getPort(),
+            INSTANA_IGNORE_ENDPOINTS: 'http:get',
+            INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION: true
+          }
+        });
+
+        await serverControls.startAndWaitForAgentConnection();
+        await clientControls.startAndWaitForAgentConnection();
+      });
+
+      after(() => Promise.all([serverControls.stop(), clientControls.stop()]));
+
+      beforeEach(() => globalAgent.instance.clearReceivedTraceData());
+
+      afterEach(() => Promise.all([serverControls.clearIpcMessages(), clientControls.clearIpcMessages()]));
+
+      it('should trace downstream calls', async () => {
+        await clientControls.sendRequest({ method: 'GET', path: '/downstream-call' });
+
+        await retry(async () => {
+          const spans = await globalAgent.instance.getSpans();
+          const downstreamHttpSpan = spans.find(
+            span =>
+              span.n === 'node.http.client' &&
+              span.k === 2 &&
+              span.data.http.method === 'GET' &&
+              span.data.http.url === `http://127.0.0.1:${globalAgent.instance.agentPort}/`
+          );
+
+          expect(spans).to.have.length(1);
+          expect(downstreamHttpSpan).to.exist;
         });
       });
     });

--- a/packages/collector/test/tracing/protocols/http/client/test.js
+++ b/packages/collector/test/tracing/protocols/http/client/test.js
@@ -261,6 +261,7 @@ mochaSuiteFn('tracing/http client', function () {
         });
       });
     });
+
     describe('when downstream suppression is disabled via INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION', function () {
       let serverControls;
       let clientControls;
@@ -293,6 +294,8 @@ mochaSuiteFn('tracing/http client', function () {
 
       afterEach(() => Promise.all([serverControls.clearIpcMessages(), clientControls.clearIpcMessages()]));
 
+      // Flow: HTTP entry (ignored)
+      //       ├── HTTP Exit (traces)
       it('should trace downstream calls', async () => {
         await clientControls.sendRequest({ method: 'GET', path: '/downstream-call' });
 
@@ -312,7 +315,7 @@ mochaSuiteFn('tracing/http client', function () {
       });
     });
 
-    describe('when root exit spans are allowed', function () {
+    describe('when root exit spans are allowed(should not ignore exits calls alone)', function () {
       let agentControls;
 
       before(async () => {
@@ -332,7 +335,7 @@ mochaSuiteFn('tracing/http client', function () {
 
       afterEach(() => agentControls.clearIpcMessages());
 
-      it('should trace only exit spans when entry spans are ignored', async () => {
+      it('should trace exit spans when ignore endpoints are configured', async () => {
         await delay(2500);
 
         await retry(async () => {

--- a/packages/collector/test/tracing/protocols/http/native_fetch/clientApp.js
+++ b/packages/collector/test/tracing/protocols/http/native_fetch/clientApp.js
@@ -55,7 +55,7 @@ app.get('/fetch-deferred', async (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/trigger-downstream', async (req, res) => {
+app.get('/downstream-call', async (req, res) => {
   await fetch(`http://127.0.0.1:${agentPort}?k=1`);
   res.sendStatus(200);
 });

--- a/packages/collector/test/tracing/protocols/http/native_fetch/clientApp.js
+++ b/packages/collector/test/tracing/protocols/http/native_fetch/clientApp.js
@@ -55,6 +55,11 @@ app.get('/fetch-deferred', async (req, res) => {
   res.sendStatus(200);
 });
 
+app.get('/trigger-downstream', async (req, res) => {
+  await fetch(`http://127.0.0.1:${agentPort}?k=1`);
+  res.sendStatus(200);
+});
+
 app.get('/fetch', async (req, res) => {
   const resourceArgument = createResourceArgument(req, '/fetch');
   let response;

--- a/packages/collector/test/tracing/protocols/http/native_fetch/files/tracing.yaml
+++ b/packages/collector/test/tracing/protocols/http/native_fetch/files/tracing.yaml
@@ -1,0 +1,5 @@
+tracing:
+  ignore-endpoints:
+    http:  
+    - methods: ["get"]  
+      endpoints: ["*"]  

--- a/packages/collector/test/tracing/protocols/http/native_fetch/test.js
+++ b/packages/collector/test/tracing/protocols/http/native_fetch/test.js
@@ -573,14 +573,16 @@ mochaSuiteFn('tracing/native fetch', function () {
     });
   });
 
-  describe('ignoring endpoints', () => {
+  describe('when endpoints are configured to be ignored', () => {
     let customServerControls;
     let customClientControls;
+
     before(async () => {
       customServerControls = new ProcessControls({
         appPath: path.join(__dirname, 'serverApp'),
         useGlobalAgent: true
       });
+
       customClientControls = new ProcessControls({
         appPath: path.join(__dirname, 'clientApp'),
         useGlobalAgent: true,
@@ -602,7 +604,7 @@ mochaSuiteFn('tracing/native fetch', function () {
     beforeEach(() => globalAgent.instance.clearReceivedTraceData());
 
     it('should not record spans', async () => {
-      await customClientControls.sendRequest({ method: 'GET', path: '/trigger-downstream' });
+      await customClientControls.sendRequest({ method: 'GET', path: '/' });
 
       await retry(async () => {
         const spans = await globalAgent.instance.getSpans();
@@ -611,7 +613,7 @@ mochaSuiteFn('tracing/native fetch', function () {
     });
 
     it('should not record downstream calls', async () => {
-      await customClientControls.sendRequest({ method: 'GET', path: '/' });
+      await customClientControls.sendRequest({ method: 'GET', path: '/downstream-call' });
 
       await retry(async () => {
         const spans = await globalAgent.instance.getSpans();

--- a/packages/collector/test/tracing/protocols/http/native_fetch/test.js
+++ b/packages/collector/test/tracing/protocols/http/native_fetch/test.js
@@ -573,6 +573,53 @@ mochaSuiteFn('tracing/native fetch', function () {
     });
   });
 
+  describe('ignoring endpoints', () => {
+    let customServerControls;
+    let customClientControls;
+    before(async () => {
+      customServerControls = new ProcessControls({
+        appPath: path.join(__dirname, 'serverApp'),
+        useGlobalAgent: true
+      });
+      customClientControls = new ProcessControls({
+        appPath: path.join(__dirname, 'clientApp'),
+        useGlobalAgent: true,
+        env: {
+          SERVER_PORT: customServerControls.port,
+          INSTANA_IGNORE_ENDPOINTS_PATH: path.join(__dirname, 'files', 'tracing.yaml')
+        }
+      });
+
+      await customServerControls.startAndWaitForAgentConnection();
+      await customClientControls.startAndWaitForAgentConnection();
+    });
+
+    after(async () => {
+      await customClientControls.stop();
+      await customServerControls.stop();
+    });
+
+    beforeEach(() => globalAgent.instance.clearReceivedTraceData());
+
+    it('should not record spans', async () => {
+      await customClientControls.sendRequest({ method: 'GET', path: '/trigger-downstream' });
+
+      await retry(async () => {
+        const spans = await globalAgent.instance.getSpans();
+        expect(spans).to.have.lengthOf(0);
+      });
+    });
+
+    it('should not record downstream calls', async () => {
+      await customClientControls.sendRequest({ method: 'GET', path: '/' });
+
+      await retry(async () => {
+        const spans = await globalAgent.instance.getSpans();
+        expect(spans).to.have.lengthOf(0);
+      });
+    });
+  });
+
   it('must suppress tracing ', async () => {
     const response = await clientControls.sendRequest({
       path: constructPath({}),

--- a/packages/collector/test/tracing/protocols/http2/test.js
+++ b/packages/collector/test/tracing/protocols/http2/test.js
@@ -362,54 +362,50 @@ mochaSuiteFn('tracing/http2', function () {
         );
       }));
 
-  describe('ignore-endpoints - test', function () {
-    this.timeout(10000);
-
-    describe('when endpoints are configured to be ignored (normal flow)', function () {
-      before(async () => {
-        serverControls = new ProcessControls({
-          appPath: path.join(__dirname, 'server'),
-          http2: true,
-          agentControls
-        });
-
-        clientControls = new ProcessControls({
-          appPath: path.join(__dirname, 'client'),
-          http2: true,
-          agentControls,
-          forcePortSearching: true,
-          env: {
-            SERVER_PORT: serverControls.getPort(),
-            INSTANA_IGNORE_ENDPOINTS: 'http:get'
-          }
-        });
-
-        await serverControls.startAndWaitForAgentConnection();
-        await clientControls.startAndWaitForAgentConnection();
+  describe('when endpoints are configured to be ignored', function () {
+    before(async () => {
+      serverControls = new ProcessControls({
+        appPath: path.join(__dirname, 'server'),
+        http2: true,
+        agentControls
       });
 
-      after(() => Promise.all([serverControls.stop(), clientControls.stop()]));
-
-      beforeEach(() => agentControls.clearReceivedTraceData());
-
-      afterEach(() => Promise.all([serverControls.clearIpcMessages(), clientControls.clearIpcMessages()]));
-
-      it('should not trace GET request as per ignore config', async () => {
-        await clientControls.sendRequest({ method: 'GET', path: '/' });
-
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          expect(spans).to.have.length(0);
-        });
+      clientControls = new ProcessControls({
+        appPath: path.join(__dirname, 'client'),
+        http2: true,
+        agentControls,
+        forcePortSearching: true,
+        env: {
+          SERVER_PORT: serverControls.getPort(),
+          INSTANA_IGNORE_ENDPOINTS: 'http:get'
+        }
       });
 
-      it('should not trace downstream calls', async () => {
-        await clientControls.sendRequest({ method: 'GET', path: '/trigger-downstream' });
+      await serverControls.startAndWaitForAgentConnection();
+      await clientControls.startAndWaitForAgentConnection();
+    });
 
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          expect(spans).to.have.length(0);
-        });
+    after(() => Promise.all([serverControls.stop(), clientControls.stop()]));
+
+    beforeEach(() => agentControls.clearReceivedTraceData());
+
+    afterEach(() => Promise.all([serverControls.clearIpcMessages(), clientControls.clearIpcMessages()]));
+
+    it('should not trace GET request as per ignore config', async () => {
+      await clientControls.sendRequest({ method: 'GET', path: '/' });
+
+      await retry(async () => {
+        const spans = await agentControls.getSpans();
+        expect(spans).to.have.length(0);
+      });
+    });
+
+    it('should not trace downstream calls', async () => {
+      await clientControls.sendRequest({ method: 'GET', path: '/trigger-downstream' });
+
+      await retry(async () => {
+        const spans = await agentControls.getSpans();
+        expect(spans).to.have.length(0);
       });
     });
   });

--- a/packages/collector/test/tracing/protocols/http2/test.js
+++ b/packages/collector/test/tracing/protocols/http2/test.js
@@ -365,6 +365,7 @@ mochaSuiteFn('tracing/http2', function () {
   describe('when endpoints are configured to be ignored', function () {
     let cusomServerControls;
     let customClientControls;
+
     before(async () => {
       cusomServerControls = new ProcessControls({
         appPath: path.join(__dirname, 'server'),

--- a/packages/collector/test/tracing/protocols/http2/test.js
+++ b/packages/collector/test/tracing/protocols/http2/test.js
@@ -367,13 +367,13 @@ mochaSuiteFn('tracing/http2', function () {
       serverControls = new ProcessControls({
         appPath: path.join(__dirname, 'server'),
         http2: true,
-        agentControls
+        useGlobalAgent: true
       });
 
       clientControls = new ProcessControls({
         appPath: path.join(__dirname, 'client'),
         http2: true,
-        agentControls,
+        useGlobalAgent: true,
         forcePortSearching: true,
         env: {
           SERVER_PORT: serverControls.getPort(),
@@ -385,7 +385,9 @@ mochaSuiteFn('tracing/http2', function () {
       await clientControls.startAndWaitForAgentConnection();
     });
 
-    after(() => Promise.all([serverControls.stop(), clientControls.stop()]));
+    after(async () => {
+      await Promise.all([serverControls.stop(), clientControls.stop(), agentControls.stopAgent()]);
+    });
 
     beforeEach(() => agentControls.clearReceivedTraceData());
 

--- a/packages/core/src/tracing/instrumentation/protocols/http2Client.js
+++ b/packages/core/src/tracing/instrumentation/protocols/http2Client.js
@@ -86,13 +86,31 @@ function instrumentClientHttp2Session(clientHttp2Session) {
     for (let i = 0; i < arguments.length; i++) {
       originalArgs[i] = arguments[i];
     }
+    let method;
+    let path;
+    method = method || 'GET';
+    path = path || '/';
 
+    /**
+     * The HTTP method and other fields are captured later during request processing,
+     * but we must initialize the span data early to ensure correct async context propagation.
+     *
+     * NOTE: HTTP span ignoring feature currently applies only to entry spans (phase 1),
+     * so setting exit span data here is safe. This will be refined in future iterations.
+     */
+    const spanData = {
+      http: {
+        operation: method,
+        endpoints: ''
+      }
+    };
     return cls.ns.runAndReturn(() => {
       const span = cls.startSpan({
         spanName: 'node.http.client',
         kind: constants.EXIT,
         traceId: parentSpan?.t,
-        parentSpanId: parentSpan?.s
+        parentSpanId: parentSpan?.s,
+        spanData
       });
 
       // startSpan updates the W3C trace context and writes it back to CLS, so we have to refetch the updated context
@@ -107,26 +125,19 @@ function instrumentClientHttp2Session(clientHttp2Session) {
       const reqHeaders = readSymbolProperty(stream, sentHeadersS);
       let capturedHeaders = getExtraHeadersCaseInsensitive(reqHeaders, extraHttpHeadersToCapture);
 
-      let method;
-      let path;
       let status;
       if (reqHeaders) {
         method = reqHeaders[HTTP2_HEADER_METHOD];
         path = reqHeaders[HTTP2_HEADER_PATH];
       }
-      method = method || 'GET';
-      path = path || '/';
 
+      span.stack = tracingUtil.getStackTrace(request);
       const pathWithoutQuery = sanitizeUrl(path);
       const params = splitAndFilter(path);
 
-      span.stack = tracingUtil.getStackTrace(request);
-
-      span.data.http = {
-        method,
-        url: origin + pathWithoutQuery,
-        params
-      };
+      span.data.http.operation = method;
+      span.data.http.endpoints = origin + pathWithoutQuery;
+      span.data.http.params = params;
 
       stream.on('response', resHeaders => {
         status = resHeaders[HTTP2_HEADER_STATUS];

--- a/packages/core/src/tracing/instrumentation/protocols/nativeFetch.js
+++ b/packages/core/src/tracing/instrumentation/protocols/nativeFetch.js
@@ -102,70 +102,70 @@ function instrument() {
 
       return originalFetch.apply(originalThis, originalArgs);
     }
+    // See https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters -> resource for the possible variants
+    // to provide a URL to fetch.
+    let completeCallUrl;
+    let method = 'GET';
+    const resource = originalArgs[0];
+    let params;
+    let capturedHeaders;
 
+    if (resource != null) {
+      let rawUrl;
+      if (typeof resource === 'string') {
+        rawUrl = resource;
+      } else if (isFetchApiRequest(resource)) {
+        // The first argument is an instance of Request, see https://developer.mozilla.org/en-US/docs/Web/API/Request.
+        rawUrl = resource.url;
+        method = resource.method;
+        capturedHeaders = getExtraHeadersFromFetchHeaders(resource.headers, extraHttpHeadersToCapture);
+      } else if (typeof resource.toString === 'function') {
+        // This also handles the case when the resource is a URL object, as well as any object that has a custom
+        // stringifier.
+        rawUrl = resource.toString();
+      }
+      completeCallUrl = sanitizeUrl(rawUrl);
+      params = splitAndFilter(rawUrl);
+    }
+
+    const options = originalArgs[1];
+    if (options) {
+      if (options.method) {
+        // Both the Request object and the options object can specify the HTTP method. If both are present, the
+        // options object takes precedence.
+        method = options.method;
+      }
+      if (options.headers) {
+        // If the resource argument is a Fetch API Request object, we might have captured headers from that object
+        // already when examining the Request object. We deliberately discard those here. This accurately represents
+        // the behavior of fetch(), if there are headers in both the Request object and the options object, only the
+        // headers from the options object are applied.
+        if (isFetchApiHeaders(options.headers)) {
+          capturedHeaders = getExtraHeadersFromFetchHeaders(options.headers, extraHttpHeadersToCapture);
+        } else {
+          capturedHeaders = getExtraHeadersCaseInsensitive(options.headers, extraHttpHeadersToCapture);
+        }
+      }
+    }
+    const spanData = {
+      http: {
+        operation: method,
+        endpoints: completeCallUrl,
+        params
+      }
+    };
     return cls.ns.runAndReturn(() => {
       // NOTE: Check for parentSpan existence, because of allowRootExitSpan is being enabled
       const span = cls.startSpan({
         spanName: 'node.http.client',
         kind: constants.EXIT,
         traceId: parentSpan?.t,
-        parentSpanId: parentSpan?.s
+        parentSpanId: parentSpan?.s,
+        spanData
       });
 
       // startSpan updates the W3C trace context and writes it back to CLS, so we have to refetch the updated context
       w3cTraceContext = cls.getW3cTraceContext();
-
-      // See https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters -> resource for the possible variants
-      // to provide a URL to fetch.
-      let completeCallUrl;
-      let method = 'GET';
-      const resource = originalArgs[0];
-      let params;
-      let capturedHeaders;
-
-      if (resource != null) {
-        let rawUrl;
-        if (typeof resource === 'string') {
-          rawUrl = resource;
-        } else if (isFetchApiRequest(resource)) {
-          // The first argument is an instance of Request, see https://developer.mozilla.org/en-US/docs/Web/API/Request.
-          rawUrl = resource.url;
-          method = resource.method;
-          capturedHeaders = getExtraHeadersFromFetchHeaders(resource.headers, extraHttpHeadersToCapture);
-        } else if (typeof resource.toString === 'function') {
-          // This also handles the case when the resource is a URL object, as well as any object that has a custom
-          // stringifier.
-          rawUrl = resource.toString();
-        }
-        completeCallUrl = sanitizeUrl(rawUrl);
-        params = splitAndFilter(rawUrl);
-      }
-
-      const options = originalArgs[1];
-      if (options) {
-        if (options.method) {
-          // Both the Request object and the options object can specify the HTTP method. If both are present, the
-          // options object takes precedence.
-          method = options.method;
-        }
-        if (options.headers) {
-          // If the resource argument is a Fetch API Request object, we might have captured headers from that object
-          // already when examining the Request object. We deliberately discard those here. This accurately represents
-          // the behavior of fetch(), if there are headers in both the Request object and the options object, only the
-          // headers from the options object are applied.
-          if (isFetchApiHeaders(options.headers)) {
-            capturedHeaders = getExtraHeadersFromFetchHeaders(options.headers, extraHttpHeadersToCapture);
-          } else {
-            capturedHeaders = getExtraHeadersCaseInsensitive(options.headers, extraHttpHeadersToCapture);
-          }
-        }
-      }
-
-      span.data.http = {
-        method,
-        url: completeCallUrl,
-        params
-      };
 
       span.stack = tracingUtil.getStackTrace(instanaFetch);
 

--- a/packages/core/src/tracing/instrumentation/protocols/nativeFetch.js
+++ b/packages/core/src/tracing/instrumentation/protocols/nativeFetch.js
@@ -102,70 +102,70 @@ function instrument() {
 
       return originalFetch.apply(originalThis, originalArgs);
     }
-    // See https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters -> resource for the possible variants
-    // to provide a URL to fetch.
-    let completeCallUrl;
-    let method = 'GET';
-    const resource = originalArgs[0];
-    let params;
-    let capturedHeaders;
 
-    if (resource != null) {
-      let rawUrl;
-      if (typeof resource === 'string') {
-        rawUrl = resource;
-      } else if (isFetchApiRequest(resource)) {
-        // The first argument is an instance of Request, see https://developer.mozilla.org/en-US/docs/Web/API/Request.
-        rawUrl = resource.url;
-        method = resource.method;
-        capturedHeaders = getExtraHeadersFromFetchHeaders(resource.headers, extraHttpHeadersToCapture);
-      } else if (typeof resource.toString === 'function') {
-        // This also handles the case when the resource is a URL object, as well as any object that has a custom
-        // stringifier.
-        rawUrl = resource.toString();
-      }
-      completeCallUrl = sanitizeUrl(rawUrl);
-      params = splitAndFilter(rawUrl);
-    }
-
-    const options = originalArgs[1];
-    if (options) {
-      if (options.method) {
-        // Both the Request object and the options object can specify the HTTP method. If both are present, the
-        // options object takes precedence.
-        method = options.method;
-      }
-      if (options.headers) {
-        // If the resource argument is a Fetch API Request object, we might have captured headers from that object
-        // already when examining the Request object. We deliberately discard those here. This accurately represents
-        // the behavior of fetch(), if there are headers in both the Request object and the options object, only the
-        // headers from the options object are applied.
-        if (isFetchApiHeaders(options.headers)) {
-          capturedHeaders = getExtraHeadersFromFetchHeaders(options.headers, extraHttpHeadersToCapture);
-        } else {
-          capturedHeaders = getExtraHeadersCaseInsensitive(options.headers, extraHttpHeadersToCapture);
-        }
-      }
-    }
-    const spanData = {
-      http: {
-        operation: method,
-        endpoints: completeCallUrl,
-        params
-      }
-    };
     return cls.ns.runAndReturn(() => {
       // NOTE: Check for parentSpan existence, because of allowRootExitSpan is being enabled
       const span = cls.startSpan({
         spanName: 'node.http.client',
         kind: constants.EXIT,
         traceId: parentSpan?.t,
-        parentSpanId: parentSpan?.s,
-        spanData
+        parentSpanId: parentSpan?.s
       });
 
       // startSpan updates the W3C trace context and writes it back to CLS, so we have to refetch the updated context
       w3cTraceContext = cls.getW3cTraceContext();
+
+      // See https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters -> resource for the possible variants
+      // to provide a URL to fetch.
+      let completeCallUrl;
+      let method = 'GET';
+      const resource = originalArgs[0];
+      let params;
+      let capturedHeaders;
+
+      if (resource != null) {
+        let rawUrl;
+        if (typeof resource === 'string') {
+          rawUrl = resource;
+        } else if (isFetchApiRequest(resource)) {
+          // The first argument is an instance of Request, see https://developer.mozilla.org/en-US/docs/Web/API/Request.
+          rawUrl = resource.url;
+          method = resource.method;
+          capturedHeaders = getExtraHeadersFromFetchHeaders(resource.headers, extraHttpHeadersToCapture);
+        } else if (typeof resource.toString === 'function') {
+          // This also handles the case when the resource is a URL object, as well as any object that has a custom
+          // stringifier.
+          rawUrl = resource.toString();
+        }
+        completeCallUrl = sanitizeUrl(rawUrl);
+        params = splitAndFilter(rawUrl);
+      }
+
+      const options = originalArgs[1];
+      if (options) {
+        if (options.method) {
+          // Both the Request object and the options object can specify the HTTP method. If both are present, the
+          // options object takes precedence.
+          method = options.method;
+        }
+        if (options.headers) {
+          // If the resource argument is a Fetch API Request object, we might have captured headers from that object
+          // already when examining the Request object. We deliberately discard those here. This accurately represents
+          // the behavior of fetch(), if there are headers in both the Request object and the options object, only the
+          // headers from the options object are applied.
+          if (isFetchApiHeaders(options.headers)) {
+            capturedHeaders = getExtraHeadersFromFetchHeaders(options.headers, extraHttpHeadersToCapture);
+          } else {
+            capturedHeaders = getExtraHeadersCaseInsensitive(options.headers, extraHttpHeadersToCapture);
+          }
+        }
+      }
+
+      span.data.http = {
+        method,
+        url: completeCallUrl,
+        params
+      };
 
       span.stack = tracingUtil.getStackTrace(instanaFetch);
 
@@ -200,6 +200,12 @@ function instrument() {
 }
 
 function injectTraceCorrelationHeaders(originalArgs, span, w3cTraceContext) {
+  if (span.shouldSuppressDownstream) {
+    // Suppress trace propagation to downstream services.
+    injectSuppressionHeader(originalArgs, w3cTraceContext);
+    return;
+  }
+
   const headersToAdd = {
     [constants.traceIdHeaderName]: span.t,
     [constants.spanIdHeaderName]: span.s,

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -9,8 +9,6 @@
  */
 let ignoreEndpoints;
 
-let spanTypeKey = '';
-
 /**
  * @param {import('../util/normalizeConfig').InstanaConfig} config
  */
@@ -49,10 +47,11 @@ const IGNORABLE_SPAN_TYPES = ['redis', 'dynamodb', 'kafka', 'node.http.server'];
 
 /**
  * @param {import('../core').InstanaBaseSpan} span
+ * @param {string} spanTypeKey
  * @param {import('../tracing').IgnoreEndpointsFields} ignoreconfig
  * @returns {boolean}
  */
-function matchEndpoints(span, ignoreconfig) {
+function matchEndpoints(span, spanTypeKey, ignoreconfig) {
   // Parse the endpoints from the span data.
   const spanEndpoints = parseSpanEndpoints(span.data[spanTypeKey]?.endpoints);
   if (!spanEndpoints.length) {
@@ -87,10 +86,11 @@ function matchEndpoints(span, ignoreconfig) {
 
 /**
  * @param {import("../core").InstanaBaseSpan} span
+ * @param {string} spanTypeKey
  * @param {import('../tracing').IgnoreEndpointsFields} ignoreconfig
  * @returns {boolean}
  */
-function matchMethods(span, ignoreconfig) {
+function matchMethods(span, spanTypeKey, ignoreconfig) {
   const spanOperation = span.data[spanTypeKey]?.operation?.toLowerCase();
   let methodMatches = false;
 
@@ -106,10 +106,11 @@ function matchMethods(span, ignoreconfig) {
 
 /**
  * @param {import("../core").InstanaBaseSpan} span
+ * @param {string} spanTypeKey
  * @param {import('../tracing').IgnoreEndpointsFields} ignoreconfig
  * @returns {boolean}
  */
-function matchConnections(span, ignoreconfig) {
+function matchConnections(span, spanTypeKey, ignoreconfig) {
   const spanOperation = span.data[spanTypeKey]?.connection?.toLowerCase();
   let connectionMatches = false;
 
@@ -135,7 +136,7 @@ function shouldIgnore(span, ignoreEndpointsConfig) {
     return false;
   }
 
-  spanTypeKey = normalizeSpanDataTypeKey(span.n);
+  const spanTypeKey = normalizeSpanDataTypeKey(span.n);
   if (!spanTypeKey) {
     return false;
   }
@@ -151,17 +152,17 @@ function shouldIgnore(span, ignoreEndpointsConfig) {
     let matched = false;
 
     if (ignoreconfig.methods) {
-      if (!matchMethods(span, ignoreconfig)) return false;
+      if (!matchMethods(span, spanTypeKey, ignoreconfig)) return false;
       matched = true;
     }
 
     if (ignoreconfig.endpoints) {
-      if (!matchEndpoints(span, ignoreconfig)) return false;
+      if (!matchEndpoints(span, spanTypeKey, ignoreconfig)) return false;
       matched = true;
     }
 
     if (ignoreconfig.connections) {
-      if (!matchConnections(span, ignoreconfig)) return false;
+      if (!matchConnections(span, spanTypeKey, ignoreconfig)) return false;
       matched = true;
     }
 

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -171,10 +171,16 @@ function shouldIgnore(span, ignoreEndpointsConfig) {
 }
 
 /**
- * Resolves the configuration key for a given span type.
+ * Normalizes the configuration key for a given span type.
  *
- * For specific span names like 'node.http.server', 'node.http.client', and 'graphql.server',
- * the normalized span data key is 'http'. This ensures that they share the same field mapping logic.
+ * For the span name 'node.http.server', this function returns 'http'
+ * to ensure consistent field mapping.
+ *
+ * Note: The 'node.http.client' span type is intentionally not normalized here
+ * because client-side HTTP spans are currently excluded from this normalization logic.
+ * This can be updated in the future if HTTP exit filtering is required.
+ *
+ * All other span types are returned unchanged.
  *
  * @param {string} spanType - The span name (e.g., span.n).
  * @returns {string} - The normalized span type key.
@@ -182,7 +188,6 @@ function shouldIgnore(span, ignoreEndpointsConfig) {
 function normalizeSpanDataTypeKey(spanType) {
   switch (spanType) {
     case 'node.http.server':
-    case 'node.http.client':
       return 'http';
     default:
       return spanType;

--- a/packages/core/test/tracing/backend_mappers/mapper_test.js
+++ b/packages/core/test/tracing/backend_mappers/mapper_test.js
@@ -176,156 +176,156 @@ describe('tracing/backend_mappers', () => {
           kafka: { operation: 'produce', endpoints: 'topic1' }
         }
       };
-
-      it('should correctly map "operation" to "access" and "endpoints" to "service"', () => {
-        const result = transform(span);
-        expect(result.data.kafka.access).to.equal('produce');
-        expect(result.data.kafka.service).to.equal('topic1');
-        expect(result.data.kafka).to.not.have.property('operation');
-        expect(result.data.kafka).to.not.have.property('endpoints');
-      });
-
-      it('should leave already mapped fields unchanged', () => {
-        span = {
-          data: {
-            kafka: { access: 'consume', service: 'topic1' },
-            otherField: 'value'
-          }
-        };
-
-        const result = transform(span);
-        expect(result.data.kafka.access).to.equal('consume');
-        expect(result.data.kafka.service).to.equal('topic1');
-        expect(result.data.kafka).to.not.have.property('operation');
-        expect(result.data.kafka).to.not.have.property('endpoints');
-        expect(result.data.otherField).to.equal('value');
-      });
-
-      it('should return the span unchanged when no mapper is found for the span type', () => {
-        span.n = 'grpc';
-        const result = transform(span);
-        expect(result).to.equal(span);
-      });
-
-      it('should produce consistent output when called multiple times on the same kafka span', () => {
-        transform(span);
-        expect(transform(span)).to.deep.equal(span);
-      });
     });
 
-    describe('Transform function with multiple entries in span.data', () => {
-      beforeEach(() => {
-        span = {
-          n: 'kafka',
-          t: '3234567803',
-          s: '3234567892',
-          p: '3234567891',
-          data: {
-            kafka: { operation: 'produce', endpoints: 'topic1' },
-            otherField: { message: 'No mapping here' }
-          }
-        };
-      });
-
-      it('should remap specific kafka fields  while leaving unrelated fields unchanged', () => {
-        const result = transform(span);
-
-        expect(result.data.kafka.access).to.equal('produce');
-        expect(result.data.kafka.service).to.equal('topic1');
-        expect(result.data.kafka).to.not.have.property('operation');
-        expect(result.data.kafka).to.not.have.property('endpoints');
-
-        // Verify that non-kafka fields are preserved without modification
-        expect(result.data.otherField).to.deep.equal({ message: 'No mapping here' });
-      });
+    it('should correctly map "operation" to "access" and "endpoints" to "service"', () => {
+      const result = transform(span);
+      expect(result.data.kafka.access).to.equal('produce');
+      expect(result.data.kafka.service).to.equal('topic1');
+      expect(result.data.kafka).to.not.have.property('operation');
+      expect(result.data.kafka).to.not.have.property('endpoints');
     });
 
-    describe('HTTP Mapper', () => {
-      it('should transform span with type node.http.server correctly', () => {
-        span = {
-          n: 'node.http.server',
-          data: {
-            http: {
-              operation: 'GET',
-              endpoints: '/api/users',
-              connection: 'localhost'
-            }
+    it('should leave already mapped fields unchanged', () => {
+      span = {
+        data: {
+          kafka: { access: 'consume', service: 'topic1' },
+          otherField: 'value'
+        }
+      };
+
+      const result = transform(span);
+      expect(result.data.kafka.access).to.equal('consume');
+      expect(result.data.kafka.service).to.equal('topic1');
+      expect(result.data.kafka).to.not.have.property('operation');
+      expect(result.data.kafka).to.not.have.property('endpoints');
+      expect(result.data.otherField).to.equal('value');
+    });
+
+    it('should return the span unchanged when no mapper is found for the span type', () => {
+      span.n = 'grpc';
+      const result = transform(span);
+      expect(result).to.equal(span);
+    });
+
+    it('should produce consistent output when called multiple times on the same kafka span', () => {
+      transform(span);
+      expect(transform(span)).to.deep.equal(span);
+    });
+  });
+
+  describe('Transform function with multiple entries in span.data', () => {
+    beforeEach(() => {
+      span = {
+        n: 'kafka',
+        t: '3234567803',
+        s: '3234567892',
+        p: '3234567891',
+        data: {
+          kafka: { operation: 'produce', endpoints: 'topic1' },
+          otherField: { message: 'No mapping here' }
+        }
+      };
+    });
+
+    it('should remap specific kafka fields  while leaving unrelated fields unchanged', () => {
+      const result = transform(span);
+
+      expect(result.data.kafka.access).to.equal('produce');
+      expect(result.data.kafka.service).to.equal('topic1');
+      expect(result.data.kafka).to.not.have.property('operation');
+      expect(result.data.kafka).to.not.have.property('endpoints');
+
+      // Verify that non-kafka fields are preserved without modification
+      expect(result.data.otherField).to.deep.equal({ message: 'No mapping here' });
+    });
+  });
+
+  describe('HTTP Mapper', () => {
+    it('should transform span with type node.http.server correctly', () => {
+      span = {
+        n: 'node.http.server',
+        data: {
+          http: {
+            operation: 'GET',
+            endpoints: '/api/users',
+            connection: 'localhost'
           }
-        };
+        }
+      };
 
-        const result = transform(span);
-        expect(result.data.http.method).to.equal('GET');
-        expect(result.data.http.url).to.equal('/api/users');
-        expect(result.data.http.host).to.equal('localhost');
-        expect(result.data.http).to.not.have.property('operation');
-        expect(result.data.http).to.not.have.property('endpoints');
-        expect(result.data.http).to.not.have.property('connection');
-      });
+      const result = transform(span);
+      expect(result.data.http.method).to.equal('GET');
+      expect(result.data.http.url).to.equal('/api/users');
+      expect(result.data.http.host).to.equal('localhost');
+      expect(result.data.http).to.not.have.property('operation');
+      expect(result.data.http).to.not.have.property('endpoints');
+      expect(result.data.http).to.not.have.property('connection');
+    });
 
-      it('should transform span with type node.http.client correctly', () => {
-        span = {
-          n: 'node.http.client',
-          data: {
-            http: {
-              operation: 'GET',
-              endpoints: '/api/users',
-              connection: 'localhost'
-            }
+    it('should transform span with type node.http.client correctly', () => {
+      span = {
+        n: 'node.http.client',
+        data: {
+          http: {
+            operation: 'GET',
+            endpoints: '/api/users',
+            connection: 'localhost'
           }
-        };
+        }
+      };
 
-        const result = transform(span);
-        expect(result.data.http.method).to.equal('GET');
-        expect(result.data.http.url).to.equal('/api/users');
-        expect(result.data.http.host).to.equal('localhost');
-        expect(result.data.http).to.not.have.property('operation');
-        expect(result.data.http).to.not.have.property('endpoints');
-        expect(result.data.http).to.not.have.property('connection');
-      });
+      const result = transform(span);
+      expect(result.data.http.method).to.equal('GET');
+      expect(result.data.http.url).to.equal('/api/users');
+      expect(result.data.http.host).to.equal('localhost');
+      expect(result.data.http).to.not.have.property('operation');
+      expect(result.data.http).to.not.have.property('endpoints');
+      expect(result.data.http).to.not.have.property('connection');
+    });
 
-      it('should transform span with type graphql.server containing http and graphql data', () => {
-        span = {
-          n: 'graphql.server',
-          data: {
-            http: {
-              operation: 'POST',
-              endpoints: '/graphql',
-              connection: '127.0.0.1'
-            },
-            graphql: {
-              operationName: 'query'
-            }
+    it('should transform span with type graphql.server containing http and graphql data', () => {
+      span = {
+        n: 'graphql.server',
+        data: {
+          http: {
+            operation: 'POST',
+            endpoints: '/graphql',
+            connection: '127.0.0.1'
+          },
+          graphql: {
+            operationName: 'query'
           }
-        };
+        }
+      };
 
-        const result = transform(span);
+      const result = transform(span);
 
-        // HTTP part
-        expect(result.data.http.method).to.equal('POST');
-        expect(result.data.http.url).to.equal('/graphql');
-        expect(result.data.http.host).to.equal('127.0.0.1');
-        expect(result.data.http).to.not.have.property('operation');
-        expect(result.data.http).to.not.have.property('endpoints');
-        expect(result.data.http).to.not.have.property('connection');
+      // HTTP part
+      expect(result.data.http.method).to.equal('POST');
+      expect(result.data.http.url).to.equal('/graphql');
+      expect(result.data.http.host).to.equal('127.0.0.1');
+      expect(result.data.http).to.not.have.property('operation');
+      expect(result.data.http).to.not.have.property('endpoints');
+      expect(result.data.http).to.not.have.property('connection');
 
-        // GraphQL part no changes
-        expect(result.data.graphql.operationName).to.equal('query');
-        expect(result.data.graphql).to.not.have.property('operation');
-      });
+      // GraphQL part no changes
+      expect(result.data.graphql.operationName).to.equal('query');
+      expect(result.data.graphql).to.not.have.property('operation');
+    });
 
-      it('should leave span unchanged if no relevant keys are found in graphql.server', () => {
-        span = {
-          n: 'graphql.server',
-          data: {
-            graphql: {
-              message: 'No mapping here'
-            }
+    it('should leave span unchanged if no relevant keys are found in graphql.server', () => {
+      span = {
+        n: 'graphql.server',
+        data: {
+          graphql: {
+            message: 'No mapping here'
           }
-        };
+        }
+      };
 
-        const result = transform(span);
-        expect(result).to.deep.equal(span);
-      });
+      const result = transform(span);
+      expect(result).to.deep.equal(span);
     });
   });
 });

--- a/packages/core/test/tracing/backend_mappers/mapper_test.js
+++ b/packages/core/test/tracing/backend_mappers/mapper_test.js
@@ -176,68 +176,156 @@ describe('tracing/backend_mappers', () => {
           kafka: { operation: 'produce', endpoints: 'topic1' }
         }
       };
+
+      it('should correctly map "operation" to "access" and "endpoints" to "service"', () => {
+        const result = transform(span);
+        expect(result.data.kafka.access).to.equal('produce');
+        expect(result.data.kafka.service).to.equal('topic1');
+        expect(result.data.kafka).to.not.have.property('operation');
+        expect(result.data.kafka).to.not.have.property('endpoints');
+      });
+
+      it('should leave already mapped fields unchanged', () => {
+        span = {
+          data: {
+            kafka: { access: 'consume', service: 'topic1' },
+            otherField: 'value'
+          }
+        };
+
+        const result = transform(span);
+        expect(result.data.kafka.access).to.equal('consume');
+        expect(result.data.kafka.service).to.equal('topic1');
+        expect(result.data.kafka).to.not.have.property('operation');
+        expect(result.data.kafka).to.not.have.property('endpoints');
+        expect(result.data.otherField).to.equal('value');
+      });
+
+      it('should return the span unchanged when no mapper is found for the span type', () => {
+        span.n = 'grpc';
+        const result = transform(span);
+        expect(result).to.equal(span);
+      });
+
+      it('should produce consistent output when called multiple times on the same kafka span', () => {
+        transform(span);
+        expect(transform(span)).to.deep.equal(span);
+      });
     });
 
-    it('should correctly map "operation" to "access" and "endpoints" to "service"', () => {
-      const result = transform(span);
-      expect(result.data.kafka.access).to.equal('produce');
-      expect(result.data.kafka.service).to.equal('topic1');
-      expect(result.data.kafka).to.not.have.property('operation');
-      expect(result.data.kafka).to.not.have.property('endpoints');
+    describe('Transform function with multiple entries in span.data', () => {
+      beforeEach(() => {
+        span = {
+          n: 'kafka',
+          t: '3234567803',
+          s: '3234567892',
+          p: '3234567891',
+          data: {
+            kafka: { operation: 'produce', endpoints: 'topic1' },
+            otherField: { message: 'No mapping here' }
+          }
+        };
+      });
+
+      it('should remap specific kafka fields  while leaving unrelated fields unchanged', () => {
+        const result = transform(span);
+
+        expect(result.data.kafka.access).to.equal('produce');
+        expect(result.data.kafka.service).to.equal('topic1');
+        expect(result.data.kafka).to.not.have.property('operation');
+        expect(result.data.kafka).to.not.have.property('endpoints');
+
+        // Verify that non-kafka fields are preserved without modification
+        expect(result.data.otherField).to.deep.equal({ message: 'No mapping here' });
+      });
     });
 
-    it('should leave already mapped fields unchanged', () => {
-      span = {
-        data: {
-          kafka: { access: 'consume', service: 'topic1' },
-          otherField: 'value'
-        }
-      };
+    describe('HTTP Mapper', () => {
+      it('should transform span with type node.http.server correctly', () => {
+        span = {
+          n: 'node.http.server',
+          data: {
+            http: {
+              operation: 'GET',
+              endpoints: '/api/users',
+              connection: 'localhost'
+            }
+          }
+        };
 
-      const result = transform(span);
-      expect(result.data.kafka.access).to.equal('consume');
-      expect(result.data.kafka.service).to.equal('topic1');
-      expect(result.data.kafka).to.not.have.property('operation');
-      expect(result.data.kafka).to.not.have.property('endpoints');
-      expect(result.data.otherField).to.equal('value');
-    });
+        const result = transform(span);
+        expect(result.data.http.method).to.equal('GET');
+        expect(result.data.http.url).to.equal('/api/users');
+        expect(result.data.http.host).to.equal('localhost');
+        expect(result.data.http).to.not.have.property('operation');
+        expect(result.data.http).to.not.have.property('endpoints');
+        expect(result.data.http).to.not.have.property('connection');
+      });
 
-    it('should return the span unchanged when no mapper is found for the span type', () => {
-      span.n = 'grpc';
-      const result = transform(span);
-      expect(result).to.equal(span);
-    });
+      it('should transform span with type node.http.client correctly', () => {
+        span = {
+          n: 'node.http.client',
+          data: {
+            http: {
+              operation: 'GET',
+              endpoints: '/api/users',
+              connection: 'localhost'
+            }
+          }
+        };
 
-    it('should produce consistent output when called multiple times on the same kafka span', () => {
-      transform(span);
-      expect(transform(span)).to.deep.equal(span);
-    });
-  });
+        const result = transform(span);
+        expect(result.data.http.method).to.equal('GET');
+        expect(result.data.http.url).to.equal('/api/users');
+        expect(result.data.http.host).to.equal('localhost');
+        expect(result.data.http).to.not.have.property('operation');
+        expect(result.data.http).to.not.have.property('endpoints');
+        expect(result.data.http).to.not.have.property('connection');
+      });
 
-  describe('Transform function with multiple entries in span.data', () => {
-    beforeEach(() => {
-      span = {
-        n: 'kafka',
-        t: '3234567803',
-        s: '3234567892',
-        p: '3234567891',
-        data: {
-          kafka: { operation: 'produce', endpoints: 'topic1' },
-          otherField: { message: 'No mapping here' }
-        }
-      };
-    });
+      it('should transform span with type graphql.server containing http and graphql data', () => {
+        span = {
+          n: 'graphql.server',
+          data: {
+            http: {
+              operation: 'POST',
+              endpoints: '/graphql',
+              connection: '127.0.0.1'
+            },
+            graphql: {
+              operationName: 'query'
+            }
+          }
+        };
 
-    it('should remap specific kafka fields  while leaving unrelated fields unchanged', () => {
-      const result = transform(span);
+        const result = transform(span);
 
-      expect(result.data.kafka.access).to.equal('produce');
-      expect(result.data.kafka.service).to.equal('topic1');
-      expect(result.data.kafka).to.not.have.property('operation');
-      expect(result.data.kafka).to.not.have.property('endpoints');
+        // HTTP part
+        expect(result.data.http.method).to.equal('POST');
+        expect(result.data.http.url).to.equal('/graphql');
+        expect(result.data.http.host).to.equal('127.0.0.1');
+        expect(result.data.http).to.not.have.property('operation');
+        expect(result.data.http).to.not.have.property('endpoints');
+        expect(result.data.http).to.not.have.property('connection');
 
-      // Verify that non-kafka fields are preserved without modification
-      expect(result.data.otherField).to.deep.equal({ message: 'No mapping here' });
+        // GraphQL part no changes
+        expect(result.data.graphql.operationName).to.equal('query');
+        expect(result.data.graphql).to.not.have.property('operation');
+      });
+
+      it('should leave span unchanged if no relevant keys are found in graphql.server', () => {
+        span = {
+          n: 'graphql.server',
+          data: {
+            graphql: {
+              message: 'No mapping here'
+            }
+          }
+        };
+
+        const result = transform(span);
+        expect(result).to.deep.equal(span);
+      });
     });
   });
 });

--- a/packages/core/test/util/spanFilter_test.js
+++ b/packages/core/test/util/spanFilter_test.js
@@ -542,5 +542,33 @@ describe('util.spanFilter', () => {
       };
       expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
     });
+
+    // eslint-disable-next-line max-len
+    it('should return true when span.n is node.http.server and the endpoint matches the configured parameterized route', () => {
+      ignoreEndpoints = {
+        http: [{ endpoints: ['/users/:userId/books/:bookId'] }]
+      };
+      span.n = 'node.http.server';
+      span.data = {
+        http: {
+          endpoints: '/users/:userId/books/:bookId'
+        }
+      };
+      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+    });
+
+    // eslint-disable-next-line max-len
+    it('should return true when span.n is node.http.server and the endpoint pattern exactly matches the configured optional segment route', () => {
+      ignoreEndpoints = {
+        http: [{ endpoints: ['/ab(cd)'] }]
+      };
+      span.n = 'node.http.server';
+      span.data = {
+        http: {
+          endpoints: '/ab(cd)'
+        }
+      };
+      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+    });
   });
 });

--- a/packages/core/test/util/spanFilter_test.js
+++ b/packages/core/test/util/spanFilter_test.js
@@ -476,5 +476,57 @@ describe('util.spanFilter', () => {
         expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
       });
     });
+
+    it('should return true when span.n is node.http.server and config has http entry with matching method', () => {
+      ignoreEndpoints = {
+        http: [{ methods: ['GET'] }]
+      };
+      span.n = 'node.http.server';
+      span.data = {
+        http: {
+          operation: 'GET'
+        }
+      };
+      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+    });
+
+    it('should return false when span.n is node.http.client and config has http entry with matching method', () => {
+      ignoreEndpoints = {
+        http: [{ methods: ['POST'] }]
+      };
+      span.n = 'node.http.client';
+      span.data = {
+        http: {
+          operation: 'POST'
+        }
+      };
+      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
+    });
+
+    it('should return false when span.n is node.http.client and method does not match', () => {
+      ignoreEndpoints = {
+        http: [{ methods: ['DELETE'] }]
+      };
+      span.n = 'node.http.client';
+      span.data = {
+        http: {
+          operation: 'PUT'
+        }
+      };
+      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
+    });
+
+    it('should return false when span.n is node.http.server and config has no http entry', () => {
+      ignoreEndpoints = {
+        redis: [{ methods: ['GET'] }]
+      };
+      span.n = 'node.http.server';
+      span.data = {
+        http: {
+          operation: 'GET'
+        }
+      };
+      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(false);
+    });
   });
 });

--- a/packages/core/test/util/spanFilter_test.js
+++ b/packages/core/test/util/spanFilter_test.js
@@ -490,6 +490,20 @@ describe('util.spanFilter', () => {
       expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
     });
 
+    it('should return true when span.n is node.http.server and config has http entry with matching endpoint', () => {
+      ignoreEndpoints = {
+        http: [{ endpoints: ['/api/test'] }]
+      };
+      span.n = 'node.http.server';
+      span.data = {
+        http: {
+          operation: 'GET',
+          endpoints: '/api/test'
+        }
+      };
+      expect(shouldIgnore(span, ignoreEndpoints)).to.equal(true);
+    });
+
     it('should return false when span.n is node.http.client and config has http entry with matching method', () => {
       ignoreEndpoints = {
         http: [{ methods: ['POST'] }]


### PR DESCRIPTION
**Overview**

This update introduces support for ignoring **HTTP calls** using configurable rules. It allows users to ignore specific incoming HTTP requests from tracing, based on request method, endpoint path, or host.

**Supported Filtering Fields**

The following fields are available for HTTP span filtering:

* `method`: HTTP method (`get`, `post`, etc.)
* `url`: URL path (e.g., `/health`, `/api/v1/user`)
* `host`: Host and port (e.g., `localhost:3000`)

All values are case-insensitive. Wildcards (`*`) are supported.

> Note: Only **HTTP entry spans** can be filtered. **HTTP exit spans are not supported**.


**Configuration Options**

1. **YAML-based configuration via `INSTANA_IGNORE_ENDPOINTS_PATH`**

Set the environment variable:

```
INSTANA_IGNORE_ENDPOINTS_PATH=/absolute/path/to/config.yaml
```

Example `config.yaml`:

```yaml
tracing:
  ignore-endpoints:
    http:
      - methods: ["get"]
        endpoints: ["/status"]

      - methods: ["get", "send"]
        endpoints: ["/status", "/v1/status"]

      - methods: ["*"]
        connection: ["localhost:3000"]
```


2. **Simple environment variable: `INSTANA_IGNORE_ENDPOINTS`**

For basic filtering by method:

```
INSTANA_IGNORE_ENDPOINTS=http:get
```

This example ignores all HTTP `GET` requests regardless of the path.

3. **In-code configuration**

You can also configure filters when initializing the Instana collector:

```js
require('@instana/collector')({
  tracing: {
    ignoreEndpoints: {
      http: [
        {
          methods: ['get'],
          endpoints: ['/status']
        }
      ]
    }
  }
});
```


3. **Agent configuration via `configuration.yaml`**

Example `configuration.yaml`:

```yaml
com.instana.tracing:
  ignore-endpoints:
    http:
      - methods: ["get"]
        endpoints: ["/status"]

      - methods: ["get", "send"]
        endpoints: ["/status", "/v1/status"]

      - methods: ["*"]
 ```      
---

**TODO**

- [x] Update instrumentation to collect span data before creation https://github.com/instana/nodejs/pull/1903
- [x] Implement entry span ignoring logic
- [x] Suppression, apply suppression flags correctly to indicate ignored spans and prevent propagation downstream if necessary.
- [x] Add unit tests + integration tests
- [ ] Public doc update


ref: https://jsw.ibm.com/browse/INSTA-46689
