### PR TITLE
chore: added support for checking exact versions for dependency bots

### DIFF
--- a/bin/dependencies/test/assets/package.json
+++ b/bin/dependencies/test/assets/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test-package-root",
+  "version": "2.1.0",
+  "devDependencies": {
+    "dev-dep": "1.0.0"
+  },
+  "optionalDependencies": {
+    "optional-dep": "1.0.0"
+  }
+}

--- a/bin/dependencies/test/assets/workspace-a/package.json
+++ b/bin/dependencies/test/assets/workspace-a/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test-package",
+  "version": "1.0.0",
+  "dependencies": {
+    "prod-dep": "1.0.0"
+  },
+  "devDependencies": {
+    "dev-dep": "^1.0.0"
+  },
+  "optionalDependencies": {
+    "optional-dep": "~1.0.0"
+  }
+}


### PR DESCRIPTION
Our dependency module needs to respect exact version updates vs tilde/caret updated.

refs https://github.com/instana/nodejs/pull/1913