### PR TITLE
refactor(core): renamed configValue to inCodeValue for clarity

### DIFF
--- a/packages/collector/src/util/normalizeConfig.js
+++ b/packages/collector/src/util/normalizeConfig.js
@@ -44,7 +44,7 @@ module.exports = function normalizeConfig(userConfig = {}) {
 function normalizeAgentHost(userConfig, defaultConfig) {
   return util.resolveStringConfig({
     envVar: 'INSTANA_AGENT_HOST',
-    configValue: userConfig.agentHost,
+    inCodeValue: userConfig.agentHost,
     defaultValue: defaultConfig.agentHost,
     configPath: 'config.agentHost'
   });
@@ -58,7 +58,7 @@ function normalizeAgentHost(userConfig, defaultConfig) {
 function normalizeAgentPort(userConfig, defaultConfig) {
   return util.resolveNumericConfig({
     envVar: 'INSTANA_AGENT_PORT',
-    configValue: userConfig.agentPort,
+    inCodeValue: userConfig.agentPort,
     defaultValue: defaultConfig.agentPort,
     configPath: 'config.agentPort'
   });
@@ -72,7 +72,7 @@ function normalizeAgentPort(userConfig, defaultConfig) {
 function normalizeAgentRequestTimeout(userConfig, defaultConfig) {
   return util.resolveNumericConfig({
     envVar: 'INSTANA_AGENT_REQUEST_TIMEOUT',
-    configValue: userConfig.agentRequestTimeout,
+    inCodeValue: userConfig.agentRequestTimeout,
     defaultValue: defaultConfig.agentRequestTimeout,
     configPath: 'config.agentRequestTimeout'
   });
@@ -86,7 +86,7 @@ function normalizeAgentRequestTimeout(userConfig, defaultConfig) {
 function normalizeAutoProfile(userConfig, defaultConfig) {
   return util.resolveBooleanConfig({
     envVar: 'INSTANA_AUTO_PROFILE',
-    configValue: userConfig.autoProfile,
+    inCodeValue: userConfig.autoProfile,
     defaultValue: defaultConfig.autoProfile,
     configPath: 'config.autoProfile'
   });

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -185,7 +185,7 @@ module.exports.normalize = ({ userConfig = {}, finalConfigBase = {}, defaultsOve
 function normalizeServiceName({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.serviceName = util.resolveStringConfig({
     envVar: 'INSTANA_SERVICE_NAME',
-    configValue: userConfig.serviceName,
+    inCodeValue: userConfig.serviceName,
     defaultValue: defaultConfig.serviceName,
     configPath: 'config.serviceName'
   });
@@ -197,7 +197,7 @@ function normalizeServiceName({ userConfig = {}, defaultConfig = {}, finalConfig
 function normalizePackageJsonPath({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.packageJsonPath = util.resolveStringConfig({
     envVar: 'INSTANA_PACKAGE_JSON_PATH',
-    configValue: userConfig.packageJsonPath,
+    inCodeValue: userConfig.packageJsonPath,
     defaultValue: defaultConfig.packageJsonPath,
     configPath: 'config.packageJsonPath'
   });
@@ -213,7 +213,7 @@ function normalizeMetricsConfig({ userConfig = {}, defaultConfig = {}, finalConf
 
   finalConfig.metrics.transmissionDelay = util.resolveNumericConfig({
     envVar: 'INSTANA_METRICS_TRANSMISSION_DELAY',
-    configValue: userMetrics?.transmissionDelay,
+    inCodeValue: userMetrics?.transmissionDelay,
     defaultValue: defaultConfig.metrics.transmissionDelay,
     configPath: 'config.metrics.transmissionDelay'
   });
@@ -260,7 +260,7 @@ function normalizeTracingEnabled({ userConfig = {}, defaultConfig = {}, finalCon
 
   finalConfig.tracing.enabled = util.resolveBooleanConfigWithInvertedEnv({
     envVar: isBooleanValue ? 'INSTANA_TRACING_DISABLE' : undefined,
-    configValue: userConfig.tracing.enabled,
+    inCodeValue: userConfig.tracing.enabled,
     defaultValue: defaultConfig.tracing.enabled,
     configPath: 'config.tracing.enabled'
   });
@@ -272,7 +272,7 @@ function normalizeTracingEnabled({ userConfig = {}, defaultConfig = {}, finalCon
 function normalizeAllowRootExitSpan({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.allowRootExitSpan = util.resolveBooleanConfig({
     envVar: 'INSTANA_ALLOW_ROOT_EXIT_SPAN',
-    configValue: userConfig.tracing.allowRootExitSpan,
+    inCodeValue: userConfig.tracing.allowRootExitSpan,
     defaultValue: defaultConfig.tracing.allowRootExitSpan,
     configPath: 'config.tracing.allowRootExitSpan'
   });
@@ -284,7 +284,7 @@ function normalizeAllowRootExitSpan({ userConfig = {}, defaultConfig = {}, final
 function normalizeUseOpentelemetry({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.useOpentelemetry = util.resolveBooleanConfigWithInvertedEnv({
     envVar: 'INSTANA_DISABLE_USE_OPENTELEMETRY',
-    configValue: userConfig.tracing.useOpentelemetry,
+    inCodeValue: userConfig.tracing.useOpentelemetry,
     defaultValue: defaultConfig.tracing.useOpentelemetry,
     configPath: 'config.tracing.useOpentelemetry'
   });
@@ -302,7 +302,7 @@ function normalizeAutomaticTracingEnabled({ userConfig = {}, defaultConfig = {},
 
   finalConfig.tracing.automaticTracingEnabled = util.resolveBooleanConfigWithInvertedEnv({
     envVar: 'INSTANA_DISABLE_AUTO_INSTR',
-    configValue: userConfig.tracing.automaticTracingEnabled,
+    inCodeValue: userConfig.tracing.automaticTracingEnabled,
     defaultValue: defaultConfig.tracing.automaticTracingEnabled,
     configPath: 'config.tracing.automaticTracingEnabled'
   });
@@ -319,7 +319,7 @@ function normalizeActivateImmediately({ userConfig = {}, defaultConfig = {}, fin
 
   finalConfig.tracing.activateImmediately = util.resolveBooleanConfig({
     envVar: 'INSTANA_TRACE_IMMEDIATELY',
-    configValue: userConfig.tracing.activateImmediately,
+    inCodeValue: userConfig.tracing.activateImmediately,
     defaultValue: defaultConfig.tracing.activateImmediately,
     configPath: 'config.tracing.activateImmediately'
   });
@@ -333,21 +333,21 @@ function normalizeTracingTransmission({ userConfig = {}, defaultConfig = {}, fin
 
   finalConfig.tracing.transmissionDelay = util.resolveNumericConfig({
     envVar: 'INSTANA_TRACING_TRANSMISSION_DELAY',
-    configValue: userConfig.tracing.transmissionDelay,
+    inCodeValue: userConfig.tracing.transmissionDelay,
     defaultValue: defaultConfig.tracing.transmissionDelay,
     configPath: 'config.tracing.transmissionDelay'
   });
 
   finalConfig.tracing.forceTransmissionStartingAt = util.resolveNumericConfig({
     envVar: 'INSTANA_FORCE_TRANSMISSION_STARTING_AT',
-    configValue: userConfig.tracing.forceTransmissionStartingAt,
+    inCodeValue: userConfig.tracing.forceTransmissionStartingAt,
     defaultValue: defaultConfig.tracing.forceTransmissionStartingAt,
     configPath: 'config.tracing.forceTransmissionStartingAt'
   });
 
   finalConfig.tracing.initialTransmissionDelay = util.resolveNumericConfig({
     envVar: 'INSTANA_TRACING_INITIAL_TRANSMISSION_DELAY',
-    configValue: userConfig.tracing.initialTransmissionDelay,
+    inCodeValue: userConfig.tracing.initialTransmissionDelay,
     defaultValue: defaultConfig.tracing.initialTransmissionDelay,
     configPath: 'config.tracing.initialTransmissionDelay'
   });
@@ -457,7 +457,7 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
   }
 
   const isLegacyLengthDefined = userTracingConfig?.stackTraceLength !== undefined;
-  const stackTraceConfigValue = userGlobal?.stackTraceLength || userTracingConfig?.stackTraceLength;
+  const stackTraceInCodeValue = userGlobal?.stackTraceLength || userTracingConfig?.stackTraceLength;
 
   // Priority 1: Environment variable
   if (envStackTraceLength !== undefined) {
@@ -474,7 +474,7 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
       logger.warn(`Invalid env INSTANA_STACK_TRACE_LENGTH: ${result.error}`);
       finalConfig.tracing.stackTraceLength = defaultConfig.tracing.stackTraceLength;
     }
-  } else if (stackTraceConfigValue !== undefined) {
+  } else if (stackTraceInCodeValue !== undefined) {
     // Priority 2: In-code configuration
     if (isLegacyLengthDefined) {
       logger.warn(
@@ -484,7 +484,7 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
       );
     }
 
-    const result = validateStackTraceLength(stackTraceConfigValue);
+    const result = validateStackTraceLength(stackTraceInCodeValue);
 
     if (result.isValid) {
       const normalized = configNormalizers.stackTrace.normalizeStackTraceLength(userConfig);
@@ -533,7 +533,7 @@ function normalizeDisableTracing({ userConfig = {}, defaultConfig = {}, finalCon
 function normalizeSpanBatchingEnabled({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.spanBatchingEnabled = util.resolveBooleanConfig({
     envVar: 'INSTANA_SPANBATCHING_ENABLED',
-    configValue: userConfig.tracing.spanBatchingEnabled,
+    inCodeValue: userConfig.tracing.spanBatchingEnabled,
     defaultValue: defaultConfig.tracing.spanBatchingEnabled,
     configPath: 'config.tracing.spanBatchingEnabled'
   });
@@ -545,7 +545,7 @@ function normalizeSpanBatchingEnabled({ userConfig = {}, defaultConfig = {}, fin
 function normalizeDisableW3cTraceCorrelation({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.disableW3cTraceCorrelation = util.resolveBooleanConfigWithTruthyEnv({
     envVar: 'INSTANA_DISABLE_W3C_TRACE_CORRELATION',
-    configValue: userConfig.tracing.disableW3cTraceCorrelation,
+    inCodeValue: userConfig.tracing.disableW3cTraceCorrelation,
     defaultValue: defaultConfig.tracing.disableW3cTraceCorrelation,
     configPath: 'config.tracing.disableW3cTraceCorrelation'
   });
@@ -560,7 +560,7 @@ function normalizeTracingKafka({ userConfig = {}, defaultConfig = {}, finalConfi
 
   finalConfig.tracing.kafka.traceCorrelation = util.resolveBooleanConfig({
     envVar: 'INSTANA_KAFKA_TRACE_CORRELATION',
-    configValue: userKafka?.traceCorrelation,
+    inCodeValue: userKafka?.traceCorrelation,
     defaultValue: defaultConfig.tracing.kafka.traceCorrelation,
     configPath: 'config.tracing.kafka.traceCorrelation'
   });
@@ -734,7 +734,7 @@ function normalizeIgnoreEndpoints({ userConfig = {}, defaultConfig = {}, finalCo
 function normalizeIgnoreEndpointsDisableSuppression({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.ignoreEndpointsDisableSuppression = util.resolveBooleanConfig({
     envVar: 'INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION',
-    configValue: userConfig.tracing.ignoreEndpointsDisableSuppression,
+    inCodeValue: userConfig.tracing.ignoreEndpointsDisableSuppression,
     defaultValue: defaultConfig.tracing.ignoreEndpointsDisableSuppression,
     configPath: 'config.tracing.ignoreEndpointsDisableSuppression'
   });
@@ -746,7 +746,7 @@ function normalizeIgnoreEndpointsDisableSuppression({ userConfig = {}, defaultCo
 function normalizeDisableEOLEvents({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.disableEOLEvents = util.resolveBooleanConfig({
     envVar: 'INSTANA_TRACING_DISABLE_EOL_EVENTS',
-    configValue: userConfig.tracing.disableEOLEvents,
+    inCodeValue: userConfig.tracing.disableEOLEvents,
     defaultValue: defaultConfig.tracing.disableEOLEvents,
     configPath: 'config.tracing.disableEOLEvents'
   });

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -17,12 +17,12 @@ exports.init = _logger => {
 /**
  * @param {Object} params
  * @param {string} params.envVar
- * @param {number|string|undefined|null} params.configValue
+ * @param {number|string|undefined|null} params.inCodeValue
  * @param {number} params.defaultValue
  * @param {string} params.configPath
  * @returns {number}
  */
-exports.resolveNumericConfig = function resolveNumericConfig({ envVar, configValue, defaultValue, configPath }) {
+exports.resolveNumericConfig = function resolveNumericConfig({ envVar, inCodeValue, defaultValue, configPath }) {
   const envRaw = process.env[envVar];
 
   /** @param {number|string|null|undefined} val */
@@ -41,15 +41,15 @@ exports.resolveNumericConfig = function resolveNumericConfig({ envVar, configVal
     logger.warn(`Invalid numeric value from env:${envVar}: "${envRaw}". Ignoring and checking config value.`);
   }
 
-  if (configValue != null) {
-    const configParsed = toValidNumber(configValue);
+  if (inCodeValue != null) {
+    const configParsed = toValidNumber(inCodeValue);
     if (configParsed !== undefined) {
-      logger.debug(`[config] incode:${configPath} = ${configValue}`);
+      logger.debug(`[config] incode:${configPath} = ${inCodeValue}`);
       return configParsed;
     }
 
     logger.warn(
-      `Invalid numeric value for ${configPath} from config: "${configValue}". Falling back to default: ${defaultValue}.`
+      `Invalid numeric value for ${configPath} from config: "${inCodeValue}". Falling back to default: ${defaultValue}.`
     );
   }
 
@@ -79,12 +79,12 @@ function parseBooleanFromEnv(envValue) {
 /**
  * @param {Object} params
  * @param {string} params.envVar
- * @param {boolean|undefined|null} params.configValue
+ * @param {boolean|undefined|null} params.inCodeValue
  * @param {boolean} params.defaultValue
  * @param {string} [params.configPath]
  * @returns {boolean}
  */
-exports.resolveBooleanConfig = function resolveBooleanConfig({ envVar, configValue, defaultValue, configPath }) {
+exports.resolveBooleanConfig = function resolveBooleanConfig({ envVar, inCodeValue, defaultValue, configPath }) {
   // Priority 1: Environment variable
   const envValue = process.env[envVar];
   const envParsed = parseBooleanFromEnv(envValue);
@@ -99,15 +99,15 @@ exports.resolveBooleanConfig = function resolveBooleanConfig({ envVar, configVal
   }
 
   // Priority 2: In-code configuration
-  if (typeof configValue === 'boolean') {
-    logger.debug(`[config] incode:${configPath} = ${configValue}`);
-    return configValue;
+  if (typeof inCodeValue === 'boolean') {
+    logger.debug(`[config] incode:${configPath} = ${inCodeValue}`);
+    return inCodeValue;
   }
 
-  if (configValue != null && configPath) {
+  if (inCodeValue != null && configPath) {
     logger.warn(
       `Invalid configuration: ${configPath} is not a boolean value, will be ignored: ${JSON.stringify(
-        configValue
+        inCodeValue
       )}. Falling back to default: ${defaultValue}.`
     );
   }
@@ -122,14 +122,14 @@ exports.resolveBooleanConfig = function resolveBooleanConfig({ envVar, configVal
  *
  * @param {Object} params
  * @param {string} params.envVar - Environment variable name (e.g., INSTANA_DISABLE_X)
- * @param {boolean|undefined|null} params.configValue - Config value
+ * @param {boolean|undefined|null} params.inCodeValue - Config value
  * @param {boolean} params.defaultValue - Default value
  * @param {string} [params.configPath] - Config path for logging (optional)
  * @returns {boolean}
  */
 exports.resolveBooleanConfigWithInvertedEnv = function resolveBooleanConfigWithInvertedEnv({
   envVar,
-  configValue,
+  inCodeValue,
   defaultValue,
   configPath
 }) {
@@ -148,15 +148,15 @@ exports.resolveBooleanConfigWithInvertedEnv = function resolveBooleanConfigWithI
   }
 
   // Priority 2: In-code configuration
-  if (typeof configValue === 'boolean') {
-    logger.debug(`[config] incode:${configPath} = ${configValue}`);
-    return configValue;
+  if (typeof inCodeValue === 'boolean') {
+    logger.debug(`[config] incode:${configPath} = ${inCodeValue}`);
+    return inCodeValue;
   }
 
-  if (configValue != null && configPath) {
+  if (inCodeValue != null && configPath) {
     logger.warn(
       `Invalid configuration: ${configPath} is not a boolean value, will be ignored: ${JSON.stringify(
-        configValue
+        inCodeValue
       )}. Falling back to default: ${defaultValue}.`
     );
   }
@@ -171,14 +171,14 @@ exports.resolveBooleanConfigWithInvertedEnv = function resolveBooleanConfigWithI
  *
  * @param {Object} params
  * @param {string} params.envVar - Environment variable name
- * @param {boolean|undefined|null} params.configValue - Config value
+ * @param {boolean|undefined|null} params.inCodeValue - Config value
  * @param {boolean} params.defaultValue - Default value
  * @param {string} [params.configPath]
  * @returns {boolean}
  */
 exports.resolveBooleanConfigWithTruthyEnv = function resolveBooleanConfigWithTruthyEnv({
   envVar,
-  configValue,
+  inCodeValue,
   defaultValue,
   configPath
 }) {
@@ -190,9 +190,9 @@ exports.resolveBooleanConfigWithTruthyEnv = function resolveBooleanConfigWithTru
   }
 
   // Priority 2: In-code configuration
-  if (typeof configValue === 'boolean') {
-    logger.debug(`[config] incode:${configPath} = ${configValue}`);
-    return configValue;
+  if (typeof inCodeValue === 'boolean') {
+    logger.debug(`[config] incode:${configPath} = ${inCodeValue}`);
+    return inCodeValue;
   }
 
   // Priority 3: Default value
@@ -202,11 +202,11 @@ exports.resolveBooleanConfigWithTruthyEnv = function resolveBooleanConfigWithTru
 /**
  * @param {Object} params
  * @param {any} params.envVar
- * @param {any} params.configValue
+ * @param {any} params.inCodeValue
  * @param {any} params.defaultValue
  * @param {string} [params.configPath]
  */
-exports.resolveStringConfig = function resolveStringConfig({ envVar, configValue, defaultValue, configPath }) {
+exports.resolveStringConfig = function resolveStringConfig({ envVar, inCodeValue, defaultValue, configPath }) {
   // Priority 1: Environment variable
   const envValue = process.env[envVar];
   if (envValue != null) {
@@ -215,17 +215,17 @@ exports.resolveStringConfig = function resolveStringConfig({ envVar, configValue
   }
 
   // Priority 2: In-code configuration
-  if (configValue != null) {
-    if (typeof configValue !== 'string') {
+  if (inCodeValue != null) {
+    if (typeof inCodeValue !== 'string') {
       logger.warn(
         `Invalid configuration: ${configPath} is not a string value, will be ignored: ${JSON.stringify(
-          configValue
+          inCodeValue
         )}. Falling back to default: ${defaultValue}.`
       );
       return defaultValue;
     }
-    logger.debug(`[config] incode:${configPath} = ${configValue}`);
-    return configValue;
+    logger.debug(`[config] incode:${configPath} = ${inCodeValue}`);
+    return inCodeValue;
   }
   return defaultValue;
 };

--- a/packages/core/test/config/util_test.js
+++ b/packages/core/test/config/util_test.js
@@ -27,7 +27,7 @@ describe('config.util', () => {
     it('should return the default value when no env var or config value is provided', () => {
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -40,7 +40,7 @@ describe('config.util', () => {
 
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: 3000,
+        inCodeValue: 3000,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -51,7 +51,7 @@ describe('config.util', () => {
     it('should use config value when env var is not set', () => {
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: 3000,
+        inCodeValue: 3000,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -62,7 +62,7 @@ describe('config.util', () => {
     it('should handle numeric config value', () => {
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: 5000,
+        inCodeValue: 5000,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -73,7 +73,7 @@ describe('config.util', () => {
     it('should handle string config value that can be parsed as number', () => {
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: '5000',
+        inCodeValue: '5000',
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -86,7 +86,7 @@ describe('config.util', () => {
 
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -99,7 +99,7 @@ describe('config.util', () => {
 
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -110,7 +110,7 @@ describe('config.util', () => {
     it('should fall back to default when config value is invalid', () => {
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: 'invalid',
+        inCodeValue: 'invalid',
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -123,7 +123,7 @@ describe('config.util', () => {
 
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: 3000,
+        inCodeValue: 3000,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -136,7 +136,7 @@ describe('config.util', () => {
 
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -147,7 +147,7 @@ describe('config.util', () => {
     it('should handle zero as a valid value from config', () => {
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: 0,
+        inCodeValue: 0,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -160,7 +160,7 @@ describe('config.util', () => {
 
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -171,7 +171,7 @@ describe('config.util', () => {
     it('should handle negative numbers from config', () => {
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: -500,
+        inCodeValue: -500,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -184,7 +184,7 @@ describe('config.util', () => {
 
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -195,7 +195,7 @@ describe('config.util', () => {
     it('should handle floating point numbers from config', () => {
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: 123.45,
+        inCodeValue: 123.45,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -206,7 +206,7 @@ describe('config.util', () => {
     it('should handle null config value', () => {
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: null,
+        inCodeValue: null,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -219,7 +219,7 @@ describe('config.util', () => {
 
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -230,7 +230,7 @@ describe('config.util', () => {
     it('should handle empty string config value as 0', () => {
       const result = util.resolveNumericConfig({
         envVar: 'TEST_ENV_VAR',
-        configValue: '',
+        inCodeValue: '',
         defaultValue: 1000,
         configPath: 'config.test.value'
       });
@@ -251,7 +251,7 @@ describe('config.util', () => {
     it('should return the default value when no env var or config value is provided', () => {
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: false,
         configPath: 'config.test.bool'
       });
@@ -264,7 +264,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
-        configValue: false,
+        inCodeValue: false,
         defaultValue: false,
         configPath: 'config.test.bool'
       });
@@ -275,7 +275,7 @@ describe('config.util', () => {
     it('should use config value when env var is not set', () => {
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
-        configValue: true,
+        inCodeValue: true,
         defaultValue: false,
         configPath: 'config.test.bool'
       });
@@ -288,7 +288,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: false,
         configPath: 'config.test.bool'
       });
@@ -301,7 +301,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: true,
         configPath: 'config.test.bool'
       });
@@ -314,7 +314,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: false,
         configPath: 'config.test.bool'
       });
@@ -327,7 +327,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: true,
         configPath: 'config.test.bool'
       });
@@ -340,7 +340,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: false,
         configPath: 'config.test.bool'
       });
@@ -353,7 +353,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: true,
         configPath: 'config.test.bool'
       });
@@ -366,7 +366,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
-        configValue: true,
+        inCodeValue: true,
         defaultValue: false,
         configPath: 'config.test.bool'
       });
@@ -379,7 +379,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
-        configValue: 'not-a-boolean',
+        inCodeValue: 'not-a-boolean',
         defaultValue: true,
         configPath: 'config.test.bool'
       });
@@ -390,7 +390,7 @@ describe('config.util', () => {
     it('should handle null config value', () => {
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
-        configValue: null,
+        inCodeValue: null,
         defaultValue: true,
         configPath: 'config.test.bool'
       });
@@ -401,7 +401,7 @@ describe('config.util', () => {
     it('should handle undefined config value', () => {
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: false,
         configPath: 'config.test.bool'
       });
@@ -424,7 +424,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfigWithInvertedEnv({
         envVar: 'TEST_DISABLE_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: true,
         configPath: 'config.test.disable'
       });
@@ -437,7 +437,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfigWithInvertedEnv({
         envVar: 'TEST_DISABLE_VAR',
-        configValue: true,
+        inCodeValue: true,
         defaultValue: true,
         configPath: 'config.test.disable'
       });
@@ -448,7 +448,7 @@ describe('config.util', () => {
     it('should use config value when env var is not set', () => {
       const result = util.resolveBooleanConfigWithInvertedEnv({
         envVar: 'TEST_DISABLE_VAR',
-        configValue: false,
+        inCodeValue: false,
         defaultValue: true,
         configPath: 'config.test.disable'
       });
@@ -461,7 +461,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfigWithInvertedEnv({
         envVar: 'TEST_DISABLE_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: true,
         configPath: 'config.test.disable'
       });
@@ -472,7 +472,7 @@ describe('config.util', () => {
     it('should handle null config value', () => {
       const result = util.resolveBooleanConfigWithInvertedEnv({
         envVar: 'TEST_DISABLE_VAR',
-        configValue: null,
+        inCodeValue: null,
         defaultValue: false,
         configPath: 'config.test.disable'
       });
@@ -480,10 +480,10 @@ describe('config.util', () => {
       expect(result).to.equal(false);
     });
 
-    it('should return default when configValue and env var are not boolean', () => {
+    it('should return default when inCodeValue and env var are not boolean', () => {
       const result = util.resolveBooleanConfigWithInvertedEnv({
         envVar: 'TEST_INVERTED_VAR',
-        configValue: 'not-a-boolean',
+        inCodeValue: 'not-a-boolean',
         defaultValue: true,
         configPath: 'config.test.inverted'
       });
@@ -506,7 +506,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: false
       });
 
@@ -518,7 +518,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: false
       });
 
@@ -530,7 +530,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: false
       });
 
@@ -542,7 +542,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
-        configValue: false,
+        inCodeValue: false,
         defaultValue: false
       });
 
@@ -552,7 +552,7 @@ describe('config.util', () => {
     it('should use config value when env var is not set', () => {
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
-        configValue: true,
+        inCodeValue: true,
         defaultValue: false
       });
 
@@ -562,7 +562,7 @@ describe('config.util', () => {
     it('should use default when env var is not set and config is not boolean', () => {
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: false
       });
 
@@ -574,7 +574,7 @@ describe('config.util', () => {
 
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: false
       });
 
@@ -594,7 +594,7 @@ describe('config.util', () => {
     it('should return the default value when no env var or config value is provided', () => {
       const result = util.resolveStringConfig({
         envVar: 'TEST_STRING_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: 'default-value',
         configPath: 'config.test.string'
       });
@@ -607,7 +607,7 @@ describe('config.util', () => {
 
       const result = util.resolveStringConfig({
         envVar: 'TEST_STRING_VAR',
-        configValue: 'config-value',
+        inCodeValue: 'config-value',
         defaultValue: 'default-value',
         configPath: 'config.test.string'
       });
@@ -620,7 +620,7 @@ describe('config.util', () => {
 
       const result = util.resolveStringConfig({
         envVar: 'TEST_STRING_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: 'default-value',
         configPath: 'config.test.string'
       });
@@ -631,7 +631,7 @@ describe('config.util', () => {
     it('should use config value when env var is not set', () => {
       const result = util.resolveStringConfig({
         envVar: 'TEST_STRING_VAR',
-        configValue: 'config-value',
+        inCodeValue: 'config-value',
         defaultValue: 'default-value',
         configPath: 'config.test.string'
       });
@@ -642,7 +642,7 @@ describe('config.util', () => {
     it('should handle empty string as a valid config value', () => {
       const result = util.resolveStringConfig({
         envVar: 'TEST_STRING_VAR',
-        configValue: '',
+        inCodeValue: '',
         defaultValue: 'default-value',
         configPath: 'config.test.string'
       });
@@ -655,7 +655,7 @@ describe('config.util', () => {
 
       const result = util.resolveStringConfig({
         envVar: 'TEST_STRING_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: 'default-value',
         configPath: 'config.test.string'
       });
@@ -668,7 +668,7 @@ describe('config.util', () => {
 
       const result = util.resolveStringConfig({
         envVar: 'TEST_STRING_VAR',
-        configValue: undefined,
+        inCodeValue: undefined,
         defaultValue: 'default-value',
         configPath: 'config.test.string'
       });
@@ -680,7 +680,7 @@ describe('config.util', () => {
       const multilineValue = 'line1\nline2\nline3';
       const result = util.resolveStringConfig({
         envVar: undefined,
-        configValue: multilineValue,
+        inCodeValue: multilineValue,
         defaultValue: 'default-value',
         configPath: 'config.test.string'
       });


### PR DESCRIPTION
Renamed the `configValue` parameter to `inCodeValue` across all config
resolver functions to better reflect that it represents configuration
values set programmatically in code, as opposed to environment variables
or defaults. 

This aligns with the existing `incode:` prefix used in
debug logs throughout the configuration system.

Two options came in: `inCodeConfig` and `inCodeValue`. Currently I use `inCodeValue` because it seemed to go along with other objects in the whole config. 