### PR TITLE
fix: optimized how we receive the package.json information

### DIFF
--- a/packages/collector/test/nativeModuleRetry/preinstall.sh
+++ b/packages/collector/test/nativeModuleRetry/preinstall.sh
@@ -4,13 +4,13 @@
 # (c) Copyright IBM Corp. 2025
 #######################################
 
-cd "$(dirname "$0")/../../../../collector"
+cd "$(dirname "$0")/../../../collector"
 echo "Running npm pack in $(pwd)"
 npm pack
 
 version=$(node -p "require('./package.json').version")
 tarball="instana-collector-${version}.tgz"
-cp "./${tarball}" "./test/tracing/opentelemetry/collector.tgz"
+cp "./${tarball}" "./test/nativeModuleRetry/collector.tgz"
 
 cd "$(dirname "$0")/../core"
 echo "Running npm pack in $(pwd)"
@@ -18,7 +18,7 @@ npm pack
 
 version=$(node -p "require('./package.json').version")
 tarball="instana-core-${version}.tgz"
-cp "./${tarball}" "../collector/test/tracing/opentelemetry/core.tgz"
+cp "./${tarball}" "../collector/test/nativeModuleRetry/core.tgz"
 
 cd "$(dirname "$0")/../shared-metrics"
 echo "Running npm pack in $(pwd)"
@@ -26,4 +26,4 @@ npm pack
 
 version=$(node -p "require('./package.json').version")
 tarball="instana-shared-metrics-${version}.tgz"
-cp "./${tarball}" "../collector/test/tracing/opentelemetry/shared-metrics.tgz"
+cp "./${tarball}" "../collector/test/nativeModuleRetry/shared-metrics.tgz"

--- a/packages/collector/test/nativeModuleRetry/test.js
+++ b/packages/collector/test/nativeModuleRetry/test.js
@@ -94,42 +94,20 @@ mochaSuiteFn('retry loading native addons', function () {
       before(async () => {
         execSync(`rm -rf ${tmpFolder}`, { cwd: __dirname, stdio: 'inherit' });
         execSync(`mkdir -p ${tmpFolder}`, { cwd: __dirname, stdio: 'inherit' });
-
         execSync(`cp app.js ${tmpFolder}/`, { cwd: __dirname, stdio: 'inherit' });
 
         // eslint-disable-next-line no-console
         console.log('Running npm install in', tmpFolder);
         execSync('rm -rf node_modules', { cwd: tmpFolder, stdio: 'inherit' });
 
-        const copath = path.join(__dirname, '..', '..', '..', 'collector');
-        runCommandSync('npm pack', copath);
+        execSync('./preinstall.sh', { cwd: __dirname, stdio: 'inherit' });
 
-        const coversion = require(`${copath}/package.json`).version;
+        runCommandSync(`npm install --no-save --no-package-lock --prefix ./ ${__dirname}/core.tgz`, tmpFolder);
         runCommandSync(
-          `npm install --production --no-optional --no-audit ${copath}/instana-collector-${coversion}.tgz`,
+          `npm install --no-save --no-package-lock --prefix ./ ${__dirname}/shared-metrics.tgz`,
           tmpFolder
         );
-
-        // NOTE: Override the core npm dependency with the local code base
-        const corepath = path.join(__dirname, '..', '..', '..', 'core');
-        runCommandSync('npm pack', corepath);
-
-        const coreversion = require(`${copath}/package.json`).version;
-        runCommandSync(
-          `npm install  --prefix ./ --production --no-optional --no-audit ${corepath}/instana-core-${coreversion}.tgz`,
-          tmpFolder
-        );
-
-        // Install the shared metrics module
-        const sharedMetricsPath = path.join(__dirname, '..', '..', '..', 'shared-metrics');
-        runCommandSync('npm pack', sharedMetricsPath);
-
-        const sharedMetricsVersion = require(`${copath}/package.json`).version;
-        runCommandSync(
-          // eslint-disable-next-line max-len
-          `npm install  --prefix ./ --production --no-optional --no-audit ${sharedMetricsPath}/instana-shared-metrics-${sharedMetricsVersion}.tgz`,
-          tmpFolder
-        );
+        runCommandSync(`npm install --no-save --no-package-lock --prefix ./ ${__dirname}/collector.tgz`, tmpFolder);
 
         // Remove the target c++ module
         execSync(`rm -rf node_modules/${opts.name}`, { cwd: tmpFolder, stdio: 'inherit' });

--- a/packages/collector/test/tracing/misc/invalid_app/test.js
+++ b/packages/collector/test/tracing/misc/invalid_app/test.js
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright IBM Corp. 2025
+ */
+
+'use strict';
+
+const path = require('path');
+const childProcess = require('child_process');
+const expect = require('chai').expect;
+const supportedVersion = require('@instana/core').tracing.supportedVersion;
+const config = require('../../../../../core/test/config');
+const mochaSuiteFn = supportedVersion(process.versions.node) ? describe : describe.skip;
+
+mochaSuiteFn('tracing/invalidApp', function () {
+  this.timeout(config.getTestTimeout() * 3);
+
+  it('when the collector is required in interactive shell', cb => {
+    const child = childProcess.spawn(
+      process.execPath,
+      ['--require', path.join(__dirname, '..', '..', '..', '..', 'src', 'immediate.js')],
+      {
+        stdio: 'inherit',
+        cwd: process.cwd(),
+        env: process.env
+      }
+    );
+
+    child.on('error', err => {
+      cb(err);
+    });
+
+    child.on('exit', (code, signal) => {
+      expect(signal).to.equal('SIGTERM');
+      expect(code).to.not.exist;
+      cb();
+    });
+
+    setTimeout(() => {
+      child.kill('SIGTERM');
+    }, 3 * 1000);
+  });
+});

--- a/packages/collector/test/tracing/opentelemetry/test.js
+++ b/packages/collector/test/tracing/opentelemetry/test.js
@@ -53,7 +53,13 @@ mochaSuiteFn('opentelemetry tests', function () {
         if (process.env.INSTANA_TEST_SKIP_INSTALLING_DEPS === 'true') {
           return;
         }
+
         execSync('npm install --no-save --no-package-lock --prefix ./ ./core.tgz', {
+          cwd: __dirname,
+          stdio: 'inherit'
+        });
+
+        execSync('npm install --no-save --no-package-lock --prefix ./ ./shared-metrics.tgz', {
           cwd: __dirname,
           stdio: 'inherit'
         });

--- a/packages/core/src/util/applicationUnderMonitoring.js
+++ b/packages/core/src/util/applicationUnderMonitoring.js
@@ -187,12 +187,17 @@ function getMainPackageJsonPathStartingAtDirectory(startDirectory, cb) {
       }
     }
 
-    // In case if require.main or process.argv[1] might be missing or invalid,
-    // so mainModule.filename can be undefined.
+    // CASE: node --require .../src/immediate.js
     if (!mainModule?.filename) {
       logger.warn('Application entrypoint could not be identified. Package.json resolution will be skipped.');
-      return process.nextTick(cb);
+      const err = new Error('Application entrypoint could not be identified. Search for package.json failed.');
+
+      // @ts-ignore
+      err.code = 'INSTANA_NO_MAIN_MODULE';
+
+      return process.nextTick(cb, err, null);
     }
+
     startDirectory = path.dirname(mainModule.filename);
   }
 

--- a/packages/core/src/util/applicationUnderMonitoring.js
+++ b/packages/core/src/util/applicationUnderMonitoring.js
@@ -187,20 +187,13 @@ function getMainPackageJsonPathStartingAtDirectory(startDirectory, cb) {
       }
     }
 
-    try {
-      // The collector may be preloaded via --require in ESM apps or frameworks (e.g., react-scripts),
-      // which is not supported and can happen in auto-tracing setups.
-      // In such cases, require.main or process.argv[1] might be missing or invalid,
-      // so mainModule.filename can be undefined.
-      if (!mainModule?.filename) {
-        logger.warn('Application entrypoint could not be identified. Package.json resolution will be skipped.');
-        return process.nextTick(cb);
-      }
-      startDirectory = path.dirname(mainModule.filename);
-    } catch (e) {
-      logger.warn(`Unable to resolve application entrypoint ${e.message}. Package.json resolution will be skipped.`);
+    // In case if require.main or process.argv[1] might be missing or invalid,
+    // so mainModule.filename can be undefined.
+    if (!mainModule?.filename) {
+      logger.warn('Application entrypoint could not be identified. Package.json resolution will be skipped.');
       return process.nextTick(cb);
     }
+    startDirectory = path.dirname(mainModule.filename);
   }
 
   searchForPackageJsonInDirectoryTreeUpwards(startDirectory, (err, main) => {

--- a/packages/core/src/util/applicationUnderMonitoring.js
+++ b/packages/core/src/util/applicationUnderMonitoring.js
@@ -189,7 +189,6 @@ function getMainPackageJsonPathStartingAtDirectory(startDirectory, cb) {
 
     // CASE: node --require .../src/immediate.js
     if (!mainModule?.filename) {
-      logger.warn('Application entrypoint could not be identified. Package.json resolution will be skipped.');
       const err = new Error('Application entrypoint could not be identified. Search for package.json failed.');
 
       // @ts-ignore

--- a/packages/core/src/util/applicationUnderMonitoring.js
+++ b/packages/core/src/util/applicationUnderMonitoring.js
@@ -187,7 +187,20 @@ function getMainPackageJsonPathStartingAtDirectory(startDirectory, cb) {
       }
     }
 
-    startDirectory = path.dirname(mainModule.filename);
+    try {
+      // The collector may be preloaded via --require in ESM apps or frameworks (e.g., react-scripts),
+      // which is not supported and can happen in auto-tracing setups.
+      // In such cases, require.main or process.argv[1] might be missing or invalid,
+      // so mainModule.filename can be undefined.
+      if (!mainModule?.filename) {
+        logger.warn('Application entrypoint could not be identified. Package.json resolution will be skipped.');
+        return process.nextTick(cb);
+      }
+      startDirectory = path.dirname(mainModule.filename);
+    } catch (e) {
+      logger.warn(`Unable to resolve application entrypoint ${e.message}. Package.json resolution will be skipped.`);
+      return process.nextTick(cb);
+    }
   }
 
   searchForPackageJsonInDirectoryTreeUpwards(startDirectory, (err, main) => {

--- a/packages/core/src/util/applicationUnderMonitoring.js
+++ b/packages/core/src/util/applicationUnderMonitoring.js
@@ -38,6 +38,10 @@ function isAppInstalledIntoNodeModules() {
   return appInstalledIntoNodeModules;
 }
 
+const MAX_ATTEMPTS = 5;
+const DELAY = 1500;
+let attempts = 0;
+
 /**
  * Looks for the app's main package.json file, parses it and returns the parsed content. The search is started at
  * path.dirname(require.main.filename).
@@ -50,7 +54,7 @@ function isAppInstalledIntoNodeModules() {
 function getMainPackageJsonStartingAtMainModule(cb) {
   // NOTE: we already cached the package.json
   if (parsedMainPackageJson !== undefined) {
-    return cb(null, parsedMainPackageJson);
+    return cb(null, { file: parsedMainPackageJson, path: mainPackageJsonPath });
   }
 
   // CASE: customer provided custom package.json path, let's try loading it
@@ -58,7 +62,23 @@ function getMainPackageJsonStartingAtMainModule(cb) {
     return readFile(packageJsonPath, cb);
   }
 
-  return getMainPackageJsonStartingAtDirectory(null, cb);
+  return getMainPackageJsonStartingAtDirectory(null, (err, pkg) => {
+    // CASE: using --require or --import can result in an empty require.main initially
+    if (err && attempts < MAX_ATTEMPTS) {
+      attempts++;
+
+      logger.warn(
+        `Could not determine main package.json yet. Retrying ${attempts}/${MAX_ATTEMPTS} after ${DELAY}ms...`
+      );
+
+      return setTimeout(() => {
+        getMainPackageJsonStartingAtMainModule(cb);
+      }, DELAY).unref();
+    }
+
+    attempts = 0;
+    return cb(err, pkg);
+  });
 }
 
 /**
@@ -110,20 +130,8 @@ function readFile(filePath, cb) {
       return cb(e, null);
     }
 
-    return cb(null, parsedMainPackageJson);
+    return cb(null, { file: parsedMainPackageJson, path: filePath });
   });
-}
-
-/**
- * Looks for path of the app's main package.json file, starting the search at path.dirname(require.main.filename).
- *
- * In case the search is successful, the result will be cached for consecutive invocations.
- *
- * @param {(err: Error, packageJsonPath: string) => void} cb - the callback will be called with an error or the path to
- * the package.json file
- */
-function getMainPackageJsonPathStartingAtMainModule(cb) {
-  return getMainPackageJsonPathStartingAtDirectory(null, cb);
 }
 
 /**
@@ -189,11 +197,7 @@ function getMainPackageJsonPathStartingAtDirectory(startDirectory, cb) {
 
     // CASE: node --require .../src/immediate.js
     if (!mainModule?.filename) {
-      const err = new Error('Application entrypoint could not be identified. Search for package.json failed.');
-
-      // @ts-ignore
-      err.code = 'INSTANA_NO_MAIN_MODULE';
-
+      const err = new Error('Application entrypoint could not be identified.');
       return process.nextTick(cb, err, null);
     }
 
@@ -342,6 +346,7 @@ function searchInParentDir(dir, onParentDir, cb) {
 const reset = () => {
   parsedMainPackageJson = undefined;
   mainPackageJsonPath = undefined;
+  attempts = 0;
 };
 
 module.exports = {
@@ -349,7 +354,6 @@ module.exports = {
   isAppInstalledIntoNodeModules,
   getMainPackageJsonStartingAtMainModule,
   getMainPackageJsonStartingAtDirectory,
-  getMainPackageJsonPathStartingAtMainModule,
   getMainPackageJsonPathStartingAtDirectory,
   findNodeModulesFolder,
   reset

--- a/packages/serverless-collector/src/metrics/name.js
+++ b/packages/serverless-collector/src/metrics/name.js
@@ -21,10 +21,13 @@ module.exports = config => {
     return process.env.INSTANA_SERVICE_NAME;
   }
 
+  // TODO: all metrics call `getMainPackageJsonStartingAtMainModule` - if `getMainPackageJsonStartingAtMainModule` fails
+  //       for the 1st metrics, the other metrics will try again...we should initiate
+  //       `getMainPackageJsonStartingAtMainModule` only once in a central place!
   return new Promise(resolve => {
     instanaCore.util.applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule((err, packageJson) => {
       if (err) {
-        logger.debug(`Failed to determine main package.json. ${err?.message} ${err?.stack}`);
+        logger.debug(`Failed to determine main package.json for "name" metric. ${err?.message} ${err?.stack}`);
         return resolve();
       }
 

--- a/packages/serverless-collector/src/metrics/name.js
+++ b/packages/serverless-collector/src/metrics/name.js
@@ -21,18 +21,15 @@ module.exports = config => {
     return process.env.INSTANA_SERVICE_NAME;
   }
 
-  // TODO: all metrics call `getMainPackageJsonStartingAtMainModule` - if `getMainPackageJsonStartingAtMainModule` fails
-  //       for the 1st metrics, the other metrics will try again...we should initiate
-  //       `getMainPackageJsonStartingAtMainModule` only once in a central place!
   return new Promise(resolve => {
-    instanaCore.util.applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule((err, packageJson) => {
+    instanaCore.util.applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule((err, packageJsonObj) => {
       if (err) {
-        logger.debug(`Failed to determine main package.json for "name" metric. ${err?.message} ${err?.stack}`);
+        logger.debug(`Failed to determine main package.json. ${err?.message} ${err?.stack}`);
         return resolve();
       }
 
-      logger.debug(`Found main package.json: ${packageJson.name}`);
-      resolve(packageJson.name);
+      logger.debug(`Found main package.json: ${packageJsonObj.file.name}`);
+      resolve(packageJsonObj.file.name);
     });
   });
 };

--- a/packages/shared-metrics/src/description.js
+++ b/packages/shared-metrics/src/description.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const { payloadPrefix } = require('./activeHandles');
+
 const { applicationUnderMonitoring } = require('@instana/core').util;
 
 /** @type {import('@instana/core/src/core').GenericLogger} */
@@ -28,9 +30,14 @@ let attempts = 0;
 exports.activate = function activate() {
   attempts++;
 
+  // TODO: all metrics call `getMainPackageJsonStartingAtMainModule` - if `getMainPackageJsonStartingAtMainModule` fails
+  //       for the 1st metrics, the other metrics will try again...we should initiate
+  //       `getMainPackageJsonStartingAtMainModule` only once in a central place!
   applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule((err, packageJson) => {
     if (err) {
-      return logger.warn(`Failed to determine main package json. Reason: ${err?.message} ${err?.stack}`);
+      return logger.warn(
+        `Failed to determine main package.json for "${payloadPrefix}" metric. Reason: ${err?.message} ${err?.stack}`
+      );
     } else if (!packageJson && attempts < MAX_ATTEMPTS) {
       setTimeout(exports.activate, DELAY).unref();
       return;

--- a/packages/shared-metrics/src/description.js
+++ b/packages/shared-metrics/src/description.js
@@ -5,48 +5,18 @@
 
 'use strict';
 
-const { payloadPrefix } = require('./activeHandles');
-
-const { applicationUnderMonitoring } = require('@instana/core').util;
-
-/** @type {import('@instana/core/src/core').GenericLogger} */
-let logger;
-
-/**
- * @param {import('@instana/core/src/config').InstanaConfig} config
- */
-exports.init = function init(config) {
-  logger = config.logger;
-};
+exports.init = function init() {};
 
 exports.payloadPrefix = 'description';
 // @ts-ignore
 exports.currentPayload = undefined;
 
-const MAX_ATTEMPTS = 20;
-const DELAY = 1000;
-let attempts = 0;
+// @ts-ignore
+exports.activate = function activate(config, packageJsonObj) {
+  if (!packageJsonObj || !packageJsonObj.file) {
+    return;
+  }
 
-exports.activate = function activate() {
-  attempts++;
-
-  // TODO: all metrics call `getMainPackageJsonStartingAtMainModule` - if `getMainPackageJsonStartingAtMainModule` fails
-  //       for the 1st metrics, the other metrics will try again...we should initiate
-  //       `getMainPackageJsonStartingAtMainModule` only once in a central place!
-  applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule((err, packageJson) => {
-    if (err) {
-      return logger.warn(
-        `Failed to determine main package.json for "${payloadPrefix}" metric. Reason: ${err?.message} ${err?.stack}`
-      );
-    } else if (!packageJson && attempts < MAX_ATTEMPTS) {
-      setTimeout(exports.activate, DELAY).unref();
-      return;
-    } else if (!packageJson) {
-      // final attempt failed, ignore silently
-      return;
-    }
-
-    // @ts-ignore
-    exports.currentPayload = packageJson.description;
-  });
+  // @ts-ignore
+  exports.currentPayload = packageJsonObj.file.description;
 };

--- a/packages/shared-metrics/src/description.js
+++ b/packages/shared-metrics/src/description.js
@@ -5,7 +5,10 @@
 
 'use strict';
 
-exports.init = function init() {};
+/**
+ * @param {import('@instana/core/src/config').InstanaConfig} config
+ */
+exports.init = function init(config) {};
 
 exports.payloadPrefix = 'description';
 // @ts-ignore

--- a/packages/shared-metrics/src/description.js
+++ b/packages/shared-metrics/src/description.js
@@ -8,6 +8,7 @@
 /**
  * @param {import('@instana/core/src/config').InstanaConfig} config
  */
+// eslint-disable-next-line no-unused-vars
 exports.init = function init(config) {};
 
 exports.payloadPrefix = 'description';

--- a/packages/shared-metrics/src/directDependencies.js
+++ b/packages/shared-metrics/src/directDependencies.js
@@ -11,6 +11,7 @@ let logger;
 /**
  * @param {import('@instana/core/src/config').InstanaConfig} config
  */
+// eslint-disable-next-line no-unused-vars
 exports.init = function init(config) {
   logger = config.logger;
 };

--- a/packages/shared-metrics/src/directDependencies.js
+++ b/packages/shared-metrics/src/directDependencies.js
@@ -5,8 +5,6 @@
 
 'use strict';
 
-const { uninstrumentedFs: fs } = require('@instana/core');
-
 /** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 

--- a/packages/shared-metrics/src/directDependencies.js
+++ b/packages/shared-metrics/src/directDependencies.js
@@ -11,7 +11,6 @@ let logger;
 /**
  * @param {import('@instana/core/src/config').InstanaConfig} config
  */
-// eslint-disable-next-line no-unused-vars
 exports.init = function init(config) {
   logger = config.logger;
 };

--- a/packages/shared-metrics/src/keywords.js
+++ b/packages/shared-metrics/src/keywords.js
@@ -8,6 +8,7 @@
 /**
  * @param {import('@instana/core/src/config').InstanaConfig} config
  */
+// eslint-disable-next-line no-unused-vars
 exports.init = function init(config) {};
 
 exports.payloadPrefix = 'keywords';

--- a/packages/shared-metrics/src/keywords.js
+++ b/packages/shared-metrics/src/keywords.js
@@ -29,9 +29,15 @@ let attempts = 0;
 exports.activate = function activate() {
   attempts++;
 
+  // TODO: all metrics call `getMainPackageJsonStartingAtMainModule` - if `getMainPackageJsonStartingAtMainModule` fails
+  //       for the 1st metrics, the other metrics will try again...we should initiate
+  //       `getMainPackageJsonStartingAtMainModule` only once in a central place!
   applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule((err, packageJson) => {
     if (err) {
-      return logger.warn(`Failed to determine main package json. Reason: ${err?.message} ${err?.stack}`);
+      return logger.warn(
+        // eslint-disable-next-line max-len
+        `Failed to determine main package.json for "${exports.payloadPrefix}" metric. Reason: ${err?.message} ${err?.stack}`
+      );
     } else if (!packageJson && attempts < MAX_ATTEMPTS) {
       setTimeout(exports.activate, DELAY).unref();
 

--- a/packages/shared-metrics/src/keywords.js
+++ b/packages/shared-metrics/src/keywords.js
@@ -5,7 +5,10 @@
 
 'use strict';
 
-exports.init = function init() {};
+/**
+ * @param {import('@instana/core/src/config').InstanaConfig} config
+ */
+exports.init = function init(config) {};
 
 exports.payloadPrefix = 'keywords';
 /** @type {Array.<string>} */

--- a/packages/shared-metrics/src/keywords.js
+++ b/packages/shared-metrics/src/keywords.js
@@ -5,51 +5,21 @@
 
 'use strict';
 
-const { applicationUnderMonitoring } = require('@instana/core').util;
-
-/** @type {import('@instana/core/src/core').GenericLogger} */
-let logger;
-
-/**
- * @param {import('@instana/core/src/config').InstanaConfig} config
- */
-exports.init = function init(config) {
-  logger = config.logger;
-};
+exports.init = function init() {};
 
 exports.payloadPrefix = 'keywords';
 /** @type {Array.<string>} */
 // @ts-ignore
 exports.currentPayload = [];
 
-const MAX_ATTEMPTS = 20;
-const DELAY = 1000;
-let attempts = 0;
+// @ts-ignore
+exports.activate = function activate(config, packageJsonObj) {
+  if (!packageJsonObj || !packageJsonObj.file) {
+    return;
+  }
 
-exports.activate = function activate() {
-  attempts++;
-
-  // TODO: all metrics call `getMainPackageJsonStartingAtMainModule` - if `getMainPackageJsonStartingAtMainModule` fails
-  //       for the 1st metrics, the other metrics will try again...we should initiate
-  //       `getMainPackageJsonStartingAtMainModule` only once in a central place!
-  applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule((err, packageJson) => {
-    if (err) {
-      return logger.warn(
-        // eslint-disable-next-line max-len
-        `Failed to determine main package.json for "${exports.payloadPrefix}" metric. Reason: ${err?.message} ${err?.stack}`
-      );
-    } else if (!packageJson && attempts < MAX_ATTEMPTS) {
-      setTimeout(exports.activate, DELAY).unref();
-
-      return;
-    } else if (!packageJson) {
-      // final attempt failed, ignore silently
-      return;
-    }
-
-    if (packageJson.keywords) {
-      // @ts-ignore
-      exports.currentPayload = packageJson.keywords;
-    }
-  });
+  if (packageJsonObj.file.keywords) {
+    // @ts-ignore
+    exports.currentPayload = packageJsonObj.file.keywords;
+  }
 };

--- a/packages/shared-metrics/src/name.js
+++ b/packages/shared-metrics/src/name.js
@@ -5,8 +5,6 @@
 
 'use strict';
 
-const { applicationUnderMonitoring } = require('@instana/core').util;
-
 /** @type {import('@instana/core/src/core').GenericLogger} */
 let logger;
 
@@ -21,45 +19,25 @@ exports.payloadPrefix = 'name';
 // @ts-ignore
 exports.currentPayload = undefined;
 
-exports.MAX_ATTEMPTS = 60;
-exports.DELAY = 1000;
-let attempts = 0;
-
-exports.activate = function activate() {
-  attempts++;
-
-  // TODO: all metrics call `getMainPackageJsonStartingAtMainModule` - if `getMainPackageJsonStartingAtMainModule` fails
-  //       for the 1st metrics, the other metrics will try again...we should initiate
-  //       `getMainPackageJsonStartingAtMainModule` only once in a central place!
-  applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule((err, packageJson) => {
-    if (err) {
-      return logger.warn(
-        `Failed to determine main package.json for "${exports.payloadPrefix}". Reason: ${err?.message} ${err?.stack}`
-      );
-    } else if (!packageJson && attempts < exports.MAX_ATTEMPTS) {
-      logger.debug('Main package.json could not be found. Will try again later.');
-      setTimeout(exports.activate, exports.DELAY).unref();
-      return;
-    } else if (!packageJson) {
-      if (require.main) {
-        // @ts-ignore
-        exports.currentPayload = require.main.filename;
-      }
-
-      return logger.warn(
-        `Main package.json could not be found. This Node.js app will be labeled "${
-          exports.currentPayload ? exports.currentPayload : 'Unknown'
-        }" in Instana.`
-      );
+// @ts-ignore
+exports.activate = function activate(config, packageJsonObj) {
+  if (!packageJsonObj || !packageJsonObj.file) {
+    if (require.main) {
+      // @ts-ignore
+      exports.currentPayload = require.main.filename;
     }
 
-    // @ts-ignore
-    exports.currentPayload = packageJson.name;
-  });
+    return logger.warn(
+      `Main package.json could not be found. This Node.js app will be labeled "${
+        exports.currentPayload ? exports.currentPayload : 'Unknown'
+      }" in Instana.`
+    );
+  }
+
+  // @ts-ignore
+  exports.currentPayload = packageJsonObj.file.name;
 };
 
 exports.reset = () => {
   exports.currentPayload = undefined;
-  exports.MAX_ATTEMPTS = 60;
-  exports.DELAY = 1000;
 };

--- a/packages/shared-metrics/src/name.js
+++ b/packages/shared-metrics/src/name.js
@@ -28,9 +28,14 @@ let attempts = 0;
 exports.activate = function activate() {
   attempts++;
 
+  // TODO: all metrics call `getMainPackageJsonStartingAtMainModule` - if `getMainPackageJsonStartingAtMainModule` fails
+  //       for the 1st metrics, the other metrics will try again...we should initiate
+  //       `getMainPackageJsonStartingAtMainModule` only once in a central place!
   applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule((err, packageJson) => {
     if (err) {
-      return logger.warn(`Failed to determine main package json. Reason: ${err?.message} ${err?.stack}`);
+      return logger.warn(
+        `Failed to determine main package.json for "${exports.payloadPrefix}". Reason: ${err?.message} ${err?.stack}`
+      );
     } else if (!packageJson && attempts < exports.MAX_ATTEMPTS) {
       logger.debug('Main package.json could not be found. Will try again later.');
       setTimeout(exports.activate, exports.DELAY).unref();

--- a/packages/shared-metrics/src/version.js
+++ b/packages/shared-metrics/src/version.js
@@ -28,9 +28,15 @@ let attempts = 0;
 exports.activate = function activate() {
   attempts++;
 
+  // TODO: all metrics call `getMainPackageJsonStartingAtMainModule` - if `getMainPackageJsonStartingAtMainModule` fails
+  //       for the 1st metrics, the other metrics will try again...we should initiate
+  //       `getMainPackageJsonStartingAtMainModule` only once in a central place!
   applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule((err, packageJson) => {
     if (err) {
-      return logger.warn(`Failed to determine main package json. Reason: ${err?.message} ${err?.stack}`);
+      return logger.warn(
+        // eslint-disable-next-line max-len
+        `Failed to determine main package.json for "${exports.payloadPrefix}" metric. Reason: ${err?.message} ${err?.stack}`
+      );
     } else if (!packageJson && attempts < MAX_ATTEMPTS) {
       setTimeout(exports.activate, DELAY).unref();
 

--- a/packages/shared-metrics/src/version.js
+++ b/packages/shared-metrics/src/version.js
@@ -8,6 +8,8 @@
 /**
  * @param {import('@instana/core/src/config').InstanaConfig} config
  */
+
+// eslint-disable-next-line no-unused-vars
 exports.init = function init(config) {};
 
 exports.payloadPrefix = 'version';

--- a/packages/shared-metrics/src/version.js
+++ b/packages/shared-metrics/src/version.js
@@ -5,7 +5,10 @@
 
 'use strict';
 
-exports.init = function init() {};
+/**
+ * @param {import('@instana/core/src/config').InstanaConfig} config
+ */
+exports.init = function init(config) {};
 
 exports.payloadPrefix = 'version';
 // @ts-ignore

--- a/packages/shared-metrics/src/version.js
+++ b/packages/shared-metrics/src/version.js
@@ -5,48 +5,18 @@
 
 'use strict';
 
-const { applicationUnderMonitoring } = require('@instana/core').util;
-
-/** @type {import('@instana/core/src/core').GenericLogger} */
-let logger;
-
-/**
- * @param {import('@instana/core/src/config').InstanaConfig} config
- */
-exports.init = function init(config) {
-  logger = config.logger;
-};
+exports.init = function init() {};
 
 exports.payloadPrefix = 'version';
 // @ts-ignore
 exports.currentPayload = undefined;
 
-const MAX_ATTEMPTS = 20;
-const DELAY = 1000;
-let attempts = 0;
+// @ts-ignore
+exports.activate = function activate(config, packageJsonObj) {
+  if (!packageJsonObj || !packageJsonObj.file) {
+    return;
+  }
 
-exports.activate = function activate() {
-  attempts++;
-
-  // TODO: all metrics call `getMainPackageJsonStartingAtMainModule` - if `getMainPackageJsonStartingAtMainModule` fails
-  //       for the 1st metrics, the other metrics will try again...we should initiate
-  //       `getMainPackageJsonStartingAtMainModule` only once in a central place!
-  applicationUnderMonitoring.getMainPackageJsonStartingAtMainModule((err, packageJson) => {
-    if (err) {
-      return logger.warn(
-        // eslint-disable-next-line max-len
-        `Failed to determine main package.json for "${exports.payloadPrefix}" metric. Reason: ${err?.message} ${err?.stack}`
-      );
-    } else if (!packageJson && attempts < MAX_ATTEMPTS) {
-      setTimeout(exports.activate, DELAY).unref();
-
-      return;
-    } else if (!packageJson) {
-      // final attempt failed, ignore silently
-      return;
-    }
-
-    // @ts-ignore
-    exports.currentPayload = packageJson.version;
-  });
+  // @ts-ignore
+  exports.currentPayload = packageJsonObj.file.version;
 };

--- a/packages/shared-metrics/test/directDependencies_test.js
+++ b/packages/shared-metrics/test/directDependencies_test.js
@@ -6,6 +6,8 @@
 'use strict';
 
 const expect = require('chai').expect;
+const path = require('path');
+const fs = require('fs');
 
 const testUtils = require('@instana/core/test/test_util');
 const directDependencies = require('../src/directDependencies');
@@ -29,11 +31,14 @@ describe('metrics.directDependencies', function () {
   });
 
   it('should provide the set of dependencies with versions', () => {
-    directDependencies.activate();
+    // We simply simulate that mocha is our app. It does not matter which package.json we use as long as it has
+    // dependencies.
+    const anyPackageJsonPath = path.join(path.dirname(require.resolve('mocha')), 'package.json');
+    const anyPackageJsonFile = JSON.parse(fs.readFileSync(anyPackageJsonPath, 'utf8'));
+
+    directDependencies.activate({}, { file: anyPackageJsonFile, path: anyPackageJsonPath });
 
     return testUtils.retry(() => {
-      // Mocha is the main module when running the tests and direct dependencies are evaluated as the content of the
-      // the main modules accompanying package.json file. Thus testing against Mocha dependencies here.
       const deps = directDependencies.currentPayload.dependencies;
       expect(deps).to.exist;
       expect(deps['browser-stdout']).to.equal('1.3.1');


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-65637

Problem:
- any metric is currently requesting the package.json lookup in parallel
- this is ineffecient and not a good approach
- it also floods the log

Before:
<img width="3829" height="1854" alt="pkgjsonbefore" src="https://github.com/user-attachments/assets/3a7e0cb1-3bd4-413f-a936-2761a71f6024" />

After:
<img width="3791" height="1110" alt="pkgjsonfail" src="https://github.com/user-attachments/assets/7f8819d6-8237-4e73-a8e8-8df573f1b4db" />

