### PR TITLE
ci: splitted collector-tracing-messaging tests into 5 builds

### DIFF
--- a/.tekton/generate-test-files.js
+++ b/.tekton/generate-test-files.js
@@ -67,7 +67,7 @@ const groups = {
       'rabbitmq'
     ],
     condition: ' && ! echo "$MODIFIED_FILES" | grep -q "packages/core/src/tracing/instrumentation/messaging"',
-    split: 4,
+    split: 5,
     scope: '@instana/collector',
     subname: 'test:ci:tracing:messaging'
   },

--- a/.tekton/tasks/test-groups/collector-tracing-messaging-split-2-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-messaging-split-2-task.yaml
@@ -224,20 +224,20 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            if [[ 4 =~ ^[0-9]+$ ]]; then
-              CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-2"
+            if [[ 5 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=2 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-2"
             else
                npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-2"
             fi
           else
-            if [[ 4 =~ ^[0-9]+$ ]]; then
-              CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"
+            if [[ 5 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=2 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"
             else
               npm run "test:ci:collector:tracing:messaging"
             fi
           fi          
           if [ $? -eq 0 ]; then
-            if [[ 4 =~ ^[0-9]+$ ]]; then
+            if [[ 5 =~ ^[0-9]+$ ]]; then
               touch "test:ci:tracing:messaging.succeeded"
             else
               touch "test:ci:collector:tracing:messaging.succeeded"
@@ -245,7 +245,7 @@ spec:
             break
           else
             if [ $retry -eq 3 ]; then
-              if [[ 4 =~ ^[0-9]+$ ]]; then
+              if [[ 5 =~ ^[0-9]+$ ]]; then
                 touch "test:ci:tracing:messaging.failed"
               else
                 touch "test:ci:collector:tracing:messaging.failed"

--- a/.tekton/tasks/test-groups/collector-tracing-messaging-split-3-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-messaging-split-3-task.yaml
@@ -224,20 +224,20 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            if [[ 4 =~ ^[0-9]+$ ]]; then
-              CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-3"
+            if [[ 5 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=3 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-3"
             else
                npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-3"
             fi
           else
-            if [[ 4 =~ ^[0-9]+$ ]]; then
-              CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=3 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"
+            if [[ 5 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=3 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"
             else
               npm run "test:ci:collector:tracing:messaging"
             fi
           fi          
           if [ $? -eq 0 ]; then
-            if [[ 4 =~ ^[0-9]+$ ]]; then
+            if [[ 5 =~ ^[0-9]+$ ]]; then
               touch "test:ci:tracing:messaging.succeeded"
             else
               touch "test:ci:collector:tracing:messaging.succeeded"
@@ -245,7 +245,7 @@ spec:
             break
           else
             if [ $retry -eq 3 ]; then
-              if [[ 4 =~ ^[0-9]+$ ]]; then
+              if [[ 5 =~ ^[0-9]+$ ]]; then
                 touch "test:ci:tracing:messaging.failed"
               else
                 touch "test:ci:collector:tracing:messaging.failed"

--- a/.tekton/tasks/test-groups/collector-tracing-messaging-split-5-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-messaging-split-5-task.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: collector-tracing-messaging-split-4
+  name: collector-tracing-messaging-split-5
 spec:
   sidecars:
     - name: zookeeper
@@ -225,13 +225,13 @@ spec:
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
             if [[ 5 =~ ^[0-9]+$ ]]; then
-              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=4 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-4"
+              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=5 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-5"
             else
-               npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-4"
+               npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging-split-5"
             fi
           else
             if [[ 5 =~ ^[0-9]+$ ]]; then
-              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=4 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"
+              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=5 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"
             else
               npm run "test:ci:collector:tracing:messaging"
             fi

--- a/.tekton/tasks/test-groups/collector-tracing-messaging-task.yaml
+++ b/.tekton/tasks/test-groups/collector-tracing-messaging-task.yaml
@@ -224,20 +224,20 @@ spec:
         retry=1
         while [ $retry -le 3 ]; do
           if [ "$(params.coverage)" == "true" ]; then
-            if [[ 4 =~ ^[0-9]+$ ]]; then
-              CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging"
+            if [[ 5 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=1 npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging"
             else
                npm run coverage-ci --npm_command="test:ci:collector:tracing:messaging" --report_dir="collector-tracing-messaging"
             fi
           else
-            if [[ 4 =~ ^[0-9]+$ ]]; then
-              CI_TEST_SPLIT=4 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"
+            if [[ 5 =~ ^[0-9]+$ ]]; then
+              CI_TEST_SPLIT=5 CI_TEST_SPLIT_CURRENT=1 npx lerna run "test:ci:tracing:messaging" --stream --scope="@instana/collector"
             else
               npm run "test:ci:collector:tracing:messaging"
             fi
           fi          
           if [ $? -eq 0 ]; then
-            if [[ 4 =~ ^[0-9]+$ ]]; then
+            if [[ 5 =~ ^[0-9]+$ ]]; then
               touch "test:ci:tracing:messaging.succeeded"
             else
               touch "test:ci:collector:tracing:messaging.succeeded"
@@ -245,7 +245,7 @@ spec:
             break
           else
             if [ $retry -eq 3 ]; then
-              if [[ 4 =~ ^[0-9]+$ ]]; then
+              if [[ 5 =~ ^[0-9]+$ ]]; then
                 touch "test:ci:tracing:messaging.failed"
               else
                 touch "test:ci:collector:tracing:messaging.failed"


### PR DESCRIPTION
- the enabling of rdkafka slows down the build