### PR TITLE
fix(core): ensured env vars take precedence over in-code config

### DIFF
--- a/packages/core/src/config/configNormalizers/disable.js
+++ b/packages/core/src/config/configNormalizers/disable.js
@@ -19,32 +19,55 @@ exports.init = function init(_config) {
  * Handles environment variables, and array inputs.
  *
  * Precedence order (highest to lowest):
- * 1. `tracing.disable`
- * 2. Environment variables (`INSTANA_TRACING_DISABLE*`)
+ * 1. Environment variables (`INSTANA_TRACING_DISABLE*`)
+ * 2. In-code tracing.disable
  *
  * @param {import('../../config').InstanaConfig} config
  */
 exports.normalize = function normalize(config) {
   if (!config?.tracing) config.tracing = {};
   try {
-    // Disable all tracing if explicitly set  'disable' to true
+    const envDisableConfig = getDisableFromEnv();
+
+    if (envDisableConfig !== null) {
+      if (envDisableConfig === true) {
+        logger?.debug('[config] env:INSTANA_TRACING_DISABLE = true');
+        return true;
+      }
+
+      if (envDisableConfig === false) {
+        logger?.debug('[config] env:INSTANA_TRACING_DISABLE = false (overrides in-code config)');
+        return {};
+      }
+
+      if (envDisableConfig.instrumentations?.length || envDisableConfig.groups?.length) {
+        logger?.debug(`[config] env:INSTANA_TRACING_DISABLE* = ${JSON.stringify(envDisableConfig)}`);
+
+        if (envDisableConfig.instrumentations) {
+          envDisableConfig.instrumentations = normalizeArray(envDisableConfig.instrumentations);
+        }
+        if (envDisableConfig.groups) {
+          envDisableConfig.groups = normalizeArray(envDisableConfig.groups);
+        }
+
+        return envDisableConfig;
+      }
+    }
+
     if (config.tracing.disable === true) {
       logger?.debug('[config] incode:tracing.disable = true');
-
       return true;
     }
+
     const hasDisableConfig = isDisableConfigNonEmpty(config);
 
     if (hasDisableConfig) {
       logger?.debug(`[config] incode:tracing.disable = ${JSON.stringify(config.tracing.disable)}`);
     }
 
-    // Fallback to environment variables if `disable` is not explicitly configured
-    const disableConfig = isDisableConfigNonEmpty(config) ? config.tracing.disable : getDisableFromEnv();
+    const disableConfig = isDisableConfigNonEmpty(config) ? config.tracing.disable : null;
 
     if (!disableConfig) return {};
-
-    if (disableConfig === true) return true;
 
     // Normalize instrumentations and groups
     if (disableConfig?.instrumentations) {
@@ -90,7 +113,7 @@ exports.normalizeExternalConfig = function normalizeExternalConfig(config) {
  * 2. INSTANA_TRACING_DISABLE_INSTRUMENTATIONS / INSTANA_TRACING_DISABLE_GROUPS
  * 3. INSTANA_TRACING_DISABLE=list
  *
- * @returns {import('../../config/types').Disable}
+ * @returns {import('../../config/types').Disable | boolean | null}
  */
 function getDisableFromEnv() {
   const disable = {};
@@ -104,7 +127,12 @@ function getDisableFromEnv() {
       return true;
     }
 
-    if (envVarValue !== 'false' && envVarValue !== '') {
+    if (envVarValue === 'false') {
+      logger?.debug('[config] env:INSTANA_TRACING_DISABLE = false');
+      return false;
+    }
+
+    if (envVarValue !== '') {
       const categorized = categorizeDisableEntries(parseEnvVar(envVarValue));
       if (categorized?.instrumentations?.length) {
         disable.instrumentations = categorized.instrumentations;

--- a/packages/core/src/config/configNormalizers/stackTrace.js
+++ b/packages/core/src/config/configNormalizers/stackTrace.js
@@ -25,7 +25,7 @@ exports.normalizeStackTraceMode = function (config) {
 
 /**
  * Normalizes stack trace length configuration based on precedence.
- * Precedence: global config > config > env var > default
+ * Precedence: env var > global config > config > default
  * @param {import('../../config').InstanaConfig} config
  * @returns {number} - Normalized value
  */

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -359,7 +359,15 @@ function normalizeTracingHttp({ userConfig = {}, defaultConfig = {}, finalConfig
 
   const userHeaders = userHttp?.extraHttpHeadersToCapture;
 
-  // 1. Check in-code configuration first
+  // 1. Check environment variable
+  if (process.env.INSTANA_EXTRA_HTTP_HEADERS) {
+    const fromEnvVar = parseHeadersEnvVar(process.env.INSTANA_EXTRA_HTTP_HEADERS);
+    finalConfig.tracing.http.extraHttpHeadersToCapture = fromEnvVar;
+    logger.debug(`[config] env:INSTANA_EXTRA_HTTP_HEADERS = ${process.env.INSTANA_EXTRA_HTTP_HEADERS}`);
+    return;
+  }
+
+  // 2. Check in-code configuration
   if (userHeaders !== undefined) {
     if (!Array.isArray(userHeaders)) {
       logger.warn(
@@ -373,14 +381,6 @@ function normalizeTracingHttp({ userConfig = {}, defaultConfig = {}, finalConfig
       logger.debug('[config] incode:config.tracing.http.extraHttpHeadersToCapture');
       return;
     }
-  }
-
-  // 2. Check environment variable
-  if (process.env.INSTANA_EXTRA_HTTP_HEADERS) {
-    const fromEnvVar = parseHeadersEnvVar(process.env.INSTANA_EXTRA_HTTP_HEADERS);
-    finalConfig.tracing.http.extraHttpHeadersToCapture = fromEnvVar;
-    logger.debug(`[config] env:INSTANA_EXTRA_HTTP_HEADERS = ${process.env.INSTANA_EXTRA_HTTP_HEADERS}`);
-    return;
   }
 
   // 3. Use default configuration
@@ -415,6 +415,7 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
   const envStackTrace = process.env.INSTANA_STACK_TRACE;
   const envStackTraceLength = process.env.INSTANA_STACK_TRACE_LENGTH;
 
+  // Priority 1: Environment variable
   if (envStackTrace !== undefined) {
     const result = validateStackTraceMode(envStackTrace);
 
@@ -430,6 +431,7 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
       finalConfig.tracing.stackTrace = defaultConfig.tracing.stackTrace;
     }
   } else if (userGlobal?.stackTrace !== undefined) {
+    // Priority 2: In-code configuration
     const result = validateStackTraceMode(userGlobal.stackTrace);
 
     if (result.isValid) {
@@ -450,6 +452,7 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
   const isLegacyLengthDefined = userTracingConfig?.stackTraceLength !== undefined;
   const stackTraceConfigValue = userGlobal?.stackTraceLength || userTracingConfig?.stackTraceLength;
 
+  // Priority 1: Environment variable
   if (envStackTraceLength !== undefined) {
     const result = validateStackTraceLength(envStackTraceLength);
 
@@ -465,6 +468,7 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
       finalConfig.tracing.stackTraceLength = defaultConfig.tracing.stackTraceLength;
     }
   } else if (stackTraceConfigValue !== undefined) {
+    // Priority 2: In-code configuration
     if (isLegacyLengthDefined) {
       logger.warn(
         // eslint-disable-next-line max-len

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -685,14 +685,7 @@ function normalizeIgnoreEndpoints({ userConfig = {}, defaultConfig = {}, finalCo
     return;
   }
 
-  // Case 1: Use in-code configuration if available
-  if (userIgnoreEndpoints && Object.keys(userIgnoreEndpoints).length) {
-    finalConfig.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.normalizeConfig(userIgnoreEndpoints);
-    logger.debug('[config] incode:config.tracing.ignoreEndpoints');
-    return;
-  }
-
-  // Case 2: Load from a YAML file if `INSTANA_IGNORE_ENDPOINTS_PATH` is set
+  // Priority 1: Load from a YAML file if `INSTANA_IGNORE_ENDPOINTS_PATH` is set
   // Introduced in Phase 2 for advanced filtering based on both methods and endpoints.
   // Also supports basic filtering for endpoints.
   if (process.env.INSTANA_IGNORE_ENDPOINTS_PATH) {
@@ -703,7 +696,7 @@ function normalizeIgnoreEndpoints({ userConfig = {}, defaultConfig = {}, finalCo
     return;
   }
 
-  // Case 3: Load from the `INSTANA_IGNORE_ENDPOINTS` environment variable
+  // Priority 2: Load from the `INSTANA_IGNORE_ENDPOINTS` environment variable
   // Introduced in Phase 1 for basic filtering based only on operations (e.g., `redis.get`, `kafka.consume`).
   // Provides a simple way to configure ignored operations via environment variables.
   if (process.env.INSTANA_IGNORE_ENDPOINTS) {
@@ -711,6 +704,13 @@ function normalizeIgnoreEndpoints({ userConfig = {}, defaultConfig = {}, finalCo
       process.env.INSTANA_IGNORE_ENDPOINTS
     );
     logger.debug('[config] env:INSTANA_IGNORE_ENDPOINTS');
+    return;
+  }
+
+  // Priority 3: Use in-code configuration if available
+  if (userIgnoreEndpoints && Object.keys(userIgnoreEndpoints).length) {
+    finalConfig.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.normalizeConfig(userIgnoreEndpoints);
+    logger.debug('[config] incode:config.tracing.ignoreEndpoints');
     return;
   }
 

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -85,6 +85,20 @@ function parseBooleanFromEnv(envValue) {
  * @returns {boolean}
  */
 exports.resolveBooleanConfig = function resolveBooleanConfig({ envVar, configValue, defaultValue, configPath }) {
+  // Priority 1: Environment variable
+  const envValue = process.env[envVar];
+  const envParsed = parseBooleanFromEnv(envValue);
+
+  if (envParsed !== undefined) {
+    logger.debug(`[config] env:${envVar} = ${envParsed}`);
+    return envParsed;
+  }
+
+  if (envValue != null) {
+    logger.warn(`Invalid boolean value for ${envVar}: "${envValue}". Checking in-code config.`);
+  }
+
+  // Priority 2: In-code configuration
   if (typeof configValue === 'boolean') {
     logger.debug(`[config] incode:${configPath} = ${configValue}`);
     return configValue;
@@ -98,18 +112,7 @@ exports.resolveBooleanConfig = function resolveBooleanConfig({ envVar, configVal
     );
   }
 
-  const envValue = process.env[envVar];
-  const envParsed = parseBooleanFromEnv(envValue);
-
-  if (envParsed !== undefined) {
-    logger.debug(`[config] env:${envVar} = ${envParsed}`);
-    return envParsed;
-  }
-
-  if (envValue != null) {
-    logger.warn(`Invalid boolean value for ${envValue}: "${envValue}".`);
-  }
-
+  // Priority 3: Default value
   return defaultValue;
 };
 
@@ -130,16 +133,24 @@ exports.resolveBooleanConfigWithInvertedEnv = function resolveBooleanConfigWithI
   defaultValue,
   configPath
 }) {
-  if (typeof configValue === 'boolean') {
-    logger.debug(`[config] incode:${configPath} = ${configValue}`);
+  // Priority 1: Environment variable
+  const envValue = process.env[envVar];
+  const envParsed = parseBooleanFromEnv(envValue);
 
-    return configValue;
+  if (envParsed !== undefined) {
+    const invertedValue = !envParsed;
+    logger.debug(`[config] env:${envVar} = ${envParsed} (inverted to ${invertedValue})`);
+    return invertedValue;
   }
 
-  const envValue = process.env[envVar];
-  if (envValue === 'true') {
-    logger.debug(`[config] env:${envVar} = true (inverted to false)`);
-    return false;
+  if (envValue != null) {
+    logger.warn(`Invalid boolean value for ${envVar}: "${envValue}". Checking in-code config.`);
+  }
+
+  // Priority 2: In-code configuration
+  if (typeof configValue === 'boolean') {
+    logger.debug(`[config] incode:${configPath} = ${configValue}`);
+    return configValue;
   }
 
   if (configValue != null && configPath) {
@@ -150,6 +161,7 @@ exports.resolveBooleanConfigWithInvertedEnv = function resolveBooleanConfigWithI
     );
   }
 
+  // Priority 3: Default value
   return defaultValue;
 };
 
@@ -170,17 +182,20 @@ exports.resolveBooleanConfigWithTruthyEnv = function resolveBooleanConfigWithTru
   defaultValue,
   configPath
 }) {
-  if (typeof configValue === 'boolean') {
-    logger.debug(`[config] incode:${configPath} = ${configValue}`);
-    return configValue;
-  }
-
+  // Priority 1: Environment variable
   const envValue = process.env[envVar];
   if (envValue) {
     logger.debug(`[config] env:${envVar} = ${envValue}`);
     return true;
   }
 
+  // Priority 2: In-code configuration
+  if (typeof configValue === 'boolean') {
+    logger.debug(`[config] incode:${configPath} = ${configValue}`);
+    return configValue;
+  }
+
+  // Priority 3: Default value
   return defaultValue;
 };
 
@@ -192,6 +207,14 @@ exports.resolveBooleanConfigWithTruthyEnv = function resolveBooleanConfigWithTru
  * @param {string} [params.configPath]
  */
 exports.resolveStringConfig = function resolveStringConfig({ envVar, configValue, defaultValue, configPath }) {
+  // Priority 1: Environment variable
+  const envValue = process.env[envVar];
+  if (envValue != null) {
+    logger.debug(`[config] env:${envVar} = ${envValue}`);
+    return envValue;
+  }
+
+  // Priority 2: In-code configuration
   if (configValue != null) {
     if (typeof configValue !== 'string') {
       logger.warn(
@@ -204,12 +227,5 @@ exports.resolveStringConfig = function resolveStringConfig({ envVar, configValue
     logger.debug(`[config] incode:${configPath} = ${configValue}`);
     return configValue;
   }
-
-  const envValue = process.env[envVar];
-  if (envValue != null) {
-    logger.debug(`[config] env:${envVar} = ${envValue}`);
-    return envValue;
-  }
-
   return defaultValue;
 };

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -95,7 +95,7 @@ exports.resolveBooleanConfig = function resolveBooleanConfig({ envVar, configVal
   }
 
   if (envValue != null) {
-    logger.warn(`Invalid boolean value for ${envVar}: "${envValue}". Checking in-code config.`);
+    logger.warn(`Invalid boolean value for ${envValue}: "${envValue}".`);
   }
 
   // Priority 2: In-code configuration

--- a/packages/core/test/config/configNormalizers/disable_test.js
+++ b/packages/core/test/config/configNormalizers/disable_test.js
@@ -288,7 +288,7 @@ describe('util.configNormalizers.disable', () => {
       expect(result).to.deep.equal({});
     });
 
-    it.skip('should give precedence to INSTANA_TRACING_DISABLE=false over config.tracing.disable=true', () => {
+    it('should give precedence to INSTANA_TRACING_DISABLE=false over config.tracing.disable=true', () => {
       process.env.INSTANA_TRACING_DISABLE = 'false';
 
       const config = {
@@ -301,7 +301,7 @@ describe('util.configNormalizers.disable', () => {
       expect(result).to.deep.equal({});
     });
 
-    it.skip('should give precedence to INSTANA_TRACING_DISABLE=false over config with instrumentations', () => {
+    it('should give precedence to INSTANA_TRACING_DISABLE=false over config with instrumentations', () => {
       process.env.INSTANA_TRACING_DISABLE = 'false';
 
       const config = {

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -73,12 +73,12 @@ describe('config.normalizeConfig', () => {
       expect(config.serviceName).to.not.exist;
     });
 
-    it.skip('should use config when env not set', () => {
+    it('should use config when env not set', () => {
       const config = coreConfig.normalize({ userConfig: { serviceName: 'config-service-name' } });
       expect(config.serviceName).to.equal('config-service-name');
     });
 
-    it.skip('should give precedence to INSTANA_SERVICE_NAME env var over config', () => {
+    it('should give precedence to INSTANA_SERVICE_NAME env var over config', () => {
       process.env.INSTANA_SERVICE_NAME = 'env-service';
       const config = coreConfig.normalize({ userConfig: { serviceName: 'config-service' } });
       expect(config.serviceName).to.equal('env-service');
@@ -114,7 +114,7 @@ describe('config.normalizeConfig', () => {
       expect(config.metrics.transmissionDelay).to.equal(1000);
     });
 
-    it.skip('should give precedence to INSTANA_METRICS_TRANSMISSION_DELAY env var over config', () => {
+    it('should give precedence to INSTANA_METRICS_TRANSMISSION_DELAY env var over config', () => {
       process.env.INSTANA_METRICS_TRANSMISSION_DELAY = '3000';
       const config = coreConfig.normalize({ userConfig: { metrics: { transmissionDelay: 5000 } } });
       expect(config.metrics.transmissionDelay).to.equal(3000);
@@ -188,19 +188,19 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.enabled).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_TRACING_DISABLE env var set to true over config set to true', () => {
+      it('should give precedence to INSTANA_TRACING_DISABLE env var set to true over config set to true', () => {
         process.env.INSTANA_TRACING_DISABLE = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { enabled: true } } });
         expect(config.tracing.enabled).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_TRACING_DISABLE env var set to false over config set to false', () => {
+      it('should give precedence to INSTANA_TRACING_DISABLE env var set to false over config set to false', () => {
         process.env.INSTANA_TRACING_DISABLE = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { enabled: false } } });
         expect(config.tracing.enabled).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_TRACING_DISABLE env var over default', () => {
+      it('should give precedence to INSTANA_TRACING_DISABLE env var over default', () => {
         process.env.INSTANA_TRACING_DISABLE = 'true';
         const config = coreConfig.normalize({});
         expect(config.tracing.enabled).to.be.false;
@@ -211,19 +211,19 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.automaticTracingEnabled).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var set to true over config set to true', () => {
+      it('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var set to true over config set to true', () => {
         process.env.INSTANA_DISABLE_AUTO_INSTR = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { automaticTracingEnabled: true } } });
         expect(config.tracing.automaticTracingEnabled).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var set to false over config set to false', () => {
+      it('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var set to false over config set to false', () => {
         process.env.INSTANA_DISABLE_AUTO_INSTR = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { automaticTracingEnabled: false } } });
         expect(config.tracing.automaticTracingEnabled).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var over default', () => {
+      it('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var over default', () => {
         process.env.INSTANA_DISABLE_AUTO_INSTR = 'true';
         const config = coreConfig.normalize({});
         expect(config.tracing.automaticTracingEnabled).to.be.false;
@@ -260,13 +260,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.activateImmediately).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_TRACE_IMMEDIATELY env var set to true over config set to false', () => {
+      it('should give precedence to INSTANA_TRACE_IMMEDIATELY env var set to true over config set to false', () => {
         process.env.INSTANA_TRACE_IMMEDIATELY = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { activateImmediately: false } } });
         expect(config.tracing.activateImmediately).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_TRACE_IMMEDIATELY env var set to false over config set to true', () => {
+      it('should give precedence to INSTANA_TRACE_IMMEDIATELY env var set to false over config set to true', () => {
         process.env.INSTANA_TRACE_IMMEDIATELY = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { activateImmediately: true } } });
         expect(config.tracing.activateImmediately).to.be.false;
@@ -305,13 +305,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.transmissionDelay).to.equal(1000);
       });
 
-      it.skip('should give precedence to INSTANA_TRACING_TRANSMISSION_DELAY env var over config', () => {
+      it('should give precedence to INSTANA_TRACING_TRANSMISSION_DELAY env var over config', () => {
         process.env.INSTANA_TRACING_TRANSMISSION_DELAY = '4000';
         const config = coreConfig.normalize({ userConfig: { tracing: { transmissionDelay: 2000 } } });
         expect(config.tracing.transmissionDelay).to.equal(4000);
       });
 
-      it.skip('should give precedence to INSTANA_FORCE_TRANSMISSION_STARTING_AT env var over config', () => {
+      it('should give precedence to INSTANA_FORCE_TRANSMISSION_STARTING_AT env var over config', () => {
         process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT = '700';
         const config = coreConfig.normalize({ userConfig: { tracing: { forceTransmissionStartingAt: 300 } } });
         expect(config.tracing.forceTransmissionStartingAt).to.equal(700);
@@ -413,7 +413,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.stackTraceLength).to.equal(3);
       });
 
-      it.skip('should give precedence to INSTANA_STACK_TRACE_LENGTH over config', () => {
+      it('should give precedence to INSTANA_STACK_TRACE_LENGTH over config', () => {
         process.env.INSTANA_STACK_TRACE_LENGTH = '5';
         const normalizedConfig = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: 20 } } });
         expect(normalizedConfig.tracing.stackTraceLength).to.equal(5);
@@ -452,7 +452,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.stackTrace).to.equal('none');
       });
 
-      it.skip('should give precedence to env INSTANA_STACK_TRACE over config', () => {
+      it('should give precedence to env INSTANA_STACK_TRACE over config', () => {
         process.env.INSTANA_STACK_TRACE = 'none';
         const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: 'all' } } } });
         expect(config.tracing.stackTrace).to.equal('none');
@@ -699,7 +699,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.stackTraceLength).to.equal(30);
       });
 
-      it.skip('should give precedence to env vars for both stack trace settings over config', () => {
+      it('should give precedence to env vars for both stack trace settings over config', () => {
         process.env.INSTANA_STACK_TRACE = 'error';
         process.env.INSTANA_STACK_TRACE_LENGTH = '15';
         const config = coreConfig.normalize({
@@ -751,7 +751,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
       });
 
-      it('config should take precedence over INSTANA_TRACING_DISABLE_INSTRUMENTATIONS  for config', () => {
+      it('env var INSTANA_TRACING_DISABLE_INSTRUMENTATIONS over config', () => {
         process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'foo, bar';
         const config = coreConfig.normalize({
           userConfig: {
@@ -760,7 +760,7 @@ describe('config.normalizeConfig', () => {
             }
           }
         });
-        expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
+        expect(config.tracing.disable.instrumentations).to.deep.equal(['foo', 'bar']);
       });
 
       it('should disable multiple instrumentations via env var INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
@@ -798,7 +798,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.disable.groups).to.deep.equal(['frameworks', 'databases']);
       });
 
-      it('config should take precedence over INSTANA_TRACING_DISABLE_GROUPS when disabling groups', () => {
+      it('env var should take precedence over config when disabling groups', () => {
         process.env.INSTANA_TRACING_DISABLE_GROUPS = 'frameworks, databases';
         const config = coreConfig.normalize({
           userConfig: {
@@ -807,7 +807,7 @@ describe('config.normalizeConfig', () => {
             }
           }
         });
-        expect(config.tracing.disable.groups).to.deep.equal(['logging']);
+        expect(config.tracing.disable.groups).to.deep.equal(['frameworks', 'databases']);
       });
 
       it('should disable instrumentations and groups when both configured', () => {
@@ -890,13 +890,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.spanBatchingEnabled).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_SPANBATCHING_ENABLED env var set to true over config set to false', () => {
+      it('should give precedence to INSTANA_SPANBATCHING_ENABLED env var set to true over config set to false', () => {
         process.env.INSTANA_SPANBATCHING_ENABLED = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { spanBatchingEnabled: false } } });
         expect(config.tracing.spanBatchingEnabled).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_SPANBATCHING_ENABLED env var set to false over config set to true', () => {
+      it('should give precedence to INSTANA_SPANBATCHING_ENABLED env var set to false over config set to true', () => {
         process.env.INSTANA_SPANBATCHING_ENABLED = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { spanBatchingEnabled: true } } });
         expect(config.tracing.spanBatchingEnabled).to.be.false;
@@ -920,7 +920,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.disableW3cTraceCorrelation).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_DISABLE_W3C_TRACE_CORRELATION env var over config (truthy env)', () => {
+      it('should give precedence to INSTANA_DISABLE_W3C_TRACE_CORRELATION env var over config (truthy env)', () => {
         process.env.INSTANA_DISABLE_W3C_TRACE_CORRELATION = 'any-value';
         const config = coreConfig.normalize({ userConfig: { tracing: { disableW3cTraceCorrelation: false } } });
         expect(config.tracing.disableW3cTraceCorrelation).to.be.true;
@@ -944,13 +944,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.kafka.traceCorrelation).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_KAFKA_TRACE_CORRELATION env var set to false over config set to true', () => {
+      it('should give precedence to INSTANA_KAFKA_TRACE_CORRELATION env var set to false over config set to true', () => {
         process.env.INSTANA_KAFKA_TRACE_CORRELATION = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { kafka: { traceCorrelation: true } } } });
         expect(config.tracing.kafka.traceCorrelation).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_KAFKA_TRACE_CORRELATION env var set to true over config set to false', () => {
+      it('should give precedence to INSTANA_KAFKA_TRACE_CORRELATION env var set to true over config set to false', () => {
         process.env.INSTANA_KAFKA_TRACE_CORRELATION = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { kafka: { traceCorrelation: false } } } });
         expect(config.tracing.kafka.traceCorrelation).to.be.true;
@@ -993,13 +993,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.useOpentelemetry).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_DISABLE_USE_OPENTELEMETRY env var set to true over config set to true', () => {
+      it('should give precedence to INSTANA_DISABLE_USE_OPENTELEMETRY env var set to true over config set to true', () => {
         process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { useOpentelemetry: true } } });
         expect(config.tracing.useOpentelemetry).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_DISABLE_USE_OPENTELEMETRY env var set to false over config set to false', () => {
+      it('should give precedence to INSTANA_DISABLE_USE_OPENTELEMETRY env var set to false over config set to false', () => {
         process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { useOpentelemetry: false } } });
         expect(config.tracing.useOpentelemetry).to.be.true;
@@ -1096,12 +1096,12 @@ describe('config.normalizeConfig', () => {
         expect(config.packageJsonPath).to.equal('/my/path');
       });
 
-      it.skip('should use default (null) when neither env nor config is set', () => {
+      it('should use default (null) when neither env nor config is set', () => {
         const config = coreConfig.normalize({});
         expect(config.packageJsonPath).to.be.null;
       });
 
-      it.skip('should give precedence to INSTANA_PACKAGE_JSON_PATH env var over config', () => {
+      it('should give precedence to INSTANA_PACKAGE_JSON_PATH env var over config', () => {
         process.env.INSTANA_PACKAGE_JSON_PATH = '/env/path/package.json';
         const config = coreConfig.normalize({ userConfig: { packageJsonPath: '/config/path/package.json' } });
         expect(config.packageJsonPath).to.equal('/env/path/package.json');
@@ -1143,13 +1143,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.allowRootExitSpan).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_ALLOW_ROOT_EXIT_SPAN env var set to true over config set to false', () => {
+      it('should give precedence to INSTANA_ALLOW_ROOT_EXIT_SPAN env var set to true over config set to false', () => {
         process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { allowRootExitSpan: false } } });
         expect(config.tracing.allowRootExitSpan).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_ALLOW_ROOT_EXIT_SPAN env var set to false over config set to true', () => {
+      it('should give precedence to INSTANA_ALLOW_ROOT_EXIT_SPAN env var set to false over config set to true', () => {
         process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { allowRootExitSpan: true } } });
         expect(config.tracing.allowRootExitSpan).to.be.false;
@@ -1348,13 +1348,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION env var set to true over config set to false', () => {
+      it('should give precedence to INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION env var set to true over config set to false', () => {
         process.env.INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { ignoreEndpointsDisableSuppression: false } } });
         expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION env var set to false over config set to true', () => {
+      it('should give precedence to INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION env var set to false over config set to true', () => {
         process.env.INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { ignoreEndpointsDisableSuppression: true } } });
         expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.false;
@@ -1462,13 +1462,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.disableEOLEvents).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_TRACING_DISABLE_EOL_EVENTS env var set to true over config set to false', () => {
+      it('should give precedence to INSTANA_TRACING_DISABLE_EOL_EVENTS env var set to true over config set to false', () => {
         process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { disableEOLEvents: false } } });
         expect(config.tracing.disableEOLEvents).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_TRACING_DISABLE_EOL_EVENTS env var set to false over config set to true', () => {
+      it('should give precedence to INSTANA_TRACING_DISABLE_EOL_EVENTS env var set to false over config set to true', () => {
         process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { disableEOLEvents: true } } });
         expect(config.tracing.disableEOLEvents).to.be.false;

--- a/packages/core/test/config/util_test.js
+++ b/packages/core/test/config/util_test.js
@@ -35,7 +35,7 @@ describe('config.util', () => {
       expect(result).to.equal(1000);
     });
 
-    it.skip('should prioritize env var over config value', () => {
+    it('should prioritize env var over config value', () => {
       process.env.TEST_ENV_VAR = '2000';
 
       const result = util.resolveNumericConfig({
@@ -259,7 +259,7 @@ describe('config.util', () => {
       expect(result).to.equal(false);
     });
 
-    it.skip('should prioritize env var over config value', () => {
+    it('should prioritize env var over config value', () => {
       process.env.TEST_BOOL_VAR = 'true';
 
       const result = util.resolveBooleanConfig({
@@ -361,7 +361,7 @@ describe('config.util', () => {
       expect(result).to.equal(false);
     });
 
-    it.skip('should fall back to config value when env var is invalid', () => {
+    it('should fall back to config value when env var is invalid', () => {
       process.env.TEST_BOOL_VAR = 'invalid';
 
       const result = util.resolveBooleanConfig({
@@ -432,7 +432,7 @@ describe('config.util', () => {
       expect(result).to.equal(false);
     });
 
-    it.skip('should prioritize env var over config value', () => {
+    it('should prioritize env var over config value', () => {
       process.env.TEST_DISABLE_VAR = 'true';
 
       const result = util.resolveBooleanConfigWithInvertedEnv({
@@ -537,7 +537,7 @@ describe('config.util', () => {
       expect(result).to.equal(true);
     });
 
-    it.skip('should prioritize env var over config value', () => {
+    it('should prioritize env var over config value', () => {
       process.env.TEST_TRUTHY_VAR = 'yes';
 
       const result = util.resolveBooleanConfigWithTruthyEnv({
@@ -602,7 +602,7 @@ describe('config.util', () => {
       expect(result).to.equal('default-value');
     });
 
-    it.skip('should prioritize env var over config value', () => {
+    it('should prioritize env var over config value', () => {
       process.env.TEST_STRING_VAR = 'env-value';
 
       const result = util.resolveStringConfig({

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -193,7 +193,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           expect(activateStubRdKafka).to.have.been.called;
         });
 
-        it.skip('should prefer env vars over config.tracing.disable', () => {
+        it('should prefer env vars over config.tracing.disable', () => {
           process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'grpc,kafkajs';
           initAndActivate({ tracing: { disable: { instrumentations: ['aws-sdk/v2'] } } });
 


### PR DESCRIPTION
This is the first PR addressing configuration precedence.

The goal of this change is to ensure the correct order between environment variables and in-code configuration:

`env > in-code`

Currently, the precedence between these two sources is mixed. This PR corrects that behavior.

Added missing logging in the configuration file when a config is set.

**Scope of This PR**

This PR only fixes the precedence between:

- Environment variables
- In-code configuration

Agent configuration precedence will be addressed in separate follow-up PRs.



Coverage:

<img width="1411" height="347" alt="image" src="https://github.com/user-attachments/assets/670d915f-d3e4-4ce7-8517-c62654aa234b" />

