### PR TITLE
build: downgraded prisma from 6.16.1 to 6.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -196,7 +196,7 @@
         "kafka-avro": "3.2.0",
         "node-rdkafka": "3.5.0",
         "pg-native": "3.5.2",
-        "prisma": "6.16.0"
+        "prisma": "6.15.0"
       }
     },
     "misc/eslint-plugin": {
@@ -18064,9 +18064,9 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.16.0.tgz",
-      "integrity": "sha512-Q9TgfnllVehvQziY9lJwRJLGmziX0OimZUEQ/MhCUBoJMSScj2VivCjw/Of2vlO1FfyaHXxrvjZAr7ASl7DVcw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.15.0.tgz",
+      "integrity": "sha512-KMEoec9b2u6zX0EbSEx/dRpx1oNLjqJEBZYyK0S3TTIbZ7GEGoVyGyFRk4C72+A38cuPLbfQGQvgOD+gBErKlA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -18077,53 +18077,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.16.0.tgz",
-      "integrity": "sha512-bxzro5vbVqAPkWyDs2A6GpQtRZunD8tyrLmSAchx9u0b+gWCDY6eV+oh5A0YtYT9245dIxQBswckayHuJG4u3w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.15.0.tgz",
+      "integrity": "sha512-y7cSeLuQmyt+A3hstAs6tsuAiVXSnw9T55ra77z0nbNkA8Lcq9rNcQg6PI00by/+WnE/aMRJ/W7sZWn2cgIy1g==",
       "license": "Apache-2.0",
       "optional": true
     },
     "node_modules/@prisma/engines": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.16.0.tgz",
-      "integrity": "sha512-RHJGCH/zi017W4CWYWqg0Sv1pquGGFVo8T3auJ9sodDNaiRzbeNldydjaQzszVS8nscdtcvLuJzy7e65C3puqQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.15.0.tgz",
+      "integrity": "sha512-opITiR5ddFJ1N2iqa7mkRlohCZqVSsHhRcc29QXeldMljOf4FSellLT0J5goVb64EzRTKcIDeIsJBgmilNcKxA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@prisma/debug": "6.16.0",
-        "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-        "@prisma/fetch-engine": "6.16.0",
-        "@prisma/get-platform": "6.16.0"
+        "@prisma/debug": "6.15.0",
+        "@prisma/engines-version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
+        "@prisma/fetch-engine": "6.15.0",
+        "@prisma/get-platform": "6.15.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43.tgz",
-      "integrity": "sha512-ThvlDaKIVrnrv97ujNFDYiQbeMQpLa0O86HFA2mNoip4mtFqM7U5GSz2ie1i2xByZtvPztJlNRgPsXGeM/kqAA==",
+      "version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb.tgz",
+      "integrity": "sha512-a/46aK5j6L3ePwilZYEgYDPrhBQ/n4gYjLxT5YncUTJJNRnTCVjPF86QdzUOLRdYjCLfhtZp9aum90W0J+trrg==",
       "license": "Apache-2.0",
       "optional": true
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.16.0.tgz",
-      "integrity": "sha512-Mx5rml0XRIDizhB9eZxSP8c0nMoXYVITTiJJwxlWn9rNCel8mG8NAqIw+vJlN3gPR+kt3IBkP1SQVsplPPpYrA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.15.0.tgz",
+      "integrity": "sha512-xcT5f6b+OWBq6vTUnRCc7qL+Im570CtwvgSj+0MTSGA1o9UDSKZ/WANvwtiRXdbYWECpyC3CukoG3A04VTAPHw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@prisma/debug": "6.16.0",
-        "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-        "@prisma/get-platform": "6.16.0"
+        "@prisma/debug": "6.15.0",
+        "@prisma/engines-version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
+        "@prisma/get-platform": "6.15.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.16.0.tgz",
-      "integrity": "sha512-eaJOOvAoGslSUTjiQrtE9E0hoBdfL43j8SymOGD6LbdrKRNtIoiy6qiBaEr2fNYD+R/Qns7QOwPhl7SVHJayKA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.15.0.tgz",
+      "integrity": "sha512-Jbb+Xbxyp05NSR1x2epabetHiXvpO8tdN2YNoWoA/ZsbYyxxu/CO/ROBauIFuMXs3Ti+W7N7SJtWsHGaWte9Rg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@prisma/debug": "6.16.0"
+        "@prisma/debug": "6.15.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -42608,15 +42608,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.16.0.tgz",
-      "integrity": "sha512-TTh+H1Kw8N68KN9cDzdAyMroqMOvdCO/Z+kS2wKEVYR1nuR21qH5Q/Db/bZHsAgw7l/TPHtM/veG5VABcdwPDw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.15.0.tgz",
+      "integrity": "sha512-E6RCgOt+kUVtjtZgLQDBJ6md2tDItLJNExwI0XJeBc1FKL+Vwb+ovxXxuok9r8oBgsOXBA33fGDuE/0qDdCWqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@prisma/config": "6.16.0",
-        "@prisma/engines": "6.16.0"
+        "@prisma/config": "6.15.0",
+        "@prisma/engines": "6.15.0"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -260,7 +260,7 @@
     "kafka-avro": "3.2.0",
     "node-rdkafka": "3.5.0",
     "pg-native": "3.5.2",
-    "prisma": "6.16.0"
+    "prisma": "6.15.0"
   },
   "overrides": {
     "kafka-avro": {


### PR DESCRIPTION
Downgrade Prisma from 6.16.1 to 6.15.0, as the latest version has some issues with ESM tests specified here: https://jsw.ibm.com/browse/INSTA-54386