### PR TITLE
Revert "fix: resolved pino compatibility issues for v18 (#2014)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49109,7 +49109,7 @@
       "dependencies": {
         "@instana/core": "4.24.1",
         "@instana/shared-metrics": "4.24.1",
-        "pino": "9.9.5",
+        "pino": "^9.9.5",
         "semver": "^7.7.2",
         "serialize-error": "^8.1.0"
       },

--- a/packages/collector/package.json
+++ b/packages/collector/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@instana/core": "4.24.1",
     "@instana/shared-metrics": "4.24.1",
-    "pino": "9.9.5",
+    "pino": "^9.9.5",
     "semver": "^7.7.2",
     "serialize-error": "^8.1.0"
   },


### PR DESCRIPTION
This reverts commit a286f2942e5620c80862322e35c3dd31f25a1757.

The compatibility issue was fixed in the latest Pino release https://github.com/pinojs/pino/releases/tag/v9.11.0