### PR TITLE
test: added timeout in the require-hook test

### DIFF
--- a/packages/core/test/util/require_hook/requireHook_test.js
+++ b/packages/core/test/util/require_hook/requireHook_test.js
@@ -167,7 +167,8 @@ describe('util/requireHook', () => {
       expect(hook.getCall(0).args[0]).to.equal('module a');
     });
 
-    describe('real modules', () => {
+    describe('real modules', function () {
+      this.timeout(3500);
       it('must support loading of specific files within a module', () => {
         Object.keys(require.cache).forEach(key => {
           if (key.indexOf('express') !== -1) {


### PR DESCRIPTION
The tests on local are failing due to a timeout.

Randomly getting this is CI: https://cloud.ibm.com/devops/pipelines/tekton/c2cd6a8d-ea5a-47b0-913e-cd172d63833f/runs/ebe67f0e-ea41-4bdc-a7db-aff924acb604/core-task?env_id=ibm:yp:eu-de&view=logs