### PR TITLE
fix: removed deprecated INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS env variable

### DIFF
--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -381,24 +381,6 @@ function normalizeTracingTransmission(config) {
     configPath: 'config.tracing.transmissionDelay'
   });
 
-  // DEPRECATED! This was never documented, but we shared it with a customer.
-  if (process.env['INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS']) {
-    logger.warn(
-      'The environment variable INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS is deprecated and will be removed in the next major release. ' +
-        'Please use INSTANA_TRACING_TRANSMISSION_DELAY instead.'
-    );
-
-    config.tracing.transmissionDelay = parseInt(process.env['INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS'], 10);
-
-    if (isNaN(config.tracing.transmissionDelay)) {
-      logger.warn(
-        `The value of INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS is not a number. Falling back to the default value ${defaults.tracing.transmissionDelay}.`
-      );
-
-      config.tracing.transmissionDelay = defaults.tracing.transmissionDelay;
-    }
-  }
-
   config.tracing.forceTransmissionStartingAt = util.resolveNumericConfig({
     envVar: 'INSTANA_FORCE_TRANSMISSION_STARTING_AT',
     configValue: config.tracing.forceTransmissionStartingAt,


### PR DESCRIPTION
BREAKING CHANGE:
The environment variable `INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS` has been removed.
Please use `INSTANA_TRACING_TRANSMISSION_DELAY` instead.