### PR TITLE
chore(config): preserved existing values when applying partial updates

### DIFF
--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -974,9 +974,11 @@ exports.update = function update(externalConfig, source) {
       return currentConfig;
     }
 
-    /** @type {any} */ (currentConfig)[key] = externalConfig[key];
+    /** @type {Record<string, any>} */
+    const configAsRecord = currentConfig;
+    configAsRecord[key] = deepMerge(configAsRecord[key], externalConfig[key]);
+
     configStore.set(configPath, { source });
-    logger.debug(`[config] Updated ${key} from source ${source}: ${JSON.stringify(externalConfig[key])}`);
   });
   return currentConfig;
 };

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -44,7 +44,7 @@ exports.resolve = function resolve({ envValue, inCodeValue, agentValue, defaultV
     default: defaultValue
   };
 
-  CONFIG_PRIORITY.find(sourceKey => {
+  CONFIG_PRIORITY.some(sourceKey => {
     const rawValue = inputs[/** @type {keyof typeof inputs} */ (sourceKey)];
 
     if (rawValue === undefined && sourceKey !== 'default') {

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -1644,6 +1644,32 @@ describe('config.normalizeConfig', () => {
 
         expect(config.preloadOpentelemetry).to.be.true;
       });
+
+      it('should preserve existing tracing config when agent updates tracing partially', () => {
+        const config = coreConfig.normalize();
+
+        expect(config.tracing.kafka.traceCorrelation).to.be.true;
+        expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal([]);
+
+        coreConfig.update(
+          {
+            tracing: {
+              http: {
+                extraHttpHeadersToCapture: ['x-instana-test']
+              }
+            }
+          },
+          CONFIG_SOURCES.AGENT
+        );
+
+        expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal(['x-instana-test']);
+        expect(config.tracing.kafka).to.deep.equal({
+          traceCorrelation: true
+        });
+        expect(config.tracing.kafka.traceCorrelation).to.be.true;
+        expect(config.tracing.enabled).to.be.true;
+        expect(config.tracing.spanBatchingEnabled).to.be.false;
+      });
     });
   });
 


### PR DESCRIPTION
External config updates now deep-merge nested plain objects into the existing normalized config instead of replacing them at the top level.