### PR TITLE
chore(core): added external config resolution

### DIFF
--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -147,7 +147,6 @@ module.exports.init = _logger => {
 
 /**
  * @param {InstanaConfig} externalConfig
-
  */
 module.exports.activate = externalConfig => {
   if (externalConfig && typeof externalConfig === 'object' && Object.keys(externalConfig).length > 0) {
@@ -793,21 +792,6 @@ function normalizeExternalConfig({ finalConfig, externalConfig = {}, defaultConf
     const externalValue = externalConfig[key];
     const currentValue = finalConfig[key];
     const defaultValue = defaultConfig[key];
-
-    if (externalValue && typeof externalValue === 'object' && !Array.isArray(externalValue)) {
-      if (!currentValue || typeof currentValue !== 'object') {
-        finalConfig[key] = {};
-      }
-
-      normalizeExternalConfig({
-        finalConfig: finalConfig[key],
-        externalConfig: externalValue,
-        defaultConfig:
-          defaultValue && typeof defaultValue === 'object' && !Array.isArray(defaultValue) ? defaultValue : {}
-      });
-
-      return;
-    }
 
     finalConfig[key] = util.resolveExternalConfig({
       currentValue: currentValue,

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -150,7 +150,11 @@ module.exports.init = _logger => {
 
  */
 module.exports.activate = externalConfig => {
-  applyExternalConfig(currentConfig, externalConfig || {}, defaults);
+  applyExternalConfig({
+    finalConfig: currentConfig,
+    externalConfig: externalConfig || {},
+    defaultConfig: defaults
+  });
 };
 
 /**
@@ -776,41 +780,37 @@ function normalizePreloadOpentelemetry({ userConfig = {}, defaultConfig = {}, fi
 }
 
 /**
- * @param {{ [x: string]: any; finalConfig?: any; externalConfig?: any; defaultConfig?: InstanaConfig; }} target
- * @param {{ [x: string]: any; }} [source]
- * @param {{ [x: string]: any; }} [defaultsRef]
+ * @param {{
+ *   finalConfig: { [key: string]: any };
+ *   externalConfig?: { [x: string]: any };
+ *   defaultConfig?: { [x: string]: any };
+ * }} params
  */
-function applyExternalConfig(target, source, defaultsRef, path = '') {
-  Object.keys(source).forEach(key => {
-    const sourceVal = source[key];
-    const targetHasKey = Object.prototype.hasOwnProperty.call(target, key);
-    const targetVal = target[key];
-    const defaultVal = defaultsRef ? defaultsRef[key] : undefined;
+function applyExternalConfig({ finalConfig, externalConfig = {}, defaultConfig = {} }) {
+  Object.keys(externalConfig).forEach(key => {
+    const externalValue = externalConfig[key];
+    const currentValue = finalConfig[key];
+    const defaultValue = defaultConfig[key];
 
-    const currentPath = path ? `${path}.${key}` : key;
-
-    // ---- Nested object ----
-    if (sourceVal && typeof sourceVal === 'object' && !Array.isArray(sourceVal)) {
-      if (!targetHasKey) {
-        target[key] = {};
+    if (externalValue && typeof externalValue === 'object' && !Array.isArray(externalValue)) {
+      if (!currentValue || typeof currentValue !== 'object') {
+        finalConfig[key] = {};
       }
 
-      applyExternalConfig(target[key], sourceVal, defaultVal || {}, currentPath);
+      applyExternalConfig({
+        finalConfig: finalConfig[key],
+        externalConfig: externalValue,
+        defaultConfig:
+          defaultValue && typeof defaultValue === 'object' && !Array.isArray(defaultValue) ? defaultValue : {}
+      });
+
       return;
     }
 
-    // ---- Resolve using util ----
-    const resolved = util.resolveExternalConfig({
-      currentValue: targetVal,
-      externalValue: sourceVal,
-      defaultValue: defaultVal
+    finalConfig[key] = util.resolveExternalConfig({
+      currentValue: currentValue,
+      externalValue: externalValue,
+      defaultValue: defaultValue
     });
-
-    if (resolved !== targetVal) {
-      target[key] = resolved;
-      logger.debug(`[config] external applied: ${currentPath}`);
-    } else {
-      logger.debug(`[config] external skipped: ${currentPath}`);
-    }
   });
 }

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -149,13 +149,11 @@ module.exports.init = _logger => {
  * @param {import('@instana/collector/src/types/collector').AgentConfig} externalConfig
  */
 module.exports.activate = externalConfig => {
-  if (externalConfig && typeof externalConfig === 'object' && Object.keys(externalConfig).length > 0) {
-    normalizeExternalConfig({
-      finalConfig: currentConfig,
-      externalConfig: externalConfig,
-      defaultConfig: defaults
-    });
-  }
+  normalizeExternalConfig({
+    finalConfig: currentConfig,
+    externalConfig: externalConfig,
+    defaultConfig: defaults
+  });
 };
 
 /**
@@ -788,15 +786,13 @@ function normalizePreloadOpentelemetry({ userConfig = {}, defaultConfig = {}, fi
  * }} params
  */
 function normalizeExternalConfig({ finalConfig, externalConfig = {}, defaultConfig = {} }) {
-  Object.keys(externalConfig).forEach(key => {
-    const externalValue = externalConfig[key];
-    const currentValue = finalConfig[key];
-    const defaultValue = defaultConfig[key];
-
-    finalConfig[key] = util.resolveExternalConfig({
-      currentValue: currentValue,
-      externalValue: externalValue,
-      defaultValue: defaultValue
+  if (externalConfig && typeof externalConfig === 'object' && Object.keys(externalConfig).length > 0) {
+    Object.keys(externalConfig).forEach(key => {
+      finalConfig[key] = util.resolveExternalConfig({
+        currentValue: finalConfig[key],
+        externalValue: externalConfig[key],
+        defaultValue: defaultConfig[key]
+      });
     });
-  });
+  }
 }

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -150,11 +150,13 @@ module.exports.init = _logger => {
 
  */
 module.exports.activate = externalConfig => {
-  applyExternalConfig({
-    finalConfig: currentConfig,
-    externalConfig: externalConfig || {},
-    defaultConfig: defaults
-  });
+  if (externalConfig && typeof externalConfig === 'object' && Object.keys(externalConfig).length > 0) {
+    applyExternalConfig({
+      finalConfig: currentConfig,
+      externalConfig: externalConfig,
+      defaultConfig: defaults
+    });
+  }
 };
 
 /**

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -146,7 +146,7 @@ module.exports.init = _logger => {
 };
 
 /**
- * @param {InstanaConfig} externalConfig
+ * @param {import('@instana/collector/src/types/collector').AgentConfig} externalConfig
  */
 module.exports.activate = externalConfig => {
   if (externalConfig && typeof externalConfig === 'object' && Object.keys(externalConfig).length > 0) {

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -151,7 +151,7 @@ module.exports.init = _logger => {
  */
 module.exports.activate = externalConfig => {
   if (externalConfig && typeof externalConfig === 'object' && Object.keys(externalConfig).length > 0) {
-    applyExternalConfig({
+    normalizeExternalConfig({
       finalConfig: currentConfig,
       externalConfig: externalConfig,
       defaultConfig: defaults
@@ -788,7 +788,7 @@ function normalizePreloadOpentelemetry({ userConfig = {}, defaultConfig = {}, fi
  *   defaultConfig?: { [x: string]: any };
  * }} params
  */
-function applyExternalConfig({ finalConfig, externalConfig = {}, defaultConfig = {} }) {
+function normalizeExternalConfig({ finalConfig, externalConfig = {}, defaultConfig = {} }) {
   Object.keys(externalConfig).forEach(key => {
     const externalValue = externalConfig[key];
     const currentValue = finalConfig[key];
@@ -799,7 +799,7 @@ function applyExternalConfig({ finalConfig, externalConfig = {}, defaultConfig =
         finalConfig[key] = {};
       }
 
-      applyExternalConfig({
+      normalizeExternalConfig({
         finalConfig: finalConfig[key],
         externalConfig: externalValue,
         defaultConfig:

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -87,6 +87,9 @@ const allowedSecretMatchers = ['equals', 'equals-ignore-case', 'contains', 'cont
 let logger;
 
 /** @type {InstanaConfig} */
+let currentConfig;
+
+/** @type {InstanaConfig} */
 let defaults = {
   serviceName: null,
   packageJsonPath: null,
@@ -143,6 +146,14 @@ module.exports.init = _logger => {
 };
 
 /**
+ * @param {InstanaConfig} externalConfig
+
+ */
+module.exports.activate = externalConfig => {
+  applyExternalConfig(currentConfig, externalConfig || {}, defaults);
+};
+
+/**
  * Merges the config that was passed to the init function with environment variables and default values.
  * @param {{ userConfig?: InstanaConfig, finalConfigBase?: Object, defaultsOverride?: InstanaConfig }} [options]
  * @returns {InstanaConfig}
@@ -176,6 +187,7 @@ module.exports.normalize = ({ userConfig = {}, finalConfigBase = {}, defaultsOve
   normalizeSecrets({ userConfig: normalizedUserConfig, defaultConfig: defaults, finalConfig });
   normalizePreloadOpentelemetry({ userConfig: normalizedUserConfig, defaultConfig: defaults, finalConfig });
 
+  currentConfig = finalConfig;
   return finalConfig;
 };
 
@@ -761,4 +773,44 @@ function normalizePreloadOpentelemetry({ userConfig = {}, defaultConfig = {}, fi
   } else {
     finalConfig.preloadOpentelemetry = defaultConfig.preloadOpentelemetry;
   }
+}
+
+/**
+ * @param {{ [x: string]: any; finalConfig?: any; externalConfig?: any; defaultConfig?: InstanaConfig; }} target
+ * @param {{ [x: string]: any; }} [source]
+ * @param {{ [x: string]: any; }} [defaultsRef]
+ */
+function applyExternalConfig(target, source, defaultsRef, path = '') {
+  Object.keys(source).forEach(key => {
+    const sourceVal = source[key];
+    const targetHasKey = Object.prototype.hasOwnProperty.call(target, key);
+    const targetVal = target[key];
+    const defaultVal = defaultsRef ? defaultsRef[key] : undefined;
+
+    const currentPath = path ? `${path}.${key}` : key;
+
+    // ---- Nested object ----
+    if (sourceVal && typeof sourceVal === 'object' && !Array.isArray(sourceVal)) {
+      if (!targetHasKey) {
+        target[key] = {};
+      }
+
+      applyExternalConfig(target[key], sourceVal, defaultVal || {}, currentPath);
+      return;
+    }
+
+    // ---- Resolve using util ----
+    const resolved = util.resolveExternalConfig({
+      currentValue: targetVal,
+      externalValue: sourceVal,
+      defaultValue: defaultVal
+    });
+
+    if (resolved !== targetVal) {
+      target[key] = resolved;
+      logger.debug(`[config] external applied: ${currentPath}`);
+    } else {
+      logger.debug(`[config] external skipped: ${currentPath}`);
+    }
+  });
 }

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -331,7 +331,6 @@ exports.resolveExternalConfig = function resolveExternalConfig({ currentValue, e
     return currentValue;
   }
 
-  // Primitive values (string/number/boolean/array)
   if (shouldApplyExternalValue(currentValue, defaultValue)) {
     return externalValue;
   }

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -232,6 +232,7 @@ exports.resolveStringConfig = function resolveStringConfig({ envVar, configValue
 
 /**
  * @param {any} value
+ * @return {boolean}
  */
 function isEmpty(value) {
   if (value === undefined || value === null) return true;
@@ -247,6 +248,7 @@ function isEmpty(value) {
 
 /**
  * @param {any} value
+ * @return {boolean}
  */
 function isObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value);
@@ -294,18 +296,28 @@ exports.resolveExternalConfig = function resolveExternalConfig({ currentValue, e
     return currentValue;
   }
 
-  if (isObject(externalValue)) {
-    const result = isObject(currentValue) ? { ...currentValue } : {};
+  if (isObject(externalValue) && isObject(currentValue)) {
+    const result = { ...currentValue };
 
     Object.keys(externalValue).forEach(key => {
       result[key] = resolveExternalConfig({
-        currentValue: currentValue ? currentValue[key] : undefined,
+        currentValue: currentValue[key],
         externalValue: externalValue[key],
         defaultValue: defaultValue ? defaultValue[key] : undefined
       });
     });
 
     return result;
+  }
+
+  if (isObject(externalValue)) {
+    if (currentValue === undefined) {
+      return externalValue;
+    }
+    if (isEqual(currentValue, defaultValue)) {
+      return externalValue;
+    }
+    return currentValue;
   }
 
   if (currentValue === undefined) {

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -253,22 +253,22 @@ function isObject(value) {
 }
 
 /**
- * @param {any[]} a
- * @param {string | any[]} b
+ * @param {any} value1
+ * @param {any} value2
  * @returns {boolean}
  */
-function isEqual(a, b) {
-  if (a === b) return true;
+function isEqual(value1, value2) {
+  if (value1 === value2) return true;
 
-  if (Array.isArray(a) && Array.isArray(b)) {
-    return a.length === b.length && a.every((val, i) => isEqual(val, b[i]));
+  if (Array.isArray(value1) && Array.isArray(value2)) {
+    return value1.length === value2.length && value1.every((val, i) => isEqual(val, value2[i]));
   }
 
-  if (isObject(a) && isObject(b)) {
-    const aKeys = Object.keys(a);
-    const bKeys = Object.keys(b);
+  if (isObject(value1) && isObject(value2)) {
+    const aKeys = Object.keys(value1);
+    const bKeys = Object.keys(value2);
 
-    return aKeys.length === bKeys.length && aKeys.every(key => isEqual(a[key], b[key]));
+    return aKeys.length === bKeys.length && aKeys.every(key => isEqual(value1[key], value2[key]));
   }
 
   return false;
@@ -281,12 +281,11 @@ function isEqual(a, b) {
  * @param {any} params.defaultValue
  */
 exports.resolveExternalConfig = function resolveExternalConfig({ currentValue, externalValue, defaultValue }) {
-  // 1. Ignore empty external values
   if (isEmpty(externalValue)) {
     return currentValue;
   }
 
-  // 2. Handle nested objects
+  // Handle nested objects
   if (isObject(externalValue)) {
     const result = isObject(currentValue) ? { ...currentValue } : {};
 

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -229,3 +229,88 @@ exports.resolveStringConfig = function resolveStringConfig({ envVar, configValue
   }
   return defaultValue;
 };
+
+/**
+ * @param {any} value
+ */
+function isEmpty(value) {
+  if (value === undefined || value === null) return true;
+
+  if (typeof value === 'string') return value.trim() === '';
+
+  if (Array.isArray(value)) return value.length === 0;
+
+  if (typeof value === 'object') return Object.keys(value).length === 0;
+
+  return false;
+}
+
+/**
+ * @param {any} value
+ */
+function isObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * @param {any[]} a
+ * @param {string | any[]} b
+ * @returns {boolean}
+ */
+function isEqual(a, b) {
+  if (a === b) return true;
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((val, i) => isEqual(val, b[i]));
+  }
+
+  if (isObject(a) && isObject(b)) {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+
+    return aKeys.length === bKeys.length && aKeys.every(key => isEqual(a[key], b[key]));
+  }
+
+  return false;
+}
+
+/**
+ * @param {Object} params
+ * @param {any} params.currentValue
+ * @param {any} params.externalValue
+ * @param {any} params.defaultValue
+ */
+exports.resolveExternalConfig = function resolveExternalConfig({ currentValue, externalValue, defaultValue }) {
+  // 1. Ignore empty external values
+  if (isEmpty(externalValue)) {
+    return currentValue;
+  }
+
+  // 2. Handle nested objects
+  if (isObject(externalValue)) {
+    const result = isObject(currentValue) ? { ...currentValue } : {};
+
+    Object.keys(externalValue).forEach(key => {
+      result[key] = resolveExternalConfig({
+        currentValue: currentValue ? currentValue[key] : undefined,
+        externalValue: externalValue[key],
+        defaultValue: defaultValue ? defaultValue[key] : undefined
+      });
+    });
+
+    return result;
+  }
+
+  // 3. If current not set → take external
+  if (currentValue === undefined) {
+    return externalValue;
+  }
+
+  // 4. If current equals default → override (FIXED)
+  if (isEqual(currentValue, defaultValue)) {
+    return externalValue;
+  }
+
+  // 5. Otherwise keep current
+  return currentValue;
+};

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -277,12 +277,26 @@ function isEqual(value1, value2) {
 }
 
 /**
- * Resolves an external config value with respect to current and default values.
- *
  * Rules:
  * - Use external value if current value is not set.
  * - Use external value if current value is equal to default value.
  * - Otherwise keep the current value.
+ * @param {any} currentValue
+ * @param {any} defaultValue
+ */
+function shouldApplyExternalValue(currentValue, defaultValue) {
+  if (currentValue === undefined) {
+    return true;
+  }
+
+  if (isEqual(currentValue, defaultValue)) {
+    return true;
+  }
+
+  return false;
+}
+/**
+ * Resolves an external config value with respect to current and default values.
  *
  * This allows external config (agent) to override only default or unset values,
  * while existing custom values(environment variables or in-code config) are preserved.
@@ -311,20 +325,14 @@ exports.resolveExternalConfig = function resolveExternalConfig({ currentValue, e
   }
 
   if (isObject(externalValue)) {
-    if (currentValue === undefined) {
-      return externalValue;
-    }
-    if (isEqual(currentValue, defaultValue)) {
+    if (shouldApplyExternalValue(currentValue, defaultValue)) {
       return externalValue;
     }
     return currentValue;
   }
 
-  if (currentValue === undefined) {
-    return externalValue;
-  }
-
-  if (isEqual(currentValue, defaultValue)) {
+  // Primitive values (string/number/boolean/array)
+  if (shouldApplyExternalValue(currentValue, defaultValue)) {
     return externalValue;
   }
 

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -275,6 +275,15 @@ function isEqual(value1, value2) {
 }
 
 /**
+ * Resolves an external config value with respect to current and default values.
+ *
+ * Rules:
+ * - Use external value if current value is not set.
+ * - Use external value if current value is equal to default value.
+ * - Otherwise keep the current value.
+ *
+ * This allows external config (agent) to override only default or unset values,
+ * while existing custom values(environment variables or in-code config) are preserved.
  * @param {Object} params
  * @param {any} params.currentValue
  * @param {any} params.externalValue
@@ -285,7 +294,6 @@ exports.resolveExternalConfig = function resolveExternalConfig({ currentValue, e
     return currentValue;
   }
 
-  // Handle nested objects
   if (isObject(externalValue)) {
     const result = isObject(currentValue) ? { ...currentValue } : {};
 
@@ -300,16 +308,13 @@ exports.resolveExternalConfig = function resolveExternalConfig({ currentValue, e
     return result;
   }
 
-  // 3. If current not set → take external
   if (currentValue === undefined) {
     return externalValue;
   }
 
-  // 4. If current equals default → override (FIXED)
   if (isEqual(currentValue, defaultValue)) {
     return externalValue;
   }
 
-  // 5. Otherwise keep current
   return currentValue;
 };

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const sdk = require('./sdk');
+const coreConfig = require('../config');
 const constants = require('./constants');
 const tracingMetrics = require('./metrics');
 const opentracing = require('./opentracing');
@@ -263,6 +264,8 @@ function initInstanaInstrumentations(_config) {
 exports.activate = function activate(extraConfig = {}) {
   if (tracingEnabled && !tracingActivated) {
     tracingActivated = true;
+    coreConfig.activate(extraConfig);
+    // Todo refactor the other activate functions to use config directly
     coreUtil.activate(extraConfig);
     tracingUtil.activate(extraConfig);
     spanBuffer.activate(extraConfig);

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -1521,6 +1521,200 @@ describe('config.normalizeConfig', () => {
     });
   });
 
+  describe('resolve external config', () => {
+    beforeEach(() => {
+      delete process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN;
+    });
+
+    it('should apply external config when not set already', () => {
+      const config = coreConfig.normalize({});
+
+      coreConfig.activate({
+        serviceName: 'external-service'
+      });
+
+      expect(config.serviceName).to.equal('external-service');
+    });
+
+    it('should override when current config equals default', () => {
+      const config = coreConfig.normalize({});
+
+      coreConfig.activate({
+        tracing: { allowRootExitSpan: true }
+      });
+
+      expect(config.tracing.allowRootExitSpan).to.equal(true);
+    });
+
+    it('should not override user-defined config', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          tracing: { allowRootExitSpan: true }
+        }
+      });
+
+      coreConfig.activate({
+        tracing: { allowRootExitSpan: false }
+      });
+
+      expect(config.tracing.allowRootExitSpan).to.equal(true);
+    });
+
+    it('should not override env-based config', () => {
+      process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = 'true';
+
+      const config = coreConfig.normalize({});
+
+      coreConfig.activate({
+        tracing: { allowRootExitSpan: false }
+      });
+
+      expect(config.tracing.allowRootExitSpan).to.equal(true);
+    });
+
+    it('should ignore empty external values', () => {
+      const config = coreConfig.normalize({
+        userConfig: { serviceName: 'my-service' }
+      });
+
+      coreConfig.activate({
+        serviceName: ''
+      });
+
+      expect(config.serviceName).to.equal('my-service');
+    });
+
+    it('should replace array when current equals default', () => {
+      const config = coreConfig.normalize({});
+
+      coreConfig.activate({
+        secrets: { keywords: ['a'] }
+      });
+
+      expect(config.secrets.keywords).to.deep.equal(['a']);
+    });
+
+    it('should not replace array when already customized', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          secrets: { keywords: ['custom'] }
+        }
+      });
+
+      coreConfig.activate({
+        secrets: { keywords: ['external'] }
+      });
+
+      expect(config.secrets.keywords).to.deep.equal(['custom']);
+    });
+
+    it('should merge nested objects when current is default', () => {
+      const config = coreConfig.normalize({});
+
+      coreConfig.activate({
+        secrets: { matcherMode: 'equals' }
+      });
+
+      expect(config.secrets.matcherMode).to.equal('equals');
+    });
+
+    it('should not override nested values when already set', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          secrets: { matcherMode: 'equals' }
+        }
+      });
+
+      coreConfig.activate({
+        secrets: { matcherMode: 'contains' }
+      });
+
+      expect(config.secrets.matcherMode).to.equal('equals');
+    });
+
+    it('should apply ignoreEndpoints as-is (already normalized)', () => {
+      const config = coreConfig.normalize({});
+
+      const external = {
+        tracing: {
+          ignoreEndpoints: {
+            redis: [{ methods: ['get', 'set'] }]
+          }
+        }
+      };
+
+      coreConfig.activate(external);
+
+      expect(config.tracing.ignoreEndpoints).to.deep.equal({
+        redis: [{ methods: ['get', 'set'] }]
+      });
+    });
+
+    it('should apply multiple ignoreEndpoints entries as-is', () => {
+      const config = coreConfig.normalize({});
+
+      const external = {
+        tracing: {
+          ignoreEndpoints: {
+            redis: [{ methods: ['get'] }],
+            dynamodb: [{ methods: ['query'] }]
+          }
+        }
+      };
+
+      coreConfig.activate(external);
+
+      expect(config.tracing.ignoreEndpoints).to.deep.equal({
+        redis: [{ methods: ['get'] }],
+        dynamodb: [{ methods: ['query'] }]
+      });
+    });
+
+    it('should apply disable config as-is (already normalized)', () => {
+      const config = coreConfig.normalize({});
+
+      const external = {
+        tracing: {
+          disable: ['logging', '!console']
+        }
+      };
+
+      coreConfig.activate(external);
+
+      expect(config.tracing.disable).to.deep.equal(['logging', '!console']);
+    });
+
+    it('should apply disable config with mixed flags as-is', () => {
+      const config = coreConfig.normalize({});
+
+      const external = {
+        tracing: {
+          disable: { instrumentations: ['redis', 'mongodb'] }
+        }
+      };
+
+      coreConfig.activate(external);
+
+      expect(config.tracing.disable).to.deep.equal({ instrumentations: ['redis', 'mongodb'] });
+    });
+
+    it('should  override disable when not set', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          tracing: { disable: {} }
+        }
+      });
+
+      coreConfig.activate({
+        tracing: {
+          disable: { instrumentations: ['external'] }
+        }
+      });
+
+      expect(config.tracing.disable).to.deep.equal({ instrumentations: ['external'] });
+    });
+  });
+
   function checkDefaults(config) {
     expect(config).to.be.an('object');
 

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -1522,12 +1522,8 @@ describe('config.normalizeConfig', () => {
   });
 
   describe('resolve external config', () => {
-    beforeEach(() => {
-      delete process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN;
-    });
-
-    it('should apply external config when not set already', () => {
-      const config = coreConfig.normalize({});
+    it('should apply external config when config not set already', () => {
+      const config = coreConfig.normalize({ userConfig: { tracing: { enabled: true } } });
 
       coreConfig.activate({
         serviceName: 'external-service'
@@ -1536,7 +1532,7 @@ describe('config.normalizeConfig', () => {
       expect(config.serviceName).to.equal('external-service');
     });
 
-    it('should override when current config equals default', () => {
+    it('should override with external config when current config equals default', () => {
       const config = coreConfig.normalize({});
 
       coreConfig.activate({
@@ -1546,7 +1542,7 @@ describe('config.normalizeConfig', () => {
       expect(config.tracing.allowRootExitSpan).to.equal(true);
     });
 
-    it('should not override user-defined config', () => {
+    it('should not override in-code config', () => {
       const config = coreConfig.normalize({
         userConfig: {
           tracing: { allowRootExitSpan: true }
@@ -1560,7 +1556,7 @@ describe('config.normalizeConfig', () => {
       expect(config.tracing.allowRootExitSpan).to.equal(true);
     });
 
-    it('should not override env-based config', () => {
+    it('should not override env config', () => {
       process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = 'true';
 
       const config = coreConfig.normalize({});
@@ -1573,18 +1569,16 @@ describe('config.normalizeConfig', () => {
     });
 
     it('should ignore empty external values', () => {
-      const config = coreConfig.normalize({
-        userConfig: { serviceName: 'my-service' }
-      });
+      const config = coreConfig.normalize({});
 
       coreConfig.activate({
         serviceName: ''
       });
 
-      expect(config.serviceName).to.equal('my-service');
+      expect(config.serviceName).to.equal(null);
     });
 
-    it('should replace array when current equals default', () => {
+    it('should handle external array config when current config equals default', () => {
       const config = coreConfig.normalize({});
 
       coreConfig.activate({
@@ -1594,7 +1588,7 @@ describe('config.normalizeConfig', () => {
       expect(config.secrets.keywords).to.deep.equal(['a']);
     });
 
-    it('should not replace array when already customized', () => {
+    it('should not replace external array config when already set via in-code config', () => {
       const config = coreConfig.normalize({
         userConfig: {
           secrets: { keywords: ['custom'] }
@@ -1608,7 +1602,7 @@ describe('config.normalizeConfig', () => {
       expect(config.secrets.keywords).to.deep.equal(['custom']);
     });
 
-    it('should merge nested objects when current is default', () => {
+    it('should handle nested objects external config when current config equals default', () => {
       const config = coreConfig.normalize({});
 
       coreConfig.activate({
@@ -1618,7 +1612,7 @@ describe('config.normalizeConfig', () => {
       expect(config.secrets.matcherMode).to.equal('equals');
     });
 
-    it('should not override nested values when already set', () => {
+    it('should not override nested values when already set via in-code config', () => {
       const config = coreConfig.normalize({
         userConfig: {
           secrets: { matcherMode: 'equals' }
@@ -1632,7 +1626,7 @@ describe('config.normalizeConfig', () => {
       expect(config.secrets.matcherMode).to.equal('equals');
     });
 
-    it('should apply ignoreEndpoints as-is (already normalized)', () => {
+    it('should apply ignoreEndpoints', () => {
       const config = coreConfig.normalize({});
 
       const external = {
@@ -1650,7 +1644,7 @@ describe('config.normalizeConfig', () => {
       });
     });
 
-    it('should apply multiple ignoreEndpoints entries as-is', () => {
+    it('should apply multiple ignoreEndpoints entries', () => {
       const config = coreConfig.normalize({});
 
       const external = {
@@ -1670,7 +1664,36 @@ describe('config.normalizeConfig', () => {
       });
     });
 
-    it('should apply disable config as-is (already normalized)', () => {
+    it('should ignore ignoreEndpoints entries when in-code is set', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          tracing: {
+            ignoreEndpoints: {
+              redis: [{ methods: ['get'] }],
+              dynamodb: [{ methods: ['query'] }]
+            }
+          }
+        }
+      });
+
+      const external = {
+        tracing: {
+          ignoreEndpoints: {
+            redis: [{ methods: ['post'] }],
+            dynamodb: [{ methods: ['select'] }]
+          }
+        }
+      };
+
+      coreConfig.activate(external);
+
+      expect(config.tracing.ignoreEndpoints).to.deep.equal({
+        redis: [{ methods: ['get'] }],
+        dynamodb: [{ methods: ['query'] }]
+      });
+    });
+
+    it('should apply disable config', () => {
       const config = coreConfig.normalize({});
 
       const external = {
@@ -1684,7 +1707,7 @@ describe('config.normalizeConfig', () => {
       expect(config.tracing.disable).to.deep.equal(['logging', '!console']);
     });
 
-    it('should apply disable config with mixed flags as-is', () => {
+    it('should apply disable config with mixed flags', () => {
       const config = coreConfig.normalize({});
 
       const external = {

--- a/packages/core/test/config/util_test.js
+++ b/packages/core/test/config/util_test.js
@@ -688,4 +688,178 @@ describe('config.util', () => {
       expect(result).to.equal(multilineValue);
     });
   });
+
+  describe('resolveExternalConfig', () => {
+    it('should return current value when external value is undefined', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: 10,
+        externalValue: undefined,
+        defaultValue: 5
+      });
+
+      expect(result).to.equal(10);
+    });
+
+    it('should return current value when external value is null', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: 10,
+        externalValue: null,
+        defaultValue: 5
+      });
+
+      expect(result).to.equal(10);
+    });
+
+    it('should return current value when external string is empty', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: 'abc',
+        externalValue: '',
+        defaultValue: 'default'
+      });
+
+      expect(result).to.equal('abc');
+    });
+
+    it('should return current value when external array is empty', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: [1, 2],
+        externalValue: [],
+        defaultValue: []
+      });
+
+      expect(result).to.deep.equal([1, 2]);
+    });
+
+    it('should return current value when external object is empty', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: { a: 1 },
+        externalValue: {},
+        defaultValue: {}
+      });
+
+      expect(result).to.deep.equal({ a: 1 });
+    });
+
+    it('should set value when current value is undefined', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: undefined,
+        externalValue: 20,
+        defaultValue: 5
+      });
+
+      expect(result).to.equal(20);
+    });
+
+    it('should override when current value equals default', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: 5,
+        externalValue: 20,
+        defaultValue: 5
+      });
+
+      expect(result).to.equal(20);
+    });
+
+    it('should not override when current value differs from default', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: 15,
+        externalValue: 20,
+        defaultValue: 5
+      });
+
+      expect(result).to.equal(15);
+    });
+
+    it('should handle boolean override when current equals default', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: false,
+        externalValue: true,
+        defaultValue: false
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should not override boolean when current differs from default', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: true,
+        externalValue: false,
+        defaultValue: false
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should replace array when current equals default', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: [],
+        externalValue: ['a'],
+        defaultValue: []
+      });
+
+      expect(result).to.deep.equal(['a']);
+    });
+
+    it('should not replace array when current differs from default', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: ['b'],
+        externalValue: ['a'],
+        defaultValue: []
+      });
+
+      expect(result).to.deep.equal(['b']);
+    });
+
+    it('should deeply resolve nested object values', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: {
+          matcherMode: 'contains-ignore-case',
+          keywords: ['key', 'pass']
+        },
+        externalValue: {
+          matcherMode: 'equals',
+          keywords: ['secret']
+        },
+        defaultValue: {
+          matcherMode: 'contains-ignore-case',
+          keywords: ['key', 'pass', 'secret']
+        }
+      });
+
+      expect(result).to.deep.equal({
+        matcherMode: 'equals',
+        keywords: ['key', 'pass']
+      });
+    });
+
+    it('should add missing nested keys from external config', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: {
+          matcherMode: 'contains-ignore-case'
+        },
+        externalValue: {
+          keywords: ['secret']
+        },
+        defaultValue: {
+          matcherMode: 'contains-ignore-case',
+          keywords: ['key']
+        }
+      });
+
+      expect(result).to.deep.equal({
+        matcherMode: 'contains-ignore-case',
+        keywords: ['secret']
+      });
+    });
+
+    it('should ignore external value when equal to default', () => {
+      const result = util.resolveExternalConfig({
+        currentValue: 'custom',
+        externalValue: 'default',
+        defaultValue: 'default'
+      });
+
+      expect(result).to.equal('custom');
+    });
+  });
 });


### PR DESCRIPTION
Added handling of external (agent-provided) configuration to ensure behavior is consistent with configuration precedence rules.

Precedence order:
env > in-code > agent-config > default

This change clarifies when external agent configuration is applied:

- External (agent) config is applied only when:
  - The current config value (from env or in-code) is not set, OR
  - The current value is still at its default state

- External config is NOT applied when:
  - The value is explicitly set via environment variables, OR
  - The value is defined in in-code configuration

This ensures that user-defined and environment-based settings always take priority,
while agent configuration only fills in missing or default values.


Tasks

- [ ] Add 100% coverage on config files
- [ ] Refactor Activate methods
- [ ] Refactor coreUtil.activate(extraConfig) #2489 
- [ ] Refactor tracingUtil.activate(extraConfig)
- [ ] Refactor  spanBuffer.activate(extraConfig)
- [ ] Refactor instrumentations
- [ ] Integration tests fix


---
<img width="1411" height="347" alt="image" src="https://github.com/user-attachments/assets/59223722-1c5c-456b-b4fe-4d6151176a14" />

