### PR TITLE
build: bumped jwa sub dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34512,12 +34512,13 @@
       }
     },
     "node_modules/jsonwebtoken/node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
@@ -34591,12 +34592,13 @@
       "dev": true
     },
     "node_modules/jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }


### PR DESCRIPTION
refs https://github.com/auth0/node-jwa/issues/46
refs https://jsw.ibm.com/browse/INSTA-55999

Before:

> @instana/root@ /Users/kirrg001/dev/instana/nodejs
├─┬ @google-cloud/pubsub@5.2.0
│ └─┬ google-auth-library@10.0.0-rc.1
│   └─┬ jws@4.0.0
│     └─┬ jwa@2.0.0
│       └── buffer-equal-constant-time@1.0.1
└─┬ tedious@19.0.0
  └─┬ @azure/identity@4.4.1
    └─┬ @azure/msal-node@2.9.2
      └─┬ jsonwebtoken@9.0.2
        └─┬ jws@3.2.2
          └─┬ jwa@1.4.1
            └── buffer-equal-constant-time@1.0.1 deduped
           
After:

> @instana/root@ /Users/kirrg001/dev/instana/nodejs
├─┬ @google-cloud/pubsub@5.2.0
│ └─┬ google-auth-library@10.0.0-rc.1
│   └─┬ jws@4.0.0
│     └─┬ jwa@2.0.1
│       └── buffer-equal-constant-time@1.0.1
└─┬ tedious@19.0.0
  └─┬ @azure/identity@4.4.1
    └─┬ @azure/msal-node@2.9.2
      └─┬ jsonwebtoken@9.0.2
        └─┬ jws@3.2.2
          └─┬ jwa@1.4.2
            └── buffer-equal-constant-time@1.0.1 deduped

This should fix some tests for v25.
