### PR TITLE
refactor(config): replaced agentConfig usage with updated config

### DIFF
--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -103,9 +103,9 @@ exports.init = function init(config, _downstreamConnection) {
 };
 
 /**
- * @param {import('@instana/collector/src/types/collector').AgentConfig} extraConfig
+ * @param {import('../config').InstanaConfig} _config
  */
-exports.activate = function activate(extraConfig) {
+exports.activate = function activate(_config) {
   if (!downstreamConnection) {
     logger.error('No downstreamConnection has been set.');
     return;
@@ -119,10 +119,8 @@ exports.activate = function activate(extraConfig) {
     return;
   }
 
-  if (extraConfig?.tracing) {
-    if (extraConfig.tracing.spanBatchingEnabled) {
-      batchingEnabled = true;
-    }
+  if (_config?.tracing.spanBatchingEnabled) {
+    batchingEnabled = true;
   }
 
   isActive = true;

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -119,7 +119,7 @@ exports.activate = function activate(_config) {
     return;
   }
 
-  if (_config?.tracing.spanBatchingEnabled) {
+  if (_config.tracing.spanBatchingEnabled) {
     batchingEnabled = true;
   }
 

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -119,9 +119,7 @@ exports.activate = function activate(_config) {
     return;
   }
 
-  if (_config.tracing.spanBatchingEnabled) {
-    batchingEnabled = true;
-  }
+  batchingEnabled = _config.tracing.spanBatchingEnabled;
 
   isActive = true;
   if (activatedAt == null) {

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -37,8 +37,8 @@ exports.init = function (config) {
  * @param {import('../config').InstanaConfig} _config
  */
 exports.activate = function activate(_config) {
-  stackTraceLength = _config.tracing?.stackTraceLength;
-  stackTraceMode = _config.tracing?.stackTrace;
+  stackTraceLength = _config.tracing.stackTraceLength;
+  stackTraceMode = _config.tracing.stackTrace;
 };
 
 /**

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -10,7 +10,7 @@ const path = require('path');
 const StringDecoder = require('string_decoder').StringDecoder;
 
 const stackTrace = require('../util/stackTrace');
-const { DEFAULT_STACK_TRACE_LENGTH, DEFAULT_STACK_TRACE_MODE, STACK_TRACE_MODES } = require('../util/constants');
+const { STACK_TRACE_MODES } = require('../util/constants');
 
 /** @type {import('../core').GenericLogger} */
 let logger;
@@ -34,26 +34,11 @@ exports.init = function (config) {
 };
 
 /**
- * @param {import('@instana/collector/src/types/collector').AgentConfig} extraConfig
+ * @param {import('../config').InstanaConfig} _config
  */
-exports.activate = function activate(extraConfig) {
-  const agentTraceConfig = extraConfig?.tracing;
-
-  // Note: We check whether the already-initialized stackTraceLength equals the default value.
-  //       If it does, we can safely override it, since the user did not explicitly configure it.
-
-  // Note: If the user configured a value via env or code and also configured a different value in the agent,
-  //       but the env/code value happens to equal the default, the agent value would overwrite it.
-  //       This is a rare edge case and acceptable for now.
-
-  if (agentTraceConfig?.stackTrace && stackTraceMode === DEFAULT_STACK_TRACE_MODE) {
-    stackTraceMode = agentTraceConfig.stackTrace;
-  }
-
-  // stackTraceLength is valid when set to any number, including 0
-  if (agentTraceConfig?.stackTraceLength != null && stackTraceLength === DEFAULT_STACK_TRACE_LENGTH) {
-    stackTraceLength = agentTraceConfig.stackTraceLength;
-  }
+exports.activate = function activate(_config) {
+  stackTraceLength = _config.tracing?.stackTraceLength;
+  stackTraceMode = _config.tracing?.stackTrace;
 };
 
 /**

--- a/packages/core/test/tracing/spanBuffer_test.js
+++ b/packages/core/test/tracing/spanBuffer_test.js
@@ -46,7 +46,9 @@ describe('tracing/spanBuffer', () => {
     });
 
     beforeEach(() => {
-      spanBuffer.activate();
+      spanBuffer.activate({
+        tracing: {}
+      });
       expect(global.setTimeout.called).to.be.false;
 
       global.setTimeout.resetHistory();
@@ -124,7 +126,9 @@ describe('tracing/spanBuffer', () => {
     });
 
     beforeEach(() => {
-      spanBuffer.activate();
+      spanBuffer.activate({
+        tracing: {}
+      });
       expect(global.setTimeout.called).to.be.true;
       global.setTimeout.resetHistory();
     });
@@ -217,7 +221,11 @@ describe('tracing/spanBuffer', () => {
         spanBuffer.addBatchableSpanName('batchable');
       });
 
-      beforeEach(() => spanBuffer.activate());
+      beforeEach(() =>
+        spanBuffer.activate({
+          tracing: {}
+        })
+      );
 
       afterEach(() => spanBuffer.deactivate());
 
@@ -563,7 +571,11 @@ describe('tracing/spanBuffer', () => {
         spanBuffer.addBatchableSpanName('batchable');
       });
 
-      beforeEach(() => spanBuffer.activate());
+      beforeEach(() =>
+        spanBuffer.activate({
+          tracing: {}
+        })
+      );
 
       afterEach(() => spanBuffer.deactivate());
 
@@ -574,7 +586,11 @@ describe('tracing/spanBuffer', () => {
     });
 
     describe('when applying span transformations', () => {
-      beforeEach(() => spanBuffer.activate());
+      beforeEach(() =>
+        spanBuffer.activate({
+          tracing: {}
+        })
+      );
 
       afterEach(() => spanBuffer.deactivate());
       const span = {

--- a/packages/core/test/tracing/spanBuffer_test.js
+++ b/packages/core/test/tracing/spanBuffer_test.js
@@ -46,8 +46,12 @@ describe('tracing/spanBuffer', () => {
     });
 
     beforeEach(() => {
+      downstreamConnectionStub.sendSpans.resetHistory();
+      spanBuffer.setTransmitImmediate(false);
       spanBuffer.activate({
-        tracing: {}
+        tracing: {
+          spanBatchingEnabled: false
+        }
       });
       expect(global.setTimeout.called).to.be.false;
 
@@ -126,8 +130,12 @@ describe('tracing/spanBuffer', () => {
     });
 
     beforeEach(() => {
+      downstreamConnectionStub.sendSpans.resetHistory();
+      spanBuffer.setTransmitImmediate(false);
       spanBuffer.activate({
-        tracing: {}
+        tracing: {
+          spanBatchingEnabled: false
+        }
       });
       expect(global.setTimeout.called).to.be.true;
       global.setTimeout.resetHistory();
@@ -221,11 +229,14 @@ describe('tracing/spanBuffer', () => {
         spanBuffer.addBatchableSpanName('batchable');
       });
 
-      beforeEach(() =>
+      beforeEach(() => {
+        spanBuffer.setTransmitImmediate(false);
         spanBuffer.activate({
-          tracing: {}
-        })
-      );
+          tracing: {
+            spanBatchingEnabled: true
+          }
+        });
+      });
 
       afterEach(() => spanBuffer.deactivate());
 
@@ -571,11 +582,14 @@ describe('tracing/spanBuffer', () => {
         spanBuffer.addBatchableSpanName('batchable');
       });
 
-      beforeEach(() =>
+      beforeEach(() => {
+        spanBuffer.setTransmitImmediate(false);
         spanBuffer.activate({
-          tracing: {}
-        })
-      );
+          tracing: {
+            spanBatchingEnabled: false
+          }
+        });
+      });
 
       afterEach(() => spanBuffer.deactivate());
 
@@ -586,11 +600,14 @@ describe('tracing/spanBuffer', () => {
     });
 
     describe('when applying span transformations', () => {
-      beforeEach(() =>
+      beforeEach(() => {
+        spanBuffer.setTransmitImmediate(false);
         spanBuffer.activate({
-          tracing: {}
-        })
-      );
+          tracing: {
+            spanBatchingEnabled: false
+          }
+        });
+      });
 
       afterEach(() => spanBuffer.deactivate());
       const span = {


### PR DESCRIPTION
In our codebase, agentConfig is used in several places such as spanBuffer and tracingUtil. This change replaces those usages. 

We will also need to update the instrumentations, which will be addressed in a separate PR