### PR TITLE
ci(sonar): fixed global binary installation for latest Sonar version

### DIFF
--- a/.tekton/tasks/tasks-results.yaml
+++ b/.tekton/tasks/tasks-results.yaml
@@ -69,8 +69,7 @@ spec:
           npx eslint packages/ -f json -o eslint-report.json || true
 
           echo "Installing SonarCloud scanner..."
-          # 4.3.3 is broken and does not ship a global binary!
-          npm install -g @sonar/scan@4.3.2
+          npm install -g @sonar/scan
 
           if [ -n "$(params.pr-number)" ]; then
             echo '$(params.pr-payload)' > pr.json


### PR DESCRIPTION
* Sonar 4.3.3 was not functioning correctly and did not install a global binary.
* Tekton was returning the error: “sonar: command not found.”

According to the latest update in sonar v4.3.4, the problem has now been resolved.

https://jsw.ibm.com/browse/INSTA-71305
