### PR TITLE
fix(aws-lambda): updated npm dependencies for icr.io/instana/aws-lambda-nodejs

### DIFF
--- a/packages/aws-lambda/layer/Dockerfile
+++ b/packages/aws-lambda/layer/Dockerfile
@@ -4,6 +4,8 @@
 ARG NODEJS_VERSION
 FROM public.ecr.aws/lambda/nodejs:${NODEJS_VERSION}
 
+RUN npm install -g npm@latest
+
 WORKDIR /opt
 COPY tmp/ .
 


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-48333

- node & npm is installed from this image: public.ecr.aws
- it can contain old subdependencies of npm
- ensure we always update npm to latest version (this will also update sub deps)