### PR TITLE
feat: added instrumentation for db2 executeNonQuery method

### DIFF
--- a/packages/collector/test/integration/currencies/databases/ibm_db/app.js
+++ b/packages/collector/test/integration/currencies/databases/ibm_db/app.js
@@ -690,6 +690,27 @@ app.get('/prepare-execute-non-query-sync', (req, res) => {
   }
 });
 
+app.get('/prepare-execute-non-query-async', (req, res) => {
+  const error = req.query.error;
+
+  const stmtObject = connection.prepareSync(
+    `insert into ${DB2_TABLE_NAME_1}(COLINT, COLDATETIME, COLTEXT) VALUES (?, ?, ?)`
+  );
+  let params = [23, null, null];
+
+  if (error) {
+    params = [];
+  }
+
+  stmtObject.executeNonQuery(params, function (err, rowCount) {
+    if (err) {
+      return res.status(error ? 200 : 500).send({ err: err.message });
+    }
+
+    res.status(200).send({ data: rowCount });
+  });
+});
+
 app.get('/query-result-async', (req, res) => {
   const txn = req.query.transaction;
   const stmt = `SELECT * FROM ${DB2_TABLE_NAME_1}`;

--- a/packages/collector/test/integration/currencies/databases/ibm_db/app.mjs
+++ b/packages/collector/test/integration/currencies/databases/ibm_db/app.mjs
@@ -656,6 +656,27 @@ app.get('/prepare-execute-non-query-sync', (req, res) => {
   }
 });
 
+app.get('/prepare-execute-non-query-async', (req, res) => {
+  const error = req.query.error;
+
+  const stmtObject = connection.prepareSync(
+    `insert into ${DB2_TABLE_NAME_1}(COLINT, COLDATETIME, COLTEXT) VALUES (?, ?, ?)`
+  );
+  let params = [23, null, null];
+
+  if (error) {
+    params = [];
+  }
+
+  stmtObject.executeNonQuery(params, function (err, rowCount) {
+    if (err) {
+      return res.status(error ? 200 : 500).send({ err: err.message });
+    }
+
+    res.status(200).send({ data: rowCount });
+  });
+});
+
 app.get('/query-result-async', (req, res) => {
   const txn = req.query.transaction;
   const stmt = `SELECT * FROM ${DB2_TABLE_NAME_1}`;

--- a/packages/collector/test/integration/currencies/databases/ibm_db/test_base.js
+++ b/packages/collector/test/integration/currencies/databases/ibm_db/test_base.js
@@ -732,6 +732,37 @@ module.exports = function (name, version, isLatest) {
           );
       });
 
+      it('prepare, executeNonQuery', function () {
+        return controls
+          .sendRequest({
+            method: 'GET',
+            path: '/prepare-execute-non-query-async'
+          })
+          .then(() =>
+            testUtils.retry(() =>
+              verifySpans(agentControls, controls, {
+                stmt: `insert into ${TABLE_NAME_1}(COLINT, COLDATETIME, COLTEXT) VALUES (?, ?, ?)`
+              })
+            )
+          );
+      });
+
+      it('[with error] prepare, executeNonQuery', function () {
+        return controls
+          .sendRequest({
+            method: 'GET',
+            path: '/prepare-execute-non-query-async?error=true'
+          })
+          .then(() =>
+            testUtils.retry(() =>
+              verifySpans(agentControls, controls, {
+                stmt: `insert into ${TABLE_NAME_1}(COLINT, COLDATETIME, COLTEXT) VALUES (?, ?, ?)`,
+                error: 'Error: [IBM][CLI Driver] CLI0100E  Wrong number of parameters. SQLSTATE=07001'
+              })
+            )
+          );
+      });
+
       it('must trace prepare execute mixed 1', function () {
         return controls
           .sendRequest({

--- a/packages/core/src/tracing/instrumentation/databases/db2.js
+++ b/packages/core/src/tracing/instrumentation/databases/db2.js
@@ -402,6 +402,50 @@ function instrumentExecuteHelper(ctx, originalArgs, stmtObject, prepareCallParen
     });
   };
 
+  const originalExecuteNonQuery = stmtObject.executeNonQuery;
+
+  stmtObject.executeNonQuery = function instanaExecuteNonQuery() {
+    return cls.ns.runAndReturn(() => {
+      if (!canTrace()) {
+        return originalExecuteNonQuery.apply(this, arguments);
+      }
+
+      const span = createSpan(originalArgs[0], instrumentExecuteHelper, ctx._instanaConnectionString);
+
+      const args = arguments;
+      const origCallbackIndex =
+        // eslint-disable-next-line no-nested-ternary
+        args.length === 1 && typeof args[0] === 'function'
+          ? 0
+          : args.length === 2 && typeof args[1] === 'function'
+          ? 1
+          : null;
+      const origCallback = args[origCallbackIndex];
+
+      if (!origCallback) {
+        // TODO: Instrumentation is currently skipped when no callback is provided.
+        // This behavior needs to be revisited.
+        // Reference: https://jsw.ibm.com/browse/INSTA-80799
+        return originalExecuteNonQuery.apply(this, arguments);
+      }
+
+      args[origCallbackIndex] = function instanaExecuteNonQueryCallback(executeErr) {
+        if (executeErr) {
+          span.ec = 1;
+          tracingUtil.setErrorDetails(span, executeErr, 'db2');
+          finishSpan(ctx, null, span);
+          return origCallback.apply(this, arguments);
+        }
+
+        // NOTE: executeNonQuery returns row count, not a result object
+        finishSpan(ctx, null, span);
+        return origCallback.apply(this, arguments);
+      };
+
+      return originalExecuteNonQuery.apply(this, arguments);
+    });
+  };
+
   const originalExecuteSync = stmtObject.executeSync;
   stmtObject.executeSync = function instanaExecuteSync() {
     return cls.ns.runAndReturn(() => {


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-80684

There was an instrumentation gap for the executeNonQuery method! Added the same 