### PR TITLE
fix: resolved pino compatibility issues for v18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49178,7 +49178,7 @@
       "dependencies": {
         "@instana/core": "4.24.0",
         "@instana/shared-metrics": "4.24.0",
-        "pino": "^9.9.5",
+        "pino": "9.9.5",
         "semver": "^7.7.2",
         "serialize-error": "^8.1.0"
       },

--- a/packages/collector/package.json
+++ b/packages/collector/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@instana/core": "4.24.0",
     "@instana/shared-metrics": "4.24.0",
-    "pino": "^9.9.5",
+    "pino": "9.9.5",
     "semver": "^7.7.2",
     "serialize-error": "^8.1.0"
   },


### PR DESCRIPTION
This PR pins `pino` to version **9.9.5**  to avoid compatibility issues in `v9.10.0`.

**Issue:**

The pipeline v18.18 ESM is failing due to the latest Pino update.

 It throws 
```
TypeError: diagChan.tracingChannel is not a function

```
 because tracingChannel() is not available in Node.js v18.18.
 
This method was added in the latest Pino release, [pino#2281](https://github.com/pinojs/pino/pull/2281) and diagnostics_channel.tracingChannel was introduced in Node.js starting from v18.19 (see [Node.js docs](https://nodejs.org/api/diagnostics_channel.html#diagnostics_channeltracingchannelnameorchannels)).


An [issue](https://github.com/pinojs/pino/issues/2289) has been created in the Pino repo regarding this incompatibility.



