### PR TITLE
chore: required otel instrumentations on runtime

### DIFF
--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -15,7 +15,6 @@ const tracingUtil = require('./tracingUtil');
 const spanBuffer = require('./spanBuffer');
 const shimmer = require('./shimmer');
 const supportedVersion = require('./supportedVersion');
-const { otelInstrumentations } = require('./opentelemetry-instrumentations');
 const cls = require('./cls');
 const coreUtil = require('../util');
 
@@ -240,6 +239,7 @@ exports.init = function init(_config, downstreamConnection, _processIdentityProv
       initInstrumenations(config);
 
       if (_config.tracing.useOpentelemetry) {
+        const { otelInstrumentations } = require('./opentelemetry-instrumentations');
         otelInstrumentations.init(config, cls);
       }
       if (coreUtil.esm.isESMApp()) {


### PR DESCRIPTION
- if you disable the otel integration, we should not require the plugin at all
- otel eats memory