### PR TITLE
chore: improved AWS SNS test resource cleanup

### DIFF
--- a/packages/collector/test/integration/currencies/cloud/@aws-sdk/client-sns/test_base.js
+++ b/packages/collector/test/integration/currencies/cloud/@aws-sdk/client-sns/test_base.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+const semver = require('semver');
 const { expect } = require('chai');
 const { fail } = expect;
 const qs = require('querystring');
@@ -27,7 +28,7 @@ const inVersionDir =
 const baseDir = inVersionDir ? path.resolve(__dirname, '..') : __dirname;
 
 let topicArn;
-const topicName = 'MyNodeTopicArn';
+const topicName = `nodejs-team-${semver.major(process.versions.node)}`;
 const availableStyles = ['default', 'callback', 'v2'];
 const availableCommands = {
   PublishCommand: {
@@ -66,12 +67,20 @@ function start() {
   });
 
   after(async () => {
-    // CASE: queue was not created in before hook
-    if (!queueUrl) {
-      return;
+    if (topicArn) {
+      try {
+        await utils.removeTopic(topicArn);
+      } catch (err) {
+        console.error('Error removing SNS topic:', err.message);
+      }
     }
-
-    await utils.removeQueue(queueUrl);
+    if (queueUrl) {
+      try {
+        await utils.removeQueue(queueUrl);
+      } catch (err) {
+        console.error('Error removing SQS queue:', err.message);
+      }
+    }
   });
 
   describe(`npm: ${libraryEnv.LIBRARY_VERSION}`, function () {

--- a/packages/collector/test/integration/currencies/cloud/@aws-sdk/client-sns/test_base.js
+++ b/packages/collector/test/integration/currencies/cloud/@aws-sdk/client-sns/test_base.js
@@ -28,7 +28,7 @@ const inVersionDir =
 const baseDir = inVersionDir ? path.resolve(__dirname, '..') : __dirname;
 
 let topicArn;
-const topicName = `nodejs-team-${semver.major(process.versions.node)}`;
+const topicName = `nodejs-team-v3-${semver.major(process.versions.node)}`;
 const availableStyles = ['default', 'callback', 'v2'];
 const availableCommands = {
   PublishCommand: {

--- a/packages/collector/test/integration/currencies/cloud/@aws-sdk/client-sns/utils.js
+++ b/packages/collector/test/integration/currencies/cloud/@aws-sdk/client-sns/utils.js
@@ -79,6 +79,10 @@ exports.removeQueue = async url => {
   });
 };
 
+exports.removeTopic = async arn => {
+  await snsClient.send(new sns.DeleteTopicCommand({ TopicArn: arn }));
+};
+
 exports.generateQueueName = () => {
   let queueName = 'nodejs-team';
 

--- a/packages/collector/test/integration/currencies/cloud/@aws-sdk/client-sns/utils.js
+++ b/packages/collector/test/integration/currencies/cloud/@aws-sdk/client-sns/utils.js
@@ -83,7 +83,7 @@ exports.removeTopic = async arn => {
 };
 
 exports.generateQueueName = () => {
-  let queueName = 'nodejs-team-sqs';
+  let queueName = 'nodejs-team';
 
   if (process.env.SQS_QUEUE_NAME) {
     queueName = `${process.env.SQS_QUEUE_NAME}-${semver.major(process.versions.node)}`;

--- a/packages/collector/test/integration/currencies/cloud/@aws-sdk/client-sns/utils.js
+++ b/packages/collector/test/integration/currencies/cloud/@aws-sdk/client-sns/utils.js
@@ -4,7 +4,6 @@
 
 'use strict';
 
-const uuid = require('uuid');
 const semver = require('semver');
 const awsSdk3 = require('@aws-sdk/client-sqs');
 const sns = require('@aws-sdk/client-sns');
@@ -84,13 +83,13 @@ exports.removeTopic = async arn => {
 };
 
 exports.generateQueueName = () => {
-  let queueName = 'nodejs-team';
+  let queueName = 'nodejs-team-sqs';
 
   if (process.env.SQS_QUEUE_NAME) {
-    queueName = `${process.env.SQS_QUEUE_NAME}-v3-${semver.major(process.versions.node)}-${uuid.v4()}`;
+    queueName = `${process.env.SQS_QUEUE_NAME}-${semver.major(process.versions.node)}`;
+  } else {
+    queueName = `${queueName}-${semver.major(process.versions.node)}`;
   }
 
-  const randomNumber = Math.floor(Math.random() * 1000);
-  queueName = `${queueName}-${randomNumber}`;
   return queueName;
 };

--- a/packages/collector/test/integration/currencies/cloud/aws-sdk/sns/suite.js
+++ b/packages/collector/test/integration/currencies/cloud/aws-sdk/sns/suite.js
@@ -22,7 +22,7 @@ const {
 } = require('@_local/core/test/test_util/common_verifications');
 const { promisifyNonSequentialCases } = require('../promisify_non_sequential');
 
-const topicAndQueueName = `nodejs-team-sns-${semver.major(process.versions.node)}`;
+const topicAndQueueName = `nodejs-team-v2-${semver.major(process.versions.node)}`;
 const topicArn = `arn:aws:sns:us-east-2:767398002385:${topicAndQueueName}`;
 const sqsQueueUrl = `https://sqs.us-east-2.amazonaws.com/767398002385/${topicAndQueueName}`;
 

--- a/packages/collector/test/integration/currencies/cloud/aws-sdk/sns/suite.js
+++ b/packages/collector/test/integration/currencies/cloud/aws-sdk/sns/suite.js
@@ -22,7 +22,7 @@ const {
 } = require('@_local/core/test/test_util/common_verifications');
 const { promisifyNonSequentialCases } = require('../promisify_non_sequential');
 
-const topicAndQueueName = `nodejs-team-v2-${semver.major(process.versions.node)}`;
+const topicAndQueueName = `nodejs-team-sns-${semver.major(process.versions.node)}`;
 const topicArn = `arn:aws:sns:us-east-2:767398002385:${topicAndQueueName}`;
 const sqsQueueUrl = `https://sqs.us-east-2.amazonaws.com/767398002385/${topicAndQueueName}`;
 

--- a/packages/collector/test/integration/currencies/cloud/aws-sdk/sns/suite.js
+++ b/packages/collector/test/integration/currencies/cloud/aws-sdk/sns/suite.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-const { v4: uuid } = require('uuid');
 const { cleanup, createTopic } = require('./util');
 const semver = require('semver');
 const { expect } = require('chai');
@@ -23,7 +22,7 @@ const {
 } = require('@_local/core/test/test_util/common_verifications');
 const { promisifyNonSequentialCases } = require('../promisify_non_sequential');
 
-const topicAndQueueName = `nodejs-team-${semver.major(process.versions.node)}-${uuid()}`;
+const topicAndQueueName = `nodejs-team-v2-${semver.major(process.versions.node)}`;
 const topicArn = `arn:aws:sns:us-east-2:767398002385:${topicAndQueueName}`;
 const sqsQueueUrl = `https://sqs.us-east-2.amazonaws.com/767398002385/${topicAndQueueName}`;
 

--- a/packages/collector/test/integration/currencies/cloud/aws-sdk/sns/util.js
+++ b/packages/collector/test/integration/currencies/cloud/aws-sdk/sns/util.js
@@ -49,20 +49,25 @@ exports.createSQSQueue = function createSQSQueue(queueName, topicName) {
 /**
  * Attempts to delete a previous created topic and SQS subscriber queue before the test starts
  * @param {string} topicArn
+ * @param {string} queueURL
  */
 exports.cleanup = async function (topicArn, queueURL) {
   try {
-    await sns
-      .deleteTopic({
-        TopicArn: topicArn
-      })
-      .promise();
+    if (topicArn) {
+      await sns
+        .deleteTopic({
+          TopicArn: topicArn
+        })
+        .promise();
+    }
 
-    await sqs
-      .deleteQueue({
-        QueueUrl: queueURL
-      })
-      .promise();
+    if (queueURL) {
+      await sqs
+        .deleteQueue({
+          QueueUrl: queueURL
+        })
+        .promise();
+    }
   } catch (err) {
     return Promise.resolve('Error cleaning up the topic and queue', err);
   }

--- a/packages/collector/test/integration/currencies/cloud/aws-sdk/sqs/suite.js
+++ b/packages/collector/test/integration/currencies/cloud/aws-sdk/sqs/suite.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-const { v4: uuid } = require('uuid');
 const { createQueues, deleteQueues } = require('./sqsUtil');
 const semver = require('semver');
 const { expect } = require('chai');
@@ -28,7 +27,7 @@ const { verifyHttpRootEntry, verifyHttpExit } = require('@_local/core/test/test_
 const defaultPrefix = 'https://sqs.us-east-2.amazonaws.com/767398002385/';
 const queueUrlPrefix = process.env.SQS_QUEUE_URL_PREFIX || defaultPrefix;
 const queueNamePrefix = process.env.SQS_QUEUE_NAME || 'nodejs-team';
-const queueName = `${queueNamePrefix}-${semver.major(process.versions.node)}-${uuid()}`;
+const queueName = `${queueNamePrefix}-${semver.major(process.versions.node)}}`;
 const queueURL = `${queueUrlPrefix}${queueName}`;
 
 const sendingMethods = ['callback', 'promise'];

--- a/packages/collector/test/integration/currencies/cloud/aws-sdk/sqs/suite.js
+++ b/packages/collector/test/integration/currencies/cloud/aws-sdk/sqs/suite.js
@@ -27,7 +27,7 @@ const { verifyHttpRootEntry, verifyHttpExit } = require('@_local/core/test/test_
 const defaultPrefix = 'https://sqs.us-east-2.amazonaws.com/767398002385/';
 const queueUrlPrefix = process.env.SQS_QUEUE_URL_PREFIX || defaultPrefix;
 const queueNamePrefix = process.env.SQS_QUEUE_NAME || 'nodejs-team';
-const queueName = `${queueNamePrefix}-${semver.major(process.versions.node)}}`;
+const queueName = `${queueNamePrefix}-${semver.major(process.versions.node)}`;
 const queueURL = `${queueUrlPrefix}${queueName}`;
 
 const sendingMethods = ['callback', 'promise'];


### PR DESCRIPTION
Removed the UUID suffix from the SNS topic and SQS queue names used in the tests. The UUID caused resources not to be cleaned up properly when a test failed midway.

ref https://jsw.ibm.com/browse/INSTA-76628