### PR TITLE
test: fixed false positive in otel-exporter tests by correcting fetch usage

### DIFF
--- a/packages/opentelemetry-exporter/test/app.js
+++ b/packages/opentelemetry-exporter/test/app.js
@@ -31,7 +31,8 @@ const app = express();
 
 app.get('/otel-test', (_req, res) => {
   delay(500)
-    .then(() => fetch('https://www.example.com'))
+    .then(() => fetch('https://www.google.com'))
+    .then(response => response.text())
     .then(text => {
       res.send({ ok: true, data: `${text.substr(0, 10)}...` });
     })
@@ -42,7 +43,8 @@ app.get('/otel-test', (_req, res) => {
 
 app.post('/otel-post', (_req, res) => {
   delay(500)
-    .then(() => fetch('https://www.example.com'))
+    .then(() => fetch('https://www.google.com', { method: 'POST' }))
+    .then(response => response.text())
     .then(text => {
       res.send({ ok: true, data: `${text.substr(0, 10)}...` });
     })

--- a/packages/opentelemetry-exporter/test/test.js
+++ b/packages/opentelemetry-exporter/test/test.js
@@ -206,15 +206,16 @@ mochaSuiteFn('Instana OpenTelemetry Exporter', function () {
 });
 
 function verifySpans(spans, appControls) {
-  // ENTRY /otel-test
-  // EXIT www.example.com
-  // 1 x tlc connect, 1 x tls connect
+  // 1 x ENTRY /otel-test
+  // 1 x EXIT https://www.google.com/
+  // 1 x tcp connect
+  // 1 x tls connect
   // NOTE: middleware spans are not collected when migrating to express v5 because:
   //       middleware initialization was removed in
   //         https://github.com/expressjs/express/commit/78e50547f16e2adb5763a953586d05308d8aba4c.
   //       middleware query functionality was removed in:
   //         https://github.com/expressjs/express/commit/dcc4eaabe86a4309437db2a853c5ef788a854699
-  expectExactlyNMatching(spans, 3, [
+  expectExactlyNMatching(spans, 4, [
     span => expect(span.ec).to.eq(0),
     span => expect(span.f.e).to.eq(appControls.getTestAppPid()),
     span => expect(span.n).to.eq('otel'),


### PR DESCRIPTION
- Fixed an issue in app.js where fetch was misused, causing OpenTelemetry spans to be generated incorrectly.
- The test expected 4 spans, but only 3 were asserted due to incorrect fetch handling.
- Corrected fetch usage to properly extract response bodies and ensure POST requests are sent as intended.
