### PR TITLE
chore: replaced mongo and rabbitmq docker images

### DIFF
--- a/docker-compose-base.yaml
+++ b/docker-compose-base.yaml
@@ -40,7 +40,7 @@ services:
             redis-server /etc/sentinel.conf --sentinel'
 
   mongo:
-    image: mongo:8.0.8
+    image: public.ecr.aws/docker/library/mongo:8.0.8
     ports:
       - 27017:27017
 
@@ -171,7 +171,7 @@ services:
       MSSQL_SA_PASSWORD: stanCanHazMsSQL1
 
   rabbitmq:
-    image: rabbitmq:3.7.8-alpine
+    image: public.ecr.aws/docker/library/rabbitmq:3.13.7-alpine
     ports:
       - 5671:5671
       - 5672:5672


### PR DESCRIPTION
refs [INSTA-73380](https://jsw.ibm.com/browse/INSTA-73380)

replaced mongo image
replaced rabbitmq image: version is updated to 3.13.7