### PR TITLE
fix(http): correctly handle default ports for HTTP/HTTPS exit spans

### DIFF
--- a/packages/collector/test/tracing/protocols/http/client/clientApp.js
+++ b/packages/collector/test/tracing/protocols/http/client/clientApp.js
@@ -345,6 +345,37 @@ app.get('/downstream-call', (req, res) => {
   downstreamReq.end();
 });
 
+app.get('/without-port', (req, res) => {
+  const options = {
+    hostname: 'www.google.com',
+    method: 'GET',
+    path: '/search?q=nodejs',
+    headers: {
+      'User-Agent': 'Node.js'
+    }
+  };
+
+  log('Initiating call to ', 'https://www.google.com/search');
+
+  const request = httpModule.request(options, response => {
+    let data = '';
+    response.on('data', chunk => {
+      data += chunk;
+    });
+    response.on('end', () => {
+      log('Call completed with response:', data);
+      res.status(200).json({ message: 'Call completed', body: data });
+    });
+  });
+
+  request.on('error', err => {
+    log('Error in downstream call:', err.message);
+    res.sendStatus(500);
+  });
+
+  request.end();
+});
+
 function createUrl(req, urlPath) {
   const pathWithQuery = req.query.withQuery ? `${urlPath}?q1=some&pass=verysecret&q2=value` : urlPath;
   return req.query.urlObject ? new URL(pathWithQuery, baseUrl) : baseUrl + pathWithQuery;

--- a/packages/collector/test/tracing/protocols/http/client/test.js
+++ b/packages/collector/test/tracing/protocols/http/client/test.js
@@ -945,6 +945,36 @@ function registerTests(appUsesHttps) {
           })
         )
       ));
+
+  if (appUsesHttps) {
+    it('must NOT append :80 for HTTPS exit spans when no port is specified', () =>
+      clientControls
+        .sendRequest({
+          method: 'GET',
+          path: '/without-port'
+        })
+        .then(() =>
+          retry(() =>
+            globalAgent.instance.getSpans().then(spans => {
+              const exitSpan = spans.find(
+                s =>
+                  s.n === 'node.http.client' &&
+                  s.k === 2 &&
+                  s.data &&
+                  s.data.http &&
+                  s.data.http.method === 'GET' &&
+                  /google\.com/.test(s.data.http.url)
+              );
+
+              expect(exitSpan, 'Expected an exit span for google.com').to.exist;
+              expect(exitSpan.data.http.url).to.equal('https://www.google.com/search');
+              if (exitSpan.data.http.host) {
+                expect(exitSpan.data.http.host).to.not.match(/:80$/);
+              }
+            })
+          )
+        ));
+  }
 }
 
 function registerConnectionRefusalTest(appUsesHttps) {


### PR DESCRIPTION

**Issue:** Outgoing HTTPS requests without an explicit port were showing `:80` in the exit span URL. HTTP requests were not affected.

**Cause:** The span URL construction added the port unconditionally, without checking if it matched the default for the protocol.

 **Fix:** Now, the port is only appended if it is not the default: `443` for HTTPS, `80` for HTTP.

