### PR TITLE
fix(core): improved handling of malformed or incomplete URLs to prevent errors

### DIFF
--- a/packages/core/src/util/url.js
+++ b/packages/core/src/util/url.js
@@ -28,18 +28,18 @@ exports.sanitizeUrl = function sanitizeUrl(urlString) {
     normalizedUrl = `${nullToEmptyString(url.protocol)}${url.protocol || url.host ? '//' : ''}${
       url.username || url.password ? '<redacted>:<redacted>@' : ''
     }${nullToEmptyString(url.host)}${nullToEmptyString(url.pathname)}`;
-  } catch (e) {
+  } catch {
     // If URL parsing fails and it's a relative URL, return its path.
     // For example, if the input is "/foo?a=b", the returned value will be "/foo".
     if (typeof urlString === 'string' && urlString.startsWith('/')) {
       try {
         return new URL(urlString, 'https://example.org/').pathname;
-      } catch (err2) {
-        // If even parsing with base URL fails, return the original string
+      } catch {
+        // Improve sanitization logic (ref: INSTA-747)
         return urlString;
       }
     } else {
-      // This case  need adjustment for complete sanitization of the URL, reference 159741
+      // Improve sanitization logic (ref: INSTA-747)
       return urlString;
     }
   }

--- a/packages/core/src/util/url.js
+++ b/packages/core/src/util/url.js
@@ -32,7 +32,12 @@ exports.sanitizeUrl = function sanitizeUrl(urlString) {
     // If URL parsing fails and it's a relative URL, return its path.
     // For example, if the input is "/foo?a=b", the returned value will be "/foo".
     if (typeof urlString === 'string' && urlString.startsWith('/')) {
-      return new URL(urlString, 'https://example.org/').pathname;
+      try {
+        return new URL(urlString, 'https://example.org/').pathname;
+      } catch (err2) {
+        // If even parsing with base URL fails, return the original string
+        return urlString;
+      }
     } else {
       // This case  need adjustment for complete sanitization of the URL, reference 159741
       return urlString;

--- a/packages/core/test/util/url_test.js
+++ b/packages/core/test/util/url_test.js
@@ -63,5 +63,31 @@ describe('util/url', () => {
         'http://example.org/ACDKey=1:00000:00000;ANI=00000111;DN=00000111'
       );
     });
+
+    it('must return malformed URL strings unchanged', () => {
+      expect(sanitizeUrl('://bad-url')).to.equal('://bad-url');
+    });
+
+    it('must not throw when given malformed URL', () => {
+      expect(() => sanitizeUrl('://bad-url')).to.not.throw();
+    });
+
+    it('must return empty string unchanged', () => {
+      expect(sanitizeUrl('')).to.equal('');
+    });
+
+    it('must not throw for invalid URL strings', () => {
+      expect(() => sanitizeUrl('invalid:url')).to.not.throw();
+    });
+
+    it('must handle double slash "//" without throwing Invalid URL error', () => {
+      expect(() => sanitizeUrl('//')).to.not.throw();
+      expect(sanitizeUrl('//')).to.equal('//');
+    });
+
+    it('must handle triple slash "///" without throwing Invalid URL error', () => {
+      expect(() => sanitizeUrl('///')).to.not.throw();
+      expect(sanitizeUrl('///')).to.equal('///');
+    });
   });
 });


### PR DESCRIPTION
The sanitizeUrl function was throwing a TypeError: Invalid URL when processing certain inputs. This change introduces an additional catch block to safely handle such cases.

In particular, it ensures handling of edge cases where the URL contains patterns like // or ///, which can cause parsing to fail.

We already have a card to improve this https://jsw.ibm.com/browse/INSTA-747

ref https://jsw.ibm.com/browse/INSTA-80766