### PR TITLE
chore(serverless): removed explicit agent-base unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29698,6 +29698,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -59203,7 +59204,6 @@
       "license": "MIT",
       "dependencies": {
         "@instana/core": "4.21.0",
-        "agent-base": "^6.0.2",
         "https-proxy-agent": "^7.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "test:ci:long-running": "lerna run test:ci:long-running --stream",
     "typecheck": "tsc",
     "verify": "lerna run verify --stream",
-    "depcheck": "lerna exec 'npx depcheck --skip-missing --ignores nan,agent-base,@types/*' --stream"
+    "depcheck": "lerna exec 'npx depcheck --skip-missing --ignores nan,@types/*' --stream"
   },
   "devDependencies": {
     "@apollo/gateway": "^2.11.2",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -66,7 +66,6 @@
   "license": "MIT",
   "dependencies": {
     "@instana/core": "4.21.0",
-    "agent-base": "^6.0.2",
     "https-proxy-agent": "^7.0.2"
   }
 }


### PR DESCRIPTION
Previously, we explicitly added agent-base@6.0.2 in packages/serverless/package.json to address a known issue in agent-base@6.0.0, which caused failures when using HTTPS connections with an HTTP proxy in Node.js 15 and 16. This was due to https-proxy-agent specifying a loose version range for agent-base.

See: https://github.com/instana/nodejs/commit/84b597773f94b4a6b18356652396c92cc16ea4c3

However, https-proxy-agent has been updated to version 7, which in turn depends on agent-base@^7.1.2, a version that already includes the necessary fix.
See: https://github.com/TooTallNate/proxy-agents/blob/main/packages/https-proxy-agent/package.json#L31C6-L31C16

As a result, the explicit agent-base dependency is no longer needed and has been safely removed.

There is no direct use of this dependency. 