### PR TITLE
test: updated test for elasticsearch to run on node.js v20 or higher

### DIFF
--- a/packages/collector/test/tracing/databases/elasticsearch/test.js
+++ b/packages/collector/test/tracing/databases/elasticsearch/test.js
@@ -41,7 +41,7 @@ mochaSuiteFn('tracing/elasticsearch', function () {
     {
       version: 'latest',
       instrumentationFlavor: 'transport',
-      engine: '18.0.0'
+      engine: '20.0.0'
     },
     {
       version: '7.17.0',


### PR DESCRIPTION
Elasticsearch v9.2.0  now requires a minimum Node.js version of 20.

see: https://www.npmjs.com/package/@elastic/elasticsearch#nodejs-support

