### PR TITLE
chore: updated unstable release keywords list in currency reports

### DIFF
--- a/bin/dependencies/utils.js
+++ b/bin/dependencies/utils.js
@@ -122,7 +122,17 @@ exports.getLatestVersion = ({ pkgName, installedVersion, isBeta }) => {
 };
 
 function filterStableReleases(releaseList) {
-  const unstableReleaseKeyWords = ['alpha', 'beta', 'canary', 'dev', 'experimental', 'next', 'rc', 'integration'];
+  const unstableReleaseKeyWords = [
+    'alpha',
+    'beta',
+    'canary',
+    'dev',
+    'experimental',
+    'integration',
+    'next',
+    'rc',
+    'unstable'
+  ];
 
   return Object.fromEntries(
     Object.entries(releaseList).filter(


### PR DESCRIPTION
The  days behind calculation for elastic search was wrong, due to they have release like [9.3.0-unstable.20251027183018](https://www.npmjs.com/package/@elastic/elasticsearch/v/9.3.0-unstable.20251027183018).

currency-report:

<img width="1035" height="81" alt="image" src="https://github.com/user-attachments/assets/e3d6d887-5c52-4006-8529-a37b75879a4c" />



