### PR TITLE
chore(config): fixed INSTANA_TRACING_DISABLE env var handling

### DIFF
--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -151,7 +151,6 @@ class ProcessControls {
         APP_CWD: this.cwd,
         INSTANA_AGENT_PORT: agentPort,
         INSTANA_LOG_LEVEL: 'warn',
-        INSTANA_TRACING_DISABLE: !this.tracingEnabled,
         INSTANA_FORCE_TRANSMISSION_STARTING_AT: '1',
         INSTANA_FULL_METRICS_INTERNAL_IN_S: 1,
         INSTANA_FIRE_MONITORING_EVENT_DURATION_IN_MS: 500,
@@ -163,6 +162,13 @@ class ProcessControls {
       },
       opts.env
     );
+
+    // Only set INSTANA_TRACING_DISABLE when tracing is actually disabled to avoid
+    // overriding other disable environment variables (INSTANA_TRACING_DISABLE_INSTRUMENTATIONS, etc.)
+    // See packages/core/src/config/configNormalizers/disable.js for precedence rules
+    if (!this.tracingEnabled) {
+      this.env.INSTANA_TRACING_DISABLE = 'true';
+    }
 
     if (this.usePreInit) {
       this.env.INSTANA_EARLY_INSTRUMENTATION = 'true';

--- a/packages/core/src/config/configNormalizers/disable.js
+++ b/packages/core/src/config/configNormalizers/disable.js
@@ -31,12 +31,10 @@ exports.normalize = function normalize(config) {
 
     if (envDisableConfig !== null) {
       if (envDisableConfig === true) {
-        logger?.debug('[config] env:INSTANA_TRACING_DISABLE = true');
         return true;
       }
 
       if (envDisableConfig === false) {
-        logger?.debug('[config] env:INSTANA_TRACING_DISABLE = false (overrides in-code config)');
         return {};
       }
 

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -251,8 +251,15 @@ function normalizeTracingConfig({ userConfig = {}, defaultConfig = {}, finalConf
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizeTracingEnabled({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
+  // INSTANA_TRACING_DISABLE can be either:
+  // 1. A boolean ('true'/'false') to enable/disable all tracing
+  // 2. A list of instrumentations/groups to selectively disable
+  // We only use it for tracing.enabled if it's a boolean value
+  const envValue = process.env.INSTANA_TRACING_DISABLE;
+  const isBooleanValue = envValue === 'true' || envValue === 'false';
+
   finalConfig.tracing.enabled = util.resolveBooleanConfigWithInvertedEnv({
-    envVar: 'INSTANA_TRACING_DISABLE',
+    envVar: isBooleanValue ? 'INSTANA_TRACING_DISABLE' : undefined,
     configValue: userConfig.tracing.enabled,
     defaultValue: defaultConfig.tracing.enabled,
     configPath: 'config.tracing.enabled'


### PR DESCRIPTION
There were two issues with how `INSTANA_TRACING_DISABLE` was handled:

1. **ProcessControls behavior**
   `ProcessControls` was setting `INSTANA_TRACING_DISABLE=false` for all tests where `tracingEnabled=true` (which is the default). Based on the precedence rules in `disable.js`, setting `INSTANA_TRACING_DISABLE` to `'false'` overrides `INSTANA_TRACING_DISABLE_INSTRUMENTATIONS` and `INSTANA_TRACING_DISABLE_GROUPS`, thereby blocking more granular disable configurations.
   This has been corrected so that `ProcessControls` now sets `INSTANA_TRACING_DISABLE='true'` only when `tracingEnabled=false`, and leaves it unset when `tracingEnabled=true`.

2. **normalizeTracingEnabled fix**
   `normalizeTracingEnabled` has been updated to consider `INSTANA_TRACING_DISABLE` for the `tracing.enabled` configuration only when its value is `'true'` or `'false'`. If the variable contains instrumentation or group names (for example, `'logging'`), it is now handled separately by the disable normalizer.
