### PR TITLE
fix: bumped tar from 7.5.1 to 7.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52640,7 +52640,7 @@
         "detect-libc": "^2.1.2",
         "event-loop-lag": "^1.4.0",
         "semver": "^7.7.3",
-        "tar": "^7.5.1"
+        "tar": "^7.5.2"
       },
       "devDependencies": {
         "@types/tar": "^6.1.6"
@@ -52702,10 +52702,10 @@
       }
     },
     "packages/shared-metrics/node_modules/tar": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
-      "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
-      "license": "ISC",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",

--- a/packages/shared-metrics/package.json
+++ b/packages/shared-metrics/package.json
@@ -63,7 +63,7 @@
     "detect-libc": "^2.1.2",
     "event-loop-lag": "^1.4.0",
     "semver": "^7.7.3",
-    "tar": "^7.5.1"
+    "tar": "^7.5.2"
   },
   "devDependencies": {
     "@types/tar": "^6.1.6"


### PR DESCRIPTION
> Severity: moderate
> @instana/shared-metrics: node-tar has a race condition leading to uninitialized memory exposure - https://github.com/advisories/GHSA-29xp-372q-xqph
> @instana/shared-metrics: fix available via `npm audit fix`
> @instana/shared-metrics: packages/shared-metrics/node_modules/tar

https://github.com/advisories/GHSA-29xp-372q-xqph

ref https://github.com/isaacs/node-tar/issues/445