### PR TITLE
feat: added support for @azure/storage-blob v12.28.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@aws-sdk/lib-dynamodb": "^3.850.0",
         "@aws-sdk/util-retry": "^3.370.0",
         "@azure/storage-blob": "^12.28.0",
+        "@azure/storage-blob-v1227": "npm:@azure/storage-blob@12.27.0",
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@elastic/elasticsearch": "^9.0.3",
@@ -18180,6 +18181,70 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-blob-v1227": {
+      "name": "@azure/storage-blob",
+      "version": "12.27.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.27.0.tgz",
+      "integrity": "sha512-IQjj9RIzAKatmNca3D6bT0qJ+Pkox1WZGOg2esJF2YLHb45pQKOwGPIAV+w3rfgkj7zV3RMxpn/c6iftzSOZJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-client": "^1.6.2",
+        "@azure/core-http-compat": "^2.0.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-rest-pipeline": "^1.10.1",
+        "@azure/core-tracing": "^1.1.2",
+        "@azure/core-util": "^1.6.1",
+        "@azure/core-xml": "^1.4.3",
+        "@azure/logger": "^1.0.0",
+        "events": "^3.0.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/storage-blob-v1227/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/storage-blob-v1227/node_modules/@azure/core-http-compat": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.3.0.tgz",
+      "integrity": "sha512-qLQujmUypBBG0gxHd0j6/Jdmul6ttl24c8WGiLXIk7IHXdBlfoBqW27hyz3Xn6xbfdyVSarl1Ttbk0AwnZBYCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-client": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.20.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/storage-blob-v1227/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/@azure/storage-blob/node_modules/@azure/abort-controller": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@aws-sdk/client-ssm": "^3.679.0",
         "@aws-sdk/lib-dynamodb": "^3.850.0",
         "@aws-sdk/util-retry": "^3.370.0",
-        "@azure/storage-blob": "^12.27.0",
+        "@azure/storage-blob": "^12.28.0",
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@elastic/elasticsearch": "^9.0.3",
@@ -17824,17 +17824,18 @@
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.7.2.tgz",
-      "integrity": "sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.0.tgz",
+      "integrity": "sha512-88Djs5vBvGbHQHf5ZZcaoNHo6Y8BKZkt3cw2iuJIQzLEgH4Ox6Tm4hjFhbqOxyYsgIG/eJbFEHpxRIfEEWv5Ow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
-        "@azure/core-util": "^1.1.0",
+        "@azure/core-util": "^1.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-auth/node_modules/@azure/abort-controller": {
@@ -17850,21 +17851,22 @@
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.2.tgz",
-      "integrity": "sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.0.tgz",
+      "integrity": "sha512-O4aP3CLFNodg8eTHXECaH3B3CjicfzkxVtnrfLkOq0XNP7TIECGfHpK/C6vADZkWP75wzmdBnsIA8ksuJMk18g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.9.1",
+        "@azure/core-rest-pipeline": "^1.20.0",
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.6.1",
         "@azure/logger": "^1.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-client/node_modules/@azure/abort-controller": {
@@ -17909,110 +17911,136 @@
       }
     },
     "node_modules/@azure/core-paging": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.5.0.tgz",
-      "integrity": "sha512-zqWdVIt+2Z+3wqxEOGzR5hXFZ8MGKK52x4vFLw8n58pR6ZfKRx3EXYTxTaYxYHc/PexPUTyimcTWFJbji9Z6Iw==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.13.0.tgz",
-      "integrity": "sha512-a62aP/wppgmnfIkJLfcB4ssPBcH94WzrzPVJ3tlJt050zX4lfmtnvy95D3igDo3f31StO+9BgPrzvkj4aOxnoA==",
-      "dev": true,
-      "dependencies": {
-        "@azure/abort-controller": "^1.1.0",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.3.0",
-        "@azure/logger": "^1.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@azure/core-tracing": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
-      "integrity": "sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-util": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.6.1.tgz",
-      "integrity": "sha512-h5taHeySlsV9qxuK64KZxy4iln1BtMYlNt5jbuEFN3UFSAd1EwKg/Gjl5a6tZ/W8t6li3xPnutOx7zbDyXnPmQ==",
-      "dev": true,
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@azure/core-xml": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.4.3.tgz",
-      "integrity": "sha512-D6G7FEmDiTctPKuWegX2WTrS1enKZwqYwdKTO6ZN6JMigcCehlT0/CYl+zWpI9vQ9frwwp7GQT3/owaEXgnOsA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-xml-parser": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.0.tgz",
+      "integrity": "sha512-OKHmb3/Kpm06HypvB3g6Q3zJuvyXcpxDpCS1PnU8OV6AJgSFaee/covXBcPbWc6XDDxtEPlbi3EMQ6nUiPaQtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.8.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.0.tgz",
+      "integrity": "sha512-+XvmZLLWPe67WXNZo9Oc9CrPj/Tm8QnHR92fFAFdnbzwNdCH1h+7UdpaQgRSBsMY+oW1kHXNUZQLdZ1gHX3ROw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.0.tgz",
+      "integrity": "sha512-o0psW8QWQ58fq3i24Q1K2XfS/jYTxr7O1HRcyUE9bV9NttLU+kYOH82Ixj8DGlMTOWgxm1Sss2QAfKK5UkSPxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.0.tgz",
+      "integrity": "sha512-D/sdlJBMJfx7gqoj66PKVmhDDaU6TKA49ptcolxdas29X7AfvLTmfAGLjAcIMBK7UZ2o4lygHIqVckOlQU3xWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.0.7",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@azure/core-xml/node_modules/fast-xml-parser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
-      "integrity": "sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^2.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
+    },
+    "node_modules/@azure/core-xml/node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@azure/identity": {
       "version": "3.4.2",
@@ -18071,15 +18099,17 @@
       }
     },
     "node_modules/@azure/logger": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.4.tgz",
-      "integrity": "sha512-ustrPY8MryhloQj7OWGe+HrYx+aoiOxzbXTtgblbV3xwCqpzUK36phH3XNHQKj3EPonyFUuDTfR3qFhTEAuZEg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "tslib": "^2.2.0"
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/msal-browser": {
@@ -18127,28 +18157,29 @@
       }
     },
     "node_modules/@azure/storage-blob": {
-      "version": "12.27.0",
-      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.27.0.tgz",
-      "integrity": "sha512-IQjj9RIzAKatmNca3D6bT0qJ+Pkox1WZGOg2esJF2YLHb45pQKOwGPIAV+w3rfgkj7zV3RMxpn/c6iftzSOZJQ==",
+      "version": "12.28.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.28.0.tgz",
+      "integrity": "sha512-VhQHITXXO03SURhDiGuHhvc/k/sD2WvJUS7hqhiVNbErVCuQoLtWql7r97fleBlIRKHJaa9R7DpBjfE0pfLYcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-client": "^1.6.2",
-        "@azure/core-http-compat": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.3",
+        "@azure/core-http-compat": "^2.2.0",
         "@azure/core-lro": "^2.2.0",
-        "@azure/core-paging": "^1.1.1",
-        "@azure/core-rest-pipeline": "^1.10.1",
-        "@azure/core-tracing": "^1.1.2",
-        "@azure/core-util": "^1.6.1",
-        "@azure/core-xml": "^1.4.3",
-        "@azure/logger": "^1.0.0",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.5",
+        "@azure/logger": "^1.1.4",
+        "@azure/storage-common": "^12.0.0-beta.2",
         "events": "^3.0.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/storage-blob/node_modules/@azure/abort-controller": {
@@ -18165,14 +18196,15 @@
       }
     },
     "node_modules/@azure/storage-blob/node_modules/@azure/core-http-compat": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.1.2.tgz",
-      "integrity": "sha512-5MnV1yqzZwgNLLjlizsU3QqOeQChkIXw781Fwh1xdAqJR5AA32IUaq6xv1BICJvfbHoa+JYcaij2HFkhLbNTJQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.3.0.tgz",
+      "integrity": "sha512-qLQujmUypBBG0gxHd0j6/Jdmul6ttl24c8WGiLXIk7IHXdBlfoBqW27hyz3Xn6xbfdyVSarl1Ttbk0AwnZBYCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-client": "^1.3.0",
-        "@azure/core-rest-pipeline": "^1.3.0"
+        "@azure/core-rest-pipeline": "^1.20.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -18183,6 +18215,65 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/@azure/storage-common": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.0.0.tgz",
+      "integrity": "sha512-QyEWXgi4kdRo0wc1rHum9/KnaWZKCdQGZK1BjU4fFL6Jtedp7KLbQihgTTVxldFy1z1ZPtuDPx8mQ5l3huPPbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.1.4",
+        "events": "^3.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-common/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/storage-common/node_modules/@azure/core-http-compat": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.3.0.tgz",
+      "integrity": "sha512-qLQujmUypBBG0gxHd0j6/Jdmul6ttl24c8WGiLXIk7IHXdBlfoBqW27hyz3Xn6xbfdyVSarl1Ttbk0AwnZBYCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-client": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.20.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/storage-common/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }
@@ -28822,6 +28913,45 @@
       "dependencies": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.0.tgz",
+      "integrity": "sha512-sOx1PKSuFwnIl7z4RN0Ls7N9AQawmR9r66eI5rFCzLDIs8HTIYrIpH9QjYWoX0lkgGrkLxXhi4QnK7MizPRrIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@ungap/promise-all-settled": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@aws-sdk/client-ssm": "^3.679.0",
     "@aws-sdk/lib-dynamodb": "^3.850.0",
     "@aws-sdk/util-retry": "^3.370.0",
-    "@azure/storage-blob": "^12.27.0",
+    "@azure/storage-blob": "^12.28.0",
     "@commitlint/cli": "^14.1.0",
     "@commitlint/config-conventional": "^14.1.0",
     "@elastic/elasticsearch": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@aws-sdk/lib-dynamodb": "^3.850.0",
     "@aws-sdk/util-retry": "^3.370.0",
     "@azure/storage-blob": "^12.28.0",
+    "@azure/storage-blob-v1227": "npm:@azure/storage-blob@12.27.0",
     "@commitlint/cli": "^14.1.0",
     "@commitlint/config-conventional": "^14.1.0",
     "@elastic/elasticsearch": "^9.0.3",

--- a/packages/collector/test/tracing/cloud/azure/blob/app.js
+++ b/packages/collector/test/tracing/cloud/azure/blob/app.js
@@ -6,6 +6,8 @@
 
 'use strict';
 
+require('./mockVersion');
+
 require('@instana/core/test/test_util/loadExpressV4');
 
 require('../../../../..')();

--- a/packages/collector/test/tracing/cloud/azure/blob/app.mjs
+++ b/packages/collector/test/tracing/cloud/azure/blob/app.mjs
@@ -4,8 +4,6 @@
 
 /* eslint-disable no-console */
 
-'use strict';
-
 import { BlobServiceClient, BlobBatchClient, BlobClient, StorageSharedKeyCredential } from '@azure/storage-blob';
 import express from 'express';
 import bodyParser from 'body-parser';

--- a/packages/collector/test/tracing/cloud/azure/blob/mockVersion.js
+++ b/packages/collector/test/tracing/cloud/azure/blob/mockVersion.js
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright IBM Corp. 2023
+ * (c) Copyright IBM Corp. 2025
  */
 
 'use strict';

--- a/packages/collector/test/tracing/cloud/azure/blob/mockVersion.js
+++ b/packages/collector/test/tracing/cloud/azure/blob/mockVersion.js
@@ -1,0 +1,14 @@
+/*
+ * (c) Copyright IBM Corp. 2023
+ */
+
+'use strict';
+
+const mock = require('@instana/core/test/test_util/mockRequire');
+const AZURE_BLOB_VERSION = process.env.AZURE_BLOB_VERSION;
+const AZURE_BLOB_REQUIRE =
+  process.env.AZURE_BLOB_VERSION === 'latest' ? '@azure/storage-blob' : `@azure/storage-blob-${AZURE_BLOB_VERSION}`;
+
+if (AZURE_BLOB_REQUIRE !== '@azure/storage-blob') {
+  mock('@azure/storage-blob', AZURE_BLOB_REQUIRE);
+}

--- a/packages/collector/test/tracing/cloud/azure/blob/test.js
+++ b/packages/collector/test/tracing/cloud/azure/blob/test.js
@@ -56,7 +56,7 @@ if (!storageAccount || !accountKey) {
 } else {
   mochaSuiteFn('tracing/cloud/azure/blob', function () {
     ['latest', 'v1227'].forEach(version => {
-      // NOTE: require-mock is not working with esm apps.
+      // NOTE: require-mock is not working with ESM apps.
       // TODO: Support for mocking `import` in ESM apps is planned under INSTA-788.
       if (process.env.RUN_ESM && version !== 'latest') return;
 

--- a/packages/collector/test/tracing/cloud/azure/blob/test.js
+++ b/packages/collector/test/tracing/cloud/azure/blob/test.js
@@ -61,6 +61,9 @@ if (!storageAccount || !accountKey) {
         mochaSuiteFn = describe.skip;
       }
 
+      // NOTE: require-mock is not working with esm apps. There is also no need to run the ESM APP for all versions.
+      if (process.env.RUN_ESM && version !== 'latest') return;
+
       this.timeout(config.getTestTimeout());
       globalAgent.setUpCleanUpHooks();
       const agentControls = globalAgent.instance;

--- a/packages/collector/test/tracing/cloud/azure/blob/test.js
+++ b/packages/collector/test/tracing/cloud/azure/blob/test.js
@@ -54,8 +54,8 @@ if (!storageAccount || !accountKey) {
     });
   });
 } else {
-  mochaSuiteFn('tracing/cloud/azure/blob', function () {
-    ['latest', 'v1227'].forEach(version => {
+  ['latest', 'v1227'].forEach(version => {
+    mochaSuiteFn('tracing/cloud/azure/blob', function () {
       // NOTE: require-mock is not working with ESM apps.
       // TODO: Support for mocking `import` in ESM apps is planned under INSTA-788.
       if (process.env.RUN_ESM && version !== 'latest') return;
@@ -76,448 +76,450 @@ if (!storageAccount || !accountKey) {
       after(async () => {
         await deleteContainer(containerClient);
       });
-      describe('tracing enabled', function () {
-        let controls;
-        before(async () => {
-          controls = new ProcessControls({
-            dirname: __dirname,
-            useGlobalAgent: true,
-            env: {
-              AZURE_CONTAINER_NAME: containerName,
-              AZURE_CONNECTION_STRING: connStr,
-              AZURE_STORAGE_ACCOUNT: storageAccount,
-              AZURE_ACCOUNT_KEY: accountKey,
-              AZURE_BLOB_VERSION: version
-            }
+      mochaSuiteFn(`@azure/storage-blob@${version}`, function () {
+        describe('tracing enabled', function () {
+          let controls;
+          before(async () => {
+            controls = new ProcessControls({
+              dirname: __dirname,
+              useGlobalAgent: true,
+              env: {
+                AZURE_CONTAINER_NAME: containerName,
+                AZURE_CONNECTION_STRING: connStr,
+                AZURE_STORAGE_ACCOUNT: storageAccount,
+                AZURE_ACCOUNT_KEY: accountKey,
+                AZURE_BLOB_VERSION: version
+              }
+            });
+
+            await controls.startAndWaitForAgentConnection();
           });
 
-          await controls.startAndWaitForAgentConnection();
-        });
-
-        beforeEach(async () => {
-          await agentControls.clearReceivedTraceData();
-        });
-
-        after(async () => {
-          await controls.stop();
-        });
-
-        afterEach(async () => {
-          await controls.clearIpcMessages();
-        });
-
-        it('uploads block data', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/uploadDataBlock'
+          beforeEach(async () => {
+            await agentControls.clearReceivedTraceData();
           });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/uploadDataBlock',
-              withError: false,
-              spans: spans,
-              op: 'upload',
-              totalspans: 3 // expects 1 azure upload span and 2 http spans
+
+          after(async () => {
+            await controls.stop();
+          });
+
+          afterEach(async () => {
+            await controls.clearIpcMessages();
+          });
+
+          it('uploads block data', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/uploadDataBlock'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/uploadDataBlock',
+                withError: false,
+                spans: spans,
+                op: 'upload',
+                totalspans: 3 // expects 1 azure upload span and 2 http spans
+              });
             });
           });
-        });
 
-        it('upload - promise', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/upload'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/upload',
-              withError: false,
-              spans: spans,
-              op: 'upload',
-              totalspans: 4 // expects 1 azure upload span, 1 fs span of otel and 2 http spans
-            });
-          });
-        });
-
-        it('upload - err', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/upload-err'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/upload-err',
-              withError: true,
-              spans: spans,
-              op: 'upload',
-              totalspans: 3 // expects 1 azure upload span, 1 fs span of otel and 1 http span
-            });
-          });
-        });
-
-        it('uploadData and delete', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/uploadData'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/uploadData',
-              withError: false,
-              spans: spans,
-              op: 'upload',
-              totalspans: 3 // expects 1 azure upload span, 1 azure delete span and 1 http span
-            });
-          });
-        });
-
-        it('Error in delete-promise', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/deleteError'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/deleteError',
-              withError: true,
-              spans: spans,
-              op: 'delete',
-              totalspans: 2 // expects 1 azure delete span and 1 http span
-            });
-          });
-        });
-
-        it('uploadData-delete-blobBatch-blobUri', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/uploadData-delete-blobBatch-blobUri'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/uploadData-delete-blobBatch-blobUri',
-              withError: false,
-              spans: spans,
-              op: 'delete',
-              totalspans: 4 // expects 1 azure delete span, 1 azure upload span and 2 http span
-            });
-          });
-        });
-
-        it('uploadData-delete-blobBatch-blobClient', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/uploadData-delete-blobBatch-blobClient'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/uploadData-delete-blobBatch-blobClient',
-              withError: false,
-              spans: spans,
-              op: 'delete',
-              totalspans: 4 // expects 1 azure delete span, 1 azure upload span and 2 http span
-            });
-          });
-        });
-
-        it('download-await', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/download-await'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/download-await',
-              withError: false,
-              spans: spans,
-              op: 'download',
-              totalspans: 4 // expects 1 azure delete span, 1 azure upload span, 1 azure download span and 1 http span
-            });
-          });
-        });
-
-        it('download', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/download'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/download',
-              withError: false,
-              spans: spans,
-              op: 'download',
-              totalspans: 6 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 1 http span
-            });
-          });
-        });
-
-        it('download to buffer', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/download-buffer'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/download-buffer',
-              withError: false,
-              spans: spans,
-              op: 'download',
-              totalspans: 7 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 2 http spans
-            });
-          });
-        });
-
-        it('download to buffer-promise', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/download-buffer-promise'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/download-buffer-promise',
-              withError: false,
-              spans: spans,
-              op: 'download',
-              totalspans: 7 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 2 http spans
-            });
-          });
-        });
-
-        it('download-promise', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/download-promise'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/download-promise',
-              withError: false,
-              spans: spans,
-              op: 'download',
-              totalspans: 6 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 1 http span
-            });
-          });
-        });
-
-        it('download-promise-err', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/download-promise-err'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/download-promise-err',
-              withError: true,
-              spans: spans,
-              op: 'download',
-              totalspans: 2 // expects 1 azure download span and 1 http span
-            });
-          });
-        });
-
-        it('download - err', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/download-err'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/download-err',
-              withError: true,
-              spans: spans,
-              op: 'download',
-              totalspans: 4 // expects 3 azure spans( delete, upload, download ) and 1 http span
-            });
-          });
-        });
-
-        it('download-blockblob-promise', async () => {
-          await controls.sendRequest({
-            method: 'GET',
-            path: '/download-blockblob-promise'
-          });
-          await retry(async () => {
-            const spans = await agentControls.getSpans();
-            await verify({
-              spanName: 'azstorage',
-              dataProperty: 'azstorage',
-              path: '/download-blockblob-promise',
-              withError: false,
-              spans: spans,
-              op: 'download',
-              totalspans: 4 // expects 3 azure spans( delete, upload, download ) and 1 http span
-            });
-          });
-        });
-
-        async function verify({ spanName, dataProperty, path, withError, spans, op, totalspans }) {
-          const _pid = String(controls.getPid());
-          const parent = verifyHttpRootEntry({
-            spans,
-            apiPath: path,
-            pid: _pid
-          });
-          expectExactlyOneMatching(spans, [
-            span => expect(span.n).to.equal('azstorage'),
-            span => expect(span.k).to.equal(constants.EXIT),
-            span => expect(span.t).to.equal(parent.t),
-            span => expect(span.p).to.equal(parent.s),
-            span => expect(span.f.e).to.equal(_pid),
-            span => expect(span.f.h).to.equal('agent-stub-uuid'),
-            span => expect(span.ec).to.equal(withError ? 1 : 0),
-            span => expect(span.data).to.exist,
-            span =>
-              withError
-                ? expect(span.data[spanName].error).to.exist
-                : expect(span.data[spanName].error).to.be.undefined,
-            span => expect(span.data[dataProperty || spanName]).to.be.an('object'),
-            span => expect(span.data[dataProperty || spanName].accountName).to.exist,
-            span => expect(span.data[dataProperty || spanName].blobName).to.exist,
-            span => expect(span.data[dataProperty || spanName].containerName).to.exist,
-            span => expect(span.data[dataProperty || spanName].op).to.exist,
-            span => expect(span.data[dataProperty].op).to.equal(op)
-          ]);
-          expectExactlyNMatching(spans, totalspans, [
-            span => expect(span.n).exist,
-            span => expect(span.k).to.exist,
-            span => expect(span.t).to.exist,
-            span => expect(span.f.e).to.equal(_pid),
-            span => expect(span.f.h).to.equal('agent-stub-uuid'),
-            span => expect(span.s).to.exist,
-            span => expect(span.data).to.exist,
-            span => expect(span.ec).to.exist,
-            span => expect(span.stack).to.exist
-          ]);
-        }
-      });
-      describe('tracing disabled', () => {
-        let controls;
-        before(async () => {
-          controls = new ProcessControls({
-            dirname: __dirname,
-            useGlobalAgent: true,
-            tracingEnabled: false,
-            env: {
-              AZURE_CONTAINER_NAME: containerName,
-              AZURE_CONNECTION_STRING: connStr,
-              AZURE_STORAGE_ACCOUNT: storageAccount,
-              AZURE_ACCOUNT_KEY: accountKey,
-              AZURE_BLOB_VERSION: version
-            }
-          });
-
-          await controls.startAndWaitForAgentConnection();
-        });
-
-        beforeEach(async () => {
-          await agentControls.clearReceivedTraceData();
-        });
-
-        after(async () => {
-          await controls.stop();
-        });
-
-        afterEach(async () => {
-          await controls.clearIpcMessages();
-        });
-
-        describe('attempt to get result', () => {
-          it('should not trace', async () => {
+          it('upload - promise', async () => {
             await controls.sendRequest({
               method: 'GET',
               path: '/upload'
             });
-            return retry(() => delay(config.getTestTimeout() / 4))
-              .then(() => agentControls.getSpans())
-              .then(spans => {
-                if (spans.length > 0) {
-                  fail(`Unexpected spans : ${stringifyItems(spans)}`);
-                }
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/upload',
+                withError: false,
+                spans: spans,
+                op: 'upload',
+                totalspans: 4 // expects 1 azure upload span, 1 fs span of otel and 2 http spans
               });
-          });
-        });
-      });
-      describe('tracing enabled, but supressed', () => {
-        let controls;
-        before(async () => {
-          controls = new ProcessControls({
-            dirname: __dirname,
-            useGlobalAgent: true,
-            env: {
-              AZURE_CONTAINER_NAME: containerName,
-              AZURE_CONNECTION_STRING: connStr,
-              AZURE_STORAGE_ACCOUNT: storageAccount,
-              AZURE_ACCOUNT_KEY: accountKey,
-              AZURE_BLOB_VERSION: version
-            }
-          });
-
-          await controls.startAndWaitForAgentConnection();
-        });
-
-        after(async () => {
-          await controls.stop();
-        });
-
-        afterEach(async () => {
-          await controls.clearIpcMessages();
-        });
-
-        describe('attempt to get result', () => {
-          it('should not trace', async () => {
-            await controls.sendRequest({
-              suppressTracing: true,
-              method: 'GET',
-              path: '/upload'
             });
-            return retry(() => delay(config.getTestTimeout() / 4))
-              .then(() => agentControls.getSpans())
-              .then(spans => {
-                if (spans.length > 0) {
-                  fail(`Unexpected spans (suppressed: ${stringifyItems(spans)})`);
-                }
+          });
+
+          it('upload - err', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/upload-err'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/upload-err',
+                withError: true,
+                spans: spans,
+                op: 'upload',
+                totalspans: 3 // expects 1 azure upload span, 1 fs span of otel and 1 http span
               });
+            });
+          });
+
+          it('uploadData and delete', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/uploadData'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/uploadData',
+                withError: false,
+                spans: spans,
+                op: 'upload',
+                totalspans: 3 // expects 1 azure upload span, 1 azure delete span and 1 http span
+              });
+            });
+          });
+
+          it('Error in delete-promise', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/deleteError'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/deleteError',
+                withError: true,
+                spans: spans,
+                op: 'delete',
+                totalspans: 2 // expects 1 azure delete span and 1 http span
+              });
+            });
+          });
+
+          it('uploadData-delete-blobBatch-blobUri', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/uploadData-delete-blobBatch-blobUri'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/uploadData-delete-blobBatch-blobUri',
+                withError: false,
+                spans: spans,
+                op: 'delete',
+                totalspans: 4 // expects 1 azure delete span, 1 azure upload span and 2 http span
+              });
+            });
+          });
+
+          it('uploadData-delete-blobBatch-blobClient', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/uploadData-delete-blobBatch-blobClient'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/uploadData-delete-blobBatch-blobClient',
+                withError: false,
+                spans: spans,
+                op: 'delete',
+                totalspans: 4 // expects 1 azure delete span, 1 azure upload span and 2 http span
+              });
+            });
+          });
+
+          it('download-await', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/download-await'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/download-await',
+                withError: false,
+                spans: spans,
+                op: 'download',
+                totalspans: 4 // expects 1 azure delete span, 1 azure upload span, 1 azure download span and 1 http span
+              });
+            });
+          });
+
+          it('download', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/download'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/download',
+                withError: false,
+                spans: spans,
+                op: 'download',
+                totalspans: 6 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 1 http span
+              });
+            });
+          });
+
+          it('download to buffer', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/download-buffer'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/download-buffer',
+                withError: false,
+                spans: spans,
+                op: 'download',
+                totalspans: 7 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 2 http spans
+              });
+            });
+          });
+
+          it('download to buffer-promise', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/download-buffer-promise'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/download-buffer-promise',
+                withError: false,
+                spans: spans,
+                op: 'download',
+                totalspans: 7 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 2 http spans
+              });
+            });
+          });
+
+          it('download-promise', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/download-promise'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/download-promise',
+                withError: false,
+                spans: spans,
+                op: 'download',
+                totalspans: 6 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 1 http span
+              });
+            });
+          });
+
+          it('download-promise-err', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/download-promise-err'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/download-promise-err',
+                withError: true,
+                spans: spans,
+                op: 'download',
+                totalspans: 2 // expects 1 azure download span and 1 http span
+              });
+            });
+          });
+
+          it('download - err', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/download-err'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/download-err',
+                withError: true,
+                spans: spans,
+                op: 'download',
+                totalspans: 4 // expects 3 azure spans( delete, upload, download ) and 1 http span
+              });
+            });
+          });
+
+          it('download-blockblob-promise', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/download-blockblob-promise'
+            });
+            await retry(async () => {
+              const spans = await agentControls.getSpans();
+              await verify({
+                spanName: 'azstorage',
+                dataProperty: 'azstorage',
+                path: '/download-blockblob-promise',
+                withError: false,
+                spans: spans,
+                op: 'download',
+                totalspans: 4 // expects 3 azure spans( delete, upload, download ) and 1 http span
+              });
+            });
+          });
+
+          async function verify({ spanName, dataProperty, path, withError, spans, op, totalspans }) {
+            const _pid = String(controls.getPid());
+            const parent = verifyHttpRootEntry({
+              spans,
+              apiPath: path,
+              pid: _pid
+            });
+            expectExactlyOneMatching(spans, [
+              span => expect(span.n).to.equal('azstorage'),
+              span => expect(span.k).to.equal(constants.EXIT),
+              span => expect(span.t).to.equal(parent.t),
+              span => expect(span.p).to.equal(parent.s),
+              span => expect(span.f.e).to.equal(_pid),
+              span => expect(span.f.h).to.equal('agent-stub-uuid'),
+              span => expect(span.ec).to.equal(withError ? 1 : 0),
+              span => expect(span.data).to.exist,
+              span =>
+                withError
+                  ? expect(span.data[spanName].error).to.exist
+                  : expect(span.data[spanName].error).to.be.undefined,
+              span => expect(span.data[dataProperty || spanName]).to.be.an('object'),
+              span => expect(span.data[dataProperty || spanName].accountName).to.exist,
+              span => expect(span.data[dataProperty || spanName].blobName).to.exist,
+              span => expect(span.data[dataProperty || spanName].containerName).to.exist,
+              span => expect(span.data[dataProperty || spanName].op).to.exist,
+              span => expect(span.data[dataProperty].op).to.equal(op)
+            ]);
+            expectExactlyNMatching(spans, totalspans, [
+              span => expect(span.n).exist,
+              span => expect(span.k).to.exist,
+              span => expect(span.t).to.exist,
+              span => expect(span.f.e).to.equal(_pid),
+              span => expect(span.f.h).to.equal('agent-stub-uuid'),
+              span => expect(span.s).to.exist,
+              span => expect(span.data).to.exist,
+              span => expect(span.ec).to.exist,
+              span => expect(span.stack).to.exist
+            ]);
+          }
+        });
+        describe('tracing disabled', () => {
+          let controls;
+          before(async () => {
+            controls = new ProcessControls({
+              dirname: __dirname,
+              useGlobalAgent: true,
+              tracingEnabled: false,
+              env: {
+                AZURE_CONTAINER_NAME: containerName,
+                AZURE_CONNECTION_STRING: connStr,
+                AZURE_STORAGE_ACCOUNT: storageAccount,
+                AZURE_ACCOUNT_KEY: accountKey,
+                AZURE_BLOB_VERSION: version
+              }
+            });
+
+            await controls.startAndWaitForAgentConnection();
+          });
+
+          beforeEach(async () => {
+            await agentControls.clearReceivedTraceData();
+          });
+
+          after(async () => {
+            await controls.stop();
+          });
+
+          afterEach(async () => {
+            await controls.clearIpcMessages();
+          });
+
+          describe('attempt to get result', () => {
+            it('should not trace', async () => {
+              await controls.sendRequest({
+                method: 'GET',
+                path: '/upload'
+              });
+              return retry(() => delay(config.getTestTimeout() / 4))
+                .then(() => agentControls.getSpans())
+                .then(spans => {
+                  if (spans.length > 0) {
+                    fail(`Unexpected spans : ${stringifyItems(spans)}`);
+                  }
+                });
+            });
+          });
+        });
+        describe('tracing enabled, but supressed', () => {
+          let controls;
+          before(async () => {
+            controls = new ProcessControls({
+              dirname: __dirname,
+              useGlobalAgent: true,
+              env: {
+                AZURE_CONTAINER_NAME: containerName,
+                AZURE_CONNECTION_STRING: connStr,
+                AZURE_STORAGE_ACCOUNT: storageAccount,
+                AZURE_ACCOUNT_KEY: accountKey,
+                AZURE_BLOB_VERSION: version
+              }
+            });
+
+            await controls.startAndWaitForAgentConnection();
+          });
+
+          after(async () => {
+            await controls.stop();
+          });
+
+          afterEach(async () => {
+            await controls.clearIpcMessages();
+          });
+
+          describe('attempt to get result', () => {
+            it('should not trace', async () => {
+              await controls.sendRequest({
+                suppressTracing: true,
+                method: 'GET',
+                path: '/upload'
+              });
+              return retry(() => delay(config.getTestTimeout() / 4))
+                .then(() => agentControls.getSpans())
+                .then(spans => {
+                  if (spans.length > 0) {
+                    fail(`Unexpected spans (suppressed: ${stringifyItems(spans)})`);
+                  }
+                });
+            });
           });
         });
       });

--- a/packages/collector/test/tracing/cloud/azure/blob/test.js
+++ b/packages/collector/test/tracing/cloud/azure/blob/test.js
@@ -35,7 +35,7 @@ const connStr = `DefaultEndpointsProtocol=https;AccountName=${storageAccount};Ac
 const blobServiceClient = BlobServiceClient.fromConnectionString(connStr);
 const containerClient = blobServiceClient.getContainerClient(containerName);
 
-const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
+let mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 
 /**
  * This suite is skipped if no storage account or account key has been provided via AZURE_STORAGE_ACCOUNT_NAME
@@ -55,454 +55,466 @@ if (!storageAccount || !accountKey) {
   });
 } else {
   mochaSuiteFn('tracing/cloud/azure/blob', function () {
-    this.timeout(config.getTestTimeout());
-    globalAgent.setUpCleanUpHooks();
-    const agentControls = globalAgent.instance;
-
-    before(async () => {
-      await createContainer(containerClient);
-    });
-
-    after(async () => {
-      await deleteContainer(containerClient);
-    });
-    describe('tracing enabled', function () {
-      let controls;
-      before(async () => {
-        controls = new ProcessControls({
-          dirname: __dirname,
-          useGlobalAgent: true,
-          env: {
-            AZURE_CONTAINER_NAME: containerName,
-            AZURE_CONNECTION_STRING: connStr,
-            AZURE_STORAGE_ACCOUNT: storageAccount,
-            AZURE_ACCOUNT_KEY: accountKey
-          }
-        });
-
-        await controls.startAndWaitForAgentConnection();
-      });
-
-      beforeEach(async () => {
-        await agentControls.clearReceivedTraceData();
-      });
-
-      after(async () => {
-        await controls.stop();
-      });
-
-      afterEach(async () => {
-        await controls.clearIpcMessages();
-      });
-
-      it('uploads block data', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/uploadDataBlock'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/uploadDataBlock',
-            withError: false,
-            spans: spans,
-            op: 'upload',
-            totalspans: 3 // expects 1 azure upload span and 2 http spans
-          });
-        });
-      });
-
-      it('upload - promise', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/upload'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/upload',
-            withError: false,
-            spans: spans,
-            op: 'upload',
-            totalspans: 4 // expects 1 azure upload span, 1 fs span of otel and 2 http spans
-          });
-        });
-      });
-
-      it('upload - err', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/upload-err'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/upload-err',
-            withError: true,
-            spans: spans,
-            op: 'upload',
-            totalspans: 3 // expects 1 azure upload span, 1 fs span of otel and 1 http span
-          });
-        });
-      });
-
-      it('uploadData and delete', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/uploadData'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/uploadData',
-            withError: false,
-            spans: spans,
-            op: 'upload',
-            totalspans: 3 // expects 1 azure upload span, 1 azure delete span and 1 http span
-          });
-        });
-      });
-
-      it('Error in delete-promise', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/deleteError'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/deleteError',
-            withError: true,
-            spans: spans,
-            op: 'delete',
-            totalspans: 2 // expects 1 azure delete span and 1 http span
-          });
-        });
-      });
-
-      it('uploadData-delete-blobBatch-blobUri', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/uploadData-delete-blobBatch-blobUri'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/uploadData-delete-blobBatch-blobUri',
-            withError: false,
-            spans: spans,
-            op: 'delete',
-            totalspans: 4 // expects 1 azure delete span, 1 azure upload span and 2 http span
-          });
-        });
-      });
-
-      it('uploadData-delete-blobBatch-blobClient', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/uploadData-delete-blobBatch-blobClient'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/uploadData-delete-blobBatch-blobClient',
-            withError: false,
-            spans: spans,
-            op: 'delete',
-            totalspans: 4 // expects 1 azure delete span, 1 azure upload span and 2 http span
-          });
-        });
-      });
-
-      it('download-await', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/download-await'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/download-await',
-            withError: false,
-            spans: spans,
-            op: 'download',
-            totalspans: 4 // expects 1 azure delete span, 1 azure upload span, 1 azure download span and 1 http span
-          });
-        });
-      });
-
-      it('download', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/download'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/download',
-            withError: false,
-            spans: spans,
-            op: 'download',
-            totalspans: 6 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 1 http span
-          });
-        });
-      });
-
-      it('download to buffer', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/download-buffer'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/download-buffer',
-            withError: false,
-            spans: spans,
-            op: 'download',
-            totalspans: 7 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 2 http spans
-          });
-        });
-      });
-
-      it('download to buffer-promise', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/download-buffer-promise'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/download-buffer-promise',
-            withError: false,
-            spans: spans,
-            op: 'download',
-            totalspans: 7 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 2 http spans
-          });
-        });
-      });
-
-      it('download-promise', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/download-promise'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/download-promise',
-            withError: false,
-            spans: spans,
-            op: 'download',
-            totalspans: 6 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 1 http span
-          });
-        });
-      });
-
-      it('download-promise-err', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/download-promise-err'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/download-promise-err',
-            withError: true,
-            spans: spans,
-            op: 'download',
-            totalspans: 2 // expects 1 azure download span and 1 http span
-          });
-        });
-      });
-
-      it('download - err', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/download-err'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/download-err',
-            withError: true,
-            spans: spans,
-            op: 'download',
-            totalspans: 4 // expects 3 azure spans( delete, upload, download ) and 1 http span
-          });
-        });
-      });
-
-      it('download-blockblob-promise', async () => {
-        await controls.sendRequest({
-          method: 'GET',
-          path: '/download-blockblob-promise'
-        });
-        await retry(async () => {
-          const spans = await agentControls.getSpans();
-          await verify({
-            spanName: 'azstorage',
-            dataProperty: 'azstorage',
-            path: '/download-blockblob-promise',
-            withError: false,
-            spans: spans,
-            op: 'download',
-            totalspans: 4 // expects 3 azure spans( delete, upload, download ) and 1 http span
-          });
-        });
-      });
-
-      async function verify({ spanName, dataProperty, path, withError, spans, op, totalspans }) {
-        const _pid = String(controls.getPid());
-        const parent = verifyHttpRootEntry({
-          spans,
-          apiPath: path,
-          pid: _pid
-        });
-        expectExactlyOneMatching(spans, [
-          span => expect(span.n).to.equal('azstorage'),
-          span => expect(span.k).to.equal(constants.EXIT),
-          span => expect(span.t).to.equal(parent.t),
-          span => expect(span.p).to.equal(parent.s),
-          span => expect(span.f.e).to.equal(_pid),
-          span => expect(span.f.h).to.equal('agent-stub-uuid'),
-          span => expect(span.ec).to.equal(withError ? 1 : 0),
-          span => expect(span.data).to.exist,
-          span =>
-            withError ? expect(span.data[spanName].error).to.exist : expect(span.data[spanName].error).to.be.undefined,
-          span => expect(span.data[dataProperty || spanName]).to.be.an('object'),
-          span => expect(span.data[dataProperty || spanName].accountName).to.exist,
-          span => expect(span.data[dataProperty || spanName].blobName).to.exist,
-          span => expect(span.data[dataProperty || spanName].containerName).to.exist,
-          span => expect(span.data[dataProperty || spanName].op).to.exist,
-          span => expect(span.data[dataProperty].op).to.equal(op)
-        ]);
-        expectExactlyNMatching(spans, totalspans, [
-          span => expect(span.n).exist,
-          span => expect(span.k).to.exist,
-          span => expect(span.t).to.exist,
-          span => expect(span.f.e).to.equal(_pid),
-          span => expect(span.f.h).to.equal('agent-stub-uuid'),
-          span => expect(span.s).to.exist,
-          span => expect(span.data).to.exist,
-          span => expect(span.ec).to.exist,
-          span => expect(span.stack).to.exist
-        ]);
+    ['latest', 'v1227'].forEach(version => {
+      // @azure/storage-blob v12.28.0 supports Node.js v20.0.0 and later.
+      if (version === 'latest' && process.versions.node < '20.0.0') {
+        mochaSuiteFn = describe.skip;
       }
-    });
-    describe('tracing disabled', () => {
-      let controls;
+
+      this.timeout(config.getTestTimeout());
+      globalAgent.setUpCleanUpHooks();
+      const agentControls = globalAgent.instance;
+
       before(async () => {
-        controls = new ProcessControls({
-          dirname: __dirname,
-          useGlobalAgent: true,
-          tracingEnabled: false,
-          env: {
-            AZURE_CONTAINER_NAME: containerName,
-            AZURE_CONNECTION_STRING: connStr,
-            AZURE_STORAGE_ACCOUNT: storageAccount,
-            AZURE_ACCOUNT_KEY: accountKey
-          }
-        });
-
-        await controls.startAndWaitForAgentConnection();
-      });
-
-      beforeEach(async () => {
-        await agentControls.clearReceivedTraceData();
+        await createContainer(containerClient);
       });
 
       after(async () => {
-        await controls.stop();
+        await deleteContainer(containerClient);
       });
+      describe('tracing enabled', function () {
+        let controls;
+        before(async () => {
+          controls = new ProcessControls({
+            dirname: __dirname,
+            useGlobalAgent: true,
+            env: {
+              AZURE_CONTAINER_NAME: containerName,
+              AZURE_CONNECTION_STRING: connStr,
+              AZURE_STORAGE_ACCOUNT: storageAccount,
+              AZURE_ACCOUNT_KEY: accountKey,
+              AZURE_BLOB_VERSION: version
+            }
+          });
 
-      afterEach(async () => {
-        await controls.clearIpcMessages();
-      });
+          await controls.startAndWaitForAgentConnection();
+        });
 
-      describe('attempt to get result', () => {
-        it('should not trace', async () => {
+        beforeEach(async () => {
+          await agentControls.clearReceivedTraceData();
+        });
+
+        after(async () => {
+          await controls.stop();
+        });
+
+        afterEach(async () => {
+          await controls.clearIpcMessages();
+        });
+
+        it('uploads block data', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/uploadDataBlock'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/uploadDataBlock',
+              withError: false,
+              spans: spans,
+              op: 'upload',
+              totalspans: 3 // expects 1 azure upload span and 2 http spans
+            });
+          });
+        });
+
+        it('upload - promise', async () => {
           await controls.sendRequest({
             method: 'GET',
             path: '/upload'
           });
-          return retry(() => delay(config.getTestTimeout() / 4))
-            .then(() => agentControls.getSpans())
-            .then(spans => {
-              if (spans.length > 0) {
-                fail(`Unexpected spans : ${stringifyItems(spans)}`);
-              }
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/upload',
+              withError: false,
+              spans: spans,
+              op: 'upload',
+              totalspans: 4 // expects 1 azure upload span, 1 fs span of otel and 2 http spans
             });
-        });
-      });
-    });
-    describe('tracing enabled, but supressed', () => {
-      let controls;
-      before(async () => {
-        controls = new ProcessControls({
-          dirname: __dirname,
-          useGlobalAgent: true,
-          env: {
-            AZURE_CONTAINER_NAME: containerName,
-            AZURE_CONNECTION_STRING: connStr,
-            AZURE_STORAGE_ACCOUNT: storageAccount,
-            AZURE_ACCOUNT_KEY: accountKey
-          }
-        });
-
-        await controls.startAndWaitForAgentConnection();
-      });
-
-      after(async () => {
-        await controls.stop();
-      });
-
-      afterEach(async () => {
-        await controls.clearIpcMessages();
-      });
-
-      describe('attempt to get result', () => {
-        it('should not trace', async () => {
-          await controls.sendRequest({
-            suppressTracing: true,
-            method: 'GET',
-            path: '/upload'
           });
-          return retry(() => delay(config.getTestTimeout() / 4))
-            .then(() => agentControls.getSpans())
-            .then(spans => {
-              if (spans.length > 0) {
-                fail(`Unexpected spans (suppressed: ${stringifyItems(spans)})`);
-              }
+        });
+
+        it('upload - err', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/upload-err'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/upload-err',
+              withError: true,
+              spans: spans,
+              op: 'upload',
+              totalspans: 3 // expects 1 azure upload span, 1 fs span of otel and 1 http span
             });
+          });
+        });
+
+        it('uploadData and delete', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/uploadData'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/uploadData',
+              withError: false,
+              spans: spans,
+              op: 'upload',
+              totalspans: 3 // expects 1 azure upload span, 1 azure delete span and 1 http span
+            });
+          });
+        });
+
+        it('Error in delete-promise', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/deleteError'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/deleteError',
+              withError: true,
+              spans: spans,
+              op: 'delete',
+              totalspans: 2 // expects 1 azure delete span and 1 http span
+            });
+          });
+        });
+
+        it('uploadData-delete-blobBatch-blobUri', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/uploadData-delete-blobBatch-blobUri'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/uploadData-delete-blobBatch-blobUri',
+              withError: false,
+              spans: spans,
+              op: 'delete',
+              totalspans: 4 // expects 1 azure delete span, 1 azure upload span and 2 http span
+            });
+          });
+        });
+
+        it('uploadData-delete-blobBatch-blobClient', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/uploadData-delete-blobBatch-blobClient'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/uploadData-delete-blobBatch-blobClient',
+              withError: false,
+              spans: spans,
+              op: 'delete',
+              totalspans: 4 // expects 1 azure delete span, 1 azure upload span and 2 http span
+            });
+          });
+        });
+
+        it('download-await', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/download-await'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/download-await',
+              withError: false,
+              spans: spans,
+              op: 'download',
+              totalspans: 4 // expects 1 azure delete span, 1 azure upload span, 1 azure download span and 1 http span
+            });
+          });
+        });
+
+        it('download', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/download'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/download',
+              withError: false,
+              spans: spans,
+              op: 'download',
+              totalspans: 6 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 1 http span
+            });
+          });
+        });
+
+        it('download to buffer', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/download-buffer'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/download-buffer',
+              withError: false,
+              spans: spans,
+              op: 'download',
+              totalspans: 7 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 2 http spans
+            });
+          });
+        });
+
+        it('download to buffer-promise', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/download-buffer-promise'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/download-buffer-promise',
+              withError: false,
+              spans: spans,
+              op: 'download',
+              totalspans: 7 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 2 http spans
+            });
+          });
+        });
+
+        it('download-promise', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/download-promise'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/download-promise',
+              withError: false,
+              spans: spans,
+              op: 'download',
+              totalspans: 6 // expects 3 azure spans( delete, upload, download ), 2 fs spans and 1 http span
+            });
+          });
+        });
+
+        it('download-promise-err', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/download-promise-err'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/download-promise-err',
+              withError: true,
+              spans: spans,
+              op: 'download',
+              totalspans: 2 // expects 1 azure download span and 1 http span
+            });
+          });
+        });
+
+        it('download - err', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/download-err'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/download-err',
+              withError: true,
+              spans: spans,
+              op: 'download',
+              totalspans: 4 // expects 3 azure spans( delete, upload, download ) and 1 http span
+            });
+          });
+        });
+
+        it('download-blockblob-promise', async () => {
+          await controls.sendRequest({
+            method: 'GET',
+            path: '/download-blockblob-promise'
+          });
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            await verify({
+              spanName: 'azstorage',
+              dataProperty: 'azstorage',
+              path: '/download-blockblob-promise',
+              withError: false,
+              spans: spans,
+              op: 'download',
+              totalspans: 4 // expects 3 azure spans( delete, upload, download ) and 1 http span
+            });
+          });
+        });
+
+        async function verify({ spanName, dataProperty, path, withError, spans, op, totalspans }) {
+          const _pid = String(controls.getPid());
+          const parent = verifyHttpRootEntry({
+            spans,
+            apiPath: path,
+            pid: _pid
+          });
+          expectExactlyOneMatching(spans, [
+            span => expect(span.n).to.equal('azstorage'),
+            span => expect(span.k).to.equal(constants.EXIT),
+            span => expect(span.t).to.equal(parent.t),
+            span => expect(span.p).to.equal(parent.s),
+            span => expect(span.f.e).to.equal(_pid),
+            span => expect(span.f.h).to.equal('agent-stub-uuid'),
+            span => expect(span.ec).to.equal(withError ? 1 : 0),
+            span => expect(span.data).to.exist,
+            span =>
+              withError
+                ? expect(span.data[spanName].error).to.exist
+                : expect(span.data[spanName].error).to.be.undefined,
+            span => expect(span.data[dataProperty || spanName]).to.be.an('object'),
+            span => expect(span.data[dataProperty || spanName].accountName).to.exist,
+            span => expect(span.data[dataProperty || spanName].blobName).to.exist,
+            span => expect(span.data[dataProperty || spanName].containerName).to.exist,
+            span => expect(span.data[dataProperty || spanName].op).to.exist,
+            span => expect(span.data[dataProperty].op).to.equal(op)
+          ]);
+          expectExactlyNMatching(spans, totalspans, [
+            span => expect(span.n).exist,
+            span => expect(span.k).to.exist,
+            span => expect(span.t).to.exist,
+            span => expect(span.f.e).to.equal(_pid),
+            span => expect(span.f.h).to.equal('agent-stub-uuid'),
+            span => expect(span.s).to.exist,
+            span => expect(span.data).to.exist,
+            span => expect(span.ec).to.exist,
+            span => expect(span.stack).to.exist
+          ]);
+        }
+      });
+      describe('tracing disabled', () => {
+        let controls;
+        before(async () => {
+          controls = new ProcessControls({
+            dirname: __dirname,
+            useGlobalAgent: true,
+            tracingEnabled: false,
+            env: {
+              AZURE_CONTAINER_NAME: containerName,
+              AZURE_CONNECTION_STRING: connStr,
+              AZURE_STORAGE_ACCOUNT: storageAccount,
+              AZURE_ACCOUNT_KEY: accountKey,
+              AZURE_BLOB_VERSION: version
+            }
+          });
+
+          await controls.startAndWaitForAgentConnection();
+        });
+
+        beforeEach(async () => {
+          await agentControls.clearReceivedTraceData();
+        });
+
+        after(async () => {
+          await controls.stop();
+        });
+
+        afterEach(async () => {
+          await controls.clearIpcMessages();
+        });
+
+        describe('attempt to get result', () => {
+          it('should not trace', async () => {
+            await controls.sendRequest({
+              method: 'GET',
+              path: '/upload'
+            });
+            return retry(() => delay(config.getTestTimeout() / 4))
+              .then(() => agentControls.getSpans())
+              .then(spans => {
+                if (spans.length > 0) {
+                  fail(`Unexpected spans : ${stringifyItems(spans)}`);
+                }
+              });
+          });
+        });
+      });
+      describe('tracing enabled, but supressed', () => {
+        let controls;
+        before(async () => {
+          controls = new ProcessControls({
+            dirname: __dirname,
+            useGlobalAgent: true,
+            env: {
+              AZURE_CONTAINER_NAME: containerName,
+              AZURE_CONNECTION_STRING: connStr,
+              AZURE_STORAGE_ACCOUNT: storageAccount,
+              AZURE_ACCOUNT_KEY: accountKey,
+              AZURE_BLOB_VERSION: version
+            }
+          });
+
+          await controls.startAndWaitForAgentConnection();
+        });
+
+        after(async () => {
+          await controls.stop();
+        });
+
+        afterEach(async () => {
+          await controls.clearIpcMessages();
+        });
+
+        describe('attempt to get result', () => {
+          it('should not trace', async () => {
+            await controls.sendRequest({
+              suppressTracing: true,
+              method: 'GET',
+              path: '/upload'
+            });
+            return retry(() => delay(config.getTestTimeout() / 4))
+              .then(() => agentControls.getSpans())
+              .then(spans => {
+                if (spans.length > 0) {
+                  fail(`Unexpected spans (suppressed: ${stringifyItems(spans)})`);
+                }
+              });
+          });
         });
       });
     });

--- a/packages/collector/test/tracing/cloud/azure/blob/test.js
+++ b/packages/collector/test/tracing/cloud/azure/blob/test.js
@@ -54,8 +54,8 @@ if (!storageAccount || !accountKey) {
     });
   });
 } else {
-  ['latest', 'v1227'].forEach(version => {
-    mochaSuiteFn('tracing/cloud/azure/blob', function () {
+  mochaSuiteFn('tracing/cloud/azure/blob', function () {
+    ['latest', 'v1227'].forEach(version => {
       // NOTE: require-mock is not working with ESM apps.
       // TODO: Support for mocking `import` in ESM apps is planned under INSTA-788.
       if (process.env.RUN_ESM && version !== 'latest') return;
@@ -76,7 +76,7 @@ if (!storageAccount || !accountKey) {
       after(async () => {
         await deleteContainer(containerClient);
       });
-      mochaSuiteFn(`@azure/storage-blob@${version}`, function () {
+      describe(`@azure/storage-blob@${version}`, function () {
         describe('tracing enabled', function () {
           let controls;
           before(async () => {

--- a/packages/collector/test/tracing/cloud/azure/blob/test.js
+++ b/packages/collector/test/tracing/cloud/azure/blob/test.js
@@ -56,13 +56,14 @@ if (!storageAccount || !accountKey) {
 } else {
   mochaSuiteFn('tracing/cloud/azure/blob', function () {
     ['latest', 'v1227'].forEach(version => {
+      // NOTE: require-mock is not working with esm apps.
+      // TODO: Support for mocking `import` in ESM apps is planned under INSTA-788.
+      if (process.env.RUN_ESM && version !== 'latest') return;
+
       // @azure/storage-blob v12.28.0 supports Node.js v20.0.0 and later.
       if (version === 'latest' && process.versions.node < '20.0.0') {
         mochaSuiteFn = describe.skip;
       }
-
-      // NOTE: require-mock is not working with esm apps. There is also no need to run the ESM APP for all versions.
-      if (process.env.RUN_ESM && version !== 'latest') return;
 
       this.timeout(config.getTestTimeout());
       globalAgent.setUpCleanUpHooks();

--- a/packages/core/src/tracing/instrumentation/cloud/azure/blob.js
+++ b/packages/core/src/tracing/instrumentation/cloud/azure/blob.js
@@ -16,8 +16,9 @@ let isActive = false;
 exports.spanName = 'azstorage';
 
 exports.init = function init() {
-  // Fronm v12.28.0 the package is purely esm and to support esm apps we use the iitm hook
-  // reference: https://github.com/Azure/azure-sdk-for-js/pull/33329
+  // Starting from v12.28.0, the package has been migrated to ESM.
+  // To support ESM-based applications, we now utilize the IITM hook.
+  // Reference: https://github.com/Azure/azure-sdk-for-js/pull/33329
   hook.onModuleLoad('@azure/storage-blob', instrumentBlob, { nativeEsm: true });
 };
 

--- a/packages/core/src/tracing/instrumentation/cloud/azure/blob.js
+++ b/packages/core/src/tracing/instrumentation/cloud/azure/blob.js
@@ -16,7 +16,9 @@ let isActive = false;
 exports.spanName = 'azstorage';
 
 exports.init = function init() {
-  hook.onModuleLoad('@azure/storage-blob', instrumentBlob);
+  // Fronm v12.28.0 the package is purely esm and to support esm apps we use the iitm hook
+  // reference: https://github.com/Azure/azure-sdk-for-js/pull/33329
+  hook.onModuleLoad('@azure/storage-blob', instrumentBlob, { nativeEsm: true });
 };
 
 function instrumentBlob(blob) {

--- a/packages/core/src/util/hook.js
+++ b/packages/core/src/util/hook.js
@@ -17,7 +17,8 @@ const isESMApp = require('./esm').isESMApp;
  * Import-in-the-middle
  *
  * Offers support for all native ECMAScript Modules within ESM applications.
- * However, it does not provide support for modules loaded from CJS applications.
+ * - Also supports CJS modules within ESM applications.
+ * - However, it does not support for modules loaded from CJS applications.
  *
  * Note: In the next major release, we might transition all CJS modules in ESM applications to be
  * supported with iitmHook. For now, this approach is chosen to minimize risk.


### PR DESCRIPTION
* **Breaking Changes in [@azure/storage-blob](https://www.npmjs.com/package/@azure/storage-blob) v12.28.0**
  * It has dropped support for end-of-life (EOL) versions of Node.js. 
      See: https://github.com/Azure/azure-sdk-for-js/commit/b8ff66f14b2fbea14aabf798b46a0625f5ce7650
  * The package has been migrated to ESM.
      See: https://github.com/Azure/azure-sdk-for-js/pull/33329/files

* **Impact**

  * Due to the migration to ESM, our ESM builds started failing.
  * ESM-based applications were not being traced.

* **Resolution**

  * To address this issue, we enabled the **IITM hook**, which was introduced a year ago.
  * Previously, the IITM hook was not really used because there were no instrumented ESM packages at that time.

  * ESM applications are now successfully traced using the IITM hook.
  * CJS applications continue to be traced using the traditional `require` hook.


ref:  https://jsw.ibm.com/browse/INSTA-47737
