### PR TITLE
test: limited ESM tests to run only latest version of the package

### DIFF
--- a/packages/collector/test/tracing/databases/mysql/test.js
+++ b/packages/collector/test/tracing/databases/mysql/test.js
@@ -49,6 +49,9 @@ function registerSuite(agentControls, driverMode, useExecute, mysql2Version) {
     // Not applicable, mysql does not provide an execute function, only the query function whereas mysql2 provides both.
     return;
   }
+  // NOTE: require-mock is not working with esm apps. There is also no need to run the ESM APP for all versions.
+  // TODO: Support for mocking `import` in ESM apps is planned under INSTA-788.
+  if (process.env.RUN_ESM && mysql2Version !== 'latest') return;
 
   describe(`driver mode: ${driverMode} version: ${mysql2Version || 'default'}, access function: ${
     useExecute ? 'execute' : 'query'

--- a/packages/collector/test/tracing/databases/prisma/test.js
+++ b/packages/collector/test/tracing/databases/prisma/test.js
@@ -30,6 +30,10 @@ describe('tracing/prisma', function () {
     providers.forEach(provider => {
       const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 
+      // NOTE: require-mock is not working with esm apps. There is also no need to run the ESM APP for all versions.
+      // TODO: Support for mocking `import` in ESM apps is planned under INSTA-788.
+      if (process.env.RUN_ESM && version !== 'latest') return;
+
       mochaSuiteFn(`[${version}] with provider ${provider}`, () => {
         if (provider === 'postgresql' && !process.env.PRISMA_POSTGRES_URL) {
           throw new Error('PRISMA_POSTGRES_URL is not set.');

--- a/packages/collector/test/tracing/frameworks/express/test.js
+++ b/packages/collector/test/tracing/frameworks/express/test.js
@@ -24,6 +24,10 @@ const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : descri
     const agentControls = globalAgent.instance;
     globalAgent.setUpCleanUpHooks();
 
+    // NOTE: require-mock is not working with esm apps. There is also no need to run the ESM APP for all versions.
+    // TODO: Support for mocking `import` in ESM apps is planned under INSTA-788.
+    if (process.env.RUN_ESM && version !== 'latest') return;
+
     let controls;
 
     before(async () => {

--- a/packages/collector/test/tracing/frameworks/express_uncaught_errors/test.js
+++ b/packages/collector/test/tracing/frameworks/express_uncaught_errors/test.js
@@ -23,6 +23,10 @@ const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : descri
     const agentControls = globalAgent.instance;
     globalAgent.setUpCleanUpHooks();
 
+    // NOTE: require-mock is not working with esm apps. There is also no need to run the ESM APP for all versions.
+    // TODO: Support for mocking `import` in ESM apps is planned under INSTA-788.
+    if (process.env.RUN_ESM && version !== 'latest') return;
+
     let controls;
 
     before(async () => {

--- a/packages/collector/test/tracing/messaging/amqp/test.js
+++ b/packages/collector/test/tracing/messaging/amqp/test.js
@@ -31,6 +31,10 @@ const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : descri
 
     globalAgent.setUpCleanUpHooks();
 
+    // NOTE: require-mock is not working with esm apps. There is also no need to run the ESM APP for all versions.
+    // TODO: Support for mocking `import` in ESM apps is planned under INSTA-788.
+    if (process.env.RUN_ESM && version !== 'latest') return;
+
     publisherControls = require('./publisherControls');
     consumerControls = require('./consumerControls');
 


### PR DESCRIPTION
ESM  tests currently lack support for mocking imported modules. Because of this limitation, there’s no advantage in running ESM tests across multiple versions of a package.

Until proper mocking support is implemented (see ticket [INSTA-788](https://jsw.ibm.com/browse/INSTA-788)), ESM tests are intentionally restricted to the latest version only.

We've observed that some ESM tests are still running redundantly across the same version of a package. This logic is already correctly enforced in some other apps, and should be consistently applied here as well.

