### PR TITLE
test(redis): removed unused redis cluster configuration from docker-compose

### DIFF
--- a/docker-compose-base.yaml
+++ b/docker-compose-base.yaml
@@ -5,43 +5,6 @@ services:
     ports:
       - 6379:6379
 
-  redis-node-0:
-    image: docker.io/bitnami/redis-cluster:7.2
-    environment:
-      - 'ALLOW_EMPTY_PASSWORD=yes'
-      - 'REDIS_NODES=172.30.0.2:6379 172.30.0.3:6379 172.30.0.4:6379'
-      - 'REDIS_CLUSTER_CREATOR=yes'
-      - 'REDIS_CLUSTER_REPLICAS=0'
-      - 'BITNAMI_DEBUG=1'
-      - 'REDIS_CLUSTER_SLEEP_BEFORE_DNS_LOOKUP=10'
-    ports:
-      - 6380:6379
-    networks:
-      redis-cluster-network:
-        ipv4_address: 172.30.0.2
-
-  redis-node-1:
-    image: docker.io/bitnami/redis-cluster:7.2
-    environment:
-      - 'ALLOW_EMPTY_PASSWORD=yes'
-      - 'REDIS_NODES=172.30.0.2:6379 172.30.0.3:6379 172.30.0.4:6379'
-    ports:
-      - 6381:6379
-    networks:
-      redis-cluster-network:
-        ipv4_address: 172.30.0.3      
-
-  redis-node-2:
-    image: docker.io/bitnami/redis-cluster:7.2
-    environment:
-      - 'ALLOW_EMPTY_PASSWORD=yes'
-      - 'REDIS_NODES=172.30.0.2:6379 172.30.0.3:6379 172.30.0.4:6379'
-    ports:
-      - 6382:6379
-    networks:
-      redis-cluster-network:
-        ipv4_address: 172.30.0.4
-
  # sentinel test setup       
   redis-slave:
     image: redis:7.4.3


### PR DESCRIPTION
The Redis cluster configuration was removed from Docker Compose because it is no longer in use, and the Bitnami images it relied on are now restricted. 

Since this config is unused, migrating it to a legacy Bitnami image or another alternative is unnecessary. All required testing has already been performed locally and in CI against the Azure Redis cluster. 

If a local or CI Redis setup becomes necessary in the future, we can revisit the configuration and choose a suitable replacement. For now, keeping the reference in Docker Compose serves no practical purpose.
