### PR TITLE
chore: removed unused dev dependency google-protobuf

### DIFF
--- a/currencies.json
+++ b/currencies.json
@@ -341,17 +341,6 @@
     "core": false
   },
   {
-    "name": "google-protobuf",
-    "policy": "45-days",
-    "lastSupportedVersion": "",
-    "latestVersion": "",
-    "cloudNative": false,
-    "isBeta": false,
-    "ignoreUpdates": false,
-    "note": "",
-    "core": false
-  },
-  {
     "name": "got",
     "policy": "45-days",
     "lastSupportedVersion": "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,6 @@
         "fastify-v4": "npm:fastify@4.28.1",
         "gcstats.js": "1.0.0",
         "get-caller-file": "2.0.5",
-        "google-protobuf": "3.21.4",
         "got": "14.4.7",
         "got-v11": "npm:got@11.8.6",
         "graphql": "16.11.0",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,6 @@
     "fastify-v4": "npm:fastify@4.28.1",
     "gcstats.js": "1.0.0",
     "get-caller-file": "2.0.5",
-    "google-protobuf": "3.21.4",
     "got": "14.4.7",
     "got-v11": "npm:got@11.8.6",
     "graphql": "16.11.0",


### PR DESCRIPTION
The **[google-protobuf](https://www.npmjs.com/package/google-protobuf)** dev dependency was originally added as part of **[gRPC](https://github.com/instana/nodejs/commit/03ccd036b112b826d3345b5a298881bd77583e92#diff-883ee43730fdc91237e7073940734c372a16858b89ceccb43941a9ddf2aa15a3)**  support and used  the dependency in tests. 

In V3, we removed gRPC from our [codebase](https://github.com/instana/nodejs/commit/acbfa27ef1ab813b52bec8f458cb19257d89c147#diff-776831654f38fa741989d41f02eb668a1bcd4dc423f0f9eb55b4a8d361a8639b) since the library was [officially deprecated](https://www.npmjs.com/package/grpc). While removing the related tests and files, this dependency was accidentally overlooked.

It is currently not used anywhere in our tracer. Therefore, it has also been removed from the currency report, as it is no longer relevant.


ref:  https://github.com/instana/nodejs/commit/03ccd036b112b826d3345b5a298881bd77583e92#diff-883ee43730fdc91237e7073940734c372a16858b89ceccb43941a9ddf2aa15a3

https://github.com/instana/nodejs/commit/acbfa27ef1ab813b52bec8f458cb19257d89c147#diff-776831654f38fa741989d41f02eb668a1bcd4dc423f0f9eb55b4a8d361a8639b
