### PR TITLE
test: ensured test folders regenerate before mocha validation

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -72,6 +72,11 @@ npm_command="npm run test:debug"
 SCOPE_PKG_NAME="${SCOPE#@instana/}"
 TEST_BASE_DIR="packages/${SCOPE_PKG_NAME}/test"
 
+# Pre-check: Ensure test folders are generated before mocha tries to load files
+if [ -f "currencies.json" ] && [ -f "$TEST_BASE_DIR/initEnv.js" ]; then
+  node -e "require('./$TEST_BASE_DIR/initEnv.js')" 2>/dev/null || true
+fi
+
 if [ -n "$PACKAGE" ]; then
   # Normalize package name for scoped packages (e.g., @redis/client -> redis_client)
   NORMALIZED_PACKAGE=$(normalize_folder_name "$PACKAGE")

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -60,6 +60,11 @@ for arg in "$@"; do
   esac
 done
 
+# Regenerate test folders if needed
+if [ "$SCOPE" = "@instana/collector" ]; then
+  node "$(dirname "$0")/sync-test-folders.js"
+fi
+
 args=""
 
 if [ "$WATCH" = true ]; then
@@ -72,10 +77,6 @@ npm_command="npm run test:debug"
 SCOPE_PKG_NAME="${SCOPE#@instana/}"
 TEST_BASE_DIR="packages/${SCOPE_PKG_NAME}/test"
 
-# Pre-check: Ensure test folders are generated before mocha tries to load files
-if [ -f "currencies.json" ] && [ -f "$TEST_BASE_DIR/initEnv.js" ]; then
-  node -e "require('./$TEST_BASE_DIR/initEnv.js')" 2>/dev/null || true
-fi
 
 if [ -n "$PACKAGE" ]; then
   # Normalize package name for scoped packages (e.g., @redis/client -> redis_client)

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -77,7 +77,6 @@ npm_command="npm run test:debug"
 SCOPE_PKG_NAME="${SCOPE#@instana/}"
 TEST_BASE_DIR="packages/${SCOPE_PKG_NAME}/test"
 
-
 if [ -n "$PACKAGE" ]; then
   # Normalize package name for scoped packages (e.g., @redis/client -> redis_client)
   NORMALIZED_PACKAGE=$(normalize_folder_name "$PACKAGE")

--- a/bin/sync-test-folders.js
+++ b/bin/sync-test-folders.js
@@ -48,7 +48,7 @@ function main() {
   try {
     needsRegen = fs.readFileSync(checksumPath, 'utf8').trim() !== currentHash;
   } catch (_) {
-    // ignore
+    // checksum file doesn't exist yet → first run
   }
 
   if (needsRegen) {

--- a/bin/sync-test-folders.js
+++ b/bin/sync-test-folders.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/*
+ * (c) Copyright IBM Corp. 2026
+ */
+
+'use strict';
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const rootDir = path.resolve(__dirname, '..');
+const currenciesPath = path.join(rootDir, 'currencies.json');
+const collectorTestDir = path.join(rootDir, 'packages', 'collector', 'test');
+const checksumPath = path.join(collectorTestDir, '.currencies-checksum');
+
+function log(msg) {
+  console.log(`[${new Date().toISOString()}] ${msg}`);
+}
+
+function hashTemplates(dir, h) {
+  fs.readdirSync(dir, { withFileTypes: true })
+    .filter(entry => entry.name !== 'node_modules' && !entry.name.startsWith('_v'))
+    .forEach(entry => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        hashTemplates(full, h);
+      } else if (entry.name === 'package.json.template' || entry.name === 'modes.json') {
+        h.update(fs.readFileSync(full, 'utf8'));
+      } else if (entry.name === 'test_base.js') {
+        h.update(full);
+      }
+    });
+}
+
+function calculateChecksum() {
+  const hash = crypto.createHash('md5');
+  hash.update(fs.readFileSync(currenciesPath, 'utf8'));
+  hashTemplates(collectorTestDir, hash);
+  return hash.digest('hex');
+}
+
+function main() {
+  const currentHash = calculateChecksum();
+  let needsRegen = true;
+
+  try {
+    needsRegen = fs.readFileSync(checksumPath, 'utf8').trim() !== currentHash;
+  } catch (_) {
+    // first run or checksum file missing
+  }
+
+  if (needsRegen) {
+    log('[INFO] Test folders out of date — regenerating...');
+    execSync('node bin/create-version-test-folders.js', { cwd: rootDir, stdio: 'inherit' });
+    fs.writeFileSync(checksumPath, currentHash);
+  } else {
+    log('[INFO] Test folders up to date, skipping generation.');
+  }
+}
+
+main();

--- a/bin/sync-test-folders.js
+++ b/bin/sync-test-folders.js
@@ -48,7 +48,7 @@ function main() {
   try {
     needsRegen = fs.readFileSync(checksumPath, 'utf8').trim() !== currentHash;
   } catch (_) {
-    // first run or checksum file missing
+    // ignore
   }
 
   if (needsRegen) {

--- a/packages/collector/test/initEnv.js
+++ b/packages/collector/test/initEnv.js
@@ -29,26 +29,7 @@ Object.keys(hostsConfig).forEach(key => {
 });
 
 if (!isCI()) {
-  const checksumPath = path.join(__dirname, '.currencies-checksum');
-  const hash = crypto.createHash('md5');
-  hash.update(fs.readFileSync(path.join(rootDir, 'currencies.json'), 'utf8'));
-  hashTemplates(__dirname, hash);
-  const currentHash = hash.digest('hex');
-
-  let needsRegen = true;
-  try {
-    needsRegen = fs.readFileSync(checksumPath, 'utf8').trim() !== currentHash;
-  } catch (_) {
-    // checksum file doesn't exist yet → first run
-  }
-
-  if (needsRegen) {
-    log('[INFO] Test folders out of date — regenerating...');
-    execSync('node bin/create-version-test-folders.js', { cwd: rootDir, stdio: 'inherit' });
-    fs.writeFileSync(checksumPath, currentHash);
-  } else {
-    log('[INFO] Test folders up to date, skipping generation.');
-  }
+  execSync('node bin/sync-test-folders.js', { cwd: rootDir, stdio: 'inherit' });
 }
 
 if (process.env.SKIP_TGZ !== 'true') {
@@ -116,21 +97,6 @@ function hashDir(dir, h) {
       h.update(fs.readFileSync(full));
     }
   });
-}
-
-function hashTemplates(dir, h) {
-  fs.readdirSync(dir, { withFileTypes: true })
-    .filter(entry => entry.name !== 'node_modules' && !entry.name.startsWith('_v'))
-    .forEach(entry => {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        hashTemplates(full, h);
-      } else if (entry.name === 'package.json.template' || entry.name === 'modes.json') {
-        h.update(fs.readFileSync(full, 'utf8'));
-      } else if (entry.name === 'test_base.js') {
-        h.update(full);
-      }
-    });
 }
 
 /**


### PR DESCRIPTION
Implemented test folder regeneration before mocha validation with a reusable approach that's called from both `initEnv` and `run-test`