### PR TITLE
test: resolved flaky rdkafka tests 

### DIFF
--- a/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
@@ -33,8 +33,9 @@ function setupConsumer() {
   let _consumer;
 
   const consumerOptions = {
-    'metadata.broker.list': '127.0.0.1:9092',
-    'group.id': uuid()
+    'metadata.broker.list': process.env.KAFKA,
+    'group.id': uuid(),
+    'enable.auto.commit': false
   };
 
   if (isStream) {

--- a/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/consumer.js
@@ -33,9 +33,8 @@ function setupConsumer() {
   let _consumer;
 
   const consumerOptions = {
-    'metadata.broker.list': process.env.KAFKA,
-    'group.id': uuid(),
-    'enable.auto.commit': false
+    'metadata.broker.list': '127.0.0.1:9092',
+    'group.id': uuid()
   };
 
   if (isStream) {
@@ -97,9 +96,8 @@ function setupConsumer() {
       span.end();
     });
   } else {
-    _consumer = new Kafka.KafkaConsumer(consumerOptions, {
-      'auto.offset.reset': 'earliest'
-    });
+    _consumer = new Kafka.KafkaConsumer(consumerOptions);
+
     _consumer.connect();
 
     _consumer.on('ready', () => {

--- a/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/producer.js
@@ -21,6 +21,7 @@ const express = require('express');
 const port = require('../../../test_util/app-port')();
 const enableDeliveryCb = process.env.RDKAFKA_PRODUCER_DELIVERY_CB === 'true';
 const isStream = process.env.RDKAFKA_PRODUCER_AS_STREAM === 'true';
+
 const app = express();
 const topic = 'rdkafka-topic';
 let throwDeliveryErr = false;
@@ -113,6 +114,8 @@ let messageCounter = 0;
 const producer = getProducer();
 
 /**
+ * @param {boolean} bufferErrorSender
+ * @param {string} method
  * @param {string} msg
  * @returns {{ wasSent: boolean, topic: string, msg: string, timestamp: number }}
  */
@@ -175,25 +178,22 @@ function doProduce(bufferErrorSender = false, method, msg = 'Node rdkafka is gre
 
       log('Sending message as standard on topic', topic);
 
-      setTimeout(() => {
-        const wasSent = producer.produce(topic, null, theMessage, null, null, null, [
-          { message_counter: ++messageCounter }
-        ]);
+      const wasSent = producer.produce(topic, null, theMessage, null, null, null, [
+        { message_counter: ++messageCounter }
+      ]);
 
-        log('Sent message as standard', wasSent);
+      log('Sent message as standard', wasSent);
 
-        setTimeout(async () => {
-          await fetch(`http://127.0.0.1:${agentPort}`);
-
-          resolve({
-            timestamp: Date.now(),
-            wasSent,
-            topic,
-            msg: theMessage,
-            messageCounter
-          });
-        }, 100);
-      }, 2 * 1000);
+      setTimeout(async () => {
+        await fetch(`http://127.0.0.1:${agentPort}`);
+        resolve({
+          timestamp: Date.now(),
+          wasSent,
+          topic,
+          msg: theMessage,
+          messageCounter
+        });
+      }, 100);
     });
   }
 }

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -58,8 +58,7 @@ const topic = 'rdkafka-topic';
 
 const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 
-// TODO: enable again. Its very flaky
-mochaSuiteFn.skip('tracing/messaging/node-rdkafka', function () {
+mochaSuiteFn.only('tracing/messaging/node-rdkafka', function () {
   this.timeout(config.getTestTimeout() * 10);
 
   globalAgent.setUpCleanUpHooks();

--- a/packages/collector/test/tracing/messaging/node-rdkafka/test.js
+++ b/packages/collector/test/tracing/messaging/node-rdkafka/test.js
@@ -58,7 +58,7 @@ const topic = 'rdkafka-topic';
 
 const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
 
-mochaSuiteFn.only('tracing/messaging/node-rdkafka', function () {
+mochaSuiteFn('tracing/messaging/node-rdkafka', function () {
   this.timeout(config.getTestTimeout() * 10);
 
   globalAgent.setUpCleanUpHooks();


### PR DESCRIPTION
- Removed `auto.offset.reset = earliest` from the Kafka consumer configuration.
  Now the consumer uses the default behavior (usually 'latest'), consuming only messages
  produced after subscription. This prevents re-consuming old messages and ensures
  deterministic test results.

- Removed the 2-second delay before producing messages in the producer.
  Messages are now sent immediately, avoiding test timeouts and race conditions
  with the consumer.
