### PR TITLE
chore: changed yargs require stmt

### DIFF
--- a/bin/clean-aws.js
+++ b/bin/clean-aws.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-const yargs = require('yargs/yargs');
+const yargs = require('yargs');
 const { hideBin } = require('yargs/helpers');
 const aws = require('aws-sdk');
 const region = { region: 'us-east-2' };


### PR DESCRIPTION
> TS error for yargs - you can see that the lock file was updated caused by the version updates. Somehow yargs/yargs cannot be resolved anymore on TS level. Fixed by just using yargs. I could not find a hint why yargs/yargs was needed.

> node bin/clean-aws.js --help

works fine

https://www.npmjs.com/package/yargs

I am not 100% sure why we get this TS error suddenly. The investigation is not worth it - its just a script. Initially I thought its caused by the sub dependency updates in #2115 , but I also saw the error in #2128 