### PR TITLE
build: added an option to skip deps from prod update bot

### DIFF
--- a/.tekton/listeners/prod-dependency-bot.yaml
+++ b/.tekton/listeners/prod-dependency-bot.yaml
@@ -28,6 +28,8 @@ spec:
       value: $(params.prod-deps-pr-limit)
     - name: org-pr-limit
       value: $(params.org-pr-limit)
+    - name: skip-deps
+      value: $(params.skip-deps)
     - name: pl-name
       value: "prod-dependency-bot-$(params.node-version)"
     - name: pipeline-ref

--- a/.tekton/pipeline/prod-dependency-bot-pipeline.yaml
+++ b/.tekton/pipeline/prod-dependency-bot-pipeline.yaml
@@ -44,6 +44,8 @@ spec:
       value: $(params.prod-deps-pr-limit)
     - name: org-pr-limit
       value: $(params.org-pr-limit)
+    - name: skip-deps
+      value: $(params.skip-deps)
   workspaces:
     - name: artifacts
   tasks:
@@ -156,6 +158,8 @@ spec:
           value: $(params.prod-deps-pr-limit)
         - name: org-pr-limit
           value: $(params.org-pr-limit)
+        - name: skip-deps
+          value: $(params.skip-deps)
       workspaces:
         - name: output
           workspace: artifacts

--- a/.tekton/pipeline/trigger-template.yaml
+++ b/.tekton/pipeline/trigger-template.yaml
@@ -58,6 +58,8 @@ spec:
       value: $(params.pr-payload)
     - name: org-pr-limit
       value: $(params.org-pr-limit)
+    - name: skip-deps
+      value: $(params.skip-deps)
 
   resourcetemplates:
     - apiVersion: v1
@@ -140,3 +142,5 @@ spec:
             value: $(params.pr-payload)
           - name: org-pr-limit
             value: $(params.org-pr-limit)
+          - name: skip-deps
+            value: $(params.skip-deps)

--- a/.tekton/tasks/update-prod-dependencies.yaml
+++ b/.tekton/tasks/update-prod-dependencies.yaml
@@ -16,6 +16,8 @@ spec:
       value: $(params.prod-deps-pr-limit)
     - name: org-pr-limit
       value: $(params.org-pr-limit)
+    - name: skip-deps
+      value: $(params.skip-deps)
   workspaces:
     - name: output
       mountPath: /artifacts
@@ -52,6 +54,6 @@ spec:
         gh auth login --with-token
         
         echo "Running production dependency updates..."
-        PROD_DEPS_PR_LIMIT=$(params.prod-deps-pr-limit) ORG_PR_LIMIT=$(params.org-pr-limit) BRANCH=build node bin/dependencies/production/update-prod-dependencies.js
+        PROD_DEPS_PR_LIMIT=$(params.prod-deps-pr-limit) ORG_PR_LIMIT=$(params.org-pr-limit) SKIP_DEPS=$(params.skip-deps) BRANCH=build node bin/dependencies/production/update-prod-dependencies.js
 
         

--- a/bin/dependencies/production/update-prod-dependencies.js
+++ b/bin/dependencies/production/update-prod-dependencies.js
@@ -11,6 +11,7 @@ const BRANCH = process.env.BRANCH;
 const SKIP_PUSH = process.env.SKIP_PUSH === 'true';
 const PROD_DEPS_PR_LIMIT = process.env.PROD_DEPS_PR_LIMIT || 5;
 const ORG_PR_LIMIT = process.env.ORG_PR_LIMIT || 2;
+const SKIP_DEPS = process.env.SKIP_DEPS ? process.env.SKIP_DEPS.split(',').map(p => p.trim()) : [];
 const cwd = path.join(__dirname, '..', '..', '..');
 
 if (!BRANCH) throw new Error('Please set env variable "BRANCH".');
@@ -19,6 +20,7 @@ console.log(`BRANCH: ${BRANCH}`);
 console.log(`SKIP_PUSH: ${SKIP_PUSH}`);
 console.log(`PROD_DEPS_PR_LIMIT: ${PROD_DEPS_PR_LIMIT}`);
 console.log(`ORG_PR_LIMIT: ${ORG_PR_LIMIT}`);
+console.log(`SKIP_DEPS: ${SKIP_DEPS.length ? SKIP_DEPS.join(', ') : '(none)'}`);
 
 const updatedProdDeps = [];
 const orgPrCount = {};
@@ -40,6 +42,10 @@ pkgPaths.forEach(obj => {
 });
 
 Object.entries(dependencyMap).some(([dep, usageList]) => {
+  if (SKIP_DEPS.includes(dep)) {
+    console.log(`Skipping ${dep}. It is listed in SKIP_DEPS.`);
+    return false;
+  }
   if (updatedProdDeps.length >= PROD_DEPS_PR_LIMIT) return true;
 
   const orgName = dep.startsWith('@') ? dep.split('/')[0] : null;


### PR DESCRIPTION
Some prod dependencies (e.g., lru-cache, pino, etc.) require Node.js v20 or higher. Since we still support Node.js v18, these packages will be skipped from the production dependency update process.

We plan to drop Node.js v18 support in version 6 (2026). Until then, there’sno need to create bump PRs for these dependencies.

The list of skipped dependencies can be easily managed through theSKIP_DEPS variable in tekton. Update this list as needed to control which packages are excluded from automatic updates.