### PR TITLE
chore(aws-fargate): removed default transmission delay transmissionCycle.js

### DIFF
--- a/packages/aws-fargate/src/metrics/transmissionCycle.js
+++ b/packages/aws-fargate/src/metrics/transmissionCycle.js
@@ -8,10 +8,13 @@
 const { backendConnector } = require('@instana/serverless');
 const processorRegistry = require('./processorRegistry');
 
-let transmissionDelay = 1000;
+let transmissionDelay;
 let transmissionTimeoutHandle;
 let isActive = false;
 
+/**
+ * @param {import('@instana/core/src/config').InstanaConfig} config
+ */
 exports.init = function init(config, metadataUri, onReady) {
   transmissionDelay = config.metrics.transmissionDelay;
   processorRegistry.init(config, metadataUri, onReady);


### PR DESCRIPTION
- the default is defined in our core config defaults (or even later in our aws fargate config overrides)
- no need to define another default