### PR TITLE
fix: OpenTelemetry instrumentation packages updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11979,6 +11979,22 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.26.0.tgz",
+      "integrity": "sha512-Z+r5EMhJqIqb6sWp0+zTI77HJ10yZOv6RUdh3U67D4KSIvpIU/WvhMa9OSoLwJSlNTXBPHJwhBpS88QVuV4OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.207.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
       "version": "0.207.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
@@ -16180,6 +16196,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.2.tgz",
       "integrity": "sha512-dKkr1bTxbEsFlh2ARpKzcaAmsYixqt9UyCdoEZk8rHyE4iQYcDCyvSjDSf7JUWJHlJiTtbIoQjxKh6ViywqDAg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/sinon": {
@@ -16219,10 +16236,10 @@
       }
     },
     "node_modules/@types/tedious": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.12.tgz",
-      "integrity": "sha512-5NBYCLmidyXG3zxiBmR0beORRQcJOBoTKVL+9WaHQbX0E386UFXw6TSlY9/oxZDYqUWlBC98Funb83eJQt1aMw==",
-      "dev": true,
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -26243,6 +26260,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -27591,6 +27609,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -28745,6 +28764,7 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
       "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -35992,7 +36012,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-platform": {
       "version": "0.11.15",
@@ -38822,6 +38843,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
       "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",
@@ -38856,6 +38878,7 @@
       "version": "1.22.6",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
       "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -41222,6 +41245,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -44765,7 +44789,7 @@
         "@opentelemetry/instrumentation-oracledb": "0.33.0",
         "@opentelemetry/instrumentation-restify": "0.53.0",
         "@opentelemetry/instrumentation-socket.io": "0.54.0",
-        "@opentelemetry/instrumentation-tedious": "0.13.0",
+        "@opentelemetry/instrumentation-tedious": "0.26.0",
         "@opentelemetry/sdk-trace-base": "1.25.0",
         "cls-bluebird": "^2.1.0",
         "import-in-the-middle": "2.0.0",
@@ -44810,63 +44834,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "packages/core/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.0.tgz",
-      "integrity": "sha512-LPwSIrw+60cheWaXsfGL8stBap/AppKQJFE+qqRvzYrgttXFH2ofoIMxWadeqPTq4BYOXM/C7Bdh/T+B60xnlQ==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.52.0",
-        "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.8.0",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "packages/core/node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.13.0.tgz",
-      "integrity": "sha512-Pob0+0R62AqXH50pjazTeGBy/1+SK4CYpFUBV5t7xpbpeuQezkkgVGvLca84QqjBqQizcXedjpUJLgHQDixPQg==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
-        "@opentelemetry/semantic-conventions": "^1.22.0",
-        "@types/tedious": "^4.0.14"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "packages/core/node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
-      "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "packages/core/node_modules/@opentelemetry/instrumentation/node_modules/import-in-the-middle": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.8.0.tgz",
-      "integrity": "sha512-/xQjze8szLNnJ5rvHSzn+dcVXqCAU6Plbk4P24U/jwPmg1wy7IIp9OjKIO5tYue8GSPhDpPDiApQjvBUmWwhsQ==",
-      "dependencies": {
-        "acorn": "^8.8.2",
-        "acorn-import-attributes": "^1.9.5",
-        "cjs-module-lexer": "^1.2.2",
-        "module-details-from-path": "^1.0.3"
-      }
-    },
     "packages/core/node_modules/@opentelemetry/resources": {
       "version": "1.25.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.0.tgz",
@@ -44904,14 +44871,6 @@
       "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ==",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "packages/core/node_modules/@types/tedious": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
-      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "packages/core/node_modules/import-in-the-middle": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
     "@opentelemetry/instrumentation-oracledb": "0.33.0",
     "@opentelemetry/instrumentation-restify": "0.53.0",
     "@opentelemetry/instrumentation-socket.io": "0.54.0",
-    "@opentelemetry/instrumentation-tedious": "0.13.0",
+    "@opentelemetry/instrumentation-tedious": "0.26.0",
     "@opentelemetry/sdk-trace-base": "1.25.0",
     "cls-bluebird": "^2.1.0",
     "import-in-the-middle": "2.0.0",


### PR DESCRIPTION
**Changes**

- Load @opentelemetry/api from the app root to ensure all instrumentations and monkey patches share the same global API instance.

- Add peer dependency with bounded version range (>=1.3.0 <1.10.0) to enforce compatibility and avoid runtime issues like NonRecordingSpan.

- Updated all @opentelemetry instrumentations versions to latest



What This PR resolves

This PR addresses the multiple API instance issue that occurred when @opentelemetry/api was also installed at the application root. In such cases, our openTelemetry integretion was not functioning correctly before.

When the OTEL SDK and our collector are used together within the same application:

- If the OTEL SDK is initialized first, it now correctly captures all our instrumented libraries (including our OTEL). Previously, this was not happening. OTEL also works.

- If our collector is initialized first, it currently blocks OTEL tracing - this is a known issue and will be addressed separately.


This PR resolves the multiple instance problem. Tests demonstrating OTEL SDK and our collector behaviors will be included in a separate PR.


There is still issue when our collector initialized first.

References:

h[ttps://github.com/open-telemetry/opentelemetry-js/issues/4832](url)
https://github.com/open-telemetry/opentelemetry-js/issues/5454
https://jsw.ibm.com/browse/INSTA-59002