### PR TITLE
fix: enforced max limit on metrics transmission config

### DIFF
--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -220,10 +220,16 @@ function normalizeMetricsConfig(config) {
     config.metrics.transmissionDelay,
     defaults.metrics.transmissionDelay,
     'config.metrics.transmissionDelay',
-    'INSTANA_METRICS_TRANSMISSION_DELAY',
-    null,
-    5000
+    'INSTANA_METRICS_TRANSMISSION_DELAY'
   );
+
+  // Validate max value of 5000 for transmissionDelay
+  if (config.metrics.transmissionDelay > 5000) {
+    logger.warn(
+      `The value of config.metrics.transmissionDelay (or INSTANA_METRICS_TRANSMISSION_DELAY) (${config.metrics.transmissionDelay}) exceeds the maximum allowed value of 5000. Assuming the default value ${defaults.metrics.transmissionDelay}.`
+    );
+    config.metrics.transmissionDelay = defaults.metrics.transmissionDelay;
+  }
 
   config.metrics.timeBetweenHealthcheckCalls =
     config.metrics.timeBetweenHealthcheckCalls || defaults.metrics.timeBetweenHealthcheckCalls;
@@ -720,11 +726,9 @@ function parseSecretsEnvVar(envVarValue) {
  * @param {*} defaultValue
  * @param {string} configPath
  * @param {string} envVarKey
- * @param {number} [minValue]
- * @param {number} [maxValue]
  * @returns {*}
  */
-function normalizeSingleValue(configValue, defaultValue, configPath, envVarKey, minValue, maxValue) {
+function normalizeSingleValue(configValue, defaultValue, configPath, envVarKey) {
   const envVarVal = process.env[envVarKey];
   let originalValue = configValue;
   if (configValue == null && envVarVal == null) {
@@ -741,21 +745,6 @@ function normalizeSingleValue(configValue, defaultValue, configPath, envVarKey, 
     );
     return defaultValue;
   }
-
-  if (minValue != null && configValue < minValue) {
-    logger.warn(
-      `The value of ${configPath} (or ${envVarKey}) (${configValue}) is below the minimum allowed value of ${minValue}. Assuming the default value ${defaultValue}.`
-    );
-    return defaultValue;
-  }
-
-  if (maxValue != null && configValue > maxValue) {
-    logger.warn(
-      `The value of ${configPath} (or ${envVarKey}) (${configValue}) exceeds the maximum allowed value of ${maxValue}. Assuming the default value ${defaultValue}.`
-    );
-    return defaultValue;
-  }
-
   return configValue;
 }
 /**

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -73,6 +73,8 @@ const { validateStackTraceMode, validateStackTraceLength } = require('./configVa
 /** @type {String[]} */
 const allowedSecretMatchers = ['equals', 'equals-ignore-case', 'contains', 'contains-ignore-case', 'regex', 'none'];
 
+const transmissionDelayMaxValue = 5000;
+
 /**
  * @typedef {Object} InstanaConfig
  * @property {string} [serviceName]
@@ -223,12 +225,12 @@ function normalizeMetricsConfig(config) {
     'INSTANA_METRICS_TRANSMISSION_DELAY'
   );
 
-  // Validate max value of 5000 for transmissionDelay
-  if (config.metrics.transmissionDelay > 5000) {
+  // Validate max value for transmissionDelay
+  if (config.metrics.transmissionDelay > transmissionDelayMaxValue) {
     logger.warn(
-      `The value of config.metrics.transmissionDelay (or INSTANA_METRICS_TRANSMISSION_DELAY) (${config.metrics.transmissionDelay}) exceeds the maximum allowed value of 5000. Assuming the default value ${defaults.metrics.transmissionDelay}.`
+      `The value of config.metrics.transmissionDelay (or INSTANA_METRICS_TRANSMISSION_DELAY) (${config.metrics.transmissionDelay}) exceeds the maximum allowed value of ${transmissionDelayMaxValue}. Assuming the max value ${transmissionDelayMaxValue}.`
     );
-    config.metrics.transmissionDelay = defaults.metrics.transmissionDelay;
+    config.metrics.transmissionDelay = transmissionDelayMaxValue;
   }
 
   config.metrics.timeBetweenHealthcheckCalls =

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -220,7 +220,9 @@ function normalizeMetricsConfig(config) {
     config.metrics.transmissionDelay,
     defaults.metrics.transmissionDelay,
     'config.metrics.transmissionDelay',
-    'INSTANA_METRICS_TRANSMISSION_DELAY'
+    'INSTANA_METRICS_TRANSMISSION_DELAY',
+    null,
+    5000
   );
 
   config.metrics.timeBetweenHealthcheckCalls =
@@ -718,9 +720,11 @@ function parseSecretsEnvVar(envVarValue) {
  * @param {*} defaultValue
  * @param {string} configPath
  * @param {string} envVarKey
+ * @param {number} [minValue]
+ * @param {number} [maxValue]
  * @returns {*}
  */
-function normalizeSingleValue(configValue, defaultValue, configPath, envVarKey) {
+function normalizeSingleValue(configValue, defaultValue, configPath, envVarKey, minValue, maxValue) {
   const envVarVal = process.env[envVarKey];
   let originalValue = configValue;
   if (configValue == null && envVarVal == null) {
@@ -737,6 +741,21 @@ function normalizeSingleValue(configValue, defaultValue, configPath, envVarKey) 
     );
     return defaultValue;
   }
+
+  if (minValue != null && configValue < minValue) {
+    logger.warn(
+      `The value of ${configPath} (or ${envVarKey}) (${configValue}) is below the minimum allowed value of ${minValue}. Assuming the default value ${defaultValue}.`
+    );
+    return defaultValue;
+  }
+
+  if (maxValue != null && configValue > maxValue) {
+    logger.warn(
+      `The value of ${configPath} (or ${envVarKey}) (${configValue}) exceeds the maximum allowed value of ${maxValue}. Assuming the default value ${defaultValue}.`
+    );
+    return defaultValue;
+  }
+
   return configValue;
 }
 /**

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -70,10 +70,10 @@ describe('config.normalizeConfig', () => {
   it('should use custom metrics transmission settings from config', () => {
     const config = coreConfig.normalize({
       metrics: {
-        transmissionDelay: 9753
+        transmissionDelay: 753
       }
     });
-    expect(config.metrics.transmissionDelay).to.equal(9753);
+    expect(config.metrics.transmissionDelay).to.equal(753);
   });
 
   it('should use custom metrics transmission settings from env vars', () => {
@@ -85,6 +85,27 @@ describe('config.normalizeConfig', () => {
   it('should use default metrics transmission settings when env vars are non-numerical', () => {
     process.env.INSTANA_METRICS_TRANSMISSION_DELAY = 'x2500';
     const config = coreConfig.normalize();
+    expect(config.metrics.transmissionDelay).to.equal(1000);
+  });
+
+  it('should use default metrics transmission settings when value exceeds max of 5000', () => {
+    process.env.INSTANA_METRICS_TRANSMISSION_DELAY = '6000';
+    const normalizedConfig = coreConfig.normalize();
+    expect(normalizedConfig.metrics.transmissionDelay).to.equal(1000);
+  });
+
+  it('should accept metrics transmission delay at max value of 5000', () => {
+    process.env.INSTANA_METRICS_TRANSMISSION_DELAY = '5000';
+    const normalizedConfig = coreConfig.normalize();
+    expect(normalizedConfig.metrics.transmissionDelay).to.equal(5000);
+  });
+
+  it('should use default metrics transmission settings when value exceeds max 5000', () => {
+    const config = coreConfig.normalize({
+      metrics: {
+        transmissionDelay: 9753
+      }
+    });
     expect(config.metrics.transmissionDelay).to.equal(1000);
   });
 

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -88,10 +88,10 @@ describe('config.normalizeConfig', () => {
     expect(config.metrics.transmissionDelay).to.equal(1000);
   });
 
-  it('should use default metrics transmission settings when value exceeds max of 5000', () => {
+  it('should use max metrics transmission settings when value exceeds max of 5000', () => {
     process.env.INSTANA_METRICS_TRANSMISSION_DELAY = '6000';
     const normalizedConfig = coreConfig.normalize();
-    expect(normalizedConfig.metrics.transmissionDelay).to.equal(1000);
+    expect(normalizedConfig.metrics.transmissionDelay).to.equal(5000);
   });
 
   it('should accept metrics transmission delay at max value of 5000', () => {
@@ -100,13 +100,13 @@ describe('config.normalizeConfig', () => {
     expect(normalizedConfig.metrics.transmissionDelay).to.equal(5000);
   });
 
-  it('should use default metrics transmission settings when value exceeds max 5000', () => {
+  it('should use max metrics transmission settings when value exceeds max 5000', () => {
     const config = coreConfig.normalize({
       metrics: {
         transmissionDelay: 9753
       }
     });
-    expect(config.metrics.transmissionDelay).to.equal(1000);
+    expect(config.metrics.transmissionDelay).to.equal(5000);
   });
 
   it('should use custom config.metrics.timeBetweenHealthcheckCalls', () => {


### PR DESCRIPTION
- added max limit of 5000 
- max value is applied if config > 5000