### PR TITLE
fix: removed deprecated env variables and config options for disable tracing

### DIFF
--- a/packages/aws-lambda/test/integration_test/test_definition.js
+++ b/packages/aws-lambda/test/integration_test/test_definition.js
@@ -1039,42 +1039,6 @@ function registerTests(handlerDefinitionPath, reduced) {
     });
   });
 
-  describeOrSkipIfReduced()('when deprecated INSTANA_DISABLE_TRACING is set', function () {
-    // - INSTANA_ENDPOINT_URL is missing
-    // - lambda function ends with success
-    const env = prelude.bind(this)({
-      handlerDefinitionPath,
-      instanaAgentKey,
-      instanaTracingDisabled: true
-    });
-
-    let control;
-
-    before(async () => {
-      control = new Control({
-        faasRuntimePath: path.join(__dirname, '../runtime_mock'),
-        handlerDefinitionPath,
-        startBackend: true,
-        env
-      });
-
-      await control.start();
-    });
-
-    beforeEach(async () => {
-      await control.reset();
-      await control.resetBackendSpansAndMetrics();
-    });
-
-    after(async () => {
-      await control.stop();
-    });
-
-    it('expect no tracing data', () => {
-      return verify(control, { error: false, expectMetrics: false, expectSpans: false });
-    });
-  });
-
   describeOrSkipIfReduced()('when INSTANA_TRACING_DISABLE is set', function () {
     // - INSTANA_ENDPOINT_URL is missing
     // - lambda function ends with success

--- a/packages/core/src/config/configNormalizers/disable.js
+++ b/packages/core/src/config/configNormalizers/disable.js
@@ -16,12 +16,11 @@ exports.init = function init(_config) {
 };
 
 /**
- * Handles deprecated properties, environment variables, and array inputs.
+ * Handles environment variables, and array inputs.
  *
  * Precedence order (highest to lowest):
  * 1. `tracing.disable`
- * 2. `tracing.disabledTracers` (deprecated)
- * 3. Environment variables (`INSTANA_TRACING_DISABLE*`)
+ * 2. Environment variables (`INSTANA_TRACING_DISABLE*`)
  *
  * @param {import('../../config').InstanaConfig} config
  */
@@ -39,17 +38,6 @@ exports.normalize = function normalize(config) {
       logger?.info(
         `Tracing selectively disabled as per "tracing.disable" configuration: ${JSON.stringify(config.tracing.disable)}`
       );
-    }
-    // Handle deprecated `disabledTracers` config
-    if (config.tracing.disabledTracers) {
-      logger?.warn(
-        'The configuration property "tracing.disabledTracers" is deprecated and will be removed in the next ' +
-          'major release. Please use "tracing.disable" instead.'
-      );
-      if (!hasDisableConfig) {
-        config.tracing.disable = { instrumentations: config.tracing.disabledTracers };
-      }
-      delete config.tracing.disabledTracers;
     }
 
     // Fallback to environment variables if `disable` is not explicitly configured
@@ -102,21 +90,11 @@ exports.normalizeExternalConfig = function normalizeExternalConfig(config) {
  * 1. INSTANA_TRACING_DISABLE=true/false
  * 2. INSTANA_TRACING_DISABLE_INSTRUMENTATIONS / INSTANA_TRACING_DISABLE_GROUPS
  * 3. INSTANA_TRACING_DISABLE=list
- * 4. INSTANA_DISABLED_TRACERS (deprecated)
  *
  * @returns {import('../../config/types').Disable}
  */
 function getDisableFromEnv() {
   const disable = {};
-
-  // @deprecated
-  if (process.env.INSTANA_DISABLED_TRACERS) {
-    logger?.warn(
-      'The environment variable "INSTANA_DISABLED_TRACERS" is deprecated and will be removed in the next ' +
-        'major release. Use "INSTANA_TRACING_DISABLE" instead.'
-    );
-    disable.instrumentations = parseEnvVar(process.env.INSTANA_DISABLED_TRACERS);
-  }
 
   // This env var may contains true/false and also both groups and instrumentations
   if (process.env.INSTANA_TRACING_DISABLE) {

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -24,7 +24,6 @@ const deepMerge = require('../util/deepMerge');
  * @property {number} [stackTraceLength]
  * @property {HTTPTracingOptions} [http]
  * @property {import('../config/types').Disable} [disable]
- * @property {Array<string>} [disabledTracers]
  * @property {boolean} [spanBatchingEnabled]
  * @property {boolean} [disableW3cTraceCorrelation]
  * @property {KafkaTracingOptions} [kafka]
@@ -247,17 +246,6 @@ function normalizeTracingEnabled(config) {
     return;
   }
   if (config.tracing.enabled === true) {
-    return;
-  }
-
-  // @deprecated
-  if (process.env['INSTANA_DISABLE_TRACING'] === 'true') {
-    logger.info('Not enabling tracing as it is explicitly disabled via environment variable INSTANA_DISABLE_TRACING.');
-    logger.warn(
-      'The environment variable INSTANA_DISABLE_TRACING is deprecated and will be removed in the next major release. ' +
-        'Please use INSTANA_TRACING_DISABLE="true" instead.'
-    );
-    config.tracing.enabled = false;
     return;
   }
 

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -20,10 +20,6 @@ describe('config.normalizeConfig', () => {
   afterEach(resetEnv);
 
   function resetEnv() {
-    // deprecated
-    delete process.env.INSTANA_DISABLED_TRACERS;
-    delete process.env.INSTANA_DISABLE_TRACING;
-
     delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
     delete process.env.INSTANA_TRACING_DISABLE_GROUPS;
     delete process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS;
@@ -108,13 +104,6 @@ describe('config.normalizeConfig', () => {
 
   it('should disable tracing with disable: true', () => {
     const config = coreConfig.normalize({ tracing: { enabled: false } });
-    expect(config.tracing.enabled).to.be.false;
-    expect(config.tracing.automaticTracingEnabled).to.be.false;
-  });
-
-  it('should disable tracing via deprecated INSTANA_DISABLE_TRACING', () => {
-    process.env.INSTANA_DISABLE_TRACING = true;
-    const config = coreConfig.normalize();
     expect(config.tracing.enabled).to.be.false;
     expect(config.tracing.automaticTracingEnabled).to.be.false;
   });
@@ -275,34 +264,6 @@ describe('config.normalizeConfig', () => {
     expect(config.tracing.disable).to.deep.equal({});
   });
 
-  it('should disable individual instrumentations via config', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        disabledTracers: ['graphQL', 'GRPC']
-      }
-    });
-    // values will be normalized to lower case
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
-  });
-
-  it('should disable individual instrumentations via env var', () => {
-    process.env.INSTANA_DISABLED_TRACERS = 'graphQL   , GRPC';
-    const config = coreConfig.normalize();
-    // values will be normalized to lower case
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
-  });
-
-  it('config should take precedence over env vars when disabling individual tracers', () => {
-    process.env.INSTANA_DISABLED_TRACERS = 'foo, bar';
-    const config = coreConfig.normalize({
-      tracing: {
-        disabledTracers: ['baz', 'fizz']
-      }
-    });
-    // values will be normalized to lower case
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
-  });
-
   it('should disable individual instrumentations via disable config', () => {
     const config = coreConfig.normalize({
       tracing: {
@@ -347,13 +308,6 @@ describe('config.normalizeConfig', () => {
     process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = '  graphql  ,  grpc  ';
     const config = coreConfig.normalize();
     expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
-  });
-
-  it('should prefer INSTANA_TRACING_DISABLE_INSTRUMENTATIONS over INSTANA_DISABLED_TRACERS', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'redis';
-    process.env.INSTANA_DISABLED_TRACERS = 'postgres';
-    const config = coreConfig.normalize();
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['redis']);
   });
 
   it('should disable individual groups via disable config', () => {

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -76,9 +76,6 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     initAwsSdkv2.reset();
     initAwsSdkv3.reset();
 
-    // @deprecated
-    delete process.env.INSTANA_DISABLED_TRACERS;
-
     delete process.env.INSTANA_TRACING_DISABLE;
     delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
     delete process.env.INSTANA_TRACING_DISABLE_GROUPS;
@@ -269,89 +266,6 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
 
           expect(initAwsSdkv2).to.have.been.called;
           expect(activateAwsSdkv2).to.have.been.called;
-        });
-      });
-
-      describe('[deprecated] when using disabledTracers config', () => {
-        it('should deactivate tracers as specified', () => {
-          initAndActivate({ tracing: { disabledTracers: ['grpc', 'kafkajs', 'aws-sdk/v2'] } });
-
-          // grpcJs instrumentation has not been disabled, make sure its init and activate are called
-          expect(initStubGrpcJs).to.have.been.called;
-          expect(activateStubGrpcJs).to.have.been.called;
-
-          // kafkajs has been disabled...
-          expect(initStubKafkaJs).to.not.have.been.called;
-          expect(activateStubKafkaJs).to.not.have.been.called;
-
-          // ...but rdkafka has not been disabled
-          expect(initStubRdKafka).to.have.been.called;
-          expect(activateStubRdKafka).to.have.been.called;
-
-          // aws-sdk/v2 has been disabled (via aws-sdk/v2)
-          expect(initAwsSdkv2).not.to.have.been.called;
-          expect(activateAwsSdkv2).not.to.have.been.called;
-
-          // aws-sdk/v3 has not been disabled
-          expect(initAwsSdkv3).to.have.been.called;
-          expect(activateAwsSdkv3).to.have.been.called;
-        });
-
-        it('should respect INSTANA_DISABLED_TRACERS environment variable', () => {
-          process.env.INSTANA_DISABLED_TRACERS = 'kafkajs';
-          initAndActivate({});
-
-          expect(initStubKafkaJs).not.to.have.been.called;
-          expect(activateStubKafkaJs).not.to.have.been.called;
-        });
-
-        it('should handle empty disabledTracers array', () => {
-          initAndActivate({ tracing: { disabledTracers: [] } });
-
-          expect(initStubGrpcJs).to.have.been.called;
-          expect(initStubKafkaJs).to.have.been.called;
-          expect(initStubRdKafka).to.have.been.called;
-        });
-
-        it('should trim whitespace in environment variable values', () => {
-          process.env.INSTANA_DISABLED_TRACERS = '  grpc  ,  kafkajs  ';
-          initAndActivate({});
-
-          expect(initStubGrpcJs).to.have.been.called;
-          expect(activateStubGrpcJs).to.have.been.called;
-
-          expect(initStubKafkaJs).not.to.have.been.called;
-          expect(activateStubKafkaJs).not.to.have.been.called;
-        });
-
-        it('should prefer disable over disabledTracers when both exist', () => {
-          initAndActivate({
-            tracing: {
-              disabledTracers: ['grpc', 'kafkajs'],
-              disable: { instrumentations: ['aws-sdk/v2'] }
-            }
-          });
-
-          expect(initAwsSdkv2).not.to.have.been.called;
-          expect(activateAwsSdkv2).not.to.have.been.called;
-
-          expect(initStubGrpcJs).to.have.been.called;
-          expect(activateStubGrpcJs).to.have.been.called;
-
-          expect(initStubKafkaJs).to.have.been.called;
-          expect(activateStubKafkaJs).to.have.been.called;
-        });
-
-        it('should prefer INSTANA_TRACING_DISABLE_INSTRUMENTATIONS over INSTANA_DISABLED_TRACERS', () => {
-          process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk/v2';
-          process.env.INSTANA_DISABLED_TRACERS = 'kafkajs';
-          initAndActivate({});
-
-          expect(initAwsSdkv2).not.to.have.been.called;
-          expect(activateAwsSdkv2).not.to.have.been.called;
-
-          expect(initStubKafkaJs).to.have.been.called;
-          expect(activateStubKafkaJs).to.have.been.called;
         });
       });
     });


### PR DESCRIPTION
**Removed Deprecated Tracing Configuration**

The following environment variables and configuration options, previously used to disable tracing, have been removed:

* `INSTANA_DISABLED_TRACERS`
* `INSTANA_DISABLE_TRACING`
* `tracing.disabledTracers`

These were deprecated in version **v4.x**, with corresponding warnings and [public documentation](https://www.ibm.com/docs/en/instana-observability/1.0.301?topic=nodejs-collector-configuration#disabling-all-tracing) also indicated the deprecation.

 **Migration Recommendations**

* Replace `INSTANA_DISABLED_TRACERS` with **`INSTANA_TRACING_DISABLE`**.
* Replace `INSTANA_DISABLE_TRACING` with **`INSTANA_TRACING_DISABLE`**.
* Replace `tracing.disabledTracers` with **`tracing.disable`**.


ref https://jsw.ibm.com/browse/INSTA-63932
