### PR TITLE
v6 major release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please use our [@instana/serverless-collector](packages/serverless-collector/REA
 
 ## Breaking Changes
 
-The current major release is `5.x.y`.
+The current major release is `6.x.y`.
 
 Checkout our [breaking changes documentation](https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-support-information#breaking-changes-in-nodejs-collector-upgrade).
 

--- a/packages/aws-lambda/src/wrapper.js
+++ b/packages/aws-lambda/src/wrapper.js
@@ -36,7 +36,7 @@ const latestRuntime = semver.gte(process.version, '24.0.0');
 
 const logger = serverlessLogger.init();
 coreConfig.init(logger);
-let config = coreConfig.normalize({}, lambdaConfigDefaults);
+let config = coreConfig.normalize({ defaultsOverride: lambdaConfigDefaults });
 let coldStart = true;
 
 // Initialize instrumentations early to allow for require statements after our
@@ -286,7 +286,7 @@ function init(event, arnInfo, _config) {
   //         - late env variables (less likely)
   //         - custom logger
   //         - we always renormalize unconditionally to ensure safety.
-  config = coreConfig.normalize(userConfig, lambdaConfigDefaults);
+  config = coreConfig.normalize({ userConfig, defaultsOverride: lambdaConfigDefaults });
 
   if (!config.tracing.enabled) {
     return false;

--- a/packages/collector/src/announceCycle/agentready.js
+++ b/packages/collector/src/announceCycle/agentready.js
@@ -12,7 +12,7 @@ try {
   // Worker threads are not available, so we know that this is the main thread.
 }
 
-const { tracing } = require('@instana/core');
+const { tracing, coreConfig, util } = require('@instana/core');
 const agentConnection = require('../agentConnection');
 const agentOpts = require('../agent/opts');
 const initializedTooLate = require('../util/initializedTooLate');
@@ -130,7 +130,8 @@ function enter(_ctx) {
     }
   }
 
-  tracing.activate(agentOpts.config);
+  const updatedConfig = coreConfig.update(agentOpts.config, util.constants.CONFIG_SOURCES.AGENT);
+  tracing.activate(updatedConfig);
 
   if (agentOpts.autoProfile && autoprofile) {
     profiler = autoprofile.start();

--- a/packages/collector/src/announceCycle/agentready.js
+++ b/packages/collector/src/announceCycle/agentready.js
@@ -130,7 +130,10 @@ function enter(_ctx) {
     }
   }
 
-  const updatedConfig = coreConfig.update(agentOpts.config, util.constants.CONFIG_SOURCES.AGENT);
+  const updatedConfig = coreConfig.update({
+    externalConfig: agentOpts.config,
+    source: util.constants.CONFIG_SOURCES.AGENT
+  });
   tracing.activate(updatedConfig);
 
   if (agentOpts.autoProfile && autoprofile) {

--- a/packages/collector/src/announceCycle/unannounced.js
+++ b/packages/collector/src/announceCycle/unannounced.js
@@ -155,7 +155,9 @@ function applySecretsConfiguration(agentResponse) {
           ${agentResponse.secrets.list}`
       );
     } else {
-      secrets.setMatcher(agentResponse.secrets.matcher, agentResponse.secrets.list);
+      ensureNestedObjectExists(agentOpts.config, ['secrets']);
+      agentOpts.config.secrets.matcherMode = agentResponse.secrets.matcher;
+      agentOpts.config.secrets.keywords = agentResponse.secrets.list;
     }
   }
 }

--- a/packages/collector/src/announceCycle/unannounced.js
+++ b/packages/collector/src/announceCycle/unannounced.js
@@ -305,7 +305,7 @@ function applyDisableConfiguration(agentResponse) {
   ensureNestedObjectExists(agentOpts.config, ['tracing', 'disable']);
   agentOpts.config.tracing.disable = configNormalizers.disable.normalizeExternalConfig({
     tracing: { disable: disablingConfig }
-  });
+  }).value;
 }
 module.exports = {
   init,

--- a/packages/collector/src/index.js
+++ b/packages/collector/src/index.js
@@ -158,8 +158,11 @@ function init(userConfig = {}) {
     log.init(userConfig);
   }
 
-  config = normalizeCollectorConfig(userConfig);
-  config = instanaNodeJsCore.coreConfig.normalize(config);
+  const collectorConfig = normalizeCollectorConfig(userConfig);
+  config = instanaNodeJsCore.coreConfig.normalize({
+    userConfig,
+    finalConfigBase: collectorConfig
+  });
 
   agentConnection = require('./agentConnection');
   const agentOpts = require('./agent/opts');

--- a/packages/collector/src/index.js
+++ b/packages/collector/src/index.js
@@ -103,7 +103,7 @@ const instanaSharedMetrics = require('@instana/shared-metrics');
 require('./tracing'); // load additional instrumentations
 
 const log = require('./logger');
-const normalizeCollectorConfig = require('./util/normalizeConfig');
+const normalizeConfig = require('./util/normalizeConfig');
 const experimental = require('./experimental');
 
 // NOTE: Default collector logger && config for cases like `preinit`.
@@ -158,10 +158,10 @@ function init(userConfig = {}) {
     log.init(userConfig);
   }
 
-  const collectorConfig = normalizeCollectorConfig(userConfig);
+  const finalCollectorConfig = normalizeConfig(userConfig);
   config = instanaNodeJsCore.coreConfig.normalize({
     userConfig,
-    finalConfigBase: collectorConfig
+    finalConfigBase: finalCollectorConfig
   });
 
   agentConnection = require('./agentConnection');

--- a/packages/collector/src/types/collector.d.ts
+++ b/packages/collector/src/types/collector.d.ts
@@ -29,7 +29,7 @@ export interface CollectorConfig {
     stackTraceLength?: number;
     [key: string]: any;
   };
-  autoProfile?: boolean | string;
+  autoProfile?: boolean;
   reportUnhandledPromiseRejections?: boolean;
   logger?: GenericLogger;
   level?: string | number;

--- a/packages/collector/src/util/normalizeConfig.js
+++ b/packages/collector/src/util/normalizeConfig.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const util = require('@instana/core/src/config/util');
+const validate = require('@instana/core/src/config/validator');
 
 const defaults = {
   agentHost: '127.0.0.1',
@@ -48,12 +49,15 @@ module.exports = function normalizeConfig(userConfig = {}) {
  * @returns {string}
  */
 function normalizeAgentHost(userConfig, defaultConfig) {
-  return util.resolveStringConfig({
-    envVar: 'INSTANA_AGENT_HOST',
-    configValue: userConfig.agentHost,
-    defaultValue: defaultConfig.agentHost,
-    configPath: 'config.agentHost'
-  });
+  const { value } = util.resolve(
+    {
+      envValue: 'INSTANA_AGENT_HOST',
+      inCodeValue: userConfig.agentHost,
+      defaultValue: defaultConfig.agentHost
+    },
+    [validate.stringValidator]
+  );
+  return value;
 }
 
 /**
@@ -62,12 +66,15 @@ function normalizeAgentHost(userConfig, defaultConfig) {
  * @returns {number}
  */
 function normalizeAgentPort(userConfig, defaultConfig) {
-  return util.resolveNumericConfig({
-    envVar: 'INSTANA_AGENT_PORT',
-    configValue: userConfig.agentPort,
-    defaultValue: defaultConfig.agentPort,
-    configPath: 'config.agentPort'
-  });
+  const { value } = util.resolve(
+    {
+      envValue: 'INSTANA_AGENT_PORT',
+      inCodeValue: userConfig.agentPort,
+      defaultValue: defaultConfig.agentPort
+    },
+    [validate.numberValidator]
+  );
+  return value;
 }
 
 /**
@@ -76,12 +83,15 @@ function normalizeAgentPort(userConfig, defaultConfig) {
  * @returns {number}
  */
 function normalizeAgentRequestTimeout(userConfig, defaultConfig) {
-  return util.resolveNumericConfig({
-    envVar: 'INSTANA_AGENT_REQUEST_TIMEOUT',
-    configValue: userConfig.agentRequestTimeout,
-    defaultValue: defaultConfig.agentRequestTimeout,
-    configPath: 'config.agentRequestTimeout'
-  });
+  const { value } = util.resolve(
+    {
+      envValue: 'INSTANA_AGENT_REQUEST_TIMEOUT',
+      inCodeValue: userConfig.agentRequestTimeout,
+      defaultValue: defaultConfig.agentRequestTimeout
+    },
+    [validate.numberValidator]
+  );
+  return value;
 }
 
 /**
@@ -90,12 +100,15 @@ function normalizeAgentRequestTimeout(userConfig, defaultConfig) {
  * @returns {boolean}
  */
 function normalizeAutoProfile(userConfig, defaultConfig) {
-  return util.resolveBooleanConfig({
-    envVar: 'INSTANA_AUTO_PROFILE',
-    configValue: userConfig.autoProfile,
-    defaultValue: defaultConfig.autoProfile,
-    configPath: 'config.autoProfile'
-  });
+  const { value } = util.resolve(
+    {
+      envValue: 'INSTANA_AUTO_PROFILE',
+      inCodeValue: userConfig.autoProfile,
+      defaultValue: defaultConfig.autoProfile
+    },
+    [validate.booleanValidator]
+  );
+  return value;
 }
 
 /**
@@ -103,5 +116,12 @@ function normalizeAutoProfile(userConfig, defaultConfig) {
  * @returns {boolean}
  */
 function normalizeUnhandledRejections(userConfig) {
-  return userConfig.reportUnhandledPromiseRejections ?? false;
+  const { value } = util.resolve(
+    {
+      inCodeValue: userConfig.reportUnhandledPromiseRejections,
+      defaultValue: false
+    },
+    [validate.booleanValidator]
+  );
+  return value;
 }

--- a/packages/collector/src/util/normalizeConfig.js
+++ b/packages/collector/src/util/normalizeConfig.js
@@ -3,9 +3,9 @@
  * (c) Copyright Instana Inc. and contributors 2019
  */
 
-/* eslint-disable dot-notation */
-
 'use strict';
+
+const util = require('@instana/core/src/config/util');
 
 const defaults = {
   agentHost: '127.0.0.1',
@@ -17,43 +17,100 @@ const defaults = {
 
 /**
  * Merges the config that was passed to the init function with environment variables and default values.
- * @param {import('../types/collector').CollectorConfig} config
+ * @param {import('../types/collector').CollectorConfig} userConfig
  * @returns {import('../types/collector').CollectorConfig}
  */
-module.exports = function normalizeConfig(config = {}) {
-  config.agentHost = config.agentHost || process.env.INSTANA_AGENT_HOST || defaults.agentHost;
-  config.agentPort = config.agentPort || parseToPositiveInteger(process.env.INSTANA_AGENT_PORT, defaults.agentPort);
-  config.agentRequestTimeout =
-    config.agentRequestTimeout ||
-    parseToPositiveInteger(process.env.INSTANA_AGENT_REQUEST_TIMEOUT, defaults.agentRequestTimeout);
+module.exports = function normalizeConfig(userConfig = {}) {
+  const finalConfig = {};
 
-  config.autoProfile = config.autoProfile || process.env.INSTANA_AUTO_PROFILE || defaults.autoProfile;
-  config.tracing = config.tracing || {};
+  // NOTE: This function only normalizes collector-specific configuration fields.
+  // Other userConfig fields (like serviceName, tracing, etc.) are passed through as-is
+  // and will be normalized later by core/config when this collector config is passed
+  // as extraFinalConfig to core's normalize function.
+  finalConfig.agentHost = normalizeAgentHost(userConfig, defaults);
+  finalConfig.agentPort = normalizeAgentPort(userConfig, defaults);
+  finalConfig.agentRequestTimeout = normalizeAgentRequestTimeout(userConfig, defaults);
+  finalConfig.autoProfile = normalizeAutoProfile(userConfig, defaults);
+  finalConfig.reportUnhandledPromiseRejections = normalizeUnhandledRejections(userConfig);
+  finalConfig.tracing = userConfig.tracing || {};
 
-  if (config.reportUnhandledPromiseRejections == null) {
-    config.reportUnhandledPromiseRejections = false;
-  }
-
-  if (config.disableCollectorInitEvent == null) {
+  if (finalConfig.disableCollectorInitEvent == null) {
     const envValue = process.env.INSTANA_DISABLE_COLLECTOR_INIT_EVENT;
-    config.disableCollectorInitEvent = envValue === 'true' ? true : defaults.disableCollectorInitEvent;
+    finalConfig.disableCollectorInitEvent = envValue === 'true' ? true : defaults.disableCollectorInitEvent;
   }
 
-  return config;
+  return finalConfig;
 };
 
 /**
- * @param {string | number} value
- * @param {number} defaultValue
+ * @param {import('../types/collector').CollectorConfig} userConfig
+ * @param {{ agentHost: string }} defaultConfig
+ * @returns {string}
+ */
+function normalizeAgentHost(userConfig, defaultConfig) {
+  return resolveConfig(process.env.INSTANA_AGENT_HOST, userConfig.agentHost, defaultConfig.agentHost);
+}
+
+/**
+ * @param {import('../types/collector').CollectorConfig} userConfig
+ * @param {{ agentPort: number }} defaultConfig
  * @returns {number}
  */
-function parseToPositiveInteger(value, defaultValue) {
-  if (typeof value !== 'string') {
-    return defaultValue;
+function normalizeAgentPort(userConfig, defaultConfig) {
+  return util.resolveNumericConfig({
+    envVar: 'INSTANA_AGENT_PORT',
+    configValue: userConfig.agentPort,
+    defaultValue: defaultConfig.agentPort,
+    configPath: 'config.agentPort'
+  });
+}
+
+/**
+ * @param {import('../types/collector').CollectorConfig} userConfig
+ * @param {{ agentRequestTimeout: number }} defaultConfig
+ * @returns {number}
+ */
+function normalizeAgentRequestTimeout(userConfig, defaultConfig) {
+  return util.resolveNumericConfig({
+    envVar: 'INSTANA_AGENT_REQUEST_TIMEOUT',
+    configValue: userConfig.agentRequestTimeout,
+    defaultValue: defaultConfig.agentRequestTimeout,
+    configPath: 'config.agentRequestTimeout'
+  });
+}
+
+/**
+ * @param {import('../types/collector').CollectorConfig} userConfig
+ * @param {{ autoProfile: string | boolean }} defaultConfig
+ * @returns {string | boolean}
+ */
+function normalizeAutoProfile(userConfig, defaultConfig) {
+  return resolveConfig(process.env.INSTANA_AUTO_PROFILE, userConfig.autoProfile, defaultConfig.autoProfile);
+}
+
+/**
+ * @param {import('../types/collector').CollectorConfig} userConfig
+ * @returns {boolean}
+ */
+function normalizeUnhandledRejections(userConfig) {
+  return userConfig.reportUnhandledPromiseRejections ?? false;
+}
+
+/**
+ * @template T
+ * @param {T | undefined} envValue
+ * @param {T | undefined} configValue
+ * @param {T} defaultValue
+ * @returns {T}
+ */
+function resolveConfig(envValue, configValue, defaultValue) {
+  if (configValue != null) {
+    return configValue;
   }
-  value = parseInt(value, 10);
-  if (!isNaN(value)) {
-    return Math.abs(Math.round(value));
+
+  if (envValue != null) {
+    return envValue;
   }
+
   return defaultValue;
 }

--- a/packages/collector/src/util/normalizeConfig.js
+++ b/packages/collector/src/util/normalizeConfig.js
@@ -48,7 +48,12 @@ module.exports = function normalizeConfig(userConfig = {}) {
  * @returns {string}
  */
 function normalizeAgentHost(userConfig, defaultConfig) {
-  return resolveConfig(process.env.INSTANA_AGENT_HOST, userConfig.agentHost, defaultConfig.agentHost);
+  return util.resolveStringConfig({
+    envVar: 'INSTANA_AGENT_HOST',
+    configValue: userConfig.agentHost,
+    defaultValue: defaultConfig.agentHost,
+    configPath: 'config.agentHost'
+  });
 }
 
 /**
@@ -81,11 +86,16 @@ function normalizeAgentRequestTimeout(userConfig, defaultConfig) {
 
 /**
  * @param {import('../types/collector').CollectorConfig} userConfig
- * @param {{ autoProfile: string | boolean }} defaultConfig
- * @returns {string | boolean}
+ * @param {{ autoProfile: boolean }} defaultConfig
+ * @returns {boolean}
  */
 function normalizeAutoProfile(userConfig, defaultConfig) {
-  return resolveConfig(process.env.INSTANA_AUTO_PROFILE, userConfig.autoProfile, defaultConfig.autoProfile);
+  return util.resolveBooleanConfig({
+    envVar: 'INSTANA_AUTO_PROFILE',
+    configValue: userConfig.autoProfile,
+    defaultValue: defaultConfig.autoProfile,
+    configPath: 'config.autoProfile'
+  });
 }
 
 /**
@@ -94,23 +104,4 @@ function normalizeAutoProfile(userConfig, defaultConfig) {
  */
 function normalizeUnhandledRejections(userConfig) {
   return userConfig.reportUnhandledPromiseRejections ?? false;
-}
-
-/**
- * @template T
- * @param {T | undefined} envValue
- * @param {T | undefined} configValue
- * @param {T} defaultValue
- * @returns {T}
- */
-function resolveConfig(envValue, configValue, defaultValue) {
-  if (configValue != null) {
-    return configValue;
-  }
-
-  if (envValue != null) {
-    return envValue;
-  }
-
-  return defaultValue;
 }

--- a/packages/collector/src/util/normalizeConfig.js
+++ b/packages/collector/src/util/normalizeConfig.js
@@ -33,12 +33,8 @@ module.exports = function normalizeConfig(userConfig = {}) {
   finalConfig.agentRequestTimeout = normalizeAgentRequestTimeout(userConfig, defaults);
   finalConfig.autoProfile = normalizeAutoProfile(userConfig, defaults);
   finalConfig.reportUnhandledPromiseRejections = normalizeUnhandledRejections(userConfig);
+  finalConfig.disableCollectorInitEvent = normalizeCollectorInitEvent(userConfig);
   finalConfig.tracing = userConfig.tracing || {};
-
-  if (finalConfig.disableCollectorInitEvent == null) {
-    const envValue = process.env.INSTANA_DISABLE_COLLECTOR_INIT_EVENT;
-    finalConfig.disableCollectorInitEvent = envValue === 'true' ? true : defaults.disableCollectorInitEvent;
-  }
 
   return finalConfig;
 };
@@ -120,6 +116,22 @@ function normalizeUnhandledRejections(userConfig) {
     {
       inCodeValue: userConfig.reportUnhandledPromiseRejections,
       defaultValue: false
+    },
+    [validate.booleanValidator]
+  );
+  return value;
+}
+
+/**
+ * @param {import('../types/collector').CollectorConfig} userConfig
+ * @returns {boolean}
+ */
+function normalizeCollectorInitEvent(userConfig) {
+  const { value } = util.resolve(
+    {
+      envValue: 'INSTANA_DISABLE_COLLECTOR_INIT_EVENT',
+      inCodeValue: userConfig.disableCollectorInitEvent,
+      defaultValue: defaults.disableCollectorInitEvent
     },
     [validate.booleanValidator]
   );

--- a/packages/collector/test/integration/currencies/databases/redis/test_base.js
+++ b/packages/collector/test/integration/currencies/databases/redis/test_base.js
@@ -21,6 +21,7 @@ const {
 } = require('@_local/core/test/test_util');
 const ProcessControls = require('@_local/collector/test/test_util/ProcessControls');
 const globalAgent = require('@_local/collector/test/globalAgent');
+const { AgentStubControls } = require('@_local/collector/test/apps/agentStubControls');
 
 // v3 is considered the legacy version.
 // - It does not support Redis clustering.
@@ -938,9 +939,69 @@ module.exports = function (name, version, isLatest, mode) {
     }
   });
 
+  describe('Config precedence', () => {
+    describe('when both agent config and env var are set, env var takes precedence', () => {
+      const customAgentControls = new AgentStubControls();
+      let controls;
+
+      before(async () => {
+        await customAgentControls.startAgent({
+          ignoreEndpoints: { redis: ['get', 'set'] }
+        });
+
+        controls = new ProcessControls({
+          agentControls: customAgentControls,
+          dirname: __dirname,
+          appName: isLegacyVersion ? 'legacyApp' : 'app',
+          env: {
+            LIBRARY_LATEST: isLatest,
+            LIBRARY_VERSION: version,
+            LIBRARY_NAME: name,
+            REDIS_SETUP_TYPE: mode,
+            INSTANA_IGNORE_ENDPOINTS: 'redis:get;'
+          }
+        });
+        await controls.startAndWaitForAgentConnection(5000, Date.now() + 1000 * 60 * 5);
+      });
+
+      beforeEach(async () => {
+        await customAgentControls.clearReceivedTraceData();
+      });
+
+      after(async () => {
+        await customAgentControls.stopAgent();
+        await controls.stop();
+      });
+
+      it('should use env var config and ignore only get (not set)', async () => {
+        await controls
+          .sendRequest({
+            method: 'POST',
+            path: '/values',
+            qs: {
+              key: 'discount',
+              value: 50
+            }
+          })
+          .then(async () => {
+            return retry(async () => {
+              const spans = await customAgentControls.getSpans();
+              // 1 x http entry span
+              // 1 x http client span
+              // 1 x redis set span (set is NOT ignored because env var only ignores 'get')
+              expect(spans.length).to.equal(3);
+
+              const redisSpans = spans.filter(span => span.n === 'redis');
+              expect(redisSpans.length).to.equal(1);
+              expect(redisSpans[0].data.redis.command).to.equal('set');
+            });
+          });
+      });
+    });
+  });
+
   mochaSuiteFn('ignore-endpoints:', function () {
     describe('when ignore-endpoints is enabled via agent configuration', () => {
-      const { AgentStubControls } = require('@_local/collector/test/apps/agentStubControls');
       const customAgentControls = new AgentStubControls();
       let controls;
 

--- a/packages/collector/test/integration/currencies/logging/console/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/console/test_base.js
@@ -379,6 +379,57 @@ module.exports = function (name, version, isLatest) {
           });
         });
       });
+
+      describe('precedence: when both agent and env are configured, env takes precedence', () => {
+        let customAgentControls;
+        let precedenceControls;
+
+        before(async () => {
+          customAgentControls = new AgentStubControls();
+          await customAgentControls.startAgent({
+            disable: { console: false }
+          });
+
+          precedenceControls = new ProcessControls({
+            agentControls: customAgentControls,
+            dirname: __dirname,
+            env: {
+              INSTANA_TRACING_DISABLE_INSTRUMENTATIONS: ['console'],
+              LIBRARY_LATEST: isLatest,
+              LIBRARY_VERSION: version,
+              LIBRARY_NAME: name
+            }
+          });
+          await precedenceControls.startAndWaitForAgentConnection();
+        });
+
+        after(async () => {
+          await precedenceControls.stop();
+          await customAgentControls.stopAgent();
+        });
+
+        it('should not trace console.warn calls (env var takes precedence over agent config)', async () => {
+          await precedenceControls.sendRequest({ path: '/warn' });
+
+          await testUtils.retry(async () => {
+            const spans = await customAgentControls.getSpans();
+            const httpEntrySpan = verifyHttpRootEntry({
+              spans,
+              apiPath: '/warn',
+              pid: String(precedenceControls.getPid())
+            });
+
+            verifyHttpExit({
+              spans,
+              parent: httpEntrySpan,
+              pid: String(precedenceControls.getPid())
+            });
+
+            const consoleLogSpans = testUtils.getSpansByName(spans, 'log.console');
+            expect(consoleLogSpans).to.be.empty;
+          });
+        });
+      });
     });
   });
 

--- a/packages/collector/test/integration/currencies/messaging/kafkajs/test_base.js
+++ b/packages/collector/test/integration/currencies/messaging/kafkajs/test_base.js
@@ -411,6 +411,152 @@ module.exports = function (name, version, isLatest, mode) {
       );
     });
 
+    describe('traceCorrelation configuration precedence', function () {
+      describe('when agent enables traceCorrelation (overriding default)', function () {
+        const customAgentControls = new AgentStubControls();
+
+        let consumerControls;
+        let producerControls;
+
+        before(async () => {
+          await customAgentControls.startAgent({
+            kafkaConfig: { traceCorrelation: true }
+          });
+
+          consumerControls = new ProcessControls({
+            dirname: __dirname,
+            appName: 'consumer',
+            agentControls: customAgentControls,
+            env: { ...libraryEnv }
+          });
+          producerControls = new ProcessControls({
+            dirname: __dirname,
+            appName: 'producer',
+            agentControls: customAgentControls,
+            env: { ...libraryEnv }
+          });
+
+          await consumerControls.startAndWaitForAgentConnection(retryTime, retryTimeUntil());
+          await producerControls.startAndWaitForAgentConnection(retryTime, retryTimeUntil());
+        });
+
+        beforeEach(async () => {
+          await customAgentControls.clearReceivedTraceData();
+          await resetMessages(consumerControls);
+        });
+
+        afterEach(async () => {
+          await resetMessages(consumerControls);
+        });
+
+        after(async () => {
+          await customAgentControls.stopAgent();
+          await producerControls.stop();
+          await consumerControls.stop();
+        });
+
+        it('must maintain trace continuity when agent config enables traceCorrelation', async () => {
+          await producerControls.sendRequest({
+            method: 'POST',
+            path: '/send-messages',
+            simple: true,
+            body: JSON.stringify({
+              key: 'someKey',
+              value: 'someMessage'
+            }),
+            headers: {
+              'Content-Type': 'application/json'
+            }
+          });
+
+          await retry(async () => {
+            const messages = await getMessages(consumerControls);
+            checkMessages(messages, {});
+            const spans = await customAgentControls.getSpans();
+            const httpEntry = verifyHttpEntry(spans);
+            verifyKafkaExits(spans, httpEntry, {});
+            verifyFollowUpHttpExit(spans, httpEntry);
+          });
+        });
+      });
+
+      describe('when both agent and environment variable configuration are provided', function () {
+        const customAgentControls = new AgentStubControls();
+
+        let consumerControls;
+        let producerControls;
+
+        before(async () => {
+          await customAgentControls.startAgent({
+            kafkaConfig: { traceCorrelation: true }
+          });
+
+          consumerControls = new ProcessControls({
+            dirname: __dirname,
+            appName: 'consumer',
+            agentControls: customAgentControls,
+            env: {
+              ...libraryEnv,
+              INSTANA_KAFKA_TRACE_CORRELATION: 'false'
+            }
+          });
+          producerControls = new ProcessControls({
+            dirname: __dirname,
+            appName: 'producer',
+            agentControls: customAgentControls,
+            env: {
+              ...libraryEnv,
+              INSTANA_KAFKA_TRACE_CORRELATION: 'false'
+            }
+          });
+
+          await consumerControls.startAndWaitForAgentConnection(retryTime, retryTimeUntil());
+          await producerControls.startAndWaitForAgentConnection(retryTime, retryTimeUntil());
+        });
+
+        beforeEach(async () => {
+          await customAgentControls.clearReceivedTraceData();
+          await resetMessages(consumerControls);
+        });
+
+        afterEach(async () => {
+          await resetMessages(consumerControls);
+        });
+
+        after(async () => {
+          await customAgentControls.stopAgent();
+          await producerControls.stop();
+          await consumerControls.stop();
+        });
+
+        const kafkaCorrelation = 'correlation-disabled';
+
+        it('must not maintain trace continuity when env var disables traceCorrelation (taking precedence over agent config)', async () => {
+          await producerControls.sendRequest({
+            method: 'POST',
+            path: '/send-messages',
+            simple: true,
+            body: JSON.stringify({
+              key: 'someKey',
+              value: 'someMessage'
+            }),
+            headers: {
+              'Content-Type': 'application/json'
+            }
+          });
+
+          await retry(async () => {
+            const messages = await getMessages(consumerControls);
+            checkMessages(messages, { kafkaCorrelation });
+            const spans = await customAgentControls.getSpans();
+            const httpEntry = verifyHttpEntry(spans);
+            verifyKafkaExits(spans, httpEntry, { kafkaCorrelation });
+            verifyFollowUpHttpExit(spans, httpEntry);
+          });
+        });
+      });
+    });
+
     describe('tracing disabled', () => {
       let consumerControls;
       let producerControls;

--- a/packages/collector/test/integration/currencies/protocols/http/client/clientApp.js
+++ b/packages/collector/test/integration/currencies/protocols/http/client/clientApp.js
@@ -89,6 +89,14 @@ app.get('/request-options-only', (req, res) => {
       ],
       'x-exit-options-not-captured-header': 'whatever'
     };
+  } else if (req.query.withHeader === 'config-test') {
+    downstreamRequest.headers = {
+      'X-Agent-Header-1': 'agent-value-1',
+      'X-Agent-Header-2': 'agent-value-2',
+      'X-Incode-Header-1': 'incode-value-1',
+      'X-Incode-Header-2': 'incode-value-2',
+      'X-Not-Configured-Header': 'should-not-be-captured'
+    };
   }
   const requestObject = httpModule.request(downstreamRequest, () => res.sendStatus(200));
   if (req.query.withHeader === 'set-on-request') {

--- a/packages/collector/test/integration/currencies/protocols/http/client/test_base.js
+++ b/packages/collector/test/integration/currencies/protocols/http/client/test_base.js
@@ -38,6 +38,137 @@ module.exports = function (name, version, isLatest) {
   registerConnectionRefusalTest.call(this, false);
   registerConnectionRefusalTest.call(this, true);
 
+  describe('extraHttpHeadersToCapture configuration precedence', function () {
+    describe('when only agent configuration is provided', function () {
+      let serverControls;
+      let clientControls;
+      const customAgentControls = new AgentStubControls();
+
+      before(async () => {
+        await customAgentControls.startAgent({
+          extraHeaders: ['x-agent-header-1', 'x-agent-header-2']
+        });
+
+        serverControls = new ProcessControls({
+          agentControls: customAgentControls,
+          dirname: __dirname,
+          appName: 'serverApp',
+          appUsesHttps: false
+        });
+
+        clientControls = new ProcessControls({
+          dirname: __dirname,
+          appName: 'clientApp',
+          agentControls: customAgentControls,
+          appUsesHttps: false,
+          env: {
+            ...commonEnv,
+            SERVER_PORT: serverControls.getPort()
+          }
+        });
+
+        await serverControls.startAndWaitForAgentConnection();
+        await clientControls.startAndWaitForAgentConnection();
+      });
+
+      after(() => Promise.all([serverControls.stop(), clientControls.stop(), customAgentControls.stopAgent()]));
+
+      beforeEach(() => customAgentControls.clearReceivedTraceData());
+
+      afterEach(() => Promise.all([serverControls.clearIpcMessages(), clientControls.clearIpcMessages()]));
+
+      it('should capture headers configured by agent (overriding defaults)', async () => {
+        await clientControls.sendRequest({
+          method: 'GET',
+          path: '/request-options-only?withHeader=config-test'
+        });
+
+        await retry(async () => {
+          const spans = await customAgentControls.getSpans();
+          expectExactlyOneMatching(spans, [
+            span => expect(span.n).to.equal('node.http.client'),
+            span => expect(span.k).to.equal(constants.EXIT),
+            span => {
+              expect(span.data.http.header).to.exist;
+
+              expect(span.data.http.header['x-agent-header-1']).to.equal('agent-value-1');
+              expect(span.data.http.header['x-agent-header-2']).to.equal('agent-value-2');
+
+              expect(span.data.http.header['x-incode-header-1']).to.be.undefined;
+              expect(span.data.http.header['x-incode-header-2']).to.be.undefined;
+              expect(span.data.http.header['x-not-configured-header']).to.be.undefined;
+            }
+          ]);
+        });
+      });
+    });
+
+    describe('when both agent and environment variable configuration are provided', function () {
+      let serverControls;
+      let clientControls;
+      const customAgentControls = new AgentStubControls();
+
+      before(async () => {
+        await customAgentControls.startAgent({
+          extraHeaders: ['x-agent-header-1', 'x-agent-header-2']
+        });
+
+        serverControls = new ProcessControls({
+          agentControls: customAgentControls,
+          dirname: __dirname,
+          appName: 'serverApp',
+          appUsesHttps: false
+        });
+
+        clientControls = new ProcessControls({
+          dirname: __dirname,
+          appName: 'clientApp',
+          agentControls: customAgentControls,
+          appUsesHttps: false,
+          env: {
+            ...commonEnv,
+            SERVER_PORT: serverControls.getPort(),
+            INSTANA_EXTRA_HTTP_HEADERS: 'x-incode-header-1,x-incode-header-2'
+          }
+        });
+
+        await serverControls.startAndWaitForAgentConnection();
+        await clientControls.startAndWaitForAgentConnection();
+      });
+
+      after(() => Promise.all([serverControls.stop(), clientControls.stop(), customAgentControls.stopAgent()]));
+
+      beforeEach(() => customAgentControls.clearReceivedTraceData());
+
+      afterEach(() => Promise.all([serverControls.clearIpcMessages(), clientControls.clearIpcMessages()]));
+
+      it('should capture headers from environment variable config (taking precedence over agent config)', async () => {
+        await clientControls.sendRequest({
+          method: 'GET',
+          path: '/request-options-only?withHeader=config-test'
+        });
+
+        await retry(async () => {
+          const spans = await customAgentControls.getSpans();
+          expectExactlyOneMatching(spans, [
+            span => expect(span.n).to.equal('node.http.client'),
+            span => expect(span.k).to.equal(constants.EXIT),
+            span => {
+              expect(span.data.http.header).to.exist;
+
+              expect(span.data.http.header['x-incode-header-1']).to.equal('incode-value-1');
+              expect(span.data.http.header['x-incode-header-2']).to.equal('incode-value-2');
+
+              expect(span.data.http.header['x-agent-header-1']).to.be.undefined;
+              expect(span.data.http.header['x-agent-header-2']).to.be.undefined;
+              expect(span.data.http.header['x-not-configured-header']).to.be.undefined;
+            }
+          ]);
+        });
+      });
+    });
+  });
+
   describe('SDK CASE 1', function () {
     let sdkControls;
 

--- a/packages/collector/test/integration/misc/secrets/app.js
+++ b/packages/collector/test/integration/misc/secrets/app.js
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright IBM Corp. 2026
+ */
+
+'use strict';
+
+// NOTE: c8 bug https://github.com/bcoe/c8/issues/166
+process.on('SIGTERM', () => {
+  process.disconnect();
+  process.exit(0);
+});
+
+const instanaConfig =
+  process.env.USE_INCODE_SECRETS_CONFIG === 'true'
+    ? {
+        secrets: {
+          matcherMode: 'equals',
+          keywords: ['incodeToken']
+        }
+      }
+    : {};
+
+require('@instana/collector')(instanaConfig);
+
+const express = require('express');
+const port = require('@_local/collector/test/test_util/app-port')();
+const app = express();
+
+const logPrefix = `Secrets Config Precedence Test (${process.pid}):\t`;
+
+app.get('/', (req, res) => {
+  res.send('OK');
+});
+
+app.listen(port, () => {
+  log(`Listening on port: ${port}`);
+});
+
+function log() {
+  const args = Array.prototype.slice.call(arguments);
+  args[0] = `${logPrefix}${args[0]}`;
+  // eslint-disable-next-line no-console
+  console.log.apply(console, args);
+}

--- a/packages/collector/test/integration/misc/secrets/package.json.template
+++ b/packages/collector/test/integration/misc/secrets/package.json.template
@@ -1,0 +1,12 @@
+{
+  "name": "test-secrets-config-precedence",
+  "version": "1.0.0",
+  "private": true,
+  "main": "app.js",
+  "dependencies": {
+    "@instana/collector": "{{collectorVersion}}",
+    "@instana/core": "{{coreVersion}}",
+    "@instana/shared-metrics": "{{sharedMetricsVersion}}",
+    "express": "^4.17.1"
+  }
+}

--- a/packages/collector/test/integration/misc/secrets/test_base.js
+++ b/packages/collector/test/integration/misc/secrets/test_base.js
@@ -1,0 +1,184 @@
+/*
+ * (c) Copyright IBM Corp. 2026
+ */
+
+'use strict';
+
+const path = require('path');
+const { expect } = require('chai');
+
+const config = require('@_local/core/test/config');
+const { retry } = require('@_local/core/test/test_util');
+const ProcessControls = require('@_local/collector/test/test_util/ProcessControls');
+const { AgentStubControls } = require('@_local/collector/test/apps/agentStubControls');
+
+module.exports = function (name, version) {
+  const inVersionDir =
+    path.basename(__dirname).startsWith('_v') || path.basename(path.dirname(__dirname)).startsWith('_v');
+  const versionDir = inVersionDir ? __dirname : path.join(__dirname, `_v${version}`);
+
+  this.timeout(config.getTestTimeout() * 2);
+
+  describe('Secrets Configuration Precedence', () => {
+    describe('when both agent config and env var are set, env var takes precedence', () => {
+      const customAgentControls = new AgentStubControls();
+      let controls;
+
+      before(async () => {
+        await customAgentControls.startAgent({
+          secrets: {
+            matcher: 'equals',
+            list: ['agentToken']
+          }
+        });
+
+        controls = new ProcessControls({
+          agentControls: customAgentControls,
+          dirname: __dirname,
+          cwd: versionDir,
+          env: {
+            INSTANA_SECRETS: 'equals:envToken'
+          }
+        });
+        await controls.startAndWaitForAgentConnection();
+      });
+
+      beforeEach(async () => {
+        await customAgentControls.clearReceivedTraceData();
+      });
+
+      after(async () => {
+        await customAgentControls.stopAgent();
+        await controls.stop();
+      });
+
+      afterEach(async () => {
+        await controls.clearIpcMessages();
+      });
+
+      it('should use env var config (equals:envToken) and ignore agent config', async () => {
+        await controls.sendRequest({
+          method: 'GET',
+          path: '/?agentToken=value1&envToken=value2&normalParam=value3'
+        });
+
+        await retry(async () => {
+          const spans = await customAgentControls.getSpans();
+          expect(spans.length).to.be.at.least(1);
+
+          const httpEntry = spans.find(span => span.n === 'node.http.server');
+          expect(httpEntry).to.exist;
+
+          expect(httpEntry.data.http.params).to.equal('agentToken=value1&envToken=<redacted>&normalParam=value3');
+        });
+      });
+    });
+
+    describe('when only agent config is provided', () => {
+      const customAgentControls = new AgentStubControls();
+      let controls;
+
+      before(async () => {
+        await customAgentControls.startAgent({
+          secrets: {
+            matcher: 'equals',
+            list: ['agentOnlyToken']
+          }
+        });
+
+        controls = new ProcessControls({
+          agentControls: customAgentControls,
+          dirname: __dirname,
+          cwd: versionDir
+        });
+        await controls.startAndWaitForAgentConnection();
+      });
+
+      beforeEach(async () => {
+        await customAgentControls.clearReceivedTraceData();
+      });
+
+      after(async () => {
+        await customAgentControls.stopAgent();
+        await controls.stop();
+      });
+
+      afterEach(async () => {
+        await controls.clearIpcMessages();
+      });
+
+      it('should use agent config', async () => {
+        await controls.sendRequest({
+          method: 'GET',
+          path: '/?agentOnlyToken=value1&otherParam=value2'
+        });
+
+        await retry(async () => {
+          const spans = await customAgentControls.getSpans();
+          expect(spans.length).to.be.at.least(1);
+
+          const httpEntry = spans.find(span => span.n === 'node.http.server');
+          expect(httpEntry).to.exist;
+
+          expect(httpEntry.data.http.params).to.equal('agentOnlyToken=<redacted>&otherParam=value2');
+        });
+      });
+    });
+
+    describe('when in-code config is provided along with agent config', () => {
+      const customAgentControls = new AgentStubControls();
+      let controls;
+
+      before(async () => {
+        await customAgentControls.startAgent({
+          secrets: {
+            matcher: 'equals',
+            list: ['agentCodeToken']
+          }
+        });
+
+        controls = new ProcessControls({
+          agentControls: customAgentControls,
+          dirname: __dirname,
+          cwd: versionDir,
+          env: {
+            USE_INCODE_SECRETS_CONFIG: 'true'
+          }
+        });
+        await controls.startAndWaitForAgentConnection();
+      });
+
+      beforeEach(async () => {
+        await customAgentControls.clearReceivedTraceData();
+      });
+
+      after(async () => {
+        await customAgentControls.stopAgent();
+        await controls.stop();
+      });
+
+      afterEach(async () => {
+        await controls.clearIpcMessages();
+      });
+
+      it('should use in-code config and ignore agent config', async () => {
+        await controls.sendRequest({
+          method: 'GET',
+          path: '/?agentCodeToken=value1&incodeToken=value2&normalParam=value3'
+        });
+
+        await retry(async () => {
+          const spans = await customAgentControls.getSpans();
+          expect(spans.length).to.be.at.least(1);
+
+          const httpEntry = spans.find(span => span.n === 'node.http.server');
+          expect(httpEntry).to.exist;
+
+          expect(httpEntry.data.http.params).to.equal(
+            'agentCodeToken=value1&incodeToken=<redacted>&normalParam=value3'
+          );
+        });
+      });
+    });
+  });
+};

--- a/packages/collector/test/test_util/ProcessControls.js
+++ b/packages/collector/test/test_util/ProcessControls.js
@@ -151,7 +151,6 @@ class ProcessControls {
         APP_CWD: this.cwd,
         INSTANA_AGENT_PORT: agentPort,
         INSTANA_LOG_LEVEL: 'warn',
-        INSTANA_TRACING_DISABLE: !this.tracingEnabled,
         INSTANA_FORCE_TRANSMISSION_STARTING_AT: '1',
         INSTANA_FULL_METRICS_INTERNAL_IN_S: 1,
         INSTANA_FIRE_MONITORING_EVENT_DURATION_IN_MS: 500,
@@ -166,6 +165,13 @@ class ProcessControls {
 
     if (!this.env.INSTANA_DISABLE_COLLECTOR_INIT_EVENT) {
       this.env.INSTANA_DISABLE_COLLECTOR_INIT_EVENT = 'false';
+    }
+
+    // Only set INSTANA_TRACING_DISABLE when tracing is actually disabled to avoid
+    // overriding other disable environment variables (INSTANA_TRACING_DISABLE_INSTRUMENTATIONS, etc.)
+    // See packages/core/src/config/configNormalizers/disable.js for precedence rules
+    if (!this.tracingEnabled) {
+      this.env.INSTANA_TRACING_DISABLE = 'true';
     }
 
     if (this.usePreInit) {

--- a/packages/collector/test/unit/src/announceCycle/agentready.test.js
+++ b/packages/collector/test/unit/src/announceCycle/agentready.test.js
@@ -35,6 +35,9 @@ describe('agent ready state', () => {
   let uncaughtStub;
   let eolStub;
   beforeEach(() => {
+    const coreConfig = require('@_local/core/src/config');
+    coreConfig.normalize({ finalConfigBase: {} });
+
     agentOptsStub = {
       config: {},
       agentUuid: 'test-uuid'
@@ -90,7 +93,8 @@ describe('agent ready state', () => {
     it('should forward agent config to tracing component', () => {
       agentOptsStub.config = { foo: { bar: 'baz' } };
       agentReadyState.enter();
-      expect(tracingStub.activate).to.have.been.calledWith(agentOptsStub.config);
+      const updatedConfig = tracingStub.activate.firstCall.args[0];
+      expect(updatedConfig.foo.bar).to.equal('baz');
     });
   });
 

--- a/packages/collector/test/unit/src/announceCycle/unannounced.test.js
+++ b/packages/collector/test/unit/src/announceCycle/unannounced.test.js
@@ -49,7 +49,6 @@ describe('unannounced state', () => {
     afterEach(() => {
       agentConnectionStub.announceNodeCollector.reset();
       tracingStub.activate.reset();
-      secretsStub.setMatcher.reset();
       agentOptsStub.agentUuid = undefined;
       agentOptsStub.config = {};
     });
@@ -90,7 +89,7 @@ describe('unannounced state', () => {
       });
     });
 
-    it('should use secrets config response', done => {
+    it('should store secrets config in agentOpts.config', done => {
       prepareAnnounceResponse({
         secrets: {
           matcher: 'equals',
@@ -99,7 +98,60 @@ describe('unannounced state', () => {
       });
       unannouncedState.enter({
         transitionTo: () => {
-          expect(secretsStub.setMatcher).to.have.been.calledWith('equals', ['hidden', 'opaque']);
+          expect(agentOptsStub.config.secrets).to.deep.equal({
+            matcherMode: 'equals',
+            keywords: ['hidden', 'opaque']
+          });
+          done();
+        }
+      });
+    });
+
+    it('should store secrets config with different matcher modes', done => {
+      prepareAnnounceResponse({
+        secrets: {
+          matcher: 'contains-ignore-case',
+          list: ['password', 'token']
+        }
+      });
+      unannouncedState.enter({
+        transitionTo: () => {
+          expect(agentOptsStub.config.secrets).to.deep.equal({
+            matcherMode: 'contains-ignore-case',
+            keywords: ['password', 'token']
+          });
+          done();
+        }
+      });
+    });
+
+    it('should handle empty secrets list', done => {
+      prepareAnnounceResponse({
+        secrets: {
+          matcher: 'none',
+          list: []
+        }
+      });
+      unannouncedState.enter({
+        transitionTo: () => {
+          expect(agentOptsStub.config.secrets).to.deep.equal({
+            matcherMode: 'none',
+            keywords: []
+          });
+          done();
+        }
+      });
+    });
+
+    it('should not set secrets config when not provided by agent', done => {
+      prepareAnnounceResponse({
+        tracing: {
+          enabled: true
+        }
+      });
+      unannouncedState.enter({
+        transitionTo: () => {
+          expect(agentOptsStub.config.secrets).to.be.undefined;
           done();
         }
       });

--- a/packages/collector/test/unit/src/util/normalizeConfig.test.js
+++ b/packages/collector/test/unit/src/util/normalizeConfig.test.js
@@ -199,4 +199,46 @@ describe('util.normalizeConfig', () => {
       expect(config.reportUnhandledPromiseRejections).to.be.true;
     });
   });
+
+  describe('disableCollectorInitEvent', () => {
+    it('should default to true', () => {
+      const config = normalizeConfig();
+
+      expect(config.disableCollectorInitEvent).to.be.true;
+    });
+
+    it('should allow explicit false', () => {
+      const config = normalizeConfig({
+        disableCollectorInitEvent: false
+      });
+
+      expect(config.disableCollectorInitEvent).to.be.false;
+    });
+
+    it('should allow explicit true', () => {
+      const config = normalizeConfig({
+        disableCollectorInitEvent: true
+      });
+
+      expect(config.disableCollectorInitEvent).to.be.true;
+    });
+
+    it('should use env over config over in-code', () => {
+      process.env.INSTANA_DISABLE_COLLECTOR_INIT_EVENT = 'false';
+
+      const config = normalizeConfig({
+        disableCollectorInitEvent: true
+      });
+
+      expect(config.disableCollectorInitEvent).to.be.false;
+    });
+
+    it('should fallback to default for invalid env value', () => {
+      process.env.INSTANA_DISABLE_COLLECTOR_INIT_EVENT = 'invalid';
+
+      const config = normalizeConfig();
+
+      expect(config.disableCollectorInitEvent).to.be.true;
+    });
+  });
 });

--- a/packages/collector/test/unit/src/util/normalizeConfig.test.js
+++ b/packages/collector/test/unit/src/util/normalizeConfig.test.js
@@ -16,60 +16,190 @@ describe('util.normalizeConfig', () => {
   function resetEnv() {
     delete process.env.INSTANA_AGENT_HOST;
     delete process.env.INSTANA_AGENT_PORT;
+    delete process.env.INSTANA_AGENT_REQUEST_TIMEOUT;
+    delete process.env.INSTANA_AUTO_PROFILE;
   }
 
-  it('should apply all defaults', () => {
-    checkDefaults(normalizeConfig());
-    checkDefaults(normalizeConfig({}));
-    checkDefaults(normalizeConfig({ unknowConfigOption: 13 }));
-  });
+  describe('defaults', () => {
+    it('should apply all defaults when nothing is provided', () => {
+      const config = normalizeConfig();
 
-  it('should accept custom agent connection configuration', () => {
-    const config = normalizeConfig({
-      agentHost: 'LOKAL_HORST',
-      agentPort: 1207
+      expect(config.agentHost).to.equal('127.0.0.1');
+      expect(config.agentPort).to.equal(42699);
+      expect(config.agentRequestTimeout).to.equal(5000);
+      expect(config.autoProfile).to.equal(false);
+      expect(config.tracing).to.be.an('object');
+      expect(config.reportUnhandledPromiseRejections).to.be.false;
     });
-    expect(config.agentHost).to.equal('LOKAL_HORST');
-    expect(config.agentPort).to.equal(1207);
   });
 
-  it('should accept custom agent connection configuration from environment', () => {
-    process.env.INSTANA_AGENT_HOST = 'yadayada';
-    process.env.INSTANA_AGENT_PORT = '1357';
-    const config = normalizeConfig();
-    expect(config.agentHost).to.equal('yadayada');
-    expect(config.agentPort).to.equal(1357);
-    expect(config.agentPort).to.be.a('number');
-  });
+  describe('agentHost', () => {
+    it.skip('should use env over config over default', () => {
+      process.env.INSTANA_AGENT_HOST = 'env-host';
 
-  it('should custom stack trace length', () => {
-    const config = normalizeConfig({
-      tracing: {
-        stackTraceLength: 7
-      }
+      const config = normalizeConfig({
+        agentHost: 'config-host'
+      });
+
+      expect(config.agentHost).to.equal('env-host');
     });
-    expect(config.tracing.stackTraceLength).to.equal(7);
-  });
 
-  it('should disable unhandled promises', () => {
-    const config = normalizeConfig({
-      reportUnhandledPromiseRejections: false
+    it('should use config when env is not set', () => {
+      const config = normalizeConfig({
+        agentHost: 'config-host'
+      });
+
+      expect(config.agentHost).to.equal('config-host');
     });
-    expect(config.reportUnhandledPromiseRejections).to.be.false;
-  });
 
-  it('should enable unhandled promises', () => {
-    const config = normalizeConfig({
-      reportUnhandledPromiseRejections: true
+    it('should fallback to default', () => {
+      const config = normalizeConfig({});
+
+      expect(config.agentHost).to.equal('127.0.0.1');
     });
-    expect(config.reportUnhandledPromiseRejections).to.be.true;
   });
 
-  function checkDefaults(config) {
-    expect(config).to.be.an('object');
-    expect(config.agentHost).to.equal('127.0.0.1');
-    expect(config.agentPort).to.equal(42699);
-    expect(config.tracing).to.be.an('object');
-    expect(config.reportUnhandledPromiseRejections).to.be.false;
-  }
+  describe('agentPort', () => {
+    it.skip('should use env over config over default', () => {
+      process.env.INSTANA_AGENT_PORT = '9999';
+
+      const config = normalizeConfig({
+        agentPort: 1234
+      });
+
+      expect(config.agentPort).to.equal(9999);
+    });
+
+    it('should use config when env is not set', () => {
+      const config = normalizeConfig({
+        agentPort: 1234
+      });
+
+      expect(config.agentPort).to.equal(1234);
+    });
+
+    it('should fallback to default', () => {
+      const config = normalizeConfig({});
+
+      expect(config.agentPort).to.equal(42699);
+    });
+
+    it('should normalize negative env values', () => {
+      process.env.INSTANA_AGENT_PORT = '-3000';
+
+      const config = normalizeConfig();
+
+      expect(config.agentPort).to.equal(3000);
+    });
+
+    it('should fallback to default for invalid env value', () => {
+      process.env.INSTANA_AGENT_PORT = 'invalid';
+
+      const config = normalizeConfig();
+
+      expect(config.agentPort).to.equal(42699);
+    });
+  });
+
+  describe('agentRequestTimeout', () => {
+    it.skip('should use env over config over default', () => {
+      process.env.INSTANA_AGENT_REQUEST_TIMEOUT = '8000';
+
+      const config = normalizeConfig({
+        agentRequestTimeout: 2000
+      });
+
+      expect(config.agentRequestTimeout).to.equal(8000);
+    });
+
+    it('should use config when env is not set', () => {
+      const config = normalizeConfig({
+        agentRequestTimeout: 2000
+      });
+
+      expect(config.agentRequestTimeout).to.equal(2000);
+    });
+
+    it('should fallback to default', () => {
+      const config = normalizeConfig({});
+
+      expect(config.agentRequestTimeout).to.equal(5000);
+    });
+
+    it('should fallback to default for invalid env value', () => {
+      process.env.INSTANA_AGENT_REQUEST_TIMEOUT = 'abc';
+
+      const config = normalizeConfig();
+
+      expect(config.agentRequestTimeout).to.equal(5000);
+    });
+  });
+
+  describe('autoProfile', () => {
+    it.skip('should use env over config over default', () => {
+      process.env.INSTANA_AUTO_PROFILE = 'true';
+
+      const config = normalizeConfig({
+        autoProfile: false
+      });
+
+      expect(config.autoProfile).to.equal('true');
+    });
+
+    it('should use config when env is not set', () => {
+      const config = normalizeConfig({
+        autoProfile: true
+      });
+
+      expect(config.autoProfile).to.equal(true);
+    });
+
+    it('should fallback to default', () => {
+      const config = normalizeConfig({});
+
+      expect(config.autoProfile).to.equal(false);
+    });
+  });
+
+  describe('tracing', () => {
+    it('should initialize tracing object if missing', () => {
+      const config = normalizeConfig();
+
+      expect(config.tracing).to.be.an('object');
+    });
+
+    it('should preserve provided tracing config', () => {
+      const config = normalizeConfig({
+        tracing: {
+          stackTraceLength: 7
+        }
+      });
+
+      expect(config.tracing.stackTraceLength).to.equal(7);
+    });
+  });
+
+  describe('reportUnhandledPromiseRejections', () => {
+    it('should default to false', () => {
+      const config = normalizeConfig();
+
+      expect(config.reportUnhandledPromiseRejections).to.be.false;
+    });
+
+    it('should allow explicit false', () => {
+      const config = normalizeConfig({
+        reportUnhandledPromiseRejections: false
+      });
+
+      expect(config.reportUnhandledPromiseRejections).to.be.false;
+    });
+
+    it('should allow explicit true', () => {
+      const config = normalizeConfig({
+        reportUnhandledPromiseRejections: true
+      });
+
+      expect(config.reportUnhandledPromiseRejections).to.be.true;
+    });
+  });
 });

--- a/packages/collector/test/unit/src/util/normalizeConfig.test.js
+++ b/packages/collector/test/unit/src/util/normalizeConfig.test.js
@@ -6,10 +6,15 @@
 'use strict';
 
 const expect = require('chai').expect;
-
+const testUtils = require('@_local/core/test/test_util');
+const coreConfig = require('@instana/core/src/config');
 const normalizeConfig = require('@_local/collector/src/util/normalizeConfig');
 
 describe('util.normalizeConfig', () => {
+  before(() => {
+    coreConfig.init(testUtils.createFakeLogger());
+  });
+
   beforeEach(resetEnv);
   afterEach(resetEnv);
 
@@ -82,14 +87,6 @@ describe('util.normalizeConfig', () => {
       const config = normalizeConfig({});
 
       expect(config.agentPort).to.equal(42699);
-    });
-
-    it('should normalize negative env values', () => {
-      process.env.INSTANA_AGENT_PORT = '-3000';
-
-      const config = normalizeConfig();
-
-      expect(config.agentPort).to.equal(3000);
     });
 
     it('should fallback to default for invalid env value', () => {

--- a/packages/collector/test/unit/src/util/normalizeConfig.test.js
+++ b/packages/collector/test/unit/src/util/normalizeConfig.test.js
@@ -39,7 +39,7 @@ describe('util.normalizeConfig', () => {
   });
 
   describe('agentHost', () => {
-    it.skip('should use env over config over default', () => {
+    it('should use env over config over default', () => {
       process.env.INSTANA_AGENT_HOST = 'env-host';
 
       const config = normalizeConfig({
@@ -65,7 +65,7 @@ describe('util.normalizeConfig', () => {
   });
 
   describe('agentPort', () => {
-    it.skip('should use env over config over default', () => {
+    it('should use env over config over default', () => {
       process.env.INSTANA_AGENT_PORT = '9999';
 
       const config = normalizeConfig({
@@ -99,7 +99,7 @@ describe('util.normalizeConfig', () => {
   });
 
   describe('agentRequestTimeout', () => {
-    it.skip('should use env over config over default', () => {
+    it('should use env over config over default', () => {
       process.env.INSTANA_AGENT_REQUEST_TIMEOUT = '8000';
 
       const config = normalizeConfig({
@@ -133,14 +133,14 @@ describe('util.normalizeConfig', () => {
   });
 
   describe('autoProfile', () => {
-    it.skip('should use env over config over default', () => {
+    it('should use env over config over default', () => {
       process.env.INSTANA_AUTO_PROFILE = 'true';
 
       const config = normalizeConfig({
         autoProfile: false
       });
 
-      expect(config.autoProfile).to.equal('true');
+      expect(config.autoProfile).to.equal(true);
     });
 
     it('should use config when env is not set', () => {

--- a/packages/core/src/config/configNormalizers/disable.js
+++ b/packages/core/src/config/configNormalizers/disable.js
@@ -31,12 +31,10 @@ exports.normalize = function normalize(config) {
 
     if (envDisableConfig !== null) {
       if (envDisableConfig === true) {
-        logger?.debug('[config] env:INSTANA_TRACING_DISABLE = true');
         return true;
       }
 
       if (envDisableConfig === false) {
-        logger?.debug('[config] env:INSTANA_TRACING_DISABLE = false (overrides in-code config)');
         return {};
       }
 

--- a/packages/core/src/config/configNormalizers/disable.js
+++ b/packages/core/src/config/configNormalizers/disable.js
@@ -19,32 +19,55 @@ exports.init = function init(_config) {
  * Handles environment variables, and array inputs.
  *
  * Precedence order (highest to lowest):
- * 1. `tracing.disable`
- * 2. Environment variables (`INSTANA_TRACING_DISABLE*`)
+ * 1. Environment variables (`INSTANA_TRACING_DISABLE*`)
+ * 2. In-code tracing.disable
  *
  * @param {import('../../config').InstanaConfig} config
  */
 exports.normalize = function normalize(config) {
   if (!config?.tracing) config.tracing = {};
   try {
-    // Disable all tracing if explicitly set  'disable' to true
+    const envDisableConfig = getDisableFromEnv();
+
+    if (envDisableConfig !== null) {
+      if (envDisableConfig === true) {
+        logger?.debug('[config] env:INSTANA_TRACING_DISABLE = true');
+        return true;
+      }
+
+      if (envDisableConfig === false) {
+        logger?.debug('[config] env:INSTANA_TRACING_DISABLE = false (overrides in-code config)');
+        return {};
+      }
+
+      if (envDisableConfig.instrumentations?.length || envDisableConfig.groups?.length) {
+        logger?.debug(`[config] env:INSTANA_TRACING_DISABLE* = ${JSON.stringify(envDisableConfig)}`);
+
+        if (envDisableConfig.instrumentations) {
+          envDisableConfig.instrumentations = normalizeArray(envDisableConfig.instrumentations);
+        }
+        if (envDisableConfig.groups) {
+          envDisableConfig.groups = normalizeArray(envDisableConfig.groups);
+        }
+
+        return envDisableConfig;
+      }
+    }
+
     if (config.tracing.disable === true) {
       logger?.debug('[config] incode:tracing.disable = true');
-
       return true;
     }
+
     const hasDisableConfig = isDisableConfigNonEmpty(config);
 
     if (hasDisableConfig) {
       logger?.debug(`[config] incode:tracing.disable = ${JSON.stringify(config.tracing.disable)}`);
     }
 
-    // Fallback to environment variables if `disable` is not explicitly configured
-    const disableConfig = isDisableConfigNonEmpty(config) ? config.tracing.disable : getDisableFromEnv();
+    const disableConfig = isDisableConfigNonEmpty(config) ? config.tracing.disable : null;
 
     if (!disableConfig) return {};
-
-    if (disableConfig === true) return true;
 
     // Normalize instrumentations and groups
     if (disableConfig?.instrumentations) {
@@ -90,7 +113,7 @@ exports.normalizeExternalConfig = function normalizeExternalConfig(config) {
  * 2. INSTANA_TRACING_DISABLE_INSTRUMENTATIONS / INSTANA_TRACING_DISABLE_GROUPS
  * 3. INSTANA_TRACING_DISABLE=list
  *
- * @returns {import('../../config/types').Disable}
+ * @returns {import('../../config/types').Disable | boolean | null}
  */
 function getDisableFromEnv() {
   const disable = {};
@@ -104,7 +127,12 @@ function getDisableFromEnv() {
       return true;
     }
 
-    if (envVarValue !== 'false' && envVarValue !== '') {
+    if (envVarValue === 'false') {
+      logger?.debug('[config] env:INSTANA_TRACING_DISABLE = false');
+      return false;
+    }
+
+    if (envVarValue !== '') {
       const categorized = categorizeDisableEntries(parseEnvVar(envVarValue));
       if (categorized?.instrumentations?.length) {
         disable.instrumentations = categorized.instrumentations;

--- a/packages/core/src/config/configNormalizers/disable.js
+++ b/packages/core/src/config/configNormalizers/disable.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const { DISABLABLE_INSTRUMENTATION_GROUPS } = require('../../tracing/constants');
+const { CONFIG_SOURCES } = require('../../util/constants');
 /** @type {import('../../core').GenericLogger} */
 let logger;
 
@@ -31,11 +32,11 @@ exports.normalize = function normalize(config) {
 
     if (envDisableConfig !== null) {
       if (envDisableConfig === true) {
-        return true;
+        return { value: true, source: CONFIG_SOURCES.ENV };
       }
 
       if (envDisableConfig === false) {
-        return {};
+        return { value: {}, source: CONFIG_SOURCES.ENV };
       }
 
       if (envDisableConfig.instrumentations?.length || envDisableConfig.groups?.length) {
@@ -48,13 +49,13 @@ exports.normalize = function normalize(config) {
           envDisableConfig.groups = normalizeArray(envDisableConfig.groups);
         }
 
-        return envDisableConfig;
+        return { value: envDisableConfig, source: CONFIG_SOURCES.ENV };
       }
     }
 
     if (config.tracing.disable === true) {
       logger?.debug('[config] incode:tracing.disable = true');
-      return true;
+      return { value: true, source: CONFIG_SOURCES.INCODE };
     }
 
     const hasDisableConfig = isDisableConfigNonEmpty(config);
@@ -65,7 +66,7 @@ exports.normalize = function normalize(config) {
 
     const disableConfig = isDisableConfigNonEmpty(config) ? config.tracing.disable : null;
 
-    if (!disableConfig) return {};
+    if (!disableConfig) return { value: {}, source: CONFIG_SOURCES.DEFAULT };
 
     // Normalize instrumentations and groups
     if (disableConfig?.instrumentations) {
@@ -77,14 +78,14 @@ exports.normalize = function normalize(config) {
 
     // Handle if tracing.disable is an array
     if (Array.isArray(disableConfig)) {
-      return categorizeDisableEntries(disableConfig);
+      return { value: categorizeDisableEntries(disableConfig), source: CONFIG_SOURCES.INCODE };
     }
 
-    return disableConfig || {};
+    return { value: disableConfig || {}, source: CONFIG_SOURCES.INCODE };
   } catch (error) {
     // Fallback to an empty disable config on error
     logger?.debug(`Error while normalizing tracing.disable config: ${error?.message} ${error?.stack}`);
-    return {};
+    return { value: {}, source: CONFIG_SOURCES.DEFAULT };
   }
 };
 
@@ -96,13 +97,13 @@ exports.normalizeExternalConfig = function normalizeExternalConfig(config) {
   try {
     if (isNonEmptyObject(config.tracing.disable)) {
       const flattenedEntries = flattenDisableConfigs(config.tracing.disable);
-      return categorizeDisableEntries(flattenedEntries);
+      return { value: categorizeDisableEntries(flattenedEntries), source: CONFIG_SOURCES.AGENT };
     }
   } catch (error) {
     logger?.debug(`Error while normalizing external tracing.disable config: ${error?.message} ${error?.stack}`);
   }
 
-  return {};
+  return { value: {}, source: CONFIG_SOURCES.DEFAULT };
 };
 
 /**

--- a/packages/core/src/config/configNormalizers/disable.js
+++ b/packages/core/src/config/configNormalizers/disable.js
@@ -29,15 +29,14 @@ exports.normalize = function normalize(config) {
   try {
     // Disable all tracing if explicitly set  'disable' to true
     if (config.tracing.disable === true) {
-      logger?.info('Tracing has been disabled via "tracing.disable: true" configuration.');
+      logger?.debug('[config] incode:tracing.disable = true');
+
       return true;
     }
     const hasDisableConfig = isDisableConfigNonEmpty(config);
 
     if (hasDisableConfig) {
-      logger?.info(
-        `Tracing selectively disabled as per "tracing.disable" configuration: ${JSON.stringify(config.tracing.disable)}`
-      );
+      logger?.debug(`[config] incode:tracing.disable = ${JSON.stringify(config.tracing.disable)}`);
     }
 
     // Fallback to environment variables if `disable` is not explicitly configured
@@ -101,7 +100,7 @@ function getDisableFromEnv() {
     const envVarValue = process.env.INSTANA_TRACING_DISABLE;
 
     if (envVarValue === 'true') {
-      logger?.info('Tracing has been disabled via environment variable "INSTANA_TRACING_DISABLE=true".');
+      logger?.debug('[config] env:INSTANA_TRACING_DISABLE = true');
       return true;
     }
 
@@ -114,24 +113,20 @@ function getDisableFromEnv() {
         disable.groups = categorized.groups;
       }
 
-      logger?.info(`Tracing has been disabled via "INSTANA_TRACING_DISABLE=${envVarValue}"`);
+      logger?.debug(`[config] env:INSTANA_TRACING_DISABLE = ${envVarValue}`);
     }
   }
 
   if (process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS) {
     disable.instrumentations = parseEnvVar(process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS);
-    logger?.info(
-      `Tracing instrumentations disabled via "INSTANA_TRACING_DISABLE_INSTRUMENTATIONS": ${JSON.stringify(
-        disable.instrumentations
-      )}`
+    logger?.debug(
+      `[config] env:INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = ${process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS}`
     );
   }
 
   if (process.env.INSTANA_TRACING_DISABLE_GROUPS) {
     disable.groups = parseEnvVar(process.env.INSTANA_TRACING_DISABLE_GROUPS);
-    logger?.info(
-      `Tracing instrumentation groups disabled via "INSTANA_TRACING_DISABLE_GROUPS": ${JSON.stringify(disable.groups)}`
-    );
+    logger?.debug(`[config] env:INSTANA_TRACING_DISABLE_GROUPS = ${process.env.INSTANA_TRACING_DISABLE_GROUPS}`);
   }
 
   return Object.keys(disable).length > 0 ? disable : null;

--- a/packages/core/src/config/configNormalizers/stackTrace.js
+++ b/packages/core/src/config/configNormalizers/stackTrace.js
@@ -25,7 +25,7 @@ exports.normalizeStackTraceMode = function (config) {
 
 /**
  * Normalizes stack trace length configuration based on precedence.
- * Precedence: global config > config > env var > default
+ * Precedence: env var > global config > config > default
  * @param {import('../../config').InstanaConfig} config
  * @returns {number} - Normalized value
  */

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -262,8 +262,15 @@ function normalizeTracingConfig({ userConfig = {}, defaultConfig = {}, finalConf
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizeTracingEnabled({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
+  // INSTANA_TRACING_DISABLE can be either:
+  // 1. A boolean ('true'/'false') to enable/disable all tracing
+  // 2. A list of instrumentations/groups to selectively disable
+  // We only use it for tracing.enabled if it's a boolean value
+  const envValue = process.env.INSTANA_TRACING_DISABLE;
+  const isBooleanValue = envValue === 'true' || envValue === 'false';
+
   finalConfig.tracing.enabled = util.resolveBooleanConfigWithInvertedEnv({
-    envVar: 'INSTANA_TRACING_DISABLE',
+    envVar: isBooleanValue ? 'INSTANA_TRACING_DISABLE' : undefined,
     configValue: userConfig.tracing.enabled,
     defaultValue: defaultConfig.tracing.enabled,
     configPath: 'config.tracing.enabled'

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -13,6 +13,7 @@ const configValidators = require('./configValidators');
 const deepMerge = require('../util/deepMerge');
 const { DEFAULT_STACK_TRACE_LENGTH, DEFAULT_STACK_TRACE_MODE } = require('../util/constants');
 const { validateStackTraceMode, validateStackTraceLength } = require('./configValidators/stackTraceValidation');
+const util = require('./util');
 
 /**
  * @typedef {Object} InstanaTracingOption
@@ -143,6 +144,7 @@ module.exports.configValidators = configValidators;
 module.exports.init = _logger => {
   logger = _logger;
   configNormalizers.init({ logger });
+  util.init(logger);
 };
 
 /**
@@ -218,12 +220,12 @@ function normalizeMetricsConfig(config) {
     config.metrics = {};
   }
 
-  config.metrics.transmissionDelay = normalizeSingleValue(
-    config.metrics.transmissionDelay,
-    defaults.metrics.transmissionDelay,
-    'config.metrics.transmissionDelay',
-    'INSTANA_METRICS_TRANSMISSION_DELAY'
-  );
+  config.metrics.transmissionDelay = util.resolveNumericConfig({
+    envVar: 'INSTANA_METRICS_TRANSMISSION_DELAY',
+    configValue: config.metrics.transmissionDelay,
+    defaultValue: defaults.metrics.transmissionDelay,
+    configPath: 'config.metrics.transmissionDelay'
+  });
 
   // Validate max value for transmissionDelay
   if (config.metrics.transmissionDelay > transmissionDelayMaxValue) {
@@ -382,12 +384,12 @@ function normalizeActivateImmediately(config) {
 function normalizeTracingTransmission(config) {
   config.tracing.maxBufferedSpans = config.tracing.maxBufferedSpans || defaults.tracing.maxBufferedSpans;
 
-  config.tracing.transmissionDelay = normalizeSingleValue(
-    config.tracing.transmissionDelay,
-    defaults.tracing.transmissionDelay,
-    'config.tracing.transmissionDelay',
-    'INSTANA_TRACING_TRANSMISSION_DELAY'
-  );
+  config.tracing.transmissionDelay = util.resolveNumericConfig({
+    envVar: 'INSTANA_TRACING_TRANSMISSION_DELAY',
+    configValue: config.tracing.transmissionDelay,
+    defaultValue: defaults.tracing.transmissionDelay,
+    configPath: 'config.tracing.transmissionDelay'
+  });
 
   // DEPRECATED! This was never documented, but we shared it with a customer.
   if (process.env['INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS']) {
@@ -407,19 +409,19 @@ function normalizeTracingTransmission(config) {
     }
   }
 
-  config.tracing.forceTransmissionStartingAt = normalizeSingleValue(
-    config.tracing.forceTransmissionStartingAt,
-    defaults.tracing.forceTransmissionStartingAt,
-    'config.tracing.forceTransmissionStartingAt',
-    'INSTANA_FORCE_TRANSMISSION_STARTING_AT'
-  );
+  config.tracing.forceTransmissionStartingAt = util.resolveNumericConfig({
+    envVar: 'INSTANA_FORCE_TRANSMISSION_STARTING_AT',
+    configValue: config.tracing.forceTransmissionStartingAt,
+    defaultValue: defaults.tracing.forceTransmissionStartingAt,
+    configPath: 'config.tracing.forceTransmissionStartingAt'
+  });
 
-  config.tracing.initialTransmissionDelay = normalizeSingleValue(
-    config.tracing.initialTransmissionDelay,
-    defaults.tracing.initialTransmissionDelay,
-    'config.tracing.initialTransmissionDelay',
-    'INSTANA_TRACING_INITIAL_TRANSMISSION_DELAY'
-  );
+  config.tracing.initialTransmissionDelay = util.resolveNumericConfig({
+    envVar: 'INSTANA_TRACING_INITIAL_TRANSMISSION_DELAY',
+    configValue: config.tracing.initialTransmissionDelay,
+    defaultValue: defaults.tracing.initialTransmissionDelay,
+    configPath: 'config.tracing.initialTransmissionDelay'
+  });
 }
 
 /**
@@ -723,32 +725,6 @@ function parseSecretsEnvVar(envVarValue) {
   };
 }
 
-/**
- * @param {*} configValue
- * @param {*} defaultValue
- * @param {string} configPath
- * @param {string} envVarKey
- * @returns {*}
- */
-function normalizeSingleValue(configValue, defaultValue, configPath, envVarKey) {
-  const envVarVal = process.env[envVarKey];
-  let originalValue = configValue;
-  if (configValue == null && envVarVal == null) {
-    return defaultValue;
-  } else if (configValue == null && envVarVal != null) {
-    originalValue = envVarVal;
-    configValue = parseInt(originalValue, 10);
-  }
-
-  if (typeof configValue !== 'number' || isNaN(configValue)) {
-    logger.warn(
-      `The value of ${configPath} (or ${envVarKey}) ("${originalValue}") is ' +
-        'not numerical or cannot be parsed to a numerical value. Assuming the default value ${defaultValue}.`
-    );
-    return defaultValue;
-  }
-  return configValue;
-}
 /**
  * @param {InstanaConfig} config
  */

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -370,7 +370,15 @@ function normalizeTracingHttp({ userConfig = {}, defaultConfig = {}, finalConfig
 
   const userHeaders = userHttp?.extraHttpHeadersToCapture;
 
-  // 1. Check in-code configuration first
+  // 1. Check environment variable
+  if (process.env.INSTANA_EXTRA_HTTP_HEADERS) {
+    const fromEnvVar = parseHeadersEnvVar(process.env.INSTANA_EXTRA_HTTP_HEADERS);
+    finalConfig.tracing.http.extraHttpHeadersToCapture = fromEnvVar;
+    logger.debug(`[config] env:INSTANA_EXTRA_HTTP_HEADERS = ${process.env.INSTANA_EXTRA_HTTP_HEADERS}`);
+    return;
+  }
+
+  // 2. Check in-code configuration
   if (userHeaders !== undefined) {
     if (!Array.isArray(userHeaders)) {
       logger.warn(
@@ -384,14 +392,6 @@ function normalizeTracingHttp({ userConfig = {}, defaultConfig = {}, finalConfig
       logger.debug('[config] incode:config.tracing.http.extraHttpHeadersToCapture');
       return;
     }
-  }
-
-  // 2. Check environment variable
-  if (process.env.INSTANA_EXTRA_HTTP_HEADERS) {
-    const fromEnvVar = parseHeadersEnvVar(process.env.INSTANA_EXTRA_HTTP_HEADERS);
-    finalConfig.tracing.http.extraHttpHeadersToCapture = fromEnvVar;
-    logger.debug(`[config] env:INSTANA_EXTRA_HTTP_HEADERS = ${process.env.INSTANA_EXTRA_HTTP_HEADERS}`);
-    return;
   }
 
   // 3. Use default configuration
@@ -426,6 +426,7 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
   const envStackTrace = process.env.INSTANA_STACK_TRACE;
   const envStackTraceLength = process.env.INSTANA_STACK_TRACE_LENGTH;
 
+  // Priority 1: Environment variable
   if (envStackTrace !== undefined) {
     const result = validateStackTraceMode(envStackTrace);
 
@@ -441,6 +442,7 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
       finalConfig.tracing.stackTrace = defaultConfig.tracing.stackTrace;
     }
   } else if (userGlobal?.stackTrace !== undefined) {
+    // Priority 2: In-code configuration
     const result = validateStackTraceMode(userGlobal.stackTrace);
 
     if (result.isValid) {
@@ -461,6 +463,7 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
   const isLegacyLengthDefined = userTracingConfig?.stackTraceLength !== undefined;
   const stackTraceConfigValue = userGlobal?.stackTraceLength || userTracingConfig?.stackTraceLength;
 
+  // Priority 1: Environment variable
   if (envStackTraceLength !== undefined) {
     const result = validateStackTraceLength(envStackTraceLength);
 
@@ -476,6 +479,7 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
       finalConfig.tracing.stackTraceLength = defaultConfig.tracing.stackTraceLength;
     }
   } else if (stackTraceConfigValue !== undefined) {
+    // Priority 2: In-code configuration
     if (isLegacyLengthDefined) {
       logger.warn(
         // eslint-disable-next-line max-len
@@ -696,14 +700,7 @@ function normalizeIgnoreEndpoints({ userConfig = {}, defaultConfig = {}, finalCo
     return;
   }
 
-  // Case 1: Use in-code configuration if available
-  if (userIgnoreEndpoints && Object.keys(userIgnoreEndpoints).length) {
-    finalConfig.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.normalizeConfig(userIgnoreEndpoints);
-    logger.debug('[config] incode:config.tracing.ignoreEndpoints');
-    return;
-  }
-
-  // Case 2: Load from a YAML file if `INSTANA_IGNORE_ENDPOINTS_PATH` is set
+  // Priority 1: Load from a YAML file if `INSTANA_IGNORE_ENDPOINTS_PATH` is set
   // Introduced in Phase 2 for advanced filtering based on both methods and endpoints.
   // Also supports basic filtering for endpoints.
   if (process.env.INSTANA_IGNORE_ENDPOINTS_PATH) {
@@ -714,7 +711,7 @@ function normalizeIgnoreEndpoints({ userConfig = {}, defaultConfig = {}, finalCo
     return;
   }
 
-  // Case 3: Load from the `INSTANA_IGNORE_ENDPOINTS` environment variable
+  // Priority 2: Load from the `INSTANA_IGNORE_ENDPOINTS` environment variable
   // Introduced in Phase 1 for basic filtering based only on operations (e.g., `redis.get`, `kafka.consume`).
   // Provides a simple way to configure ignored operations via environment variables.
   if (process.env.INSTANA_IGNORE_ENDPOINTS) {
@@ -722,6 +719,13 @@ function normalizeIgnoreEndpoints({ userConfig = {}, defaultConfig = {}, finalCo
       process.env.INSTANA_IGNORE_ENDPOINTS
     );
     logger.debug('[config] env:INSTANA_IGNORE_ENDPOINTS');
+    return;
+  }
+
+  // Priority 3: Use in-code configuration if available
+  if (userIgnoreEndpoints && Object.keys(userIgnoreEndpoints).length) {
+    finalConfig.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.normalizeConfig(userIgnoreEndpoints);
+    logger.debug('[config] incode:config.tracing.ignoreEndpoints');
     return;
   }
 

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -390,36 +390,34 @@ function normalizeTracingHttp({ userConfig = {}, defaultConfig = {}, finalConfig
   const userHttp = userConfig.tracing.http;
   finalConfig.tracing.http = {};
 
-  let fromEnvVar;
-  if (process.env.INSTANA_EXTRA_HTTP_HEADERS) {
-    fromEnvVar = parseHeadersEnvVar(process.env.INSTANA_EXTRA_HTTP_HEADERS);
-  }
-
   const userHeaders = userHttp?.extraHttpHeadersToCapture;
 
-  if (!userHeaders && !fromEnvVar) {
-    finalConfig.tracing.http.extraHttpHeadersToCapture = defaultConfig.tracing.http.extraHttpHeadersToCapture;
-    return;
-  } else if (!userHeaders && fromEnvVar) {
+  // 1. Check in-code configuration first
+  if (userHeaders !== undefined) {
+    if (!Array.isArray(userHeaders)) {
+      logger.warn(
+        // eslint-disable-next-line max-len
+        `Invalid configuration: config.tracing.http.extraHttpHeadersToCapture is not an array, the value will be ignored: ${JSON.stringify(
+          userHeaders
+        )}`
+      );
+    } else {
+      finalConfig.tracing.http.extraHttpHeadersToCapture = userHeaders.map(s => s.toLowerCase());
+      logger.debug('[config] incode:config.tracing.http.extraHttpHeadersToCapture');
+      return;
+    }
+  }
+
+  // 2. Check environment variable
+  if (process.env.INSTANA_EXTRA_HTTP_HEADERS) {
+    const fromEnvVar = parseHeadersEnvVar(process.env.INSTANA_EXTRA_HTTP_HEADERS);
     finalConfig.tracing.http.extraHttpHeadersToCapture = fromEnvVar;
     logger.debug(`[config] env:INSTANA_EXTRA_HTTP_HEADERS = ${process.env.INSTANA_EXTRA_HTTP_HEADERS}`);
     return;
-  } else if (finalConfig.tracing.http.extraHttpHeadersToCapture) {
-    logger.debug('[config] incode:config.tracing.http.extraHttpHeadersToCapture');
   }
 
-  if (!Array.isArray(userHeaders)) {
-    logger.warn(
-      // eslint-disable-next-line max-len
-      `Invalid configuration: config.tracing.http.extraHttpHeadersToCapture is not an array, the value will be ignored: ${JSON.stringify(
-        userHeaders
-      )}`
-    );
-    finalConfig.tracing.http.extraHttpHeadersToCapture = defaultConfig.tracing.http.extraHttpHeadersToCapture;
-    return;
-  }
-
-  finalConfig.tracing.http.extraHttpHeadersToCapture = userHeaders.map(s => s.toLowerCase());
+  // 3. Use default configuration
+  finalConfig.tracing.http.extraHttpHeadersToCapture = defaultConfig.tracing.http.extraHttpHeadersToCapture;
 }
 
 /**

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -364,6 +364,10 @@ function normalizeTracingTransmission(config) {
 }
 
 /**
+ * NOTE: This normalization logic is not handled in the resolver.
+ * because it involves complex multi-step processing:
+ * Future improvement: Consider refactoring to use a more generic resolver pattern.
+ *
  * @param {InstanaConfig} config
  */
 function normalizeTracingHttp(config) {
@@ -411,6 +415,11 @@ function parseHeadersEnvVar(envVarValue) {
 
 /**
  * Handles both stackTrace and stackTraceLength configuration
+ *
+ * NOTE: This normalization logic is not handled in the resolver.
+ * because it involves complex multi-step processing:
+ * Future improvement: Consider refactoring to use a more generic resolver pattern.
+ *
  * @param {InstanaConfig} config
  */
 function normalizeTracingStackTrace(config) {
@@ -496,6 +505,10 @@ function normalizeTracingStackTrace(config) {
 }
 
 /**
+ * NOTE: This normalization logic is not handled in the resolver.
+ * because it involves complex multi-step processing:
+ * Future improvement: Consider refactoring to use a more generic resolver pattern.
+ *
  * @param {InstanaConfig} config
  */
 function normalizeDisableTracing(config) {
@@ -554,6 +567,10 @@ function normalizeTracingKafka(config) {
 }
 
 /**
+ * NOTE: This normalization logic is not handled in the resolver.
+ * because it involves complex multi-step processing:
+ * Future improvement: Consider refactoring to use a more generic resolver pattern.
+ *
  * @param {InstanaConfig} config
  */
 function normalizeSecrets(config) {
@@ -642,6 +659,10 @@ function parseSecretsEnvVar(envVarValue) {
 }
 
 /**
+ * NOTE: This normalization logic is not handled in the resolver.
+ * because it involves complex multi-step processing:
+ * Future improvement: Consider refactoring to use a more generic resolver pattern.
+ *
  * @param {InstanaConfig} config
  */
 function normalizeIgnoreEndpoints(config) {

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -751,7 +751,7 @@ function normalizeDisableTracing({ userConfig = {}, defaultConfig = {}, finalCon
     finalConfig.tracing.enabled = false;
     finalConfig.tracing.disable = {};
     configStore.set('config.tracing.disable', {
-      source: CONFIG_SOURCES.DEFAULT
+      source: disableRes.source
     });
     return;
   }
@@ -857,24 +857,37 @@ function normalizeSecrets({ userConfig = {}, defaultConfig = {}, finalConfig = {
     fromEnvVar = parseSecretsEnvVar(process.env.INSTANA_SECRETS);
   }
 
-  if (finalConfig.secrets.matcherMode) {
-    logger.debug(`[config] incode:config.secrets.matcherMode = ${finalConfig.secrets.matcherMode}`);
-    configStore.set('config.secrets.matcherMode', { source: CONFIG_SOURCES.INCODE });
-  } else if (fromEnvVar.matcherMode) {
-    logger.debug(`[config] env:INSTANA_SECRETS (matcherMode) = ${fromEnvVar.matcherMode}`);
-    configStore.set('config.secrets.matcherMode', { source: CONFIG_SOURCES.ENV });
+  let matcherModeSource;
+  let matcherMode;
+
+  if (fromEnvVar.matcherMode) {
+    matcherMode = fromEnvVar.matcherMode;
+    matcherModeSource = CONFIG_SOURCES.ENV;
+    logger.debug(`[config] env:INSTANA_SECRETS (matcherMode) = ${matcherMode}`);
+  } else if (userSecrets?.matcherMode) {
+    matcherMode = userSecrets.matcherMode;
+    matcherModeSource = CONFIG_SOURCES.INCODE;
+    logger.debug(`[config] incode:config.secrets.matcherMode = ${matcherMode}`);
+  } else {
+    matcherMode = defaultConfig.secrets.matcherMode;
+    matcherModeSource = CONFIG_SOURCES.DEFAULT;
   }
 
-  if (finalConfig.secrets.keywords) {
-    logger.debug('[config] incode:config.secrets.keywords');
-    configStore.set('config.secrets.keywords', { source: CONFIG_SOURCES.INCODE });
-  } else if (fromEnvVar.keywords) {
+  let keywordsSource;
+  let keywords;
+
+  if (fromEnvVar.keywords) {
+    keywords = fromEnvVar.keywords;
+    keywordsSource = CONFIG_SOURCES.ENV;
     logger.debug('[config] env:INSTANA_SECRETS (keywords)');
-    configStore.set('config.secrets.keywords', { source: CONFIG_SOURCES.ENV });
+  } else if (userSecrets?.keywords) {
+    keywords = userSecrets.keywords;
+    keywordsSource = CONFIG_SOURCES.INCODE;
+    logger.debug('[config] incode:config.secrets.keywords');
+  } else {
+    keywords = defaultConfig.secrets.keywords;
+    keywordsSource = CONFIG_SOURCES.DEFAULT;
   }
-  const matcherMode = userSecrets?.matcherMode || fromEnvVar.matcherMode || defaultConfig.secrets.matcherMode;
-
-  const keywords = userSecrets?.keywords || fromEnvVar.keywords || defaultConfig.secrets.keywords;
 
   if (typeof matcherMode !== 'string') {
     logger.warn(
@@ -882,19 +895,17 @@ function normalizeSecrets({ userConfig = {}, defaultConfig = {}, finalConfig = {
       `The value of config.secrets.matcherMode ("${matcherMode}") is not a string. Assuming the default value ${defaults.secrets.matcherMode}.`
     );
     finalConfig.secrets.matcherMode = defaultConfig.secrets.matcherMode;
-    configStore.set('config.secrets.matcherMode', { source: CONFIG_SOURCES.INCODE });
+    configStore.set('config.secrets.matcherMode', { source: CONFIG_SOURCES.DEFAULT });
   } else if (validSecretsMatcherModes.indexOf(matcherMode) < 0) {
     logger.warn(
       // eslint-disable-next-line max-len
       `The value of config.secrets.matcherMode (or the matcher mode parsed from INSTANA_SECRETS) (${matcherMode}) is not a supported matcher mode. Assuming the default value ${defaults.secrets.matcherMode}.`
     );
     finalConfig.secrets.matcherMode = defaultConfig.secrets.matcherMode;
-    configStore.set('config.secrets.matcherMode', {
-      source: CONFIG_SOURCES.INCODE
-    });
+    configStore.set('config.secrets.matcherMode', { source: CONFIG_SOURCES.DEFAULT });
   } else {
     finalConfig.secrets.matcherMode = matcherMode;
-    configStore.set('config.secrets.matcherMode', { source: CONFIG_SOURCES.INCODE });
+    configStore.set('config.secrets.matcherMode', { source: matcherModeSource });
   }
 
   if (!Array.isArray(keywords)) {
@@ -903,15 +914,15 @@ function normalizeSecrets({ userConfig = {}, defaultConfig = {}, finalConfig = {
       `The value of config.secrets.keywords (${keywords}) is not an array. Assuming the default value ${defaults.secrets.keywords}.`
     );
     finalConfig.secrets.keywords = defaultConfig.secrets.keywords;
-    configStore.set('config.secrets.keywords', { source: CONFIG_SOURCES.INCODE });
+    configStore.set('config.secrets.keywords', { source: CONFIG_SOURCES.DEFAULT });
   } else {
     finalConfig.secrets.keywords = keywords;
-    configStore.set('config.secrets.keywords', { source: CONFIG_SOURCES.INCODE });
+    configStore.set('config.secrets.keywords', { source: keywordsSource });
   }
 
   if (finalConfig.secrets.matcherMode === 'none') {
     finalConfig.secrets.keywords = [];
-    configStore.set('config.secrets.keywords', { source: CONFIG_SOURCES.INCODE });
+    configStore.set('config.secrets.keywords', { source: matcherModeSource });
   }
 }
 

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -146,10 +146,7 @@ module.exports.init = _logger => {
 
 /**
  * Merges the config that was passed to the init function with environment variables and default values.
- * @param {Object} [options]
- * @param {InstanaConfig} [options.userConfig]
- * @param {Object} [options.finalConfigBase]
- * @param {InstanaConfig} [options.defaultsOverride]
+ * @param {{ userConfig?: InstanaConfig, finalConfigBase?: Object, defaultsOverride?: InstanaConfig }} [options]
  * @returns {InstanaConfig}
  */
 module.exports.normalize = ({ userConfig = {}, finalConfigBase = {}, defaultsOverride = {} } = {}) => {
@@ -174,22 +171,20 @@ module.exports.normalize = ({ userConfig = {}, finalConfigBase = {}, defaultsOve
   // TODO: remove this and forward the logger via init fn.
   finalConfig.logger = logger;
 
-  normalizeServiceName(normalizedUserConfig, defaults, finalConfig);
-  normalizePackageJsonPath(normalizedUserConfig, defaults, finalConfig);
-  normalizeMetricsConfig(normalizedUserConfig, defaults, finalConfig);
-  normalizeTracingConfig(normalizedUserConfig, defaults, finalConfig);
-  normalizeSecrets(normalizedUserConfig, defaults, finalConfig);
-  normalizePreloadOpentelemetry(normalizedUserConfig, defaults, finalConfig);
+  normalizeServiceName({ userConfig: normalizedUserConfig, defaultConfig: defaults, finalConfig });
+  normalizePackageJsonPath({ userConfig: normalizedUserConfig, defaultConfig: defaults, finalConfig });
+  normalizeMetricsConfig({ userConfig: normalizedUserConfig, defaultConfig: defaults, finalConfig });
+  normalizeTracingConfig({ userConfig: normalizedUserConfig, defaultConfig: defaults, finalConfig });
+  normalizeSecrets({ userConfig: normalizedUserConfig, defaultConfig: defaults, finalConfig });
+  normalizePreloadOpentelemetry({ userConfig: normalizedUserConfig, defaultConfig: defaults, finalConfig });
 
   return finalConfig;
 };
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeServiceName(userConfig, defaultConfig, finalConfig) {
+function normalizeServiceName({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   const userValue = userConfig.serviceName;
 
   if (userValue != null) {
@@ -209,11 +204,9 @@ function normalizeServiceName(userConfig, defaultConfig, finalConfig) {
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizePackageJsonPath(userConfig, defaultConfig, finalConfig) {
+function normalizePackageJsonPath({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   const userValue = userConfig.packageJsonPath;
 
   if (userValue != null) {
@@ -235,11 +228,9 @@ function normalizePackageJsonPath(userConfig, defaultConfig, finalConfig) {
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeMetricsConfig(userConfig, defaultConfig, finalConfig) {
+function normalizeMetricsConfig({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   const userMetrics = userConfig.metrics;
 
   finalConfig.metrics = {};
@@ -265,38 +256,34 @@ function normalizeMetricsConfig(userConfig, defaultConfig, finalConfig) {
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeTracingConfig(userConfig, defaultConfig, finalConfig) {
+function normalizeTracingConfig({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing = finalConfig.tracing || {};
 
   userConfig.tracing = userConfig.tracing || {};
 
-  normalizeTracingEnabled(userConfig, defaultConfig, finalConfig);
-  normalizeUseOpentelemetry(userConfig, defaultConfig, finalConfig);
-  normalizeDisableTracing(userConfig, defaultConfig, finalConfig);
-  normalizeAutomaticTracingEnabled(userConfig, defaultConfig, finalConfig);
-  normalizeActivateImmediately(userConfig, defaultConfig, finalConfig);
-  normalizeTracingTransmission(userConfig, defaultConfig, finalConfig);
-  normalizeTracingHttp(userConfig, defaultConfig, finalConfig);
-  normalizeTracingStackTrace(userConfig, defaultConfig, finalConfig);
-  normalizeSpanBatchingEnabled(userConfig, defaultConfig, finalConfig);
-  normalizeDisableW3cTraceCorrelation(userConfig, defaultConfig, finalConfig);
-  normalizeTracingKafka(userConfig, defaultConfig, finalConfig);
-  normalizeAllowRootExitSpan(userConfig, defaultConfig, finalConfig);
-  normalizeIgnoreEndpoints(userConfig, defaultConfig, finalConfig);
-  normalizeIgnoreEndpointsDisableSuppression(userConfig, defaultConfig, finalConfig);
-  normalizeDisableEOLEvents(userConfig, defaultConfig, finalConfig);
+  normalizeTracingEnabled({ userConfig, defaultConfig, finalConfig });
+  normalizeUseOpentelemetry({ userConfig, defaultConfig, finalConfig });
+  normalizeDisableTracing({ userConfig, defaultConfig, finalConfig });
+  normalizeAutomaticTracingEnabled({ userConfig, defaultConfig, finalConfig });
+  normalizeActivateImmediately({ userConfig, defaultConfig, finalConfig });
+  normalizeTracingTransmission({ userConfig, defaultConfig, finalConfig });
+  normalizeTracingHttp({ userConfig, defaultConfig, finalConfig });
+  normalizeTracingStackTrace({ userConfig, defaultConfig, finalConfig });
+  normalizeSpanBatchingEnabled({ userConfig, defaultConfig, finalConfig });
+  normalizeDisableW3cTraceCorrelation({ userConfig, defaultConfig, finalConfig });
+  normalizeTracingKafka({ userConfig, defaultConfig, finalConfig });
+  normalizeAllowRootExitSpan({ userConfig, defaultConfig, finalConfig });
+  normalizeIgnoreEndpoints({ userConfig, defaultConfig, finalConfig });
+  normalizeIgnoreEndpointsDisableSuppression({ userConfig, defaultConfig, finalConfig });
+  normalizeDisableEOLEvents({ userConfig, defaultConfig, finalConfig });
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeTracingEnabled(userConfig, defaultConfig, finalConfig) {
+function normalizeTracingEnabled({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.enabled = util.resolveBooleanConfigWithInvertedEnv({
     envVar: 'INSTANA_TRACING_DISABLE',
     configValue: userConfig.tracing.enabled,
@@ -306,11 +293,9 @@ function normalizeTracingEnabled(userConfig, defaultConfig, finalConfig) {
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeAllowRootExitSpan(userConfig, defaultConfig, finalConfig) {
+function normalizeAllowRootExitSpan({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.allowRootExitSpan = util.resolveBooleanConfig({
     envVar: 'INSTANA_ALLOW_ROOT_EXIT_SPAN',
     configValue: userConfig.tracing.allowRootExitSpan,
@@ -320,11 +305,9 @@ function normalizeAllowRootExitSpan(userConfig, defaultConfig, finalConfig) {
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeUseOpentelemetry(userConfig, defaultConfig, finalConfig) {
+function normalizeUseOpentelemetry({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.useOpentelemetry = util.resolveBooleanConfigWithInvertedEnv({
     envVar: 'INSTANA_DISABLE_USE_OPENTELEMETRY',
     configValue: userConfig.tracing.useOpentelemetry,
@@ -334,11 +317,9 @@ function normalizeUseOpentelemetry(userConfig, defaultConfig, finalConfig) {
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeAutomaticTracingEnabled(userConfig, defaultConfig, finalConfig) {
+function normalizeAutomaticTracingEnabled({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   if (!finalConfig.tracing.enabled) {
     logger.info('Not enabling automatic tracing as tracing in general is explicitly disabled via finalConfig.');
     finalConfig.tracing.automaticTracingEnabled = false;
@@ -354,11 +335,9 @@ function normalizeAutomaticTracingEnabled(userConfig, defaultConfig, finalConfig
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeActivateImmediately(userConfig, defaultConfig, finalConfig) {
+function normalizeActivateImmediately({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   if (!finalConfig.tracing.enabled) {
     finalConfig.tracing.activateImmediately = false;
     return;
@@ -373,11 +352,9 @@ function normalizeActivateImmediately(userConfig, defaultConfig, finalConfig) {
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeTracingTransmission(userConfig, defaultConfig, finalConfig) {
+function normalizeTracingTransmission({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.maxBufferedSpans = userConfig.tracing.maxBufferedSpans || defaultConfig.tracing.maxBufferedSpans;
 
   finalConfig.tracing.transmissionDelay = util.resolveNumericConfig({
@@ -407,11 +384,9 @@ function normalizeTracingTransmission(userConfig, defaultConfig, finalConfig) {
  * because it involves complex multi-step processing:
  * Future improvement: Consider refactoring to use a more generic resolver pattern.
  *
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeTracingHttp(userConfig, defaultConfig, finalConfig) {
+function normalizeTracingHttp({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   const userHttp = userConfig.tracing.http;
   finalConfig.tracing.http = {};
 
@@ -466,11 +441,9 @@ function parseHeadersEnvVar(envVarValue) {
  * Future improvement: Consider refactoring to use a more generic resolver pattern.
  *
  *
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeTracingStackTrace(userConfig, defaultConfig, finalConfig) {
+function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   const userTracingConfig = userConfig.tracing;
   const userGlobal = userTracingConfig.global;
 
@@ -558,11 +531,9 @@ function normalizeTracingStackTrace(userConfig, defaultConfig, finalConfig) {
  * because it involves complex multi-step processing:
  * Future improvement: Consider refactoring to use a more generic resolver pattern.
  *
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeDisableTracing(userConfig, defaultConfig, finalConfig) {
+function normalizeDisableTracing({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   const disableConfig = configNormalizers.disable.normalize(userConfig);
 
   // If tracing is globally disabled (via `disable: true` or INSTANA_TRACING_DISABLE=true ),
@@ -581,11 +552,9 @@ function normalizeDisableTracing(userConfig, defaultConfig, finalConfig) {
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeSpanBatchingEnabled(userConfig, defaultConfig, finalConfig) {
+function normalizeSpanBatchingEnabled({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.spanBatchingEnabled = util.resolveBooleanConfig({
     envVar: 'INSTANA_SPANBATCHING_ENABLED',
     configValue: userConfig.tracing.spanBatchingEnabled,
@@ -595,11 +564,9 @@ function normalizeSpanBatchingEnabled(userConfig, defaultConfig, finalConfig) {
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeDisableW3cTraceCorrelation(userConfig, defaultConfig, finalConfig) {
+function normalizeDisableW3cTraceCorrelation({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.disableW3cTraceCorrelation = util.resolveBooleanConfigWithTruthyEnv({
     envVar: 'INSTANA_DISABLE_W3C_TRACE_CORRELATION',
     configValue: userConfig.tracing.disableW3cTraceCorrelation,
@@ -609,11 +576,9 @@ function normalizeDisableW3cTraceCorrelation(userConfig, defaultConfig, finalCon
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeTracingKafka(userConfig, defaultConfig, finalConfig) {
+function normalizeTracingKafka({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   const userKafka = userConfig.tracing.kafka;
   finalConfig.tracing.kafka = {};
 
@@ -630,11 +595,9 @@ function normalizeTracingKafka(userConfig, defaultConfig, finalConfig) {
  * because it involves complex multi-step processing:
  * Future improvement: Consider refactoring to use a more generic resolver pattern.
  *
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeSecrets(userConfig, defaultConfig, finalConfig) {
+function normalizeSecrets({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   const userSecrets = userConfig.secrets;
   finalConfig.secrets = {};
 
@@ -742,11 +705,9 @@ function parseSecretsEnvVar(envVarValue) {
  * because it involves complex multi-step processing:
  * Future improvement: Consider refactoring to use a more generic resolver pattern.
  *
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeIgnoreEndpoints(userConfig, defaultConfig, finalConfig) {
+function normalizeIgnoreEndpoints({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   const userIgnoreEndpoints = userConfig.tracing.ignoreEndpoints;
 
   if (userIgnoreEndpoints && (typeof userIgnoreEndpoints !== 'object' || Array.isArray(userIgnoreEndpoints))) {
@@ -792,11 +753,9 @@ function normalizeIgnoreEndpoints(userConfig, defaultConfig, finalConfig) {
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeIgnoreEndpointsDisableSuppression(userConfig, defaultConfig, finalConfig) {
+function normalizeIgnoreEndpointsDisableSuppression({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.ignoreEndpointsDisableSuppression = util.resolveBooleanConfig({
     envVar: 'INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION',
     configValue: userConfig.tracing.ignoreEndpointsDisableSuppression,
@@ -806,11 +765,9 @@ function normalizeIgnoreEndpointsDisableSuppression(userConfig, defaultConfig, f
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeDisableEOLEvents(userConfig, defaultConfig, finalConfig) {
+function normalizeDisableEOLEvents({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.disableEOLEvents = util.resolveBooleanConfig({
     envVar: 'INSTANA_TRACING_DISABLE_EOL_EVENTS',
     configValue: userConfig.tracing.disableEOLEvents,
@@ -820,11 +777,9 @@ function normalizeDisableEOLEvents(userConfig, defaultConfig, finalConfig) {
 }
 
 /**
- * @param {InstanaConfig|null} userConfig
- * @param {InstanaConfig} defaultConfig
- * @param {InstanaConfig} finalConfig
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizePreloadOpentelemetry(userConfig, defaultConfig, finalConfig) {
+function normalizePreloadOpentelemetry({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   if (userConfig.preloadOpentelemetry === true) {
     finalConfig.preloadOpentelemetry = true;
   } else {

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -986,9 +986,11 @@ exports.update = function update(externalConfig, source) {
       return currentConfig;
     }
 
-    /** @type {any} */ (currentConfig)[key] = externalConfig[key];
+    /** @type {Record<string, any>} */
+    const configAsRecord = currentConfig;
+    configAsRecord[key] = deepMerge(configAsRecord[key], externalConfig[key]);
+
     configStore.set(configPath, { source });
-    logger.debug(`[config] Updated ${key} from source ${source}: ${JSON.stringify(externalConfig[key])}`);
   });
   return currentConfig;
 };

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -7,7 +7,6 @@
 
 'use strict';
 
-const supportedTracingVersion = require('../tracing/supportedVersion');
 const configNormalizers = require('./configNormalizers');
 const configValidators = require('./configValidators');
 const deepMerge = require('../util/deepMerge');
@@ -269,15 +268,12 @@ function normalizeTracingConfig(config) {
  * @param {InstanaConfig} config
  */
 function normalizeTracingEnabled(config) {
-  if (config.tracing.enabled === false) {
-    logger.info('Not enabling tracing as it is explicitly disabled via config.');
-    return;
-  }
-  if (config.tracing.enabled === true) {
-    return;
-  }
-
-  config.tracing.enabled = defaults.tracing.enabled;
+  config.tracing.enabled = util.resolveBooleanConfigWithInvertedEnv({
+    envVar: 'INSTANA_TRACING_DISABLE',
+    configValue: config.tracing.enabled,
+    defaultValue: defaults.tracing.enabled,
+    configPath: 'config.tracing.enabled'
+  });
 }
 
 /**
@@ -286,20 +282,12 @@ function normalizeTracingEnabled(config) {
  */
 
 function normalizeAllowRootExitSpan(config) {
-  if (config.tracing.allowRootExitSpan === false) {
-    return;
-  }
-  if (config.tracing.allowRootExitSpan === true) {
-    return;
-  }
-
-  const INSTANA_ALLOW_ROOT_EXIT_SPAN = process.env['INSTANA_ALLOW_ROOT_EXIT_SPAN']?.toLowerCase();
-
-  config.tracing.allowRootExitSpan =
-    INSTANA_ALLOW_ROOT_EXIT_SPAN === '1' ||
-    INSTANA_ALLOW_ROOT_EXIT_SPAN === 'true' ||
-    defaults.tracing.allowRootExitSpan;
-  return;
+  config.tracing.allowRootExitSpan = util.resolveBooleanConfig({
+    envVar: 'INSTANA_ALLOW_ROOT_EXIT_SPAN',
+    configValue: config.tracing.allowRootExitSpan,
+    defaultValue: defaults.tracing.allowRootExitSpan,
+    configPath: 'config.tracing.allowRootExitSpan'
+  });
 }
 
 /**
@@ -307,18 +295,12 @@ function normalizeAllowRootExitSpan(config) {
  * @param {InstanaConfig} config
  */
 function normalizeUseOpentelemetry(config) {
-  if (config.tracing.useOpentelemetry === false) {
-    return;
-  }
-  if (config.tracing.useOpentelemetry === true) {
-    return;
-  }
-  if (process.env['INSTANA_DISABLE_USE_OPENTELEMETRY'] === 'true') {
-    config.tracing.useOpentelemetry = false;
-    return;
-  }
-
-  config.tracing.useOpentelemetry = defaults.tracing.useOpentelemetry;
+  config.tracing.useOpentelemetry = util.resolveBooleanConfigWithInvertedEnv({
+    envVar: 'INSTANA_DISABLE_USE_OPENTELEMETRY',
+    configValue: config.tracing.useOpentelemetry,
+    defaultValue: defaults.tracing.useOpentelemetry,
+    configPath: 'config.tracing.useOpentelemetry'
+  });
 }
 
 /**
@@ -331,30 +313,12 @@ function normalizeAutomaticTracingEnabled(config) {
     return;
   }
 
-  if (config.tracing.automaticTracingEnabled === false) {
-    logger.info('Not enabling automatic tracing as it is explicitly disabled via config.');
-    config.tracing.automaticTracingEnabled = false;
-    return;
-  }
-
-  if (process.env['INSTANA_DISABLE_AUTO_INSTR'] === 'true') {
-    logger.info(
-      'Not enabling automatic tracing as it is explicitly disabled via environment variable INSTANA_DISABLE_AUTO_INSTR.'
-    );
-    config.tracing.automaticTracingEnabled = false;
-    return;
-  }
-
-  if (!supportedTracingVersion(process.versions.node)) {
-    logger.warn(
-      'Not enabling automatic tracing, this is an unsupported version of Node.js. ' +
-        'See: https://www.ibm.com/docs/en/instana-observability/current?topic=nodejs-support-information#supported-nodejs-versions'
-    );
-    config.tracing.automaticTracingEnabled = false;
-    return;
-  }
-
-  config.tracing.automaticTracingEnabled = defaults.tracing.automaticTracingEnabled;
+  config.tracing.automaticTracingEnabled = util.resolveBooleanConfigWithInvertedEnv({
+    envVar: 'INSTANA_DISABLE_AUTO_INSTR',
+    configValue: config.tracing.automaticTracingEnabled,
+    defaultValue: defaults.tracing.automaticTracingEnabled,
+    configPath: 'config.tracing.automaticTracingEnabled'
+  });
 }
 
 /**
@@ -366,16 +330,12 @@ function normalizeActivateImmediately(config) {
     return;
   }
 
-  if (typeof config.tracing.activateImmediately === 'boolean') {
-    return;
-  }
-
-  if (process.env['INSTANA_TRACE_IMMEDIATELY'] === 'true') {
-    config.tracing.activateImmediately = true;
-    return;
-  }
-
-  config.tracing.activateImmediately = defaults.tracing.activateImmediately;
+  config.tracing.activateImmediately = util.resolveBooleanConfig({
+    envVar: 'INSTANA_TRACE_IMMEDIATELY',
+    configValue: config.tracing.activateImmediately,
+    defaultValue: defaults.tracing.activateImmediately,
+    configPath: 'config.tracing.activateImmediately'
+  });
 }
 
 /**
@@ -561,47 +521,23 @@ function normalizeDisableTracing(config) {
  * @param {InstanaConfig} config
  */
 function normalizeSpanBatchingEnabled(config) {
-  if (config.tracing.spanBatchingEnabled != null) {
-    if (typeof config.tracing.spanBatchingEnabled === 'boolean') {
-      if (config.tracing.spanBatchingEnabled) {
-        logger.info('Span batching is enabled via config.');
-      }
-      return;
-    } else {
-      logger.warn(
-        `Invalid configuration: config.tracing.spanBatchingEnabled is not a boolean value, will be ignored: ${JSON.stringify(
-          config.tracing.spanBatchingEnabled
-        )}`
-      );
-    }
-  }
-
-  if (process.env['INSTANA_SPANBATCHING_ENABLED'] === 'true') {
-    logger.info('Span batching is enabled via environment variable INSTANA_SPANBATCHING_ENABLED.');
-    config.tracing.spanBatchingEnabled = true;
-    return;
-  }
-
-  config.tracing.spanBatchingEnabled = defaults.tracing.spanBatchingEnabled;
+  config.tracing.spanBatchingEnabled = util.resolveBooleanConfig({
+    envVar: 'INSTANA_SPANBATCHING_ENABLED',
+    configValue: config.tracing.spanBatchingEnabled,
+    defaultValue: defaults.tracing.spanBatchingEnabled,
+    configPath: 'config.tracing.spanBatchingEnabled'
+  });
 }
 
 /**
  * @param {InstanaConfig} config
  */
 function normalizeDisableW3cTraceCorrelation(config) {
-  if (config.tracing.disableW3cTraceCorrelation === true) {
-    logger.info('W3C trace correlation has been disabled via config.');
-    return;
-  }
-  if (process.env['INSTANA_DISABLE_W3C_TRACE_CORRELATION']) {
-    logger.info(
-      'W3C trace correlation has been disabled via environment variable INSTANA_DISABLE_W3C_TRACE_CORRELATION.'
-    );
-    config.tracing.disableW3cTraceCorrelation = true;
-    return;
-  }
-
-  config.tracing.disableW3cTraceCorrelation = defaults.tracing.disableW3cTraceCorrelation;
+  config.tracing.disableW3cTraceCorrelation = util.resolveBooleanConfigWithTruthyEnv({
+    envVar: 'INSTANA_DISABLE_W3C_TRACE_CORRELATION',
+    configValue: config.tracing.disableW3cTraceCorrelation,
+    defaultValue: defaults.tracing.disableW3cTraceCorrelation
+  });
 }
 
 /**
@@ -610,17 +546,12 @@ function normalizeDisableW3cTraceCorrelation(config) {
 function normalizeTracingKafka(config) {
   config.tracing.kafka = config.tracing.kafka || {};
 
-  if (config.tracing.kafka.traceCorrelation === false) {
-    logger.info('Kafka trace correlation has been disabled via config.');
-  } else if (
-    process.env['INSTANA_KAFKA_TRACE_CORRELATION'] != null &&
-    process.env['INSTANA_KAFKA_TRACE_CORRELATION'].toLowerCase() === 'false'
-  ) {
-    logger.info('Kafka trace correlation has been disabled via environment variable INSTANA_KAFKA_TRACE_CORRELATION.');
-    config.tracing.kafka.traceCorrelation = false;
-  } else {
-    config.tracing.kafka.traceCorrelation = defaults.tracing.kafka.traceCorrelation;
-  }
+  config.tracing.kafka.traceCorrelation = util.resolveBooleanConfig({
+    envVar: 'INSTANA_KAFKA_TRACE_CORRELATION',
+    configValue: config.tracing.kafka.traceCorrelation,
+    defaultValue: defaults.tracing.kafka.traceCorrelation,
+    configPath: 'config.tracing.kafka.traceCorrelation'
+  });
 }
 
 /**
@@ -759,32 +690,24 @@ function normalizeIgnoreEndpoints(config) {
  * @param {InstanaConfig} config
  */
 function normalizeIgnoreEndpointsDisableSuppression(config) {
-  if (process.env['INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION'] === 'true') {
-    logger.info(
-      'Disabling downstream suppression for ignoring endpoints feature as it is explicitly disabled via environment variable "INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION".'
-    );
-    config.tracing.ignoreEndpointsDisableSuppression = true;
-    return;
-  }
-
-  config.tracing.ignoreEndpointsDisableSuppression = defaults.tracing.ignoreEndpointsDisableSuppression;
+  config.tracing.ignoreEndpointsDisableSuppression = util.resolveBooleanConfig({
+    envVar: 'INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION',
+    configValue: config.tracing.ignoreEndpointsDisableSuppression,
+    defaultValue: defaults.tracing.ignoreEndpointsDisableSuppression,
+    configPath: 'config.tracing.ignoreEndpointsDisableSuppression'
+  });
 }
 
 /**
  * @param {InstanaConfig} config
  */
 function normalizeDisableEOLEvents(config) {
-  config.tracing = config.tracing || {};
-
-  if (process.env['INSTANA_TRACING_DISABLE_EOL_EVENTS'] === 'true') {
-    logger.info(
-      'Disabling EOL events as it is explicitly disabled via environment variable "INSTANA_TRACING_DISABLE_EOL_EVENTS".'
-    );
-    config.tracing.disableEOLEvents = true;
-    return;
-  }
-
-  config.tracing.disableEOLEvents = defaults.tracing.disableEOLEvents;
+  config.tracing.disableEOLEvents = util.resolveBooleanConfig({
+    envVar: 'INSTANA_TRACING_DISABLE_EOL_EVENTS',
+    configValue: config.tracing.disableEOLEvents,
+    defaultValue: defaults.tracing.disableEOLEvents,
+    configPath: 'config.tracing.disableEOLEvents'
+  });
 }
 
 /**

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -969,28 +969,40 @@ function normalizePreloadOpentelemetry({ userConfig = {}, defaultConfig = {}, fi
 /**
  * Updates configuration values dynamically from external sources (e.g., agent)
  *
- * @param {Object.<string, any>} externalConfig
- * @param {number} source
+ * @param {Object} [params]
+ * @param {Record<string, any>} [params.externalConfig]
+ * @param {number} [params.source]
+ * @param {Record<string, any>} [params.target=currentConfig]
+ * @param {string} [params.basePath='config']
+ * @returns {Record<string, any>}
  */
-exports.update = function update(externalConfig, source) {
+exports.update = function update({ externalConfig = {}, source, target = currentConfig, basePath = 'config' } = {}) {
   if (!externalConfig || typeof externalConfig !== 'object' || Object.keys(externalConfig).length === 0) {
     return currentConfig;
   }
 
   Object.keys(externalConfig).forEach(key => {
-    const configPath = `config.${key}`;
-    const currentMeta = configStore.get(configPath);
+    const path = `${basePath}.${key}`;
+    const currentMeta = configStore.get(path);
 
     if (currentMeta && currentMeta.source < source) {
-      logger.debug(`[config] Skipping ${key}: current source ${currentMeta.source} > incoming ${source}`);
-      return currentConfig;
+      logger.debug(`[config] Skipping ${path}: current source ${currentMeta.source} > incoming ${source}`);
+      return;
     }
 
-    /** @type {Record<string, any>} */
-    const configAsRecord = currentConfig;
-    configAsRecord[key] = deepMerge(configAsRecord[key], externalConfig[key]);
+    const incomingValue = externalConfig[key];
 
-    configStore.set(configPath, { source });
+    if (incomingValue && typeof incomingValue === 'object' && !Array.isArray(incomingValue)) {
+      if (!target[key] || typeof target[key] !== 'object') {
+        target[key] = {};
+      }
+
+      update({ externalConfig: incomingValue, source, target: target[key], basePath: path });
+    } else {
+      target[key] = incomingValue;
+      configStore.set(path, { source });
+    }
   });
+
   return currentConfig;
 };

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -8,9 +8,48 @@
 const configNormalizers = require('./configNormalizers');
 const configValidators = require('./configValidators');
 const deepMerge = require('../util/deepMerge');
-const { DEFAULT_STACK_TRACE_LENGTH, DEFAULT_STACK_TRACE_MODE } = require('../util/constants');
+const { DEFAULT_STACK_TRACE_LENGTH, DEFAULT_STACK_TRACE_MODE, CONFIG_SOURCES } = require('../util/constants');
 const { validateStackTraceMode, validateStackTraceLength } = require('./configValidators/stackTraceValidation');
 const util = require('./util');
+const validate = require('./validator');
+
+// @typedef {{ [x: string]: any }} configMeta
+/** @type {configMeta} */
+const configMeta = {};
+
+const configStore = {
+  /**
+   * @param {string} configPath
+   * @param {{ source: number }} obj
+   */
+  set(configPath, obj) {
+    configMeta[configPath] = obj;
+  },
+
+  /**
+   * @param {string} configPath - The config path
+   * @returns {{ source: number } | undefined}
+   */
+  get(configPath) {
+    return configMeta[configPath];
+  },
+
+  clear() {
+    Object.keys(configMeta).forEach(key => delete configMeta[key]);
+  }
+};
+
+/**
+ * @type {InstanaConfig}
+ *
+ * NOTE: currentConfig is a reference to the config object returned by normalize().
+ * This variable exists to allow dynamic config updates via the update() function without
+ * requiring the config object to be passed as a parameter.
+ *
+ * TODO: This can be removed in the future when we implement config.get()/config.set()
+ * methods. The values will be kept in the configStore instance.
+ */
+let currentConfig;
 
 /**
  * @typedef {Object} InstanaTracingOption
@@ -162,6 +201,8 @@ module.exports.normalize = ({ userConfig = {}, finalConfigBase = {}, defaultsOve
   } else {
     normalizedUserConfig = {};
   }
+  // TODO: This call needs to be reconsidered when we add the full config instance (`config.get(...)`).
+  configStore.clear();
 
   // Preserve finalConfigBase in the finalConfig to allow additional config values
   // that are not part of the core config schema. Eg: collector config needs to be preserved.
@@ -177,7 +218,7 @@ module.exports.normalize = ({ userConfig = {}, finalConfigBase = {}, defaultsOve
   normalizeTracingConfig({ userConfig: normalizedUserConfig, defaultConfig: defaults, finalConfig });
   normalizeSecrets({ userConfig: normalizedUserConfig, defaultConfig: defaults, finalConfig });
   normalizePreloadOpentelemetry({ userConfig: normalizedUserConfig, defaultConfig: defaults, finalConfig });
-
+  currentConfig = finalConfig;
   return finalConfig;
 };
 
@@ -185,24 +226,34 @@ module.exports.normalize = ({ userConfig = {}, finalConfigBase = {}, defaultsOve
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizeServiceName({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  finalConfig.serviceName = util.resolveStringConfig({
-    envVar: 'INSTANA_SERVICE_NAME',
-    configValue: userConfig.serviceName,
-    defaultValue: defaultConfig.serviceName,
-    configPath: 'config.serviceName'
-  });
+  const { value, source } = util.resolve(
+    {
+      envValue: 'INSTANA_SERVICE_NAME',
+      inCodeValue: userConfig.serviceName,
+      defaultValue: defaultConfig.serviceName
+    },
+    [validate.stringValidator]
+  );
+
+  configStore.set('config.serviceName', { source });
+  finalConfig.serviceName = value;
 }
 
 /**
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizePackageJsonPath({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  finalConfig.packageJsonPath = util.resolveStringConfig({
-    envVar: 'INSTANA_PACKAGE_JSON_PATH',
-    configValue: userConfig.packageJsonPath,
-    defaultValue: defaultConfig.packageJsonPath,
-    configPath: 'config.packageJsonPath'
-  });
+  const { value, source } = util.resolve(
+    {
+      envValue: 'INSTANA_PACKAGE_JSON_PATH',
+      inCodeValue: userConfig.packageJsonPath,
+      defaultValue: defaultConfig.packageJsonPath
+    },
+    [validate.stringValidator]
+  );
+
+  configStore.set('config.packageJsonPath', { source });
+  finalConfig.packageJsonPath = value;
 }
 
 /**
@@ -213,12 +264,16 @@ function normalizeMetricsConfig({ userConfig = {}, defaultConfig = {}, finalConf
 
   finalConfig.metrics = {};
 
-  finalConfig.metrics.transmissionDelay = util.resolveNumericConfig({
-    envVar: 'INSTANA_METRICS_TRANSMISSION_DELAY',
-    configValue: userMetrics?.transmissionDelay,
-    defaultValue: defaultConfig.metrics.transmissionDelay,
-    configPath: 'config.metrics.transmissionDelay'
-  });
+  const { value: transmissionDelay, source: transmissionDelaySource } = util.resolve(
+    {
+      envValue: 'INSTANA_METRICS_TRANSMISSION_DELAY',
+      inCodeValue: userMetrics?.transmissionDelay,
+      defaultValue: defaultConfig.metrics.transmissionDelay
+    },
+    [validate.numberValidator]
+  );
+
+  finalConfig.metrics.transmissionDelay = transmissionDelay;
 
   // Validate max value for transmissionDelay
   if (finalConfig.metrics.transmissionDelay > transmissionDelayMaxValue) {
@@ -229,8 +284,20 @@ function normalizeMetricsConfig({ userConfig = {}, defaultConfig = {}, finalConf
     finalConfig.metrics.transmissionDelay = transmissionDelayMaxValue;
   }
 
-  finalConfig.metrics.timeBetweenHealthcheckCalls =
-    userMetrics?.timeBetweenHealthcheckCalls || defaultConfig.metrics.timeBetweenHealthcheckCalls;
+  configStore.set('config.metrics.transmissionDelay', { source: transmissionDelaySource });
+
+  const { value: healthcheckInterval, source: healthcheckSource } = util.resolve(
+    {
+      inCodeValue: userMetrics?.timeBetweenHealthcheckCalls,
+      defaultValue: defaultConfig.metrics.timeBetweenHealthcheckCalls
+    },
+    [validate.numberValidator]
+  );
+
+  finalConfig.metrics.timeBetweenHealthcheckCalls = healthcheckInterval;
+  configStore.set('config.metrics.timeBetweenHealthcheckCalls', {
+    source: healthcheckSource
+  });
 }
 
 /**
@@ -269,36 +336,59 @@ function normalizeTracingEnabled({ userConfig = {}, defaultConfig = {}, finalCon
   const envValue = process.env.INSTANA_TRACING_DISABLE;
   const isBooleanValue = envValue === 'true' || envValue === 'false';
 
-  finalConfig.tracing.enabled = util.resolveBooleanConfigWithInvertedEnv({
-    envVar: isBooleanValue ? 'INSTANA_TRACING_DISABLE' : undefined,
-    configValue: userConfig.tracing.enabled,
-    defaultValue: defaultConfig.tracing.enabled,
-    configPath: 'config.tracing.enabled'
-  });
+  const { value, source } = util.resolve(
+    {
+      envValue: isBooleanValue ? 'INSTANA_TRACING_DISABLE' : undefined,
+      inCodeValue: userConfig.tracing.enabled,
+      defaultValue: defaultConfig.tracing.enabled
+    },
+    [validate.booleanValidator]
+  );
+
+  // The env var is TRACING_DISABLE, so we need to invert it when it comes from env
+  // TODO: Consider adding this normalization support to util.resolver
+  const finalValue = source === CONFIG_SOURCES.ENV ? !value : value;
+
+  configStore.set('config.tracing.enabled', { source });
+  finalConfig.tracing.enabled = finalValue;
 }
 
 /**
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizeAllowRootExitSpan({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  finalConfig.tracing.allowRootExitSpan = util.resolveBooleanConfig({
-    envVar: 'INSTANA_ALLOW_ROOT_EXIT_SPAN',
-    configValue: userConfig.tracing.allowRootExitSpan,
-    defaultValue: defaultConfig.tracing.allowRootExitSpan,
-    configPath: 'config.tracing.allowRootExitSpan'
-  });
+  const { value, source } = util.resolve(
+    {
+      envValue: 'INSTANA_ALLOW_ROOT_EXIT_SPAN',
+      inCodeValue: userConfig.tracing.allowRootExitSpan,
+      defaultValue: defaultConfig.tracing.allowRootExitSpan
+    },
+    [validate.booleanValidator]
+  );
+
+  configStore.set('config.tracing.allowRootExitSpan', { source });
+  finalConfig.tracing.allowRootExitSpan = value;
 }
 
 /**
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizeUseOpentelemetry({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  finalConfig.tracing.useOpentelemetry = util.resolveBooleanConfigWithInvertedEnv({
-    envVar: 'INSTANA_DISABLE_USE_OPENTELEMETRY',
-    configValue: userConfig.tracing.useOpentelemetry,
-    defaultValue: defaultConfig.tracing.useOpentelemetry,
-    configPath: 'config.tracing.useOpentelemetry'
-  });
+  const { value, source } = util.resolve(
+    {
+      envValue: 'INSTANA_DISABLE_USE_OPENTELEMETRY',
+      inCodeValue: userConfig.tracing.useOpentelemetry,
+      defaultValue: defaultConfig.tracing.useOpentelemetry
+    },
+    [validate.booleanValidator]
+  );
+
+  // The env var is DISABLE_USE_OPENTELEMETRY, so we need to invert it when it comes from env
+  // TODO: add normalization helpers to util.resolve(...)
+  const finalValue = source === CONFIG_SOURCES.ENV ? !value : value;
+
+  configStore.set('config.tracing.useOpentelemetry', { source });
+  finalConfig.tracing.useOpentelemetry = finalValue;
 }
 
 /**
@@ -306,17 +396,25 @@ function normalizeUseOpentelemetry({ userConfig = {}, defaultConfig = {}, finalC
  */
 function normalizeAutomaticTracingEnabled({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   if (!finalConfig.tracing.enabled) {
-    logger.info('Not enabling automatic tracing as tracing in general is explicitly disabled via finalConfig.');
     finalConfig.tracing.automaticTracingEnabled = false;
     return;
   }
 
-  finalConfig.tracing.automaticTracingEnabled = util.resolveBooleanConfigWithInvertedEnv({
-    envVar: 'INSTANA_DISABLE_AUTO_INSTR',
-    configValue: userConfig.tracing.automaticTracingEnabled,
-    defaultValue: defaultConfig.tracing.automaticTracingEnabled,
-    configPath: 'config.tracing.automaticTracingEnabled'
-  });
+  const { value, source } = util.resolve(
+    {
+      envValue: 'INSTANA_DISABLE_AUTO_INSTR',
+      inCodeValue: userConfig.tracing.automaticTracingEnabled,
+      defaultValue: defaultConfig.tracing.automaticTracingEnabled
+    },
+    [validate.booleanValidator]
+  );
+
+  // The env var is DISABLE_AUTO_INSTR, so we need to invert it when it comes from env
+  // TODO: add normalization helpers to util.resolve(...)
+  const finalValue = source === CONFIG_SOURCES.ENV ? !value : value;
+
+  configStore.set('config.tracing.automaticTracingEnabled', { source });
+  finalConfig.tracing.automaticTracingEnabled = finalValue;
 }
 
 /**
@@ -328,40 +426,64 @@ function normalizeActivateImmediately({ userConfig = {}, defaultConfig = {}, fin
     return;
   }
 
-  finalConfig.tracing.activateImmediately = util.resolveBooleanConfig({
-    envVar: 'INSTANA_TRACE_IMMEDIATELY',
-    configValue: userConfig.tracing.activateImmediately,
-    defaultValue: defaultConfig.tracing.activateImmediately,
-    configPath: 'config.tracing.activateImmediately'
-  });
+  const { value, source } = util.resolve(
+    {
+      envValue: 'INSTANA_TRACE_IMMEDIATELY',
+      inCodeValue: userConfig.tracing.activateImmediately,
+      defaultValue: defaultConfig.tracing.activateImmediately
+    },
+    [validate.booleanValidator]
+  );
+
+  configStore.set('config.tracing.activateImmediately', { source });
+  finalConfig.tracing.activateImmediately = value;
 }
 
 /**
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizeTracingTransmission({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  finalConfig.tracing.maxBufferedSpans = userConfig.tracing.maxBufferedSpans || defaultConfig.tracing.maxBufferedSpans;
+  finalConfig.tracing.maxBufferedSpans = userConfig.tracing.maxBufferedSpans ?? defaultConfig.tracing.maxBufferedSpans;
 
-  finalConfig.tracing.transmissionDelay = util.resolveNumericConfig({
-    envVar: 'INSTANA_TRACING_TRANSMISSION_DELAY',
-    configValue: userConfig.tracing.transmissionDelay,
-    defaultValue: defaultConfig.tracing.transmissionDelay,
-    configPath: 'config.tracing.transmissionDelay'
+  configStore.set('config.tracing.maxBufferedSpans', {
+    source: userConfig.tracing.maxBufferedSpans !== undefined ? CONFIG_SOURCES.INCODE : CONFIG_SOURCES.DEFAULT
   });
 
-  finalConfig.tracing.forceTransmissionStartingAt = util.resolveNumericConfig({
-    envVar: 'INSTANA_FORCE_TRANSMISSION_STARTING_AT',
-    configValue: userConfig.tracing.forceTransmissionStartingAt,
-    defaultValue: defaultConfig.tracing.forceTransmissionStartingAt,
-    configPath: 'config.tracing.forceTransmissionStartingAt'
-  });
+  const { value: tracingTransmissionDelay, source: tracingTransmissionDelaySource } = util.resolve(
+    {
+      envValue: 'INSTANA_TRACING_TRANSMISSION_DELAY',
+      inCodeValue: userConfig.tracing.transmissionDelay,
+      defaultValue: defaultConfig.tracing.transmissionDelay
+    },
+    [validate.numberValidator]
+  );
 
-  finalConfig.tracing.initialTransmissionDelay = util.resolveNumericConfig({
-    envVar: 'INSTANA_TRACING_INITIAL_TRANSMISSION_DELAY',
-    configValue: userConfig.tracing.initialTransmissionDelay,
-    defaultValue: defaultConfig.tracing.initialTransmissionDelay,
-    configPath: 'config.tracing.initialTransmissionDelay'
-  });
+  configStore.set('config.tracing.transmissionDelay', { source: tracingTransmissionDelaySource });
+  finalConfig.tracing.transmissionDelay = tracingTransmissionDelay;
+
+  const { value: forceTransmissionStartingAt, source: forceTransmissionStartingAtSource } = util.resolve(
+    {
+      envValue: 'INSTANA_FORCE_TRANSMISSION_STARTING_AT',
+      inCodeValue: userConfig.tracing.forceTransmissionStartingAt,
+      defaultValue: defaultConfig.tracing.forceTransmissionStartingAt
+    },
+    [validate.numberValidator]
+  );
+
+  configStore.set('config.tracing.forceTransmissionStartingAt', { source: forceTransmissionStartingAtSource });
+  finalConfig.tracing.forceTransmissionStartingAt = forceTransmissionStartingAt;
+
+  const { value: initialTransmissionDelay, source: initialTransmissionDelaySource } = util.resolve(
+    {
+      envValue: 'INSTANA_TRACING_INITIAL_TRANSMISSION_DELAY',
+      inCodeValue: userConfig.tracing.initialTransmissionDelay,
+      defaultValue: defaultConfig.tracing.initialTransmissionDelay
+    },
+    [validate.numberValidator]
+  );
+
+  configStore.set('config.tracing.initialTransmissionDelay', { source: initialTransmissionDelaySource });
+  finalConfig.tracing.initialTransmissionDelay = initialTransmissionDelay;
 }
 
 /**
@@ -381,7 +503,8 @@ function normalizeTracingHttp({ userConfig = {}, defaultConfig = {}, finalConfig
   if (process.env.INSTANA_EXTRA_HTTP_HEADERS) {
     const fromEnvVar = parseHeadersEnvVar(process.env.INSTANA_EXTRA_HTTP_HEADERS);
     finalConfig.tracing.http.extraHttpHeadersToCapture = fromEnvVar;
-    logger.debug(`[config] env:INSTANA_EXTRA_HTTP_HEADERS = ${process.env.INSTANA_EXTRA_HTTP_HEADERS}`);
+
+    configStore.set('config.tracing.http.extraHttpHeadersToCapture', { source: CONFIG_SOURCES.ENV });
     return;
   }
 
@@ -396,6 +519,7 @@ function normalizeTracingHttp({ userConfig = {}, defaultConfig = {}, finalConfig
       );
     } else {
       finalConfig.tracing.http.extraHttpHeadersToCapture = userHeaders.map(s => s.toLowerCase());
+      configStore.set('config.tracing.http.extraHttpHeadersToCapture', { source: CONFIG_SOURCES.INCODE });
       logger.debug('[config] incode:config.tracing.http.extraHttpHeadersToCapture');
       return;
     }
@@ -403,8 +527,8 @@ function normalizeTracingHttp({ userConfig = {}, defaultConfig = {}, finalConfig
 
   // 3. Use default configuration
   finalConfig.tracing.http.extraHttpHeadersToCapture = defaultConfig.tracing.http.extraHttpHeadersToCapture;
+  configStore.set('config.tracing.http.extraHttpHeadersToCapture', { source: CONFIG_SOURCES.DEFAULT });
 }
-
 /**
  * @param {string} envVarValue
  * @returns {Array<string>}
@@ -441,12 +565,15 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
       const normalized = configNormalizers.stackTrace.normalizeStackTraceModeFromEnv(envStackTrace);
       if (normalized !== null) {
         finalConfig.tracing.stackTrace = normalized;
+        configStore.set('config.tracing.stackTrace', { source: CONFIG_SOURCES.ENV });
       } else {
         finalConfig.tracing.stackTrace = defaultConfig.tracing.stackTrace;
+        configStore.set('config.tracing.stackTrace', { source: CONFIG_SOURCES.DEFAULT });
       }
     } else {
       logger.warn(`Invalid env INSTANA_STACK_TRACE: ${result.error}`);
       finalConfig.tracing.stackTrace = defaultConfig.tracing.stackTrace;
+      configStore.set('config.tracing.stackTrace', { source: CONFIG_SOURCES.DEFAULT });
     }
   } else if (userGlobal?.stackTrace !== undefined) {
     // Priority 2: In-code configuration
@@ -456,15 +583,19 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
       const normalized = configNormalizers.stackTrace.normalizeStackTraceMode(userConfig);
       if (normalized !== null) {
         finalConfig.tracing.stackTrace = normalized;
+        configStore.set('config.tracing.stackTrace', { source: CONFIG_SOURCES.INCODE });
       } else {
         finalConfig.tracing.stackTrace = defaultConfig.tracing.stackTrace;
+        configStore.set('config.tracing.stackTrace', { source: CONFIG_SOURCES.DEFAULT });
       }
     } else {
       logger.warn(`Invalid config.tracing.global.stackTrace: ${result.error}`);
       finalConfig.tracing.stackTrace = defaultConfig.tracing.stackTrace;
+      configStore.set('config.tracing.stackTrace', { source: CONFIG_SOURCES.DEFAULT });
     }
   } else {
     finalConfig.tracing.stackTrace = defaultConfig.tracing.stackTrace;
+    configStore.set('config.tracing.stackTrace', { source: CONFIG_SOURCES.DEFAULT });
   }
 
   const isLegacyLengthDefined = userTracingConfig?.stackTraceLength !== undefined;
@@ -478,12 +609,15 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
       const normalized = configNormalizers.stackTrace.normalizeStackTraceLengthFromEnv(envStackTraceLength);
       if (normalized !== null) {
         finalConfig.tracing.stackTraceLength = normalized;
+        configStore.set('config.tracing.stackTraceLength', { source: CONFIG_SOURCES.ENV });
       } else {
         finalConfig.tracing.stackTraceLength = defaultConfig.tracing.stackTraceLength;
+        configStore.set('config.tracing.stackTraceLength', { source: CONFIG_SOURCES.DEFAULT });
       }
     } else {
       logger.warn(`Invalid env INSTANA_STACK_TRACE_LENGTH: ${result.error}`);
       finalConfig.tracing.stackTraceLength = defaultConfig.tracing.stackTraceLength;
+      configStore.set('config.tracing.stackTraceLength', { source: CONFIG_SOURCES.DEFAULT });
     }
   } else if (stackTraceConfigValue !== undefined) {
     // Priority 2: In-code configuration
@@ -501,15 +635,19 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
       const normalized = configNormalizers.stackTrace.normalizeStackTraceLength(userConfig);
       if (normalized !== null) {
         finalConfig.tracing.stackTraceLength = normalized;
+        configStore.set('config.tracing.stackTraceLength', { source: CONFIG_SOURCES.INCODE });
       } else {
         finalConfig.tracing.stackTraceLength = defaultConfig.tracing.stackTraceLength;
+        configStore.set('config.tracing.stackTraceLength', { source: CONFIG_SOURCES.DEFAULT });
       }
     } else {
       logger.warn(`Invalid stackTraceLength value: ${result.error}`);
       finalConfig.tracing.stackTraceLength = defaultConfig.tracing.stackTraceLength;
+      configStore.set('config.tracing.stackTraceLength', { source: CONFIG_SOURCES.DEFAULT });
     }
   } else {
     finalConfig.tracing.stackTraceLength = defaultConfig.tracing.stackTraceLength;
+    configStore.set('config.tracing.stackTraceLength', { source: CONFIG_SOURCES.DEFAULT });
   }
 }
 
@@ -521,60 +659,84 @@ function normalizeTracingStackTrace({ userConfig = {}, defaultConfig = {}, final
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizeDisableTracing({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  const disableConfig = configNormalizers.disable.normalize(userConfig);
+  const disableRes = configNormalizers.disable.normalize(userConfig);
+  const disableConfig = disableRes?.value;
 
   // If tracing is globally disabled (via `disable: true` or INSTANA_TRACING_DISABLE=true ),
   // mark `tracing.enabled` as false and clear any specific disable rules.
   if (disableConfig === true) {
     finalConfig.tracing.enabled = false;
     finalConfig.tracing.disable = {};
+    configStore.set('config.tracing.disable', {
+      source: CONFIG_SOURCES.DEFAULT
+    });
     return;
   }
 
   if (typeof disableConfig === 'object' && (disableConfig.instrumentations?.length || disableConfig.groups?.length)) {
     finalConfig.tracing.disable = disableConfig;
+    configStore.set('config.tracing.disable', {
+      source: disableRes.source
+    });
     return;
   }
   finalConfig.tracing.disable = defaultConfig.tracing.disable;
+  configStore.set('config.tracing.disable', { source: CONFIG_SOURCES.DEFAULT });
 }
 
 /**
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizeSpanBatchingEnabled({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  finalConfig.tracing.spanBatchingEnabled = util.resolveBooleanConfig({
-    envVar: 'INSTANA_SPANBATCHING_ENABLED',
-    configValue: userConfig.tracing.spanBatchingEnabled,
-    defaultValue: defaultConfig.tracing.spanBatchingEnabled,
-    configPath: 'config.tracing.spanBatchingEnabled'
-  });
+  const { value, source } = util.resolve(
+    {
+      envValue: 'INSTANA_SPANBATCHING_ENABLED',
+      inCodeValue: userConfig.tracing.spanBatchingEnabled,
+      defaultValue: defaultConfig.tracing.spanBatchingEnabled
+    },
+    [validate.booleanValidator]
+  );
+
+  configStore.set('config.tracing.spanBatchingEnabled', { source });
+  finalConfig.tracing.spanBatchingEnabled = value;
 }
 
 /**
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizeDisableW3cTraceCorrelation({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  finalConfig.tracing.disableW3cTraceCorrelation = util.resolveBooleanConfigWithTruthyEnv({
-    envVar: 'INSTANA_DISABLE_W3C_TRACE_CORRELATION',
-    configValue: userConfig.tracing.disableW3cTraceCorrelation,
-    defaultValue: defaultConfig.tracing.disableW3cTraceCorrelation,
-    configPath: 'config.tracing.disableW3cTraceCorrelation'
-  });
+  const { value, source } = util.resolve(
+    {
+      envValue: 'INSTANA_DISABLE_W3C_TRACE_CORRELATION',
+      inCodeValue: userConfig.tracing.disableW3cTraceCorrelation,
+      defaultValue: defaultConfig.tracing.disableW3cTraceCorrelation
+    },
+    [validate.validateTruthyBoolean]
+  );
+
+  configStore.set('config.tracing.disableW3cTraceCorrelation', { source });
+  finalConfig.tracing.disableW3cTraceCorrelation = value;
 }
 
 /**
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizeTracingKafka({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  const userKafka = userConfig.tracing.kafka;
-  finalConfig.tracing.kafka = {};
+  const userKafka = userConfig.tracing.kafka || {};
 
-  finalConfig.tracing.kafka.traceCorrelation = util.resolveBooleanConfig({
-    envVar: 'INSTANA_KAFKA_TRACE_CORRELATION',
-    configValue: userKafka?.traceCorrelation,
-    defaultValue: defaultConfig.tracing.kafka.traceCorrelation,
-    configPath: 'config.tracing.kafka.traceCorrelation'
-  });
+  finalConfig.tracing.kafka = finalConfig.tracing.kafka || {};
+
+  const { value, source } = util.resolve(
+    {
+      envValue: 'INSTANA_KAFKA_TRACE_CORRELATION',
+      inCodeValue: userKafka.traceCorrelation,
+      defaultValue: defaultConfig.tracing.kafka.traceCorrelation
+    },
+    [validate.booleanValidator]
+  );
+
+  configStore.set('config.tracing.kafka.traceCorrelation', { source });
+  finalConfig.tracing.kafka.traceCorrelation = value;
 }
 
 /**
@@ -596,14 +758,18 @@ function normalizeSecrets({ userConfig = {}, defaultConfig = {}, finalConfig = {
 
   if (finalConfig.secrets.matcherMode) {
     logger.debug(`[config] incode:config.secrets.matcherMode = ${finalConfig.secrets.matcherMode}`);
+    configStore.set('config.secrets.matcherMode', { source: CONFIG_SOURCES.INCODE });
   } else if (fromEnvVar.matcherMode) {
     logger.debug(`[config] env:INSTANA_SECRETS (matcherMode) = ${fromEnvVar.matcherMode}`);
+    configStore.set('config.secrets.matcherMode', { source: CONFIG_SOURCES.ENV });
   }
 
   if (finalConfig.secrets.keywords) {
     logger.debug('[config] incode:config.secrets.keywords');
+    configStore.set('config.secrets.keywords', { source: CONFIG_SOURCES.INCODE });
   } else if (fromEnvVar.keywords) {
     logger.debug('[config] env:INSTANA_SECRETS (keywords)');
+    configStore.set('config.secrets.keywords', { source: CONFIG_SOURCES.ENV });
   }
   const matcherMode = userSecrets?.matcherMode || fromEnvVar.matcherMode || defaultConfig.secrets.matcherMode;
 
@@ -615,14 +781,19 @@ function normalizeSecrets({ userConfig = {}, defaultConfig = {}, finalConfig = {
       `The value of config.secrets.matcherMode ("${matcherMode}") is not a string. Assuming the default value ${defaults.secrets.matcherMode}.`
     );
     finalConfig.secrets.matcherMode = defaultConfig.secrets.matcherMode;
+    configStore.set('config.secrets.matcherMode', { source: CONFIG_SOURCES.INCODE });
   } else if (validSecretsMatcherModes.indexOf(matcherMode) < 0) {
     logger.warn(
       // eslint-disable-next-line max-len
       `The value of config.secrets.matcherMode (or the matcher mode parsed from INSTANA_SECRETS) (${matcherMode}) is not a supported matcher mode. Assuming the default value ${defaults.secrets.matcherMode}.`
     );
     finalConfig.secrets.matcherMode = defaultConfig.secrets.matcherMode;
+    configStore.set('config.secrets.matcherMode', {
+      source: CONFIG_SOURCES.INCODE
+    });
   } else {
     finalConfig.secrets.matcherMode = matcherMode;
+    configStore.set('config.secrets.matcherMode', { source: CONFIG_SOURCES.INCODE });
   }
 
   if (!Array.isArray(keywords)) {
@@ -631,12 +802,15 @@ function normalizeSecrets({ userConfig = {}, defaultConfig = {}, finalConfig = {
       `The value of config.secrets.keywords (${keywords}) is not an array. Assuming the default value ${defaults.secrets.keywords}.`
     );
     finalConfig.secrets.keywords = defaultConfig.secrets.keywords;
+    configStore.set('config.secrets.keywords', { source: CONFIG_SOURCES.INCODE });
   } else {
     finalConfig.secrets.keywords = keywords;
+    configStore.set('config.secrets.keywords', { source: CONFIG_SOURCES.INCODE });
   }
 
   if (finalConfig.secrets.matcherMode === 'none') {
     finalConfig.secrets.keywords = [];
+    configStore.set('config.secrets.keywords', { source: CONFIG_SOURCES.INCODE });
   }
 }
 
@@ -686,7 +860,6 @@ function parseSecretsEnvVar(envVarValue) {
     keywords: keywordsArray
   };
 }
-
 /**
  * NOTE: This normalization logic is not handled in the resolver.
  * because it involves complex multi-step processing:
@@ -697,16 +870,6 @@ function parseSecretsEnvVar(envVarValue) {
 function normalizeIgnoreEndpoints({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   const userIgnoreEndpoints = userConfig.tracing.ignoreEndpoints;
 
-  if (userIgnoreEndpoints && (typeof userIgnoreEndpoints !== 'object' || Array.isArray(userIgnoreEndpoints))) {
-    logger.warn(
-      `Invalid tracing.ignoreEndpoints configuration. Expected an object, but received: ${JSON.stringify(
-        userIgnoreEndpoints
-      )}`
-    );
-    finalConfig.tracing.ignoreEndpoints = {};
-    return;
-  }
-
   // Priority 1: Load from a YAML file if `INSTANA_IGNORE_ENDPOINTS_PATH` is set
   // Introduced in Phase 2 for advanced filtering based on both methods and endpoints.
   // Also supports basic filtering for endpoints.
@@ -715,6 +878,7 @@ function normalizeIgnoreEndpoints({ userConfig = {}, defaultConfig = {}, finalCo
       process.env.INSTANA_IGNORE_ENDPOINTS_PATH
     );
     logger.debug('[config] env:INSTANA_IGNORE_ENDPOINTS_PATH');
+    configStore.set('config.tracing.ignoreEndpoints', { source: CONFIG_SOURCES.ENV });
     return;
   }
 
@@ -726,50 +890,105 @@ function normalizeIgnoreEndpoints({ userConfig = {}, defaultConfig = {}, finalCo
       process.env.INSTANA_IGNORE_ENDPOINTS
     );
     logger.debug('[config] env:INSTANA_IGNORE_ENDPOINTS');
+    configStore.set('config.tracing.ignoreEndpoints', { source: CONFIG_SOURCES.ENV });
     return;
   }
 
   // Priority 3: Use in-code configuration if available
+  if (userIgnoreEndpoints && (typeof userIgnoreEndpoints !== 'object' || Array.isArray(userIgnoreEndpoints))) {
+    logger.warn(
+      `Invalid tracing.ignoreEndpoints configuration. Expected an object, but received: ${JSON.stringify(
+        userIgnoreEndpoints
+      )}`
+    );
+    finalConfig.tracing.ignoreEndpoints = defaultConfig.tracing.ignoreEndpoints;
+    configStore.set('config.tracing.ignoreEndpoints', { source: CONFIG_SOURCES.DEFAULT });
+    return;
+  }
   if (userIgnoreEndpoints && Object.keys(userIgnoreEndpoints).length) {
     finalConfig.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.normalizeConfig(userIgnoreEndpoints);
     logger.debug('[config] incode:config.tracing.ignoreEndpoints');
+    configStore.set('config.tracing.ignoreEndpoints', { source: CONFIG_SOURCES.INCODE });
     return;
   }
 
   finalConfig.tracing.ignoreEndpoints = defaultConfig.tracing.ignoreEndpoints;
+  configStore.set('config.tracing.ignoreEndpoints', { source: CONFIG_SOURCES.DEFAULT });
 }
 
 /**
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizeIgnoreEndpointsDisableSuppression({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  finalConfig.tracing.ignoreEndpointsDisableSuppression = util.resolveBooleanConfig({
-    envVar: 'INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION',
-    configValue: userConfig.tracing.ignoreEndpointsDisableSuppression,
-    defaultValue: defaultConfig.tracing.ignoreEndpointsDisableSuppression,
-    configPath: 'config.tracing.ignoreEndpointsDisableSuppression'
-  });
+  const { value, source } = util.resolve(
+    {
+      envValue: 'INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION',
+      inCodeValue: userConfig.tracing.ignoreEndpointsDisableSuppression,
+      defaultValue: defaultConfig.tracing.ignoreEndpointsDisableSuppression
+    },
+    [validate.booleanValidator]
+  );
+
+  configStore.set('config.tracing.ignoreEndpointsDisableSuppression', { source });
+  finalConfig.tracing.ignoreEndpointsDisableSuppression = value;
 }
 
 /**
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizeDisableEOLEvents({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  finalConfig.tracing.disableEOLEvents = util.resolveBooleanConfig({
-    envVar: 'INSTANA_TRACING_DISABLE_EOL_EVENTS',
-    configValue: userConfig.tracing.disableEOLEvents,
-    defaultValue: defaultConfig.tracing.disableEOLEvents,
-    configPath: 'config.tracing.disableEOLEvents'
-  });
+  const { value, source } = util.resolve(
+    {
+      envValue: 'INSTANA_TRACING_DISABLE_EOL_EVENTS',
+      inCodeValue: userConfig.tracing.disableEOLEvents,
+      defaultValue: defaultConfig.tracing.disableEOLEvents
+    },
+    [validate.booleanValidator]
+  );
+
+  configStore.set('config.tracing.disableEOLEvents', { source });
+  finalConfig.tracing.disableEOLEvents = value;
 }
 
 /**
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizePreloadOpentelemetry({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  if (userConfig.preloadOpentelemetry === true) {
-    finalConfig.preloadOpentelemetry = true;
-  } else {
-    finalConfig.preloadOpentelemetry = defaultConfig.preloadOpentelemetry;
-  }
+  const { value, source } = util.resolve(
+    {
+      inCodeValue: userConfig.preloadOpentelemetry,
+      defaultValue: defaultConfig.preloadOpentelemetry
+    },
+    [validate.booleanValidator]
+  );
+
+  finalConfig.preloadOpentelemetry = value;
+  configStore.set('config.preloadOpentelemetry', { source });
 }
+
+/**
+ * Updates configuration values dynamically from external sources (e.g., agent)
+ *
+ * @param {Object.<string, any>} externalConfig
+ * @param {number} source
+ */
+exports.update = function update(externalConfig, source) {
+  if (!externalConfig || typeof externalConfig !== 'object' || Object.keys(externalConfig).length === 0) {
+    return currentConfig;
+  }
+
+  Object.keys(externalConfig).forEach(key => {
+    const configPath = `config.${key}`;
+    const currentMeta = configStore.get(configPath);
+
+    if (currentMeta && currentMeta.source < source) {
+      logger.debug(`[config] Skipping ${key}: current source ${currentMeta.source} > incoming ${source}`);
+      return currentConfig;
+    }
+
+    /** @type {any} */ (currentConfig)[key] = externalConfig[key];
+    configStore.set(configPath, { source });
+    logger.debug(`[config] Updated ${key} from source ${source}: ${JSON.stringify(externalConfig[key])}`);
+  });
+  return currentConfig;
+};

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -185,46 +185,24 @@ module.exports.normalize = ({ userConfig = {}, finalConfigBase = {}, defaultsOve
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizeServiceName({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  const userValue = userConfig.serviceName;
-
-  if (userValue != null) {
-    if (typeof userValue === 'string') {
-      finalConfig.serviceName = userValue;
-      logger.debug(`[config] incode:config.serviceName = ${finalConfig.serviceName}`);
-    } else {
-      logger.warn(`Invalid configuration: config.serviceName is not a string, the value will be ignored: ${userValue}`);
-      finalConfig.serviceName = defaultConfig.serviceName;
-    }
-  } else if (process.env.INSTANA_SERVICE_NAME) {
-    finalConfig.serviceName = process.env.INSTANA_SERVICE_NAME;
-    logger.debug(`[config] env:INSTANA_SERVICE_NAME = ${process.env.INSTANA_SERVICE_NAME}`);
-  } else {
-    finalConfig.serviceName = defaultConfig.serviceName;
-  }
+  finalConfig.serviceName = util.resolveStringConfig({
+    envVar: 'INSTANA_SERVICE_NAME',
+    configValue: userConfig.serviceName,
+    defaultValue: defaultConfig.serviceName,
+    configPath: 'config.serviceName'
+  });
 }
 
 /**
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
 function normalizePackageJsonPath({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
-  const userValue = userConfig.packageJsonPath;
-
-  if (userValue != null) {
-    if (typeof userValue === 'string') {
-      finalConfig.packageJsonPath = userValue;
-      logger.debug(`[config] incode:config.packageJsonPath = ${finalConfig.packageJsonPath}`);
-    } else {
-      logger.warn(
-        `Invalid configuration: config.packageJsonPath is not a string, the value will be ignored: ${userValue}`
-      );
-      finalConfig.packageJsonPath = defaultConfig.packageJsonPath;
-    }
-  } else if (process.env.INSTANA_PACKAGE_JSON_PATH) {
-    finalConfig.packageJsonPath = process.env.INSTANA_PACKAGE_JSON_PATH;
-    logger.debug(`[config] env:INSTANA_PACKAGE_JSON_PATH = ${process.env.INSTANA_PACKAGE_JSON_PATH}`);
-  } else {
-    finalConfig.packageJsonPath = defaultConfig.packageJsonPath;
-  }
+  finalConfig.packageJsonPath = util.resolveStringConfig({
+    envVar: 'INSTANA_PACKAGE_JSON_PATH',
+    configValue: userConfig.packageJsonPath,
+    defaultValue: defaultConfig.packageJsonPath,
+    configPath: 'config.packageJsonPath'
+  });
 }
 
 /**

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -184,6 +184,9 @@ module.exports.normalize = (userConfig, defaultsOverride = {}) => {
 function normalizeServiceName(config) {
   if (config.serviceName == null && process.env.INSTANA_SERVICE_NAME) {
     config.serviceName = process.env.INSTANA_SERVICE_NAME;
+    logger.debug(`[config] env:INSTANA_SERVICE_NAME = ${process.env.INSTANA_SERVICE_NAME}`);
+  } else if (config.serviceName != null && typeof config.serviceName === 'string') {
+    logger.debug(`[config] incode:config.serviceName = ${config.serviceName}`);
   }
   if (config.serviceName != null && typeof config.serviceName !== 'string') {
     logger.warn(
@@ -199,6 +202,9 @@ function normalizeServiceName(config) {
 function normalizePackageJsonPath(config) {
   if (config.packageJsonPath == null && process.env.INSTANA_PACKAGE_JSON_PATH) {
     config.packageJsonPath = process.env.INSTANA_PACKAGE_JSON_PATH;
+    logger.debug(`[config] env:INSTANA_PACKAGE_JSON_PATH = ${process.env.INSTANA_PACKAGE_JSON_PATH}`);
+  } else if (config.packageJsonPath != null && typeof config.packageJsonPath === 'string') {
+    logger.debug(`[config] incode:config.packageJsonPath = ${config.packageJsonPath}`);
   }
   if (config.packageJsonPath != null && typeof config.packageJsonPath !== 'string') {
     logger.warn(
@@ -305,7 +311,7 @@ function normalizeUseOpentelemetry(config) {
  */
 function normalizeAutomaticTracingEnabled(config) {
   if (!config.tracing.enabled) {
-    logger.info('Not enabling automatic tracing as tracing in general is explicitly disabled via config.');
+    logger.debug('Not enabling automatic tracing as tracing in general is explicitly disabled via config.');
     config.tracing.automaticTracingEnabled = false;
     return;
   }
@@ -383,6 +389,9 @@ function normalizeTracingHttp(config) {
     return;
   } else if (!config.tracing.http.extraHttpHeadersToCapture && fromEnvVar) {
     config.tracing.http.extraHttpHeadersToCapture = fromEnvVar;
+    logger.debug(`[config] env:INSTANA_EXTRA_HTTP_HEADERS = ${process.env.INSTANA_EXTRA_HTTP_HEADERS}`);
+  } else if (config.tracing.http.extraHttpHeadersToCapture) {
+    logger.debug('[config] incode:config.tracing.http.extraHttpHeadersToCapture');
   }
   if (!Array.isArray(config.tracing.http.extraHttpHeadersToCapture)) {
     logger.warn(
@@ -548,7 +557,8 @@ function normalizeDisableW3cTraceCorrelation(config) {
   config.tracing.disableW3cTraceCorrelation = util.resolveBooleanConfigWithTruthyEnv({
     envVar: 'INSTANA_DISABLE_W3C_TRACE_CORRELATION',
     configValue: config.tracing.disableW3cTraceCorrelation,
-    defaultValue: defaults.tracing.disableW3cTraceCorrelation
+    defaultValue: defaults.tracing.disableW3cTraceCorrelation,
+    configPath: 'config.tracing.disableW3cTraceCorrelation'
   });
 }
 
@@ -582,6 +592,18 @@ function normalizeSecrets(config) {
   let fromEnvVar = {};
   if (process.env.INSTANA_SECRETS) {
     fromEnvVar = parseSecretsEnvVar(process.env.INSTANA_SECRETS);
+  }
+
+  if (config.secrets.matcherMode) {
+    logger.debug(`[config] incode:config.secrets.matcherMode = ${config.secrets.matcherMode}`);
+  } else if (fromEnvVar.matcherMode) {
+    logger.debug(`[config] env:INSTANA_SECRETS (matcherMode) = ${fromEnvVar.matcherMode}`);
+  }
+
+  if (config.secrets.keywords) {
+    logger.debug('[config] incode:config.secrets.keywords');
+  } else if (fromEnvVar.keywords) {
+    logger.debug('[config] env:INSTANA_SECRETS (keywords)');
   }
 
   config.secrets.matcherMode = config.secrets.matcherMode || fromEnvVar.matcherMode || defaults.secrets.matcherMode;
@@ -684,7 +706,7 @@ function normalizeIgnoreEndpoints(config) {
   // Case 1: Use in-code configuration if available
   if (Object.keys(ignoreEndpointsConfig).length) {
     config.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.normalizeConfig(ignoreEndpointsConfig);
-    logger.debug(`Ignore endpoints have been configured: ${JSON.stringify(config.tracing.ignoreEndpoints)}`);
+    logger.debug('[config] incode:config.tracing.ignoreEndpoints');
     return;
   }
 
@@ -696,7 +718,7 @@ function normalizeIgnoreEndpoints(config) {
       process.env.INSTANA_IGNORE_ENDPOINTS_PATH
     );
 
-    logger.debug(`Ignore endpoints have been configured: ${JSON.stringify(config.tracing.ignoreEndpoints)}`);
+    logger.debug('[config] env:INSTANA_IGNORE_ENDPOINTS_PATH');
     return;
   }
 
@@ -705,7 +727,7 @@ function normalizeIgnoreEndpoints(config) {
   // Provides a simple way to configure ignored operations via environment variables.
   if (process.env.INSTANA_IGNORE_ENDPOINTS) {
     config.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.fromEnv(process.env.INSTANA_IGNORE_ENDPOINTS);
-    logger.debug(`Ignore endpoints have been configured: ${JSON.stringify(config.tracing.ignoreEndpoints)}`);
+    logger.debug('[config] env:INSTANA_IGNORE_ENDPOINTS');
   }
 }
 

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -391,24 +391,6 @@ function normalizeTracingTransmission(config) {
     configPath: 'config.tracing.transmissionDelay'
   });
 
-  // DEPRECATED! This was never documented, but we shared it with a customer.
-  if (process.env['INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS']) {
-    logger.warn(
-      'The environment variable INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS is deprecated and will be removed in the next major release. ' +
-        'Please use INSTANA_TRACING_TRANSMISSION_DELAY instead.'
-    );
-
-    config.tracing.transmissionDelay = parseInt(process.env['INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS'], 10);
-
-    if (isNaN(config.tracing.transmissionDelay)) {
-      logger.warn(
-        `The value of INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS is not a number. Falling back to the default value ${defaults.tracing.transmissionDelay}.`
-      );
-
-      config.tracing.transmissionDelay = defaults.tracing.transmissionDelay;
-    }
-  }
-
   config.tracing.forceTransmissionStartingAt = util.resolveNumericConfig({
     envVar: 'INSTANA_FORCE_TRANSMISSION_STARTING_AT',
     configValue: config.tracing.forceTransmissionStartingAt,

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -3,8 +3,6 @@
  * (c) Copyright Instana Inc. and contributors 2019
  */
 
-/* eslint-disable */
-
 'use strict';
 
 const configNormalizers = require('./configNormalizers');
@@ -184,8 +182,8 @@ module.exports.normalize = (userConfig, defaultsOverride = {}) => {
  * @param {InstanaConfig} config
  */
 function normalizeServiceName(config) {
-  if (config.serviceName == null && process.env['INSTANA_SERVICE_NAME']) {
-    config.serviceName = process.env['INSTANA_SERVICE_NAME'];
+  if (config.serviceName == null && process.env.INSTANA_SERVICE_NAME) {
+    config.serviceName = process.env.INSTANA_SERVICE_NAME;
   }
   if (config.serviceName != null && typeof config.serviceName !== 'string') {
     logger.warn(
@@ -199,14 +197,14 @@ function normalizeServiceName(config) {
  * @param {InstanaConfig} config
  */
 function normalizePackageJsonPath(config) {
-  if (config.packageJsonPath == null && process.env['INSTANA_PACKAGE_JSON_PATH']) {
-    config.packageJsonPath = process.env['INSTANA_PACKAGE_JSON_PATH'];
+  if (config.packageJsonPath == null && process.env.INSTANA_PACKAGE_JSON_PATH) {
+    config.packageJsonPath = process.env.INSTANA_PACKAGE_JSON_PATH;
   }
   if (config.packageJsonPath != null && typeof config.packageJsonPath !== 'string') {
     logger.warn(
+      // eslint-disable-next-line max-len
       `Invalid configuration: config.packageJsonPath is not a string, the value will be ignored: ${config.packageJsonPath}`
     );
-
     config.packageJsonPath = null;
   }
 }
@@ -280,7 +278,6 @@ function normalizeTracingEnabled(config) {
  *
  * @param {InstanaConfig} config
  */
-
 function normalizeAllowRootExitSpan(config) {
   config.tracing.allowRootExitSpan = util.resolveBooleanConfig({
     envVar: 'INSTANA_ALLOW_ROOT_EXIT_SPAN',
@@ -385,6 +382,7 @@ function normalizeTracingHttp(config) {
   }
   if (!Array.isArray(config.tracing.http.extraHttpHeadersToCapture)) {
     logger.warn(
+      // eslint-disable-next-line max-len
       `Invalid configuration: config.tracing.http.extraHttpHeadersToCapture is not an array, the value will be ignored: ${JSON.stringify(
         config.tracing.http.extraHttpHeadersToCapture
       )}`
@@ -418,8 +416,8 @@ function parseHeadersEnvVar(envVarValue) {
 function normalizeTracingStackTrace(config) {
   const tracing = config.tracing;
 
-  const envStackTrace = process.env['INSTANA_STACK_TRACE'];
-  const envStackTraceLength = process.env['INSTANA_STACK_TRACE_LENGTH'];
+  const envStackTrace = process.env.INSTANA_STACK_TRACE;
+  const envStackTraceLength = process.env.INSTANA_STACK_TRACE_LENGTH;
 
   if (envStackTrace !== undefined) {
     const result = validateStackTraceMode(envStackTrace);
@@ -473,6 +471,7 @@ function normalizeTracingStackTrace(config) {
   } else if (stackTraceConfigValue !== undefined) {
     if (isLegacyLengthDefined) {
       logger.warn(
+        // eslint-disable-next-line max-len
         '[Deprecation Warning] The configuration option config.tracing.stackTraceLength is deprecated and will be removed in a future release. ' +
           'Please use config.tracing.global.stackTraceLength instead.'
       );
@@ -573,16 +572,19 @@ function normalizeSecrets(config) {
 
   if (typeof config.secrets.matcherMode !== 'string') {
     logger.warn(
+      // eslint-disable-next-line max-len
       `The value of config.secrets.matcherMode ("${config.secrets.matcherMode}") is not a string. Assuming the default value ${defaults.secrets.matcherMode}.`
     );
     config.secrets.matcherMode = defaults.secrets.matcherMode;
   } else if (validSecretsMatcherModes.indexOf(config.secrets.matcherMode) < 0) {
     logger.warn(
+      // eslint-disable-next-line max-len
       `The value of config.secrets.matcherMode (or the matcher mode parsed from INSTANA_SECRETS) (${config.secrets.matcherMode}) is not a supported matcher mode. Assuming the default value ${defaults.secrets.matcherMode}.`
     );
     config.secrets.matcherMode = defaults.secrets.matcherMode;
   } else if (!Array.isArray(config.secrets.keywords)) {
     logger.warn(
+      // eslint-disable-next-line max-len
       `The value of config.secrets.keywords (${config.secrets.keywords}) is not an array. Assuming the default value ${defaults.secrets.keywords}.`
     );
     config.secrets.keywords = defaults.secrets.keywords;
@@ -612,7 +614,7 @@ function parseMatcherMode(matcherMode) {
  * @returns {InstanaSecretsOption}
  */
 function parseSecretsEnvVar(envVarValue) {
-  let [matcherMode, keywords] = envVarValue.split(':', 2);
+  const [matcherMode, keywords] = envVarValue.split(':', 2);
 
   const parsedMatcherMode = parseMatcherMode(matcherMode);
 
@@ -626,6 +628,7 @@ function parseSecretsEnvVar(envVarValue) {
   if (!keywords) {
     // a list of keywords (with at least one element) is mandatory for all matcher modes except "none"
     logger.warn(
+      // eslint-disable-next-line max-len
       `The value of INSTANA_SECRETS (${envVarValue}) cannot be parsed. Please use the following format: INSTANA_SECRETS=<matcher>:<secret>[,<secret>]. This setting will be ignored.`
     );
     return {};
@@ -682,7 +685,6 @@ function normalizeIgnoreEndpoints(config) {
   if (process.env.INSTANA_IGNORE_ENDPOINTS) {
     config.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.fromEnv(process.env.INSTANA_IGNORE_ENDPOINTS);
     logger.debug(`Ignore endpoints have been configured: ${JSON.stringify(config.tracing.ignoreEndpoints)}`);
-    return;
   }
 }
 

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -146,225 +146,258 @@ module.exports.init = _logger => {
 
 /**
  * Merges the config that was passed to the init function with environment variables and default values.
- */
-
-/**
- * @param {InstanaConfig} [userConfig]
- * @param {InstanaConfig} [defaultsOverride]
+ * @param {Object} [options]
+ * @param {InstanaConfig} [options.userConfig]
+ * @param {Object} [options.finalConfigBase]
+ * @param {InstanaConfig} [options.defaultsOverride]
  * @returns {InstanaConfig}
  */
-module.exports.normalize = (userConfig, defaultsOverride = {}) => {
-  if (defaultsOverride && typeof defaultsOverride === 'object') {
+module.exports.normalize = ({ userConfig = {}, finalConfigBase = {}, defaultsOverride = {} } = {}) => {
+  if (defaultsOverride && typeof defaultsOverride === 'object' && Object.keys(defaultsOverride).length > 0) {
     defaults = deepMerge(defaults, defaultsOverride);
   }
 
-  /** @type InstanaConfig */
-  let targetConfig = {};
+  let normalizedUserConfig;
 
-  // NOTE: Do not modify the original object
-  if (userConfig !== null) {
-    targetConfig = Object.assign({}, userConfig);
+  // NOTE: Do not modify the original user input object
+  if (userConfig !== null && userConfig !== undefined) {
+    normalizedUserConfig = Object.assign({}, userConfig);
+  } else {
+    normalizedUserConfig = {};
   }
 
-  // TODO: remove this and forward the logger via init fn.
-  targetConfig.logger = logger;
+  // Preserve finalConfigBase in the finalConfig to allow additional config values
+  // that are not part of the core config schema. Eg: collector config needs to be preserved.
+  /** @type InstanaConfig */
+  const finalConfig = finalConfigBase ? Object.assign({}, finalConfigBase) : {};
 
-  normalizeServiceName(targetConfig);
-  normalizePackageJsonPath(targetConfig);
-  normalizeMetricsConfig(targetConfig);
-  normalizeTracingConfig(targetConfig);
-  normalizeSecrets(targetConfig);
-  normalizePreloadOpentelemetry(targetConfig);
-  return targetConfig;
+  // TODO: remove this and forward the logger via init fn.
+  finalConfig.logger = logger;
+
+  normalizeServiceName(normalizedUserConfig, defaults, finalConfig);
+  normalizePackageJsonPath(normalizedUserConfig, defaults, finalConfig);
+  normalizeMetricsConfig(normalizedUserConfig, defaults, finalConfig);
+  normalizeTracingConfig(normalizedUserConfig, defaults, finalConfig);
+  normalizeSecrets(normalizedUserConfig, defaults, finalConfig);
+  normalizePreloadOpentelemetry(normalizedUserConfig, defaults, finalConfig);
+
+  return finalConfig;
 };
 
 /**
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeServiceName(config) {
-  if (config.serviceName == null && process.env.INSTANA_SERVICE_NAME) {
-    config.serviceName = process.env.INSTANA_SERVICE_NAME;
+function normalizeServiceName(userConfig, defaultConfig, finalConfig) {
+  const userValue = userConfig.serviceName;
+
+  if (userValue != null) {
+    if (typeof userValue === 'string') {
+      finalConfig.serviceName = userValue;
+      logger.debug(`[config] incode:config.serviceName = ${finalConfig.serviceName}`);
+    } else {
+      logger.warn(`Invalid configuration: config.serviceName is not a string, the value will be ignored: ${userValue}`);
+      finalConfig.serviceName = defaultConfig.serviceName;
+    }
+  } else if (process.env.INSTANA_SERVICE_NAME) {
+    finalConfig.serviceName = process.env.INSTANA_SERVICE_NAME;
     logger.debug(`[config] env:INSTANA_SERVICE_NAME = ${process.env.INSTANA_SERVICE_NAME}`);
-  } else if (config.serviceName != null && typeof config.serviceName === 'string') {
-    logger.debug(`[config] incode:config.serviceName = ${config.serviceName}`);
-  }
-  if (config.serviceName != null && typeof config.serviceName !== 'string') {
-    logger.warn(
-      `Invalid configuration: config.serviceName is not a string, the value will be ignored: ${config.serviceName}`
-    );
-    config.serviceName = defaults.serviceName;
+  } else {
+    finalConfig.serviceName = defaultConfig.serviceName;
   }
 }
 
 /**
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizePackageJsonPath(config) {
-  if (config.packageJsonPath == null && process.env.INSTANA_PACKAGE_JSON_PATH) {
-    config.packageJsonPath = process.env.INSTANA_PACKAGE_JSON_PATH;
+function normalizePackageJsonPath(userConfig, defaultConfig, finalConfig) {
+  const userValue = userConfig.packageJsonPath;
+
+  if (userValue != null) {
+    if (typeof userValue === 'string') {
+      finalConfig.packageJsonPath = userValue;
+      logger.debug(`[config] incode:config.packageJsonPath = ${finalConfig.packageJsonPath}`);
+    } else {
+      logger.warn(
+        `Invalid configuration: config.packageJsonPath is not a string, the value will be ignored: ${userValue}`
+      );
+      finalConfig.packageJsonPath = defaultConfig.packageJsonPath;
+    }
+  } else if (process.env.INSTANA_PACKAGE_JSON_PATH) {
+    finalConfig.packageJsonPath = process.env.INSTANA_PACKAGE_JSON_PATH;
     logger.debug(`[config] env:INSTANA_PACKAGE_JSON_PATH = ${process.env.INSTANA_PACKAGE_JSON_PATH}`);
-  } else if (config.packageJsonPath != null && typeof config.packageJsonPath === 'string') {
-    logger.debug(`[config] incode:config.packageJsonPath = ${config.packageJsonPath}`);
-  }
-  if (config.packageJsonPath != null && typeof config.packageJsonPath !== 'string') {
-    logger.warn(
-      // eslint-disable-next-line max-len
-      `Invalid configuration: config.packageJsonPath is not a string, the value will be ignored: ${config.packageJsonPath}`
-    );
-    config.packageJsonPath = null;
+  } else {
+    finalConfig.packageJsonPath = defaultConfig.packageJsonPath;
   }
 }
 
 /**
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeMetricsConfig(config) {
-  if (config.metrics == null) {
-    config.metrics = {};
-  }
+function normalizeMetricsConfig(userConfig, defaultConfig, finalConfig) {
+  const userMetrics = userConfig.metrics;
 
-  config.metrics.transmissionDelay = util.resolveNumericConfig({
+  finalConfig.metrics = {};
+
+  finalConfig.metrics.transmissionDelay = util.resolveNumericConfig({
     envVar: 'INSTANA_METRICS_TRANSMISSION_DELAY',
-    configValue: config.metrics.transmissionDelay,
-    defaultValue: defaults.metrics.transmissionDelay,
+    configValue: userMetrics?.transmissionDelay,
+    defaultValue: defaultConfig.metrics.transmissionDelay,
     configPath: 'config.metrics.transmissionDelay'
   });
 
   // Validate max value for transmissionDelay
-  if (config.metrics.transmissionDelay > transmissionDelayMaxValue) {
+  if (finalConfig.metrics.transmissionDelay > transmissionDelayMaxValue) {
     logger.warn(
-      `The value of config.metrics.transmissionDelay (or INSTANA_METRICS_TRANSMISSION_DELAY) (${config.metrics.transmissionDelay}) exceeds the maximum allowed value of ${transmissionDelayMaxValue}. Assuming the max value ${transmissionDelayMaxValue}.`
+      // eslint-disable-next-line max-len
+      `The value of config.metrics.transmissionDelay (or INSTANA_METRICS_TRANSMISSION_DELAY) (${finalConfig.metrics.transmissionDelay}) exceeds the maximum allowed value of ${transmissionDelayMaxValue}. Assuming the max value ${transmissionDelayMaxValue}.`
     );
-    config.metrics.transmissionDelay = transmissionDelayMaxValue;
+    finalConfig.metrics.transmissionDelay = transmissionDelayMaxValue;
   }
 
-  config.metrics.timeBetweenHealthcheckCalls =
-    config.metrics.timeBetweenHealthcheckCalls || defaults.metrics.timeBetweenHealthcheckCalls;
+  finalConfig.metrics.timeBetweenHealthcheckCalls =
+    userMetrics?.timeBetweenHealthcheckCalls || defaultConfig.metrics.timeBetweenHealthcheckCalls;
 }
 
 /**
- *
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeTracingConfig(config) {
-  if (config.tracing == null) {
-    config.tracing = {};
-  }
-  normalizeTracingEnabled(config);
-  normalizeUseOpentelemetry(config);
-  normalizeDisableTracing(config);
-  normalizeAutomaticTracingEnabled(config);
-  normalizeActivateImmediately(config);
-  normalizeTracingTransmission(config);
-  normalizeTracingHttp(config);
-  normalizeTracingStackTrace(config);
-  normalizeSpanBatchingEnabled(config);
-  normalizeDisableW3cTraceCorrelation(config);
-  normalizeTracingKafka(config);
-  normalizeAllowRootExitSpan(config);
-  normalizeIgnoreEndpoints(config);
-  normalizeIgnoreEndpointsDisableSuppression(config);
-  normalizeDisableEOLEvents(config);
+function normalizeTracingConfig(userConfig, defaultConfig, finalConfig) {
+  finalConfig.tracing = finalConfig.tracing || {};
+
+  userConfig.tracing = userConfig.tracing || {};
+
+  normalizeTracingEnabled(userConfig, defaultConfig, finalConfig);
+  normalizeUseOpentelemetry(userConfig, defaultConfig, finalConfig);
+  normalizeDisableTracing(userConfig, defaultConfig, finalConfig);
+  normalizeAutomaticTracingEnabled(userConfig, defaultConfig, finalConfig);
+  normalizeActivateImmediately(userConfig, defaultConfig, finalConfig);
+  normalizeTracingTransmission(userConfig, defaultConfig, finalConfig);
+  normalizeTracingHttp(userConfig, defaultConfig, finalConfig);
+  normalizeTracingStackTrace(userConfig, defaultConfig, finalConfig);
+  normalizeSpanBatchingEnabled(userConfig, defaultConfig, finalConfig);
+  normalizeDisableW3cTraceCorrelation(userConfig, defaultConfig, finalConfig);
+  normalizeTracingKafka(userConfig, defaultConfig, finalConfig);
+  normalizeAllowRootExitSpan(userConfig, defaultConfig, finalConfig);
+  normalizeIgnoreEndpoints(userConfig, defaultConfig, finalConfig);
+  normalizeIgnoreEndpointsDisableSuppression(userConfig, defaultConfig, finalConfig);
+  normalizeDisableEOLEvents(userConfig, defaultConfig, finalConfig);
 }
 
 /**
- *
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeTracingEnabled(config) {
-  config.tracing.enabled = util.resolveBooleanConfigWithInvertedEnv({
+function normalizeTracingEnabled(userConfig, defaultConfig, finalConfig) {
+  finalConfig.tracing.enabled = util.resolveBooleanConfigWithInvertedEnv({
     envVar: 'INSTANA_TRACING_DISABLE',
-    configValue: config.tracing.enabled,
-    defaultValue: defaults.tracing.enabled,
+    configValue: userConfig.tracing.enabled,
+    defaultValue: defaultConfig.tracing.enabled,
     configPath: 'config.tracing.enabled'
   });
 }
 
 /**
- *
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeAllowRootExitSpan(config) {
-  config.tracing.allowRootExitSpan = util.resolveBooleanConfig({
+function normalizeAllowRootExitSpan(userConfig, defaultConfig, finalConfig) {
+  finalConfig.tracing.allowRootExitSpan = util.resolveBooleanConfig({
     envVar: 'INSTANA_ALLOW_ROOT_EXIT_SPAN',
-    configValue: config.tracing.allowRootExitSpan,
-    defaultValue: defaults.tracing.allowRootExitSpan,
+    configValue: userConfig.tracing.allowRootExitSpan,
+    defaultValue: defaultConfig.tracing.allowRootExitSpan,
     configPath: 'config.tracing.allowRootExitSpan'
   });
 }
 
 /**
- *
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeUseOpentelemetry(config) {
-  config.tracing.useOpentelemetry = util.resolveBooleanConfigWithInvertedEnv({
+function normalizeUseOpentelemetry(userConfig, defaultConfig, finalConfig) {
+  finalConfig.tracing.useOpentelemetry = util.resolveBooleanConfigWithInvertedEnv({
     envVar: 'INSTANA_DISABLE_USE_OPENTELEMETRY',
-    configValue: config.tracing.useOpentelemetry,
-    defaultValue: defaults.tracing.useOpentelemetry,
+    configValue: userConfig.tracing.useOpentelemetry,
+    defaultValue: defaultConfig.tracing.useOpentelemetry,
     configPath: 'config.tracing.useOpentelemetry'
   });
 }
 
 /**
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeAutomaticTracingEnabled(config) {
-  if (!config.tracing.enabled) {
-    logger.debug('Not enabling automatic tracing as tracing in general is explicitly disabled via config.');
-    config.tracing.automaticTracingEnabled = false;
+function normalizeAutomaticTracingEnabled(userConfig, defaultConfig, finalConfig) {
+  if (!finalConfig.tracing.enabled) {
+    logger.info('Not enabling automatic tracing as tracing in general is explicitly disabled via finalConfig.');
+    finalConfig.tracing.automaticTracingEnabled = false;
     return;
   }
 
-  config.tracing.automaticTracingEnabled = util.resolveBooleanConfigWithInvertedEnv({
+  finalConfig.tracing.automaticTracingEnabled = util.resolveBooleanConfigWithInvertedEnv({
     envVar: 'INSTANA_DISABLE_AUTO_INSTR',
-    configValue: config.tracing.automaticTracingEnabled,
-    defaultValue: defaults.tracing.automaticTracingEnabled,
+    configValue: userConfig.tracing.automaticTracingEnabled,
+    defaultValue: defaultConfig.tracing.automaticTracingEnabled,
     configPath: 'config.tracing.automaticTracingEnabled'
   });
 }
 
 /**
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeActivateImmediately(config) {
-  if (!config.tracing.enabled) {
-    config.tracing.activateImmediately = false;
+function normalizeActivateImmediately(userConfig, defaultConfig, finalConfig) {
+  if (!finalConfig.tracing.enabled) {
+    finalConfig.tracing.activateImmediately = false;
     return;
   }
 
-  config.tracing.activateImmediately = util.resolveBooleanConfig({
+  finalConfig.tracing.activateImmediately = util.resolveBooleanConfig({
     envVar: 'INSTANA_TRACE_IMMEDIATELY',
-    configValue: config.tracing.activateImmediately,
-    defaultValue: defaults.tracing.activateImmediately,
+    configValue: userConfig.tracing.activateImmediately,
+    defaultValue: defaultConfig.tracing.activateImmediately,
     configPath: 'config.tracing.activateImmediately'
   });
 }
 
 /**
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeTracingTransmission(config) {
-  config.tracing.maxBufferedSpans = config.tracing.maxBufferedSpans || defaults.tracing.maxBufferedSpans;
+function normalizeTracingTransmission(userConfig, defaultConfig, finalConfig) {
+  finalConfig.tracing.maxBufferedSpans = userConfig.tracing.maxBufferedSpans || defaultConfig.tracing.maxBufferedSpans;
 
-  config.tracing.transmissionDelay = util.resolveNumericConfig({
+  finalConfig.tracing.transmissionDelay = util.resolveNumericConfig({
     envVar: 'INSTANA_TRACING_TRANSMISSION_DELAY',
-    configValue: config.tracing.transmissionDelay,
-    defaultValue: defaults.tracing.transmissionDelay,
+    configValue: userConfig.tracing.transmissionDelay,
+    defaultValue: defaultConfig.tracing.transmissionDelay,
     configPath: 'config.tracing.transmissionDelay'
   });
 
-  config.tracing.forceTransmissionStartingAt = util.resolveNumericConfig({
+  finalConfig.tracing.forceTransmissionStartingAt = util.resolveNumericConfig({
     envVar: 'INSTANA_FORCE_TRANSMISSION_STARTING_AT',
-    configValue: config.tracing.forceTransmissionStartingAt,
-    defaultValue: defaults.tracing.forceTransmissionStartingAt,
+    configValue: userConfig.tracing.forceTransmissionStartingAt,
+    defaultValue: defaultConfig.tracing.forceTransmissionStartingAt,
     configPath: 'config.tracing.forceTransmissionStartingAt'
   });
 
-  config.tracing.initialTransmissionDelay = util.resolveNumericConfig({
+  finalConfig.tracing.initialTransmissionDelay = util.resolveNumericConfig({
     envVar: 'INSTANA_TRACING_INITIAL_TRANSMISSION_DELAY',
-    configValue: config.tracing.initialTransmissionDelay,
-    defaultValue: defaults.tracing.initialTransmissionDelay,
+    configValue: userConfig.tracing.initialTransmissionDelay,
+    defaultValue: defaultConfig.tracing.initialTransmissionDelay,
     configPath: 'config.tracing.initialTransmissionDelay'
   });
 }
@@ -374,41 +407,44 @@ function normalizeTracingTransmission(config) {
  * because it involves complex multi-step processing:
  * Future improvement: Consider refactoring to use a more generic resolver pattern.
  *
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeTracingHttp(config) {
-  config.tracing.http = config.tracing.http || {};
+function normalizeTracingHttp(userConfig, defaultConfig, finalConfig) {
+  const userHttp = userConfig.tracing.http;
+  finalConfig.tracing.http = {};
 
   let fromEnvVar;
   if (process.env.INSTANA_EXTRA_HTTP_HEADERS) {
     fromEnvVar = parseHeadersEnvVar(process.env.INSTANA_EXTRA_HTTP_HEADERS);
   }
 
-  if (!config.tracing.http.extraHttpHeadersToCapture && !fromEnvVar) {
-    config.tracing.http.extraHttpHeadersToCapture = defaults.tracing.http.extraHttpHeadersToCapture;
+  const userHeaders = userHttp?.extraHttpHeadersToCapture;
+
+  if (!userHeaders && !fromEnvVar) {
+    finalConfig.tracing.http.extraHttpHeadersToCapture = defaultConfig.tracing.http.extraHttpHeadersToCapture;
     return;
-  } else if (!config.tracing.http.extraHttpHeadersToCapture && fromEnvVar) {
-    config.tracing.http.extraHttpHeadersToCapture = fromEnvVar;
+  } else if (!userHeaders && fromEnvVar) {
+    finalConfig.tracing.http.extraHttpHeadersToCapture = fromEnvVar;
     logger.debug(`[config] env:INSTANA_EXTRA_HTTP_HEADERS = ${process.env.INSTANA_EXTRA_HTTP_HEADERS}`);
-  } else if (config.tracing.http.extraHttpHeadersToCapture) {
+    return;
+  } else if (finalConfig.tracing.http.extraHttpHeadersToCapture) {
     logger.debug('[config] incode:config.tracing.http.extraHttpHeadersToCapture');
   }
-  if (!Array.isArray(config.tracing.http.extraHttpHeadersToCapture)) {
+
+  if (!Array.isArray(userHeaders)) {
     logger.warn(
       // eslint-disable-next-line max-len
       `Invalid configuration: config.tracing.http.extraHttpHeadersToCapture is not an array, the value will be ignored: ${JSON.stringify(
-        config.tracing.http.extraHttpHeadersToCapture
+        userHeaders
       )}`
     );
-    config.tracing.http.extraHttpHeadersToCapture = defaults.tracing.http.extraHttpHeadersToCapture;
+    finalConfig.tracing.http.extraHttpHeadersToCapture = defaultConfig.tracing.http.extraHttpHeadersToCapture;
     return;
   }
 
-  config.tracing.http.extraHttpHeadersToCapture = config.tracing.http.extraHttpHeadersToCapture.map(
-    (
-      s // Node.js HTTP API turns all incoming HTTP headers into lowercase.
-    ) => s.toLowerCase()
-  );
+  finalConfig.tracing.http.extraHttpHeadersToCapture = userHeaders.map(s => s.toLowerCase());
 }
 
 /**
@@ -418,7 +454,7 @@ function normalizeTracingHttp(config) {
 function parseHeadersEnvVar(envVarValue) {
   return envVarValue
     .split(/[;,]/)
-    .map(header => header.trim())
+    .map(header => header.trim().toLowerCase())
     .filter(header => header !== '');
 }
 
@@ -429,10 +465,14 @@ function parseHeadersEnvVar(envVarValue) {
  * because it involves complex multi-step processing:
  * Future improvement: Consider refactoring to use a more generic resolver pattern.
  *
- * @param {InstanaConfig} config
+ *
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeTracingStackTrace(config) {
-  const tracing = config.tracing;
+function normalizeTracingStackTrace(userConfig, defaultConfig, finalConfig) {
+  const userTracingConfig = userConfig.tracing;
+  const userGlobal = userTracingConfig.global;
 
   const envStackTrace = process.env.INSTANA_STACK_TRACE;
   const envStackTraceLength = process.env.INSTANA_STACK_TRACE_LENGTH;
@@ -443,34 +483,34 @@ function normalizeTracingStackTrace(config) {
     if (result.isValid) {
       const normalized = configNormalizers.stackTrace.normalizeStackTraceModeFromEnv(envStackTrace);
       if (normalized !== null) {
-        tracing.stackTrace = normalized;
+        finalConfig.tracing.stackTrace = normalized;
       } else {
-        tracing.stackTrace = defaults.tracing.stackTrace;
+        finalConfig.tracing.stackTrace = defaultConfig.tracing.stackTrace;
       }
     } else {
       logger.warn(`Invalid env INSTANA_STACK_TRACE: ${result.error}`);
-      tracing.stackTrace = defaults.tracing.stackTrace;
+      finalConfig.tracing.stackTrace = defaultConfig.tracing.stackTrace;
     }
-  } else if (tracing.global?.stackTrace !== undefined) {
-    const result = validateStackTraceMode(tracing.global.stackTrace);
+  } else if (userGlobal?.stackTrace !== undefined) {
+    const result = validateStackTraceMode(userGlobal.stackTrace);
 
     if (result.isValid) {
-      const normalized = configNormalizers.stackTrace.normalizeStackTraceMode(config);
+      const normalized = configNormalizers.stackTrace.normalizeStackTraceMode(userConfig);
       if (normalized !== null) {
-        tracing.stackTrace = normalized;
+        finalConfig.tracing.stackTrace = normalized;
       } else {
-        tracing.stackTrace = defaults.tracing.stackTrace;
+        finalConfig.tracing.stackTrace = defaultConfig.tracing.stackTrace;
       }
     } else {
       logger.warn(`Invalid config.tracing.global.stackTrace: ${result.error}`);
-      tracing.stackTrace = defaults.tracing.stackTrace;
+      finalConfig.tracing.stackTrace = defaultConfig.tracing.stackTrace;
     }
   } else {
-    tracing.stackTrace = defaults.tracing.stackTrace;
+    finalConfig.tracing.stackTrace = defaultConfig.tracing.stackTrace;
   }
 
-  const isLegacyLengthDefined = tracing.stackTraceLength !== undefined;
-  const stackTraceConfigValue = tracing.global?.stackTraceLength || tracing.stackTraceLength;
+  const isLegacyLengthDefined = userTracingConfig?.stackTraceLength !== undefined;
+  const stackTraceConfigValue = userGlobal?.stackTraceLength || userTracingConfig?.stackTraceLength;
 
   if (envStackTraceLength !== undefined) {
     const result = validateStackTraceLength(envStackTraceLength);
@@ -478,13 +518,13 @@ function normalizeTracingStackTrace(config) {
     if (result.isValid) {
       const normalized = configNormalizers.stackTrace.normalizeStackTraceLengthFromEnv(envStackTraceLength);
       if (normalized !== null) {
-        tracing.stackTraceLength = normalized;
+        finalConfig.tracing.stackTraceLength = normalized;
       } else {
-        tracing.stackTraceLength = defaults.tracing.stackTraceLength;
+        finalConfig.tracing.stackTraceLength = defaultConfig.tracing.stackTraceLength;
       }
     } else {
       logger.warn(`Invalid env INSTANA_STACK_TRACE_LENGTH: ${result.error}`);
-      tracing.stackTraceLength = defaults.tracing.stackTraceLength;
+      finalConfig.tracing.stackTraceLength = defaultConfig.tracing.stackTraceLength;
     }
   } else if (stackTraceConfigValue !== undefined) {
     if (isLegacyLengthDefined) {
@@ -498,18 +538,18 @@ function normalizeTracingStackTrace(config) {
     const result = validateStackTraceLength(stackTraceConfigValue);
 
     if (result.isValid) {
-      const normalized = configNormalizers.stackTrace.normalizeStackTraceLength(config);
+      const normalized = configNormalizers.stackTrace.normalizeStackTraceLength(userConfig);
       if (normalized !== null) {
-        tracing.stackTraceLength = normalized;
+        finalConfig.tracing.stackTraceLength = normalized;
       } else {
-        tracing.stackTraceLength = defaults.tracing.stackTraceLength;
+        finalConfig.tracing.stackTraceLength = defaultConfig.tracing.stackTraceLength;
       }
     } else {
       logger.warn(`Invalid stackTraceLength value: ${result.error}`);
-      tracing.stackTraceLength = defaults.tracing.stackTraceLength;
+      finalConfig.tracing.stackTraceLength = defaultConfig.tracing.stackTraceLength;
     }
   } else {
-    tracing.stackTraceLength = defaults.tracing.stackTraceLength;
+    finalConfig.tracing.stackTraceLength = defaultConfig.tracing.stackTraceLength;
   }
 }
 
@@ -518,60 +558,69 @@ function normalizeTracingStackTrace(config) {
  * because it involves complex multi-step processing:
  * Future improvement: Consider refactoring to use a more generic resolver pattern.
  *
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeDisableTracing(config) {
-  const disableConfig = configNormalizers.disable.normalize(config);
+function normalizeDisableTracing(userConfig, defaultConfig, finalConfig) {
+  const disableConfig = configNormalizers.disable.normalize(userConfig);
 
   // If tracing is globally disabled (via `disable: true` or INSTANA_TRACING_DISABLE=true ),
   // mark `tracing.enabled` as false and clear any specific disable rules.
   if (disableConfig === true) {
-    config.tracing.enabled = false;
-    config.tracing.disable = {};
+    finalConfig.tracing.enabled = false;
+    finalConfig.tracing.disable = {};
     return;
   }
 
   if (typeof disableConfig === 'object' && (disableConfig.instrumentations?.length || disableConfig.groups?.length)) {
-    config.tracing.disable = disableConfig;
+    finalConfig.tracing.disable = disableConfig;
     return;
   }
-  config.tracing.disable = defaults.tracing.disable;
+  finalConfig.tracing.disable = defaultConfig.tracing.disable;
 }
 
 /**
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeSpanBatchingEnabled(config) {
-  config.tracing.spanBatchingEnabled = util.resolveBooleanConfig({
+function normalizeSpanBatchingEnabled(userConfig, defaultConfig, finalConfig) {
+  finalConfig.tracing.spanBatchingEnabled = util.resolveBooleanConfig({
     envVar: 'INSTANA_SPANBATCHING_ENABLED',
-    configValue: config.tracing.spanBatchingEnabled,
-    defaultValue: defaults.tracing.spanBatchingEnabled,
+    configValue: userConfig.tracing.spanBatchingEnabled,
+    defaultValue: defaultConfig.tracing.spanBatchingEnabled,
     configPath: 'config.tracing.spanBatchingEnabled'
   });
 }
 
 /**
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeDisableW3cTraceCorrelation(config) {
-  config.tracing.disableW3cTraceCorrelation = util.resolveBooleanConfigWithTruthyEnv({
+function normalizeDisableW3cTraceCorrelation(userConfig, defaultConfig, finalConfig) {
+  finalConfig.tracing.disableW3cTraceCorrelation = util.resolveBooleanConfigWithTruthyEnv({
     envVar: 'INSTANA_DISABLE_W3C_TRACE_CORRELATION',
-    configValue: config.tracing.disableW3cTraceCorrelation,
-    defaultValue: defaults.tracing.disableW3cTraceCorrelation,
+    configValue: userConfig.tracing.disableW3cTraceCorrelation,
+    defaultValue: defaultConfig.tracing.disableW3cTraceCorrelation,
     configPath: 'config.tracing.disableW3cTraceCorrelation'
   });
 }
 
 /**
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeTracingKafka(config) {
-  config.tracing.kafka = config.tracing.kafka || {};
+function normalizeTracingKafka(userConfig, defaultConfig, finalConfig) {
+  const userKafka = userConfig.tracing.kafka;
+  finalConfig.tracing.kafka = {};
 
-  config.tracing.kafka.traceCorrelation = util.resolveBooleanConfig({
+  finalConfig.tracing.kafka.traceCorrelation = util.resolveBooleanConfig({
     envVar: 'INSTANA_KAFKA_TRACE_CORRELATION',
-    configValue: config.tracing.kafka.traceCorrelation,
-    defaultValue: defaults.tracing.kafka.traceCorrelation,
+    configValue: userKafka?.traceCorrelation,
+    defaultValue: defaultConfig.tracing.kafka.traceCorrelation,
     configPath: 'config.tracing.kafka.traceCorrelation'
   });
 }
@@ -581,12 +630,13 @@ function normalizeTracingKafka(config) {
  * because it involves complex multi-step processing:
  * Future improvement: Consider refactoring to use a more generic resolver pattern.
  *
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeSecrets(config) {
-  if (config.secrets == null) {
-    config.secrets = {};
-  }
+function normalizeSecrets(userConfig, defaultConfig, finalConfig) {
+  const userSecrets = userConfig.secrets;
+  finalConfig.secrets = {};
 
   /** @type {InstanaSecretsOption} */
   let fromEnvVar = {};
@@ -594,42 +644,49 @@ function normalizeSecrets(config) {
     fromEnvVar = parseSecretsEnvVar(process.env.INSTANA_SECRETS);
   }
 
-  if (config.secrets.matcherMode) {
-    logger.debug(`[config] incode:config.secrets.matcherMode = ${config.secrets.matcherMode}`);
+  if (finalConfig.secrets.matcherMode) {
+    logger.debug(`[config] incode:config.secrets.matcherMode = ${finalConfig.secrets.matcherMode}`);
   } else if (fromEnvVar.matcherMode) {
     logger.debug(`[config] env:INSTANA_SECRETS (matcherMode) = ${fromEnvVar.matcherMode}`);
   }
 
-  if (config.secrets.keywords) {
+  if (finalConfig.secrets.keywords) {
     logger.debug('[config] incode:config.secrets.keywords');
   } else if (fromEnvVar.keywords) {
     logger.debug('[config] env:INSTANA_SECRETS (keywords)');
   }
+  const matcherMode = userSecrets?.matcherMode || fromEnvVar.matcherMode || defaultConfig.secrets.matcherMode;
 
-  config.secrets.matcherMode = config.secrets.matcherMode || fromEnvVar.matcherMode || defaults.secrets.matcherMode;
-  config.secrets.keywords = config.secrets.keywords || fromEnvVar.keywords || defaults.secrets.keywords;
+  const keywords = userSecrets?.keywords || fromEnvVar.keywords || defaultConfig.secrets.keywords;
 
-  if (typeof config.secrets.matcherMode !== 'string') {
+  if (typeof matcherMode !== 'string') {
     logger.warn(
       // eslint-disable-next-line max-len
-      `The value of config.secrets.matcherMode ("${config.secrets.matcherMode}") is not a string. Assuming the default value ${defaults.secrets.matcherMode}.`
+      `The value of config.secrets.matcherMode ("${matcherMode}") is not a string. Assuming the default value ${defaults.secrets.matcherMode}.`
     );
-    config.secrets.matcherMode = defaults.secrets.matcherMode;
-  } else if (validSecretsMatcherModes.indexOf(config.secrets.matcherMode) < 0) {
+    finalConfig.secrets.matcherMode = defaultConfig.secrets.matcherMode;
+  } else if (validSecretsMatcherModes.indexOf(matcherMode) < 0) {
     logger.warn(
       // eslint-disable-next-line max-len
-      `The value of config.secrets.matcherMode (or the matcher mode parsed from INSTANA_SECRETS) (${config.secrets.matcherMode}) is not a supported matcher mode. Assuming the default value ${defaults.secrets.matcherMode}.`
+      `The value of config.secrets.matcherMode (or the matcher mode parsed from INSTANA_SECRETS) (${matcherMode}) is not a supported matcher mode. Assuming the default value ${defaults.secrets.matcherMode}.`
     );
-    config.secrets.matcherMode = defaults.secrets.matcherMode;
-  } else if (!Array.isArray(config.secrets.keywords)) {
-    logger.warn(
-      // eslint-disable-next-line max-len
-      `The value of config.secrets.keywords (${config.secrets.keywords}) is not an array. Assuming the default value ${defaults.secrets.keywords}.`
-    );
-    config.secrets.keywords = defaults.secrets.keywords;
+    finalConfig.secrets.matcherMode = defaultConfig.secrets.matcherMode;
+  } else {
+    finalConfig.secrets.matcherMode = matcherMode;
   }
-  if (config.secrets.matcherMode === 'none') {
-    config.secrets.keywords = [];
+
+  if (!Array.isArray(keywords)) {
+    logger.warn(
+      // eslint-disable-next-line max-len
+      `The value of config.secrets.keywords (${keywords}) is not an array. Assuming the default value ${defaults.secrets.keywords}.`
+    );
+    finalConfig.secrets.keywords = defaultConfig.secrets.keywords;
+  } else {
+    finalConfig.secrets.keywords = keywords;
+  }
+
+  if (finalConfig.secrets.matcherMode === 'none') {
+    finalConfig.secrets.keywords = [];
   }
 }
 
@@ -685,27 +742,26 @@ function parseSecretsEnvVar(envVarValue) {
  * because it involves complex multi-step processing:
  * Future improvement: Consider refactoring to use a more generic resolver pattern.
  *
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeIgnoreEndpoints(config) {
-  if (!config.tracing.ignoreEndpoints) {
-    config.tracing.ignoreEndpoints = {};
-  }
+function normalizeIgnoreEndpoints(userConfig, defaultConfig, finalConfig) {
+  const userIgnoreEndpoints = userConfig.tracing.ignoreEndpoints;
 
-  const ignoreEndpointsConfig = config.tracing.ignoreEndpoints;
-
-  if (typeof ignoreEndpointsConfig !== 'object' || Array.isArray(ignoreEndpointsConfig)) {
+  if (userIgnoreEndpoints && (typeof userIgnoreEndpoints !== 'object' || Array.isArray(userIgnoreEndpoints))) {
     logger.warn(
       `Invalid tracing.ignoreEndpoints configuration. Expected an object, but received: ${JSON.stringify(
-        ignoreEndpointsConfig
+        userIgnoreEndpoints
       )}`
     );
-    config.tracing.ignoreEndpoints = {};
+    finalConfig.tracing.ignoreEndpoints = {};
     return;
   }
+
   // Case 1: Use in-code configuration if available
-  if (Object.keys(ignoreEndpointsConfig).length) {
-    config.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.normalizeConfig(ignoreEndpointsConfig);
+  if (userIgnoreEndpoints && Object.keys(userIgnoreEndpoints).length) {
+    finalConfig.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.normalizeConfig(userIgnoreEndpoints);
     logger.debug('[config] incode:config.tracing.ignoreEndpoints');
     return;
   }
@@ -714,10 +770,9 @@ function normalizeIgnoreEndpoints(config) {
   // Introduced in Phase 2 for advanced filtering based on both methods and endpoints.
   // Also supports basic filtering for endpoints.
   if (process.env.INSTANA_IGNORE_ENDPOINTS_PATH) {
-    config.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.fromYaml(
+    finalConfig.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.fromYaml(
       process.env.INSTANA_IGNORE_ENDPOINTS_PATH
     );
-
     logger.debug('[config] env:INSTANA_IGNORE_ENDPOINTS_PATH');
     return;
   }
@@ -726,42 +781,53 @@ function normalizeIgnoreEndpoints(config) {
   // Introduced in Phase 1 for basic filtering based only on operations (e.g., `redis.get`, `kafka.consume`).
   // Provides a simple way to configure ignored operations via environment variables.
   if (process.env.INSTANA_IGNORE_ENDPOINTS) {
-    config.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.fromEnv(process.env.INSTANA_IGNORE_ENDPOINTS);
+    finalConfig.tracing.ignoreEndpoints = configNormalizers.ignoreEndpoints.fromEnv(
+      process.env.INSTANA_IGNORE_ENDPOINTS
+    );
     logger.debug('[config] env:INSTANA_IGNORE_ENDPOINTS');
+    return;
   }
+
+  finalConfig.tracing.ignoreEndpoints = defaultConfig.tracing.ignoreEndpoints;
 }
 
 /**
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeIgnoreEndpointsDisableSuppression(config) {
-  config.tracing.ignoreEndpointsDisableSuppression = util.resolveBooleanConfig({
+function normalizeIgnoreEndpointsDisableSuppression(userConfig, defaultConfig, finalConfig) {
+  finalConfig.tracing.ignoreEndpointsDisableSuppression = util.resolveBooleanConfig({
     envVar: 'INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION',
-    configValue: config.tracing.ignoreEndpointsDisableSuppression,
-    defaultValue: defaults.tracing.ignoreEndpointsDisableSuppression,
+    configValue: userConfig.tracing.ignoreEndpointsDisableSuppression,
+    defaultValue: defaultConfig.tracing.ignoreEndpointsDisableSuppression,
     configPath: 'config.tracing.ignoreEndpointsDisableSuppression'
   });
 }
 
 /**
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizeDisableEOLEvents(config) {
-  config.tracing.disableEOLEvents = util.resolveBooleanConfig({
+function normalizeDisableEOLEvents(userConfig, defaultConfig, finalConfig) {
+  finalConfig.tracing.disableEOLEvents = util.resolveBooleanConfig({
     envVar: 'INSTANA_TRACING_DISABLE_EOL_EVENTS',
-    configValue: config.tracing.disableEOLEvents,
-    defaultValue: defaults.tracing.disableEOLEvents,
+    configValue: userConfig.tracing.disableEOLEvents,
+    defaultValue: defaultConfig.tracing.disableEOLEvents,
     configPath: 'config.tracing.disableEOLEvents'
   });
 }
 
 /**
- * @param {InstanaConfig} config
+ * @param {InstanaConfig|null} userConfig
+ * @param {InstanaConfig} defaultConfig
+ * @param {InstanaConfig} finalConfig
  */
-function normalizePreloadOpentelemetry(config) {
-  if (config.preloadOpentelemetry === true) {
-    return;
+function normalizePreloadOpentelemetry(userConfig, defaultConfig, finalConfig) {
+  if (userConfig.preloadOpentelemetry === true) {
+    finalConfig.preloadOpentelemetry = true;
+  } else {
+    finalConfig.preloadOpentelemetry = defaultConfig.preloadOpentelemetry;
   }
-
-  config.preloadOpentelemetry = defaults.preloadOpentelemetry;
 }

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -673,7 +673,7 @@ function normalizeDisableTracing({ userConfig = {}, defaultConfig = {}, finalCon
     return;
   }
 
-  if (typeof disableConfig === 'object' && (disableConfig.instrumentations?.length || disableConfig.groups?.length)) {
+  if (typeof disableConfig === 'object' && disableRes.source !== CONFIG_SOURCES.DEFAULT) {
     finalConfig.tracing.disable = disableConfig;
     configStore.set('config.tracing.disable', {
       source: disableRes.source

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -237,6 +237,7 @@ function normalizeServiceName({ userConfig = {}, defaultConfig = {}, finalConfig
 
   configStore.set('config.serviceName', { source });
   finalConfig.serviceName = value;
+  util.log({ configPath: 'config.serviceName', source, value, envVarName: 'INSTANA_SERVICE_NAME' });
 }
 
 /**
@@ -254,6 +255,12 @@ function normalizePackageJsonPath({ userConfig = {}, defaultConfig = {}, finalCo
 
   configStore.set('config.packageJsonPath', { source });
   finalConfig.packageJsonPath = value;
+  util.log({
+    configPath: 'config.packageJsonPath',
+    source,
+    value,
+    envVarName: 'INSTANA_PACKAGE_JSON_PATH'
+  });
 }
 
 /**
@@ -285,6 +292,12 @@ function normalizeMetricsConfig({ userConfig = {}, defaultConfig = {}, finalConf
   }
 
   configStore.set('config.metrics.transmissionDelay', { source: transmissionDelaySource });
+  util.log({
+    configPath: 'config.metrics.transmissionDelay',
+    source: transmissionDelaySource,
+    value: transmissionDelay,
+    envVarName: 'INSTANA_METRICS_TRANSMISSION_DELAY'
+  });
 
   const { value: healthcheckInterval, source: healthcheckSource } = util.resolve(
     {
@@ -297,6 +310,11 @@ function normalizeMetricsConfig({ userConfig = {}, defaultConfig = {}, finalConf
   finalConfig.metrics.timeBetweenHealthcheckCalls = healthcheckInterval;
   configStore.set('config.metrics.timeBetweenHealthcheckCalls', {
     source: healthcheckSource
+  });
+  util.log({
+    configPath: 'config.metrics.timeBetweenHealthcheckCalls',
+    source: healthcheckSource,
+    value: healthcheckInterval
   });
 }
 
@@ -351,6 +369,12 @@ function normalizeTracingEnabled({ userConfig = {}, defaultConfig = {}, finalCon
 
   configStore.set('config.tracing.enabled', { source });
   finalConfig.tracing.enabled = finalValue;
+  util.log({
+    configPath: 'config.tracing.enabled',
+    source,
+    value: finalValue,
+    envVarName: source === CONFIG_SOURCES.ENV ? 'INSTANA_TRACING_DISABLE' : undefined
+  });
 }
 
 /**
@@ -368,6 +392,12 @@ function normalizeAllowRootExitSpan({ userConfig = {}, defaultConfig = {}, final
 
   configStore.set('config.tracing.allowRootExitSpan', { source });
   finalConfig.tracing.allowRootExitSpan = value;
+  util.log({
+    configPath: 'config.tracing.allowRootExitSpan',
+    source,
+    value,
+    envVarName: 'INSTANA_ALLOW_ROOT_EXIT_SPAN'
+  });
 }
 
 /**
@@ -389,6 +419,12 @@ function normalizeUseOpentelemetry({ userConfig = {}, defaultConfig = {}, finalC
 
   configStore.set('config.tracing.useOpentelemetry', { source });
   finalConfig.tracing.useOpentelemetry = finalValue;
+  util.log({
+    configPath: 'config.tracing.useOpentelemetry',
+    source,
+    value: finalValue,
+    envVarName: source === CONFIG_SOURCES.ENV ? 'INSTANA_DISABLE_USE_OPENTELEMETRY' : undefined
+  });
 }
 
 /**
@@ -415,6 +451,12 @@ function normalizeAutomaticTracingEnabled({ userConfig = {}, defaultConfig = {},
 
   configStore.set('config.tracing.automaticTracingEnabled', { source });
   finalConfig.tracing.automaticTracingEnabled = finalValue;
+  util.log({
+    configPath: 'config.tracing.automaticTracingEnabled',
+    source,
+    value: finalValue,
+    envVarName: source === CONFIG_SOURCES.ENV ? 'INSTANA_DISABLE_AUTO_INSTR' : undefined
+  });
 }
 
 /**
@@ -437,6 +479,12 @@ function normalizeActivateImmediately({ userConfig = {}, defaultConfig = {}, fin
 
   configStore.set('config.tracing.activateImmediately', { source });
   finalConfig.tracing.activateImmediately = value;
+  util.log({
+    configPath: 'config.tracing.activateImmediately',
+    source,
+    value,
+    envVarName: 'INSTANA_TRACE_IMMEDIATELY'
+  });
 }
 
 /**
@@ -445,8 +493,15 @@ function normalizeActivateImmediately({ userConfig = {}, defaultConfig = {}, fin
 function normalizeTracingTransmission({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
   finalConfig.tracing.maxBufferedSpans = userConfig.tracing.maxBufferedSpans ?? defaultConfig.tracing.maxBufferedSpans;
 
+  const maxBufferedSpansSource =
+    userConfig.tracing.maxBufferedSpans !== undefined ? CONFIG_SOURCES.INCODE : CONFIG_SOURCES.DEFAULT;
   configStore.set('config.tracing.maxBufferedSpans', {
-    source: userConfig.tracing.maxBufferedSpans !== undefined ? CONFIG_SOURCES.INCODE : CONFIG_SOURCES.DEFAULT
+    source: maxBufferedSpansSource
+  });
+  util.log({
+    configPath: 'config.tracing.maxBufferedSpans',
+    source: maxBufferedSpansSource,
+    value: finalConfig.tracing.maxBufferedSpans
   });
 
   const { value: tracingTransmissionDelay, source: tracingTransmissionDelaySource } = util.resolve(
@@ -460,6 +515,12 @@ function normalizeTracingTransmission({ userConfig = {}, defaultConfig = {}, fin
 
   configStore.set('config.tracing.transmissionDelay', { source: tracingTransmissionDelaySource });
   finalConfig.tracing.transmissionDelay = tracingTransmissionDelay;
+  util.log({
+    configPath: 'config.tracing.transmissionDelay',
+    source: tracingTransmissionDelaySource,
+    value: tracingTransmissionDelay,
+    envVarName: 'INSTANA_TRACING_TRANSMISSION_DELAY'
+  });
 
   const { value: forceTransmissionStartingAt, source: forceTransmissionStartingAtSource } = util.resolve(
     {
@@ -472,6 +533,12 @@ function normalizeTracingTransmission({ userConfig = {}, defaultConfig = {}, fin
 
   configStore.set('config.tracing.forceTransmissionStartingAt', { source: forceTransmissionStartingAtSource });
   finalConfig.tracing.forceTransmissionStartingAt = forceTransmissionStartingAt;
+  util.log({
+    configPath: 'config.tracing.forceTransmissionStartingAt',
+    source: forceTransmissionStartingAtSource,
+    value: forceTransmissionStartingAt,
+    envVarName: 'INSTANA_FORCE_TRANSMISSION_STARTING_AT'
+  });
 
   const { value: initialTransmissionDelay, source: initialTransmissionDelaySource } = util.resolve(
     {
@@ -484,6 +551,12 @@ function normalizeTracingTransmission({ userConfig = {}, defaultConfig = {}, fin
 
   configStore.set('config.tracing.initialTransmissionDelay', { source: initialTransmissionDelaySource });
   finalConfig.tracing.initialTransmissionDelay = initialTransmissionDelay;
+  util.log({
+    configPath: 'config.tracing.initialTransmissionDelay',
+    source: initialTransmissionDelaySource,
+    value: initialTransmissionDelay,
+    envVarName: 'INSTANA_TRACING_INITIAL_TRANSMISSION_DELAY'
+  });
 }
 
 /**
@@ -505,6 +578,12 @@ function normalizeTracingHttp({ userConfig = {}, defaultConfig = {}, finalConfig
     finalConfig.tracing.http.extraHttpHeadersToCapture = fromEnvVar;
 
     configStore.set('config.tracing.http.extraHttpHeadersToCapture', { source: CONFIG_SOURCES.ENV });
+    util.log({
+      configPath: 'config.tracing.http.extraHttpHeadersToCapture',
+      source: CONFIG_SOURCES.ENV,
+      value: fromEnvVar,
+      envVarName: 'INSTANA_EXTRA_HTTP_HEADERS'
+    });
     return;
   }
 
@@ -520,7 +599,11 @@ function normalizeTracingHttp({ userConfig = {}, defaultConfig = {}, finalConfig
     } else {
       finalConfig.tracing.http.extraHttpHeadersToCapture = userHeaders.map(s => s.toLowerCase());
       configStore.set('config.tracing.http.extraHttpHeadersToCapture', { source: CONFIG_SOURCES.INCODE });
-      logger.debug('[config] incode:config.tracing.http.extraHttpHeadersToCapture');
+      util.log({
+        configPath: 'config.tracing.http.extraHttpHeadersToCapture',
+        source: CONFIG_SOURCES.INCODE,
+        value: finalConfig.tracing.http.extraHttpHeadersToCapture
+      });
       return;
     }
   }
@@ -699,6 +782,12 @@ function normalizeSpanBatchingEnabled({ userConfig = {}, defaultConfig = {}, fin
 
   configStore.set('config.tracing.spanBatchingEnabled', { source });
   finalConfig.tracing.spanBatchingEnabled = value;
+  util.log({
+    configPath: 'config.tracing.spanBatchingEnabled',
+    source,
+    value,
+    envVarName: 'INSTANA_SPANBATCHING_ENABLED'
+  });
 }
 
 /**
@@ -716,6 +805,12 @@ function normalizeDisableW3cTraceCorrelation({ userConfig = {}, defaultConfig = 
 
   configStore.set('config.tracing.disableW3cTraceCorrelation', { source });
   finalConfig.tracing.disableW3cTraceCorrelation = value;
+  util.log({
+    configPath: 'config.tracing.disableW3cTraceCorrelation',
+    source,
+    value,
+    envVarName: 'INSTANA_DISABLE_W3C_TRACE_CORRELATION'
+  });
 }
 
 /**
@@ -737,6 +832,12 @@ function normalizeTracingKafka({ userConfig = {}, defaultConfig = {}, finalConfi
 
   configStore.set('config.tracing.kafka.traceCorrelation', { source });
   finalConfig.tracing.kafka.traceCorrelation = value;
+  util.log({
+    configPath: 'config.tracing.kafka.traceCorrelation',
+    source,
+    value,
+    envVarName: 'INSTANA_KAFKA_TRACE_CORRELATION'
+  });
 }
 
 /**
@@ -931,6 +1032,12 @@ function normalizeIgnoreEndpointsDisableSuppression({ userConfig = {}, defaultCo
 
   configStore.set('config.tracing.ignoreEndpointsDisableSuppression', { source });
   finalConfig.tracing.ignoreEndpointsDisableSuppression = value;
+  util.log({
+    configPath: 'config.tracing.ignoreEndpointsDisableSuppression',
+    source,
+    value,
+    envVarName: 'INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION'
+  });
 }
 
 /**
@@ -948,6 +1055,12 @@ function normalizeDisableEOLEvents({ userConfig = {}, defaultConfig = {}, finalC
 
   configStore.set('config.tracing.disableEOLEvents', { source });
   finalConfig.tracing.disableEOLEvents = value;
+  util.log({
+    configPath: 'config.tracing.disableEOLEvents',
+    source,
+    value,
+    envVarName: 'INSTANA_TRACING_DISABLE_EOL_EVENTS'
+  });
 }
 
 /**
@@ -964,6 +1077,11 @@ function normalizePreloadOpentelemetry({ userConfig = {}, defaultConfig = {}, fi
 
   finalConfig.preloadOpentelemetry = value;
   configStore.set('config.preloadOpentelemetry', { source });
+  util.log({
+    configPath: 'config.preloadOpentelemetry',
+    source,
+    value
+  });
 }
 
 /**
@@ -1001,6 +1119,11 @@ exports.update = function update({ externalConfig = {}, source, target = current
     } else {
       target[key] = incomingValue;
       configStore.set(path, { source });
+      util.log({
+        configPath: path,
+        source,
+        value: incomingValue
+      });
     }
   });
 

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -6,6 +6,13 @@
 
 const { CONFIG_SOURCES } = require('../util/constants');
 
+const SOURCE_LABELS = {
+  [CONFIG_SOURCES.ENV]: 'env',
+  [CONFIG_SOURCES.INCODE]: 'incode',
+  [CONFIG_SOURCES.AGENT]: 'agent',
+  [CONFIG_SOURCES.DEFAULT]: 'default'
+};
+
 /** @type {import('../core').GenericLogger} */
 let logger;
 
@@ -62,11 +69,6 @@ exports.resolve = function resolve({ envValue, inCodeValue, agentValue, defaultV
         source: CONFIG_SOURCES[/** @type {keyof typeof CONFIG_SOURCES} */ (sourceKey.toUpperCase())]
       };
 
-      if (
-        CONFIG_SOURCES[/** @type {keyof typeof CONFIG_SOURCES} */ (sourceKey.toUpperCase())] !== CONFIG_SOURCES.DEFAULT
-      ) {
-        logger?.debug(`[config] Resolved from ${sourceKey}: ${JSON.stringify(parsedValue)}`);
-      }
       return true;
     }
 
@@ -79,4 +81,20 @@ exports.resolve = function resolve({ envValue, inCodeValue, agentValue, defaultV
       source: CONFIG_SOURCES.DEFAULT
     }
   );
+};
+
+/**
+ * @param {{ configPath: string, source: number, value: any, envVarName?: string }} params
+ */
+exports.log = function log({ configPath, source, value, envVarName }) {
+  if (source === CONFIG_SOURCES.DEFAULT) {
+    return;
+  }
+
+  if (source === CONFIG_SOURCES.ENV && envVarName) {
+    logger?.debug(`[config] ${configPath} <- env:${envVarName} = ${JSON.stringify(value)}`);
+    return;
+  }
+
+  logger?.debug(`[config] ${configPath} <- ${SOURCE_LABELS[source]}:${configPath} = ${JSON.stringify(value)}`);
 };

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -66,10 +66,6 @@ exports.resolve = function resolve({ envValue, inCodeValue, agentValue, defaultV
       return true;
     }
 
-    if (rawValue !== undefined) {
-      logger?.warn(`[config] Validation failed for ${sourceKey}: ${JSON.stringify(rawValue)}`);
-    }
-
     return false;
   });
 

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -62,7 +62,11 @@ exports.resolve = function resolve({ envValue, inCodeValue, agentValue, defaultV
         source: CONFIG_SOURCES[/** @type {keyof typeof CONFIG_SOURCES} */ (sourceKey.toUpperCase())]
       };
 
-      logger?.debug(`[config] Resolved from ${sourceKey}: ${JSON.stringify(parsedValue)}`);
+      if (
+        CONFIG_SOURCES[/** @type {keyof typeof CONFIG_SOURCES} */ (sourceKey.toUpperCase())] !== CONFIG_SOURCES.DEFAULT
+      ) {
+        logger?.debug(`[config] Resolved from ${sourceKey}: ${JSON.stringify(parsedValue)}`);
+      }
       return true;
     }
 

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -44,7 +44,7 @@ exports.resolve = function resolve({ envValue, inCodeValue, agentValue, defaultV
     default: defaultValue
   };
 
-  CONFIG_PRIORITY.find(sourceKey => {
+  CONFIG_PRIORITY.some(sourceKey => {
     const rawValue = inputs[/** @type {keyof typeof inputs} */ (sourceKey)];
 
     if (rawValue === undefined && sourceKey !== 'default') {

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright IBM Corp. 2026
+ */
+
+'use strict';
+
+/** @type {import('../core').GenericLogger} */
+let logger;
+
+/**
+ * @param {import('../core').GenericLogger} [_logger]
+ */
+exports.init = _logger => {
+  logger = _logger;
+};
+
+/**
+ * @param {Object} params
+ * @param {string} params.envVar
+ * @param {number|string|undefined|null} params.configValue
+ * @param {number} params.defaultValue
+ * @param {string} params.configPath
+ * @returns {number}
+ */
+exports.resolveNumericConfig = function resolveNumericConfig({ envVar, configValue, defaultValue, configPath }) {
+  const envRaw = process.env[envVar];
+
+  /** @param {number|string|null|undefined} val */
+  const toValidNumber = val => {
+    const num = typeof val === 'number' ? val : Number(val);
+    return Number.isNaN(num) ? undefined : num;
+  };
+
+  if (envRaw != null) {
+    const envParsed = toValidNumber(envRaw);
+    if (envParsed !== undefined) {
+      return envParsed;
+    }
+
+    logger.warn(`Invalid numeric value from env:${envVar}: "${envRaw}". Ignoring and checking config value.`);
+  }
+
+  if (configValue != null) {
+    const configParsed = toValidNumber(configValue);
+    if (configParsed !== undefined) {
+      return configParsed;
+    }
+
+    logger.warn(
+      `Invalid numeric value for ${configPath} from config: "${configValue}". Falling back to default: ${defaultValue}.`
+    );
+  }
+
+  return defaultValue;
+};

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -34,6 +34,7 @@ exports.resolveNumericConfig = function resolveNumericConfig({ envVar, configVal
   if (envRaw != null) {
     const envParsed = toValidNumber(envRaw);
     if (envParsed !== undefined) {
+      logger.debug(`[config] env:${envVar} = ${envParsed}`);
       return envParsed;
     }
 
@@ -43,6 +44,7 @@ exports.resolveNumericConfig = function resolveNumericConfig({ envVar, configVal
   if (configValue != null) {
     const configParsed = toValidNumber(configValue);
     if (configParsed !== undefined) {
+      logger.debug(`[config] incode:${configPath} = ${configValue}`);
       return configParsed;
     }
 
@@ -84,6 +86,7 @@ function parseBooleanFromEnv(envValue) {
  */
 exports.resolveBooleanConfig = function resolveBooleanConfig({ envVar, configValue, defaultValue, configPath }) {
   if (typeof configValue === 'boolean') {
+    logger.debug(`[config] incode:${configPath} = ${configValue}`);
     return configValue;
   }
 
@@ -99,6 +102,7 @@ exports.resolveBooleanConfig = function resolveBooleanConfig({ envVar, configVal
   const envParsed = parseBooleanFromEnv(envValue);
 
   if (envParsed !== undefined) {
+    logger.debug(`[config] env:${envVar} = ${envParsed}`);
     return envParsed;
   }
 
@@ -127,11 +131,14 @@ exports.resolveBooleanConfigWithInvertedEnv = function resolveBooleanConfigWithI
   configPath
 }) {
   if (typeof configValue === 'boolean') {
+    logger.debug(`[config] incode:${configPath} = ${configValue}`);
+
     return configValue;
   }
 
   const envValue = process.env[envVar];
   if (envValue === 'true') {
+    logger.debug(`[config] env:${envVar} = true (inverted to false)`);
     return false;
   }
 
@@ -154,19 +161,23 @@ exports.resolveBooleanConfigWithInvertedEnv = function resolveBooleanConfigWithI
  * @param {string} params.envVar - Environment variable name
  * @param {boolean|undefined|null} params.configValue - Config value
  * @param {boolean} params.defaultValue - Default value
+ * @param {string} [params.configPath]
  * @returns {boolean}
  */
 exports.resolveBooleanConfigWithTruthyEnv = function resolveBooleanConfigWithTruthyEnv({
   envVar,
   configValue,
-  defaultValue
+  defaultValue,
+  configPath
 }) {
   if (typeof configValue === 'boolean') {
+    logger.debug(`[config] incode:${configPath} = ${configValue}`);
     return configValue;
   }
 
   const envValue = process.env[envVar];
   if (envValue) {
+    logger.debug(`[config] env:${envVar} = ${envValue}`);
     return true;
   }
 

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -53,3 +53,122 @@ exports.resolveNumericConfig = function resolveNumericConfig({ envVar, configVal
 
   return defaultValue;
 };
+
+/**
+ * @param {string|undefined} envValue
+ * @returns {boolean|undefined}
+ */
+function parseBooleanFromEnv(envValue) {
+  if (envValue == null) {
+    return undefined;
+  }
+
+  const normalized = envValue.toLowerCase();
+  if (normalized === 'true' || normalized === '1') {
+    return true;
+  }
+  if (normalized === 'false' || normalized === '0') {
+    return false;
+  }
+
+  return undefined;
+}
+
+/**
+ * @param {Object} params
+ * @param {string} params.envVar
+ * @param {boolean|undefined|null} params.configValue
+ * @param {boolean} params.defaultValue
+ * @param {string} [params.configPath]
+ * @returns {boolean}
+ */
+exports.resolveBooleanConfig = function resolveBooleanConfig({ envVar, configValue, defaultValue, configPath }) {
+  if (typeof configValue === 'boolean') {
+    return configValue;
+  }
+
+  if (configValue != null && configPath) {
+    logger.warn(
+      `Invalid configuration: ${configPath} is not a boolean value, will be ignored: ${JSON.stringify(
+        configValue
+      )}. Falling back to default: ${defaultValue}.`
+    );
+  }
+
+  const envValue = process.env[envVar];
+  const envParsed = parseBooleanFromEnv(envValue);
+
+  if (envParsed !== undefined) {
+    return envParsed;
+  }
+
+  if (envValue != null) {
+    logger.warn(`Invalid boolean value for ${envValue}: "${envValue}".`);
+  }
+
+  return defaultValue;
+};
+
+/**
+ * special cases:
+ * eg: "INSTANA_DISABLE_USE_OPENTELEMETRY" where env var presence means false in the config "useOpentelemetry".
+ *
+ * @param {Object} params
+ * @param {string} params.envVar - Environment variable name (e.g., INSTANA_DISABLE_X)
+ * @param {boolean|undefined|null} params.configValue - Config value
+ * @param {boolean} params.defaultValue - Default value
+ * @param {string} [params.configPath] - Config path for logging (optional)
+ * @returns {boolean}
+ */
+exports.resolveBooleanConfigWithInvertedEnv = function resolveBooleanConfigWithInvertedEnv({
+  envVar,
+  configValue,
+  defaultValue,
+  configPath
+}) {
+  if (typeof configValue === 'boolean') {
+    return configValue;
+  }
+
+  const envValue = process.env[envVar];
+  if (envValue === 'true') {
+    return false;
+  }
+
+  if (configValue != null && configPath) {
+    logger.warn(
+      `Invalid configuration: ${configPath} is not a boolean value, will be ignored: ${JSON.stringify(
+        configValue
+      )}. Falling back to default: ${defaultValue}.`
+    );
+  }
+
+  return defaultValue;
+};
+
+/**
+ * Returns true if env var exists and is truthy, otherwise uses config or default.
+ * eg: "INSTANA_DISABLE_W3C_TRACE_CORRELATION" where env var presence means true in the config .
+ *
+ * @param {Object} params
+ * @param {string} params.envVar - Environment variable name
+ * @param {boolean|undefined|null} params.configValue - Config value
+ * @param {boolean} params.defaultValue - Default value
+ * @returns {boolean}
+ */
+exports.resolveBooleanConfigWithTruthyEnv = function resolveBooleanConfigWithTruthyEnv({
+  envVar,
+  configValue,
+  defaultValue
+}) {
+  if (typeof configValue === 'boolean') {
+    return configValue;
+  }
+
+  const envValue = process.env[envVar];
+  if (envValue) {
+    return true;
+  }
+
+  return defaultValue;
+};

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -183,3 +183,33 @@ exports.resolveBooleanConfigWithTruthyEnv = function resolveBooleanConfigWithTru
 
   return defaultValue;
 };
+
+/**
+ * @param {Object} params
+ * @param {any} params.envVar
+ * @param {any} params.configValue
+ * @param {any} params.defaultValue
+ * @param {string} [params.configPath]
+ */
+exports.resolveStringConfig = function resolveStringConfig({ envVar, configValue, defaultValue, configPath }) {
+  if (configValue != null) {
+    if (typeof configValue !== 'string') {
+      logger.warn(
+        `Invalid configuration: ${configPath} is not a string value, will be ignored: ${JSON.stringify(
+          configValue
+        )}. Falling back to default: ${defaultValue}.`
+      );
+      return defaultValue;
+    }
+    logger.debug(`[config] incode:${configPath} = ${configValue}`);
+    return configValue;
+  }
+
+  const envValue = process.env[envVar];
+  if (envValue != null) {
+    logger.debug(`[config] env:${envVar} = ${envValue}`);
+    return envValue;
+  }
+
+  return defaultValue;
+};

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -85,6 +85,20 @@ function parseBooleanFromEnv(envValue) {
  * @returns {boolean}
  */
 exports.resolveBooleanConfig = function resolveBooleanConfig({ envVar, configValue, defaultValue, configPath }) {
+  // Priority 1: Environment variable
+  const envValue = process.env[envVar];
+  const envParsed = parseBooleanFromEnv(envValue);
+
+  if (envParsed !== undefined) {
+    logger.debug(`[config] env:${envVar} = ${envParsed}`);
+    return envParsed;
+  }
+
+  if (envValue != null) {
+    logger.warn(`Invalid boolean value for ${envValue}: "${envValue}".`);
+  }
+
+  // Priority 2: In-code configuration
   if (typeof configValue === 'boolean') {
     logger.debug(`[config] incode:${configPath} = ${configValue}`);
     return configValue;
@@ -98,18 +112,7 @@ exports.resolveBooleanConfig = function resolveBooleanConfig({ envVar, configVal
     );
   }
 
-  const envValue = process.env[envVar];
-  const envParsed = parseBooleanFromEnv(envValue);
-
-  if (envParsed !== undefined) {
-    logger.debug(`[config] env:${envVar} = ${envParsed}`);
-    return envParsed;
-  }
-
-  if (envValue != null) {
-    logger.warn(`Invalid boolean value for ${envValue}: "${envValue}".`);
-  }
-
+  // Priority 3: Default value
   return defaultValue;
 };
 
@@ -130,16 +133,24 @@ exports.resolveBooleanConfigWithInvertedEnv = function resolveBooleanConfigWithI
   defaultValue,
   configPath
 }) {
-  if (typeof configValue === 'boolean') {
-    logger.debug(`[config] incode:${configPath} = ${configValue}`);
+  // Priority 1: Environment variable
+  const envValue = process.env[envVar];
+  const envParsed = parseBooleanFromEnv(envValue);
 
-    return configValue;
+  if (envParsed !== undefined) {
+    const invertedValue = !envParsed;
+    logger.debug(`[config] env:${envVar} = ${envParsed} (inverted to ${invertedValue})`);
+    return invertedValue;
   }
 
-  const envValue = process.env[envVar];
-  if (envValue === 'true') {
-    logger.debug(`[config] env:${envVar} = true (inverted to false)`);
-    return false;
+  if (envValue != null) {
+    logger.warn(`Invalid boolean value for ${envVar}: "${envValue}". Checking in-code config.`);
+  }
+
+  // Priority 2: In-code configuration
+  if (typeof configValue === 'boolean') {
+    logger.debug(`[config] incode:${configPath} = ${configValue}`);
+    return configValue;
   }
 
   if (configValue != null && configPath) {
@@ -150,6 +161,7 @@ exports.resolveBooleanConfigWithInvertedEnv = function resolveBooleanConfigWithI
     );
   }
 
+  // Priority 3: Default value
   return defaultValue;
 };
 
@@ -170,17 +182,20 @@ exports.resolveBooleanConfigWithTruthyEnv = function resolveBooleanConfigWithTru
   defaultValue,
   configPath
 }) {
-  if (typeof configValue === 'boolean') {
-    logger.debug(`[config] incode:${configPath} = ${configValue}`);
-    return configValue;
-  }
-
+  // Priority 1: Environment variable
   const envValue = process.env[envVar];
   if (envValue) {
     logger.debug(`[config] env:${envVar} = ${envValue}`);
     return true;
   }
 
+  // Priority 2: In-code configuration
+  if (typeof configValue === 'boolean') {
+    logger.debug(`[config] incode:${configPath} = ${configValue}`);
+    return configValue;
+  }
+
+  // Priority 3: Default value
   return defaultValue;
 };
 
@@ -192,6 +207,14 @@ exports.resolveBooleanConfigWithTruthyEnv = function resolveBooleanConfigWithTru
  * @param {string} [params.configPath]
  */
 exports.resolveStringConfig = function resolveStringConfig({ envVar, configValue, defaultValue, configPath }) {
+  // Priority 1: Environment variable
+  const envValue = process.env[envVar];
+  if (envValue != null) {
+    logger.debug(`[config] env:${envVar} = ${envValue}`);
+    return envValue;
+  }
+
+  // Priority 2: In-code configuration
   if (configValue != null) {
     if (typeof configValue !== 'string') {
       logger.warn(
@@ -204,12 +227,5 @@ exports.resolveStringConfig = function resolveStringConfig({ envVar, configValue
     logger.debug(`[config] incode:${configPath} = ${configValue}`);
     return configValue;
   }
-
-  const envValue = process.env[envVar];
-  if (envValue != null) {
-    logger.debug(`[config] env:${envVar} = ${envValue}`);
-    return envValue;
-  }
-
   return defaultValue;
 };

--- a/packages/core/src/config/util.js
+++ b/packages/core/src/config/util.js
@@ -4,6 +4,8 @@
 
 'use strict';
 
+const { CONFIG_SOURCES } = require('../util/constants');
+
 /** @type {import('../core').GenericLogger} */
 let logger;
 
@@ -14,218 +16,67 @@ exports.init = _logger => {
   logger = _logger;
 };
 
-/**
- * @param {Object} params
- * @param {string} params.envVar
- * @param {number|string|undefined|null} params.configValue
- * @param {number} params.defaultValue
- * @param {string} params.configPath
- * @returns {number}
- */
-exports.resolveNumericConfig = function resolveNumericConfig({ envVar, configValue, defaultValue, configPath }) {
-  const envRaw = process.env[envVar];
+const CONFIG_PRIORITY = Object.entries(CONFIG_SOURCES)
+  .sort((a, b) => a[1] - b[1])
+  .map(([key]) => {
+    return key.toLowerCase();
+  });
 
-  /** @param {number|string|null|undefined} val */
-  const toValidNumber = val => {
-    const num = typeof val === 'number' ? val : Number(val);
-    return Number.isNaN(num) ? undefined : num;
+/**
+ *
+ * @param {Object} params
+ * @param {string} [params.envValue]
+ * @param {any} [params.inCodeValue]
+ * @param {any} [params.agentValue]
+ * @param {any} params.defaultValue
+ * @param {Function|Function[]} validators - validator(s) returning value | undefined
+ * @returns {{ value: any, source: number }}
+ */
+exports.resolve = function resolve({ envValue, inCodeValue, agentValue, defaultValue }, validators) {
+  let resolved;
+
+  const validatorList = Array.isArray(validators) ? validators : [validators];
+
+  const inputs = {
+    env: envValue ? process.env[envValue] : undefined,
+    incode: inCodeValue,
+    agent: agentValue,
+    default: defaultValue
   };
 
-  if (envRaw != null) {
-    const envParsed = toValidNumber(envRaw);
-    if (envParsed !== undefined) {
-      logger.debug(`[config] env:${envVar} = ${envParsed}`);
-      return envParsed;
+  CONFIG_PRIORITY.find(sourceKey => {
+    const rawValue = inputs[/** @type {keyof typeof inputs} */ (sourceKey)];
+
+    if (rawValue === undefined && sourceKey !== 'default') {
+      return false;
     }
 
-    logger.warn(`Invalid numeric value from env:${envVar}: "${envRaw}". Ignoring and checking config value.`);
-  }
+    const parsedValue = validatorList.reduce((val, fn) => {
+      if (val === undefined) return undefined;
+      return fn(val);
+    }, rawValue);
 
-  if (configValue != null) {
-    const configParsed = toValidNumber(configValue);
-    if (configParsed !== undefined) {
-      logger.debug(`[config] incode:${configPath} = ${configValue}`);
-      return configParsed;
+    if (parsedValue !== undefined) {
+      resolved = {
+        value: parsedValue,
+        source: CONFIG_SOURCES[/** @type {keyof typeof CONFIG_SOURCES} */ (sourceKey.toUpperCase())]
+      };
+
+      logger?.debug(`[config] Resolved from ${sourceKey}: ${JSON.stringify(parsedValue)}`);
+      return true;
     }
 
-    logger.warn(
-      `Invalid numeric value for ${configPath} from config: "${configValue}". Falling back to default: ${defaultValue}.`
-    );
-  }
+    if (rawValue !== undefined) {
+      logger?.warn(`[config] Validation failed for ${sourceKey}: ${JSON.stringify(rawValue)}`);
+    }
 
-  return defaultValue;
-};
-
-/**
- * @param {string|undefined} envValue
- * @returns {boolean|undefined}
- */
-function parseBooleanFromEnv(envValue) {
-  if (envValue == null) {
-    return undefined;
-  }
-
-  const normalized = envValue.toLowerCase();
-  if (normalized === 'true' || normalized === '1') {
-    return true;
-  }
-  if (normalized === 'false' || normalized === '0') {
     return false;
-  }
+  });
 
-  return undefined;
-}
-
-/**
- * @param {Object} params
- * @param {string} params.envVar
- * @param {boolean|undefined|null} params.configValue
- * @param {boolean} params.defaultValue
- * @param {string} [params.configPath]
- * @returns {boolean}
- */
-exports.resolveBooleanConfig = function resolveBooleanConfig({ envVar, configValue, defaultValue, configPath }) {
-  // Priority 1: Environment variable
-  const envValue = process.env[envVar];
-  const envParsed = parseBooleanFromEnv(envValue);
-
-  if (envParsed !== undefined) {
-    logger.debug(`[config] env:${envVar} = ${envParsed}`);
-    return envParsed;
-  }
-
-  if (envValue != null) {
-    logger.warn(`Invalid boolean value for ${envValue}: "${envValue}".`);
-  }
-
-  // Priority 2: In-code configuration
-  if (typeof configValue === 'boolean') {
-    logger.debug(`[config] incode:${configPath} = ${configValue}`);
-    return configValue;
-  }
-
-  if (configValue != null && configPath) {
-    logger.warn(
-      `Invalid configuration: ${configPath} is not a boolean value, will be ignored: ${JSON.stringify(
-        configValue
-      )}. Falling back to default: ${defaultValue}.`
-    );
-  }
-
-  // Priority 3: Default value
-  return defaultValue;
-};
-
-/**
- * special cases:
- * eg: "INSTANA_DISABLE_USE_OPENTELEMETRY" where env var presence means false in the config "useOpentelemetry".
- *
- * @param {Object} params
- * @param {string} params.envVar - Environment variable name (e.g., INSTANA_DISABLE_X)
- * @param {boolean|undefined|null} params.configValue - Config value
- * @param {boolean} params.defaultValue - Default value
- * @param {string} [params.configPath] - Config path for logging (optional)
- * @returns {boolean}
- */
-exports.resolveBooleanConfigWithInvertedEnv = function resolveBooleanConfigWithInvertedEnv({
-  envVar,
-  configValue,
-  defaultValue,
-  configPath
-}) {
-  // Priority 1: Environment variable
-  const envValue = process.env[envVar];
-  const envParsed = parseBooleanFromEnv(envValue);
-
-  if (envParsed !== undefined) {
-    const invertedValue = !envParsed;
-    logger.debug(`[config] env:${envVar} = ${envParsed} (inverted to ${invertedValue})`);
-    return invertedValue;
-  }
-
-  if (envValue != null) {
-    logger.warn(`Invalid boolean value for ${envVar}: "${envValue}". Checking in-code config.`);
-  }
-
-  // Priority 2: In-code configuration
-  if (typeof configValue === 'boolean') {
-    logger.debug(`[config] incode:${configPath} = ${configValue}`);
-    return configValue;
-  }
-
-  if (configValue != null && configPath) {
-    logger.warn(
-      `Invalid configuration: ${configPath} is not a boolean value, will be ignored: ${JSON.stringify(
-        configValue
-      )}. Falling back to default: ${defaultValue}.`
-    );
-  }
-
-  // Priority 3: Default value
-  return defaultValue;
-};
-
-/**
- * Returns true if env var exists and is truthy, otherwise uses config or default.
- * eg: "INSTANA_DISABLE_W3C_TRACE_CORRELATION" where env var presence means true in the config .
- *
- * @param {Object} params
- * @param {string} params.envVar - Environment variable name
- * @param {boolean|undefined|null} params.configValue - Config value
- * @param {boolean} params.defaultValue - Default value
- * @param {string} [params.configPath]
- * @returns {boolean}
- */
-exports.resolveBooleanConfigWithTruthyEnv = function resolveBooleanConfigWithTruthyEnv({
-  envVar,
-  configValue,
-  defaultValue,
-  configPath
-}) {
-  // Priority 1: Environment variable
-  const envValue = process.env[envVar];
-  if (envValue) {
-    logger.debug(`[config] env:${envVar} = ${envValue}`);
-    return true;
-  }
-
-  // Priority 2: In-code configuration
-  if (typeof configValue === 'boolean') {
-    logger.debug(`[config] incode:${configPath} = ${configValue}`);
-    return configValue;
-  }
-
-  // Priority 3: Default value
-  return defaultValue;
-};
-
-/**
- * @param {Object} params
- * @param {any} params.envVar
- * @param {any} params.configValue
- * @param {any} params.defaultValue
- * @param {string} [params.configPath]
- */
-exports.resolveStringConfig = function resolveStringConfig({ envVar, configValue, defaultValue, configPath }) {
-  // Priority 1: Environment variable
-  const envValue = process.env[envVar];
-  if (envValue != null) {
-    logger.debug(`[config] env:${envVar} = ${envValue}`);
-    return envValue;
-  }
-
-  // Priority 2: In-code configuration
-  if (configValue != null) {
-    if (typeof configValue !== 'string') {
-      logger.warn(
-        `Invalid configuration: ${configPath} is not a string value, will be ignored: ${JSON.stringify(
-          configValue
-        )}. Falling back to default: ${defaultValue}.`
-      );
-      return defaultValue;
+  return (
+    resolved || {
+      value: defaultValue,
+      source: CONFIG_SOURCES.DEFAULT
     }
-    logger.debug(`[config] incode:${configPath} = ${configValue}`);
-    return configValue;
-  }
-  return defaultValue;
+  );
 };

--- a/packages/core/src/config/validator.js
+++ b/packages/core/src/config/validator.js
@@ -1,0 +1,51 @@
+/*
+ * (c) Copyright IBM Corp. 2026
+ */
+
+'use strict';
+
+/**
+ * @param {any} value
+ * @returns {number|undefined}
+ */
+exports.numberValidator = function numberValidator(value) {
+  if (value == null) return undefined;
+  const num = typeof value === 'number' ? value : Number(value);
+  return Number.isNaN(num) ? undefined : num;
+};
+
+/**
+ * @param {any} value
+ * @returns {boolean|undefined}
+ */
+exports.booleanValidator = function booleanValidator(value) {
+  if (value == null) return undefined;
+
+  if (typeof value === 'boolean') return value;
+
+  if (typeof value === 'string') {
+    const normalized = value.toLowerCase();
+    if (normalized === 'true' || normalized === '1') return true;
+    if (normalized === 'false' || normalized === '0') return false;
+  }
+
+  return undefined;
+};
+
+/**
+ * @param {any} value
+ * @returns {string|undefined}
+ */
+exports.stringValidator = function stringValidator(value) {
+  if (value == null) return undefined;
+  return typeof value === 'string' ? value : undefined;
+};
+
+/**
+ * @param {any} value
+ * @returns {boolean|undefined}
+ */
+exports.validateTruthyBoolean = function validateTruthyBoolean(value) {
+  // Return true if value is truthy, undefined otherwise
+  return value ? true : undefined;
+};

--- a/packages/core/src/secrets.js
+++ b/packages/core/src/secrets.js
@@ -181,25 +181,18 @@ exports.init = function init(config) {
   isSecretInternal = matchers[config.secrets.matcherMode](config.secrets.keywords);
 };
 
+/**
+ * @param {import('./config').InstanaConfig} config
+ */
+exports.activate = function activate(config) {
+  if (config.secrets.matcherMode && config.secrets.keywords) {
+    isSecretInternal = matchers[config.secrets.matcherMode](config.secrets.keywords);
+  }
+};
+
 exports.matchers = matchers;
 
 /** @type {(key: string) => boolean} */
 exports.isSecret = function isSecret(key) {
   return isSecretInternal(key);
-};
-
-/**
- * @param {import('@instana/core/src/config').MatchingOption} matcherId
- * @param {Array.<string>} secretsList
- */
-exports.setMatcher = function setMatcher(matcherId, secretsList) {
-  if (!(typeof matcherId === 'string')) {
-    logger.warn(`Received invalid secrets configuration, attribute matcher is not a string: ${matcherId}`);
-  } else if (Object.keys(exports.matchers).indexOf(matcherId) < 0) {
-    logger.warn(`Received invalid secrets configuration, matcher is not supported: ${matcherId}`);
-  } else if (!Array.isArray(secretsList)) {
-    logger.warn(`Received invalid secrets configuration, attribute list is not an array: ${secretsList}`);
-  } else {
-    isSecretInternal = exports.matchers[matcherId](secretsList);
-  }
 };

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -260,12 +260,12 @@ function initInstanaInstrumentations(_config) {
   }
 }
 
-exports.activate = function activate(extraConfig = {}) {
+exports.activate = function activate(_config = config) {
   if (tracingEnabled && !tracingActivated) {
     tracingActivated = true;
-    coreUtil.activate(extraConfig);
-    tracingUtil.activate(extraConfig);
-    spanBuffer.activate(extraConfig);
+    coreUtil.activate(_config);
+    tracingUtil.activate(_config);
+    spanBuffer.activate(_config);
     opentracing.activate();
     sdk.activate();
 
@@ -285,7 +285,7 @@ exports.activate = function activate(extraConfig = {}) {
             instrumentationKey
           })
         ) {
-          instrumentationModules[instrumentationKey].activate(extraConfig);
+          instrumentationModules[instrumentationKey].activate(_config);
         }
       });
     }

--- a/packages/core/src/tracing/index.js
+++ b/packages/core/src/tracing/index.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const sdk = require('./sdk');
+const secrets = require('../secrets');
 const constants = require('./constants');
 const tracingMetrics = require('./metrics');
 const opentracing = require('./opentracing');
@@ -266,6 +267,7 @@ exports.activate = function activate(_config = config) {
     coreUtil.activate(_config);
     tracingUtil.activate(_config);
     spanBuffer.activate(_config);
+    secrets.activate(_config);
     opentracing.activate();
     sdk.activate();
 

--- a/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafkaJs.js
@@ -28,12 +28,9 @@ exports.updateConfig = function updateConfig(config) {
   traceCorrelationEnabled = config.tracing.kafka.traceCorrelation;
 };
 
-exports.activate = function activate(extraConfig) {
-  if (extraConfig && extraConfig.tracing && extraConfig.tracing.kafka) {
-    if (extraConfig.tracing.kafka.traceCorrelation != null) {
-      traceCorrelationEnabled = extraConfig.tracing.kafka.traceCorrelation;
-    }
-  }
+// TODO: We will remove _config as soon as the config object is a config instance (`config.get`)
+exports.activate = function activate(_config) {
+  traceCorrelationEnabled = _config.tracing.kafka.traceCorrelation;
   isActive = true;
 };
 

--- a/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
+++ b/packages/core/src/tracing/instrumentation/messaging/rdkafka.js
@@ -27,13 +27,10 @@ exports.init = function init(config) {
 exports.updateConfig = function updateConfig(config) {
   traceCorrelationEnabled = config.tracing.kafka.traceCorrelation;
 };
-// The extraConfig is coming from the agent configs. You can set the kafka format in the agent.
-exports.activate = function activate(extraConfig) {
-  if (extraConfig && extraConfig.tracing && extraConfig.tracing.kafka) {
-    if (extraConfig.tracing.kafka.traceCorrelation != null) {
-      traceCorrelationEnabled = extraConfig.tracing.kafka.traceCorrelation;
-    }
-  }
+
+//
+exports.activate = function activate(_config) {
+  traceCorrelationEnabled = _config.tracing.kafka.traceCorrelation;
   isActive = true;
 };
 

--- a/packages/core/src/tracing/instrumentation/protocols/http2Client.js
+++ b/packages/core/src/tracing/instrumentation/protocols/http2Client.js
@@ -35,15 +35,9 @@ exports.updateConfig = config => {
   extraHttpHeadersToCapture = config.tracing.http.extraHttpHeadersToCapture;
 };
 
-exports.activate = function activate(extraConfig) {
-  if (
-    extraConfig &&
-    extraConfig.tracing &&
-    extraConfig.tracing.http &&
-    Array.isArray(extraConfig.tracing.http.extraHttpHeadersToCapture)
-  ) {
-    extraHttpHeadersToCapture = extraConfig.tracing.http.extraHttpHeadersToCapture;
-  }
+exports.activate = function activate(_config) {
+  extraHttpHeadersToCapture = _config.tracing.http.extraHttpHeadersToCapture;
+
   isActive = true;
 };
 

--- a/packages/core/src/tracing/instrumentation/protocols/http2Server.js
+++ b/packages/core/src/tracing/instrumentation/protocols/http2Server.js
@@ -38,15 +38,9 @@ exports.updateConfig = function updateConfig(config) {
   extraHttpHeadersToCapture = config.tracing.http.extraHttpHeadersToCapture;
 };
 
-exports.activate = function activate(extraConfig) {
-  if (
-    extraConfig &&
-    extraConfig.tracing &&
-    extraConfig.tracing.http &&
-    Array.isArray(extraConfig.tracing.http.extraHttpHeadersToCapture)
-  ) {
-    extraHttpHeadersToCapture = extraConfig.tracing.http.extraHttpHeadersToCapture;
-  }
+exports.activate = function activate(_config) {
+  extraHttpHeadersToCapture = _config.tracing.http.extraHttpHeadersToCapture;
+
   isActive = true;
 };
 

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -43,15 +43,9 @@ exports.updateConfig = function updateConfig(config) {
   extraHttpHeadersToCapture = config.tracing.http.extraHttpHeadersToCapture;
 };
 
-exports.activate = function activate(extraConfig) {
-  if (
-    extraConfig &&
-    extraConfig.tracing &&
-    extraConfig.tracing.http &&
-    Array.isArray(extraConfig.tracing.http.extraHttpHeadersToCapture)
-  ) {
-    extraHttpHeadersToCapture = extraConfig.tracing.http.extraHttpHeadersToCapture;
-  }
+exports.activate = function activate(_config) {
+  extraHttpHeadersToCapture = _config.tracing.http.extraHttpHeadersToCapture;
+
   isActive = true;
 };
 

--- a/packages/core/src/tracing/instrumentation/protocols/httpServer.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpServer.js
@@ -32,15 +32,9 @@ exports.updateConfig = function updateConfig(config) {
   extraHttpHeadersToCapture = config.tracing.http.extraHttpHeadersToCapture;
 };
 
-exports.activate = function activate(extraConfig) {
-  if (
-    extraConfig &&
-    extraConfig.tracing &&
-    extraConfig.tracing.http &&
-    Array.isArray(extraConfig.tracing.http.extraHttpHeadersToCapture)
-  ) {
-    extraHttpHeadersToCapture = extraConfig.tracing.http.extraHttpHeadersToCapture;
-  }
+exports.activate = function activate(_config) {
+  extraHttpHeadersToCapture = _config.tracing.http.extraHttpHeadersToCapture;
+
   isActive = true;
 };
 

--- a/packages/core/src/tracing/instrumentation/protocols/nativeFetch.js
+++ b/packages/core/src/tracing/instrumentation/protocols/nativeFetch.js
@@ -53,20 +53,14 @@ exports.updateConfig = function updateConfig(config) {
   extraHttpHeadersToCapture = config.tracing.http.extraHttpHeadersToCapture;
 };
 
-exports.activate = function activate(extraConfig) {
+exports.activate = function activate(_config) {
   if (originalFetch == null) {
     // Do nothing in Node.js versions that do not support native fetch.
     return;
   }
 
-  if (
-    extraConfig &&
-    extraConfig.tracing &&
-    extraConfig.tracing.http &&
-    Array.isArray(extraConfig.tracing.http.extraHttpHeadersToCapture)
-  ) {
-    extraHttpHeadersToCapture = extraConfig.tracing.http.extraHttpHeadersToCapture;
-  }
+  extraHttpHeadersToCapture = _config.tracing.http.extraHttpHeadersToCapture;
+
   isActive = true;
 };
 

--- a/packages/core/src/tracing/spanBuffer.js
+++ b/packages/core/src/tracing/spanBuffer.js
@@ -103,9 +103,9 @@ exports.init = function init(config, _downstreamConnection) {
 };
 
 /**
- * @param {import('@instana/collector/src/types/collector').AgentConfig} extraConfig
+ * @param {import('../config').InstanaConfig} _config
  */
-exports.activate = function activate(extraConfig) {
+exports.activate = function activate(_config) {
   if (!downstreamConnection) {
     logger.error('No downstreamConnection has been set.');
     return;
@@ -119,11 +119,7 @@ exports.activate = function activate(extraConfig) {
     return;
   }
 
-  if (extraConfig?.tracing) {
-    if (extraConfig.tracing.spanBatchingEnabled) {
-      batchingEnabled = true;
-    }
-  }
+  batchingEnabled = _config.tracing.spanBatchingEnabled;
 
   isActive = true;
   if (activatedAt == null) {

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -10,7 +10,7 @@ const path = require('path');
 const StringDecoder = require('string_decoder').StringDecoder;
 
 const stackTrace = require('../util/stackTrace');
-const { DEFAULT_STACK_TRACE_LENGTH, DEFAULT_STACK_TRACE_MODE, STACK_TRACE_MODES } = require('../util/constants');
+const { STACK_TRACE_MODES } = require('../util/constants');
 
 /** @type {import('../core').GenericLogger} */
 let logger;
@@ -34,26 +34,11 @@ exports.init = function (config) {
 };
 
 /**
- * @param {import('@instana/collector/src/types/collector').AgentConfig} extraConfig
+ * @param {import('../config').InstanaConfig} _config
  */
-exports.activate = function activate(extraConfig) {
-  const agentTraceConfig = extraConfig?.tracing;
-
-  // Note: We check whether the already-initialized stackTraceLength equals the default value.
-  //       If it does, we can safely override it, since the user did not explicitly configure it.
-
-  // Note: If the user configured a value via env or code and also configured a different value in the agent,
-  //       but the env/code value happens to equal the default, the agent value would overwrite it.
-  //       This is a rare edge case and acceptable for now.
-
-  if (agentTraceConfig?.stackTrace && stackTraceMode === DEFAULT_STACK_TRACE_MODE) {
-    stackTraceMode = agentTraceConfig.stackTrace;
-  }
-
-  // stackTraceLength is valid when set to any number, including 0
-  if (agentTraceConfig?.stackTraceLength != null && stackTraceLength === DEFAULT_STACK_TRACE_LENGTH) {
-    stackTraceLength = agentTraceConfig.stackTraceLength;
-  }
+exports.activate = function activate(_config) {
+  stackTraceLength = _config.tracing.stackTraceLength;
+  stackTraceMode = _config.tracing.stackTrace;
 };
 
 /**

--- a/packages/core/src/util/constants.js
+++ b/packages/core/src/util/constants.js
@@ -17,3 +17,10 @@ exports.STACK_TRACE_MODES = {
   ALL: 'all',
   NONE: 'none'
 };
+
+exports.CONFIG_SOURCES = {
+  ENV: 1,
+  INCODE: 2,
+  AGENT: 3,
+  DEFAULT: 4
+};

--- a/packages/core/src/util/disableInstrumentation.js
+++ b/packages/core/src/util/disableInstrumentation.js
@@ -9,9 +9,6 @@ const { DISABLABLE_INSTRUMENTATION_GROUPS } = require('../tracing/constants');
 /** @type {import('../config').InstanaConfig} */
 let config;
 
-/** @type {import('@instana/collector/src/types/collector').AgentConfig} */
-let agentConfig;
-
 /**
  * @param {import('../config').InstanaConfig} _config
  */
@@ -20,10 +17,10 @@ function init(_config) {
 }
 
 /**
- * @param {import('@instana/collector/src/types/collector').AgentConfig} _agentConfig
+ * @param {import('../config').InstanaConfig} _config
  */
-function activate(_agentConfig) {
-  agentConfig = _agentConfig;
+function activate(_config) {
+  config = _config;
 }
 
 /**
@@ -110,14 +107,7 @@ function isInstrumentationDisabled({ instrumentationModules = {}, instrumentatio
 
   const context = { moduleName, instrumentationName, group };
 
-  // Give priority to service-level config
   if (config && shouldDisable(config, context)) {
-    return true;
-  }
-
-  // Fallback to agent-level config if not disabled above
-  // NOTE: We currently have no single config object.
-  if (agentConfig && shouldDisable(agentConfig, context)) {
     return true;
   }
 

--- a/packages/core/src/util/index.js
+++ b/packages/core/src/util/index.js
@@ -44,11 +44,11 @@ exports.init = function init(config) {
 };
 
 /**
- * @param {import('@instana/collector/src/types/collector').AgentConfig} extraConfig
+ * @param {import('@instana/core/src/config').InstanaConfig} config
  */
-exports.activate = function activate(extraConfig) {
-  disableInstrumentation.activate(extraConfig);
-  spanFilter.activate(extraConfig);
+exports.activate = function activate(config) {
+  disableInstrumentation.activate(config);
+  spanFilter.activate(config);
 };
 
 exports.applicationUnderMonitoring = applicationUnderMonitoring;

--- a/packages/core/src/util/spanFilter.js
+++ b/packages/core/src/util/spanFilter.js
@@ -19,26 +19,11 @@ function init(config) {
 }
 
 /**
- * @param {import('@instana/collector/src/types/collector').AgentConfig} extraConfig
+ * @param {import('../config').InstanaConfig} _config
  */
-function activate(extraConfig) {
-  /**
-   * Configuration priority order:
-   * 1. In-code configuration
-   * 2. Environment variables:
-   *    - `INSTANA_IGNORE_ENDPOINTS_PATH`
-   *    - `INSTANA_IGNORE_ENDPOINTS`
-   * 3. Agent configuration (loaded later)
-   *
-   * Since the agent configuration is loaded later, we first check
-   * that `ignoreEndpoints` MUST be empty. If yes, we
-   * are allowed to fall back to the agent's configuration (`extraConfig.tracing.ignoreEndpoints`).
-   *
-   * TODO: Perform a major refactoring of configuration priority ordering in INSTA-817.
-   */
-  const isIgnoreEndpointsEmpty = !ignoreEndpoints || Object.keys(ignoreEndpoints).length === 0;
-  if (isIgnoreEndpointsEmpty && extraConfig?.tracing?.ignoreEndpoints) {
-    ignoreEndpoints = extraConfig.tracing.ignoreEndpoints;
+function activate(_config) {
+  if (_config?.tracing?.ignoreEndpoints) {
+    ignoreEndpoints = _config.tracing.ignoreEndpoints;
   }
 }
 

--- a/packages/core/test/config/configNormalizers/disable_test.js
+++ b/packages/core/test/config/configNormalizers/disable_test.js
@@ -8,6 +8,7 @@ const { describe, it, beforeEach, afterEach } = require('mocha');
 const { expect } = require('chai');
 
 const { normalize, normalizeExternalConfig } = require('../../../src/config/configNormalizers/disable');
+const { CONFIG_SOURCES } = require('../../../src/util/constants');
 
 function resetEnv() {
   delete process.env.INSTANA_TRACING_DISABLE;
@@ -15,7 +16,7 @@ function resetEnv() {
   delete process.env.INSTANA_TRACING_DISABLE_GROUPS;
 }
 
-describe('util.configNormalizers.disable', () => {
+describe.skip('util.configNormalizers.disable', () => {
   beforeEach(() => {
     resetEnv();
   });
@@ -29,7 +30,11 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result).to.deep.equal({});
+      expect(result).to.deep.equal({
+        value: {},
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.tracing.disable'
+      });
       expect(config.tracing).to.exist;
     });
 
@@ -43,7 +48,9 @@ describe('util.configNormalizers.disable', () => {
       };
 
       const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
+      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should handle non-array "instrumentations" input gracefully', () => {
@@ -56,7 +63,9 @@ describe('util.configNormalizers.disable', () => {
       };
 
       const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal([]);
+      expect(result.value.instrumentations).to.deep.equal([]);
+      expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
+      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should handle flat disable config', () => {
@@ -67,7 +76,9 @@ describe('util.configNormalizers.disable', () => {
       };
 
       const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
+      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should support disabling by group names', () => {
@@ -80,7 +91,9 @@ describe('util.configNormalizers.disable', () => {
       };
 
       const result = normalize(config);
-      expect(result.groups).to.deep.equal(['logging', 'databases']);
+      expect(result.value.groups).to.deep.equal(['logging', 'databases']);
+      expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
+      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should normalize group names: lowercase and trim whitespace', () => {
@@ -93,7 +106,9 @@ describe('util.configNormalizers.disable', () => {
       };
 
       const result = normalize(config);
-      expect(result.groups).to.deep.equal(['logging', 'databases', 'messaging']);
+      expect(result.value.groups).to.deep.equal(['logging', 'databases', 'messaging']);
+      expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
+      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should handle non-array "groups" input gracefully', () => {
@@ -106,7 +121,9 @@ describe('util.configNormalizers.disable', () => {
       };
 
       const result = normalize(config);
-      expect(result.groups).to.deep.equal([]);
+      expect(result.value.groups).to.deep.equal([]);
+      expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
+      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should handle mixed array of instrumentations and groups', () => {
@@ -118,8 +135,12 @@ describe('util.configNormalizers.disable', () => {
 
       const result = normalize(config);
       expect(result).to.deep.equal({
-        instrumentations: ['aws-sdk', 'mongodb'],
-        groups: ['logging', 'databases']
+        value: {
+          instrumentations: ['aws-sdk', 'mongodb'],
+          groups: ['logging', 'databases']
+        },
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.tracing.disable'
       });
     });
 
@@ -131,15 +152,27 @@ describe('util.configNormalizers.disable', () => {
       };
 
       const result = normalize(config);
-      expect(result).to.deep.equal({});
+      expect(result).to.deep.equal({
+        value: {},
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.tracing.disable'
+      });
     });
 
     it('should return an empty object if disable is null or undefined', () => {
       const config1 = { tracing: { disable: null } };
       const config2 = { tracing: { disable: undefined } };
 
-      expect(normalize(config1)).to.deep.equal({});
-      expect(normalize(config2)).to.deep.equal({});
+      expect(normalize(config1)).to.deep.equal({
+        value: {},
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.tracing.disable'
+      });
+      expect(normalize(config2)).to.deep.equal({
+        value: {},
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.tracing.disable'
+      });
     });
 
     it('should ignore non-string values in disable array', () => {
@@ -150,7 +183,9 @@ describe('util.configNormalizers.disable', () => {
       };
 
       const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb']);
+      expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb']);
+      expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
+      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should ignore non-string values inside disable.instrumentations', () => {
@@ -161,7 +196,9 @@ describe('util.configNormalizers.disable', () => {
       };
 
       const result = normalize(config);
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb']);
+      expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb']);
+      expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
+      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should return true if tracing is globally disabled (disable = true)', () => {
@@ -172,7 +209,11 @@ describe('util.configNormalizers.disable', () => {
       };
 
       const result = normalize(config);
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.tracing.disable'
+      });
     });
 
     it('should return an empty object if tracing disable is set to false', () => {
@@ -183,7 +224,11 @@ describe('util.configNormalizers.disable', () => {
       };
 
       const result = normalize(config);
-      expect(result).to.deep.equal({});
+      expect(result).to.deep.equal({
+        value: {},
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.tracing.disable'
+      });
     });
   });
 
@@ -194,7 +239,9 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.source).to.equal(CONFIG_SOURCES.ENV);
+      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should parse "INSTANA_TRACING_DISABLE" as instrumentations', () => {
@@ -203,7 +250,9 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.source).to.equal(CONFIG_SOURCES.ENV);
+      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should parse "INSTANA_TRACING_DISABLE_GROUPS"', () => {
@@ -212,7 +261,9 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result.groups).to.deep.equal(['logging', 'databases']);
+      expect(result.value.groups).to.deep.equal(['logging', 'databases']);
+      expect(result.source).to.equal(CONFIG_SOURCES.ENV);
+      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should support semicolon-separated values in environment variable', () => {
@@ -221,7 +272,9 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.source).to.equal(CONFIG_SOURCES.ENV);
+      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should ignore empty or whitespace-only entries in environment variable', () => {
@@ -231,8 +284,10 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
-      expect(result.groups).to.deep.equal(['logging', 'databases', 'messaging']);
+      expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
+      expect(result.value.groups).to.deep.equal(['logging', 'databases', 'messaging']);
+      expect(result.source).to.equal(CONFIG_SOURCES.ENV);
+      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should combine env instrumentation and group variables', () => {
@@ -243,8 +298,12 @@ describe('util.configNormalizers.disable', () => {
       const result = normalize(config);
 
       expect(result).to.deep.equal({
-        instrumentations: ['aws-sdk', 'mongodb'],
-        groups: ['logging', 'databases']
+        value: {
+          instrumentations: ['aws-sdk', 'mongodb'],
+          groups: ['logging', 'databases']
+        },
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.tracing.disable'
       });
     });
 
@@ -255,8 +314,12 @@ describe('util.configNormalizers.disable', () => {
       const result = normalize(config);
 
       expect(result).to.deep.equal({
-        instrumentations: ['aws-sdk', 'mongodb'],
-        groups: ['logging', 'databases']
+        value: {
+          instrumentations: ['aws-sdk', 'mongodb'],
+          groups: ['logging', 'databases']
+        },
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.tracing.disable'
       });
     });
 
@@ -267,7 +330,11 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result).to.deep.equal({});
+      expect(result).to.deep.equal({
+        value: {},
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.tracing.disable'
+      });
     });
 
     it('should return true if INSTANA_TRACING_DISABLE is "true"', () => {
@@ -276,7 +343,11 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.tracing.disable'
+      });
     });
 
     it('should return empty object if INSTANA_TRACING_DISABLE is "false"', () => {
@@ -285,7 +356,11 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result).to.deep.equal({});
+      expect(result).to.deep.equal({
+        value: {},
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.tracing.disable'
+      });
     });
 
     it('should give precedence to INSTANA_TRACING_DISABLE=false over config.tracing.disable=true', () => {
@@ -298,7 +373,11 @@ describe('util.configNormalizers.disable', () => {
       };
       const result = normalize(config);
 
-      expect(result).to.deep.equal({});
+      expect(result).to.deep.equal({
+        value: {},
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.tracing.disable'
+      });
     });
 
     it('should give precedence to INSTANA_TRACING_DISABLE=false over config with instrumentations', () => {
@@ -313,7 +392,11 @@ describe('util.configNormalizers.disable', () => {
       };
       const result = normalize(config);
 
-      expect(result).to.deep.equal({});
+      expect(result).to.deep.equal({
+        value: {},
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.tracing.disable'
+      });
     });
 
     it('should give precedence to INSTANA_TRACING_DISABLE=true over other env vars', () => {
@@ -324,7 +407,11 @@ describe('util.configNormalizers.disable', () => {
       const config = {};
       const result = normalize(config);
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.tracing.disable'
+      });
     });
   });
 

--- a/packages/core/test/config/configNormalizers/disable_test.js
+++ b/packages/core/test/config/configNormalizers/disable_test.js
@@ -288,6 +288,34 @@ describe('util.configNormalizers.disable', () => {
       expect(result).to.deep.equal({});
     });
 
+    it.skip('should give precedence to INSTANA_TRACING_DISABLE=false over config.tracing.disable=true', () => {
+      process.env.INSTANA_TRACING_DISABLE = 'false';
+
+      const config = {
+        tracing: {
+          disable: true
+        }
+      };
+      const result = normalize(config);
+
+      expect(result).to.deep.equal({});
+    });
+
+    it.skip('should give precedence to INSTANA_TRACING_DISABLE=false over config with instrumentations', () => {
+      process.env.INSTANA_TRACING_DISABLE = 'false';
+
+      const config = {
+        tracing: {
+          disable: {
+            instrumentations: ['aws-sdk', 'mongodb']
+          }
+        }
+      };
+      const result = normalize(config);
+
+      expect(result).to.deep.equal({});
+    });
+
     it('should give precedence to INSTANA_TRACING_DISABLE=true over other env vars', () => {
       process.env.INSTANA_TRACING_DISABLE = 'true';
       process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'aws-sdk,mongodb';

--- a/packages/core/test/config/configNormalizers/disable_test.js
+++ b/packages/core/test/config/configNormalizers/disable_test.js
@@ -288,7 +288,7 @@ describe('util.configNormalizers.disable', () => {
       expect(result).to.deep.equal({});
     });
 
-    it.skip('should give precedence to INSTANA_TRACING_DISABLE=false over config.tracing.disable=true', () => {
+    it('should give precedence to INSTANA_TRACING_DISABLE=false over config.tracing.disable=true', () => {
       process.env.INSTANA_TRACING_DISABLE = 'false';
 
       const config = {
@@ -301,7 +301,7 @@ describe('util.configNormalizers.disable', () => {
       expect(result).to.deep.equal({});
     });
 
-    it.skip('should give precedence to INSTANA_TRACING_DISABLE=false over config with instrumentations', () => {
+    it('should give precedence to INSTANA_TRACING_DISABLE=false over config with instrumentations', () => {
       process.env.INSTANA_TRACING_DISABLE = 'false';
 
       const config = {

--- a/packages/core/test/config/configNormalizers/disable_test.js
+++ b/packages/core/test/config/configNormalizers/disable_test.js
@@ -16,7 +16,7 @@ function resetEnv() {
   delete process.env.INSTANA_TRACING_DISABLE_GROUPS;
 }
 
-describe.skip('util.configNormalizers.disable', () => {
+describe('util.configNormalizers.disable', () => {
   beforeEach(() => {
     resetEnv();
   });
@@ -32,8 +32,7 @@ describe.skip('util.configNormalizers.disable', () => {
 
       expect(result).to.deep.equal({
         value: {},
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.DEFAULT
       });
       expect(config.tracing).to.exist;
     });
@@ -50,7 +49,6 @@ describe.skip('util.configNormalizers.disable', () => {
       const result = normalize(config);
       expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
       expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
-      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should handle non-array "instrumentations" input gracefully', () => {
@@ -65,7 +63,6 @@ describe.skip('util.configNormalizers.disable', () => {
       const result = normalize(config);
       expect(result.value.instrumentations).to.deep.equal([]);
       expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
-      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should handle flat disable config', () => {
@@ -78,7 +75,6 @@ describe.skip('util.configNormalizers.disable', () => {
       const result = normalize(config);
       expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
       expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
-      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should support disabling by group names', () => {
@@ -93,7 +89,6 @@ describe.skip('util.configNormalizers.disable', () => {
       const result = normalize(config);
       expect(result.value.groups).to.deep.equal(['logging', 'databases']);
       expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
-      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should normalize group names: lowercase and trim whitespace', () => {
@@ -108,7 +103,6 @@ describe.skip('util.configNormalizers.disable', () => {
       const result = normalize(config);
       expect(result.value.groups).to.deep.equal(['logging', 'databases', 'messaging']);
       expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
-      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should handle non-array "groups" input gracefully', () => {
@@ -123,7 +117,6 @@ describe.skip('util.configNormalizers.disable', () => {
       const result = normalize(config);
       expect(result.value.groups).to.deep.equal([]);
       expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
-      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should handle mixed array of instrumentations and groups', () => {
@@ -139,8 +132,7 @@ describe.skip('util.configNormalizers.disable', () => {
           instrumentations: ['aws-sdk', 'mongodb'],
           groups: ['logging', 'databases']
         },
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.INCODE
       });
     });
 
@@ -154,8 +146,7 @@ describe.skip('util.configNormalizers.disable', () => {
       const result = normalize(config);
       expect(result).to.deep.equal({
         value: {},
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.DEFAULT
       });
     });
 
@@ -165,13 +156,11 @@ describe.skip('util.configNormalizers.disable', () => {
 
       expect(normalize(config1)).to.deep.equal({
         value: {},
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.DEFAULT
       });
       expect(normalize(config2)).to.deep.equal({
         value: {},
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.DEFAULT
       });
     });
 
@@ -185,7 +174,6 @@ describe.skip('util.configNormalizers.disable', () => {
       const result = normalize(config);
       expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb']);
       expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
-      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should ignore non-string values inside disable.instrumentations', () => {
@@ -198,7 +186,6 @@ describe.skip('util.configNormalizers.disable', () => {
       const result = normalize(config);
       expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb']);
       expect(result.source).to.equal(CONFIG_SOURCES.INCODE);
-      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should return true if tracing is globally disabled (disable = true)', () => {
@@ -211,8 +198,7 @@ describe.skip('util.configNormalizers.disable', () => {
       const result = normalize(config);
       expect(result).to.deep.equal({
         value: true,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.INCODE
       });
     });
 
@@ -226,8 +212,7 @@ describe.skip('util.configNormalizers.disable', () => {
       const result = normalize(config);
       expect(result).to.deep.equal({
         value: {},
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.DEFAULT
       });
     });
   });
@@ -241,7 +226,6 @@ describe.skip('util.configNormalizers.disable', () => {
 
       expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
       expect(result.source).to.equal(CONFIG_SOURCES.ENV);
-      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should parse "INSTANA_TRACING_DISABLE" as instrumentations', () => {
@@ -252,7 +236,6 @@ describe.skip('util.configNormalizers.disable', () => {
 
       expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
       expect(result.source).to.equal(CONFIG_SOURCES.ENV);
-      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should parse "INSTANA_TRACING_DISABLE_GROUPS"', () => {
@@ -263,7 +246,6 @@ describe.skip('util.configNormalizers.disable', () => {
 
       expect(result.value.groups).to.deep.equal(['logging', 'databases']);
       expect(result.source).to.equal(CONFIG_SOURCES.ENV);
-      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should support semicolon-separated values in environment variable', () => {
@@ -274,7 +256,6 @@ describe.skip('util.configNormalizers.disable', () => {
 
       expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
       expect(result.source).to.equal(CONFIG_SOURCES.ENV);
-      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should ignore empty or whitespace-only entries in environment variable', () => {
@@ -287,7 +268,6 @@ describe.skip('util.configNormalizers.disable', () => {
       expect(result.value.instrumentations).to.deep.equal(['aws-sdk', 'mongodb', 'postgres']);
       expect(result.value.groups).to.deep.equal(['logging', 'databases', 'messaging']);
       expect(result.source).to.equal(CONFIG_SOURCES.ENV);
-      expect(result.configPath).to.equal('config.tracing.disable');
     });
 
     it('should combine env instrumentation and group variables', () => {
@@ -302,8 +282,7 @@ describe.skip('util.configNormalizers.disable', () => {
           instrumentations: ['aws-sdk', 'mongodb'],
           groups: ['logging', 'databases']
         },
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.ENV
       });
     });
 
@@ -318,8 +297,7 @@ describe.skip('util.configNormalizers.disable', () => {
           instrumentations: ['aws-sdk', 'mongodb'],
           groups: ['logging', 'databases']
         },
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.ENV
       });
     });
 
@@ -332,8 +310,7 @@ describe.skip('util.configNormalizers.disable', () => {
 
       expect(result).to.deep.equal({
         value: {},
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.DEFAULT
       });
     });
 
@@ -345,8 +322,7 @@ describe.skip('util.configNormalizers.disable', () => {
 
       expect(result).to.deep.equal({
         value: true,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.ENV
       });
     });
 
@@ -358,8 +334,7 @@ describe.skip('util.configNormalizers.disable', () => {
 
       expect(result).to.deep.equal({
         value: {},
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.ENV
       });
     });
 
@@ -375,8 +350,7 @@ describe.skip('util.configNormalizers.disable', () => {
 
       expect(result).to.deep.equal({
         value: {},
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.ENV
       });
     });
 
@@ -394,8 +368,7 @@ describe.skip('util.configNormalizers.disable', () => {
 
       expect(result).to.deep.equal({
         value: {},
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.ENV
       });
     });
 
@@ -409,8 +382,7 @@ describe.skip('util.configNormalizers.disable', () => {
 
       expect(result).to.deep.equal({
         value: true,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.tracing.disable'
+        source: CONFIG_SOURCES.ENV
       });
     });
   });
@@ -427,7 +399,12 @@ describe.skip('util.configNormalizers.disable', () => {
       };
 
       const result = normalizeExternalConfig(config);
-      expect(result.instrumentations).to.deep.equal(['redis', 'console']);
+      expect(result).to.deep.equal({
+        value: {
+          instrumentations: ['redis', 'console']
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
     });
 
     it('should correctly categorize known group names', () => {
@@ -441,8 +418,9 @@ describe.skip('util.configNormalizers.disable', () => {
       };
 
       const result = normalizeExternalConfig(config);
-      expect(result.groups).to.include('messaging');
-      expect(result.instrumentations).to.include('kafka');
+      expect(result.source).to.equal(CONFIG_SOURCES.AGENT);
+      expect(result.value.groups).to.include('messaging');
+      expect(result.value.instrumentations).to.include('kafka');
     });
 
     it('should represent false values with negated names', () => {
@@ -458,8 +436,9 @@ describe.skip('util.configNormalizers.disable', () => {
       };
 
       const result = normalizeExternalConfig(config);
-      expect(result.instrumentations).to.deep.equal(['redis', '!console']);
-      expect(result.groups).to.include('logging', '!databases');
+      expect(result.source).to.equal(CONFIG_SOURCES.AGENT);
+      expect(result.value.instrumentations).to.deep.equal(['redis', '!console']);
+      expect(result.value.groups).to.include('logging', '!databases');
     });
 
     it('should return negated names if all values are false', () => {
@@ -473,7 +452,12 @@ describe.skip('util.configNormalizers.disable', () => {
       };
 
       const result = normalizeExternalConfig(config);
-      expect(result.instrumentations).to.deep.equal(['!redis', '!pg']);
+      expect(result).to.deep.equal({
+        value: {
+          instrumentations: ['!redis', '!pg']
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
     });
 
     it('should ignore non-boolean entries in config object', () => {
@@ -488,7 +472,12 @@ describe.skip('util.configNormalizers.disable', () => {
       };
 
       const result = normalizeExternalConfig(config);
-      expect(result.instrumentations).to.deep.equal(['redis']);
+      expect(result).to.deep.equal({
+        value: {
+          instrumentations: ['redis']
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
     });
   });
 });

--- a/packages/core/test/config/configNormalizers/stackTrace_test.js
+++ b/packages/core/test/config/configNormalizers/stackTrace_test.js
@@ -376,6 +376,28 @@ describe('config.configNormalizers.stackTrace', () => {
 
       expect(result).to.equal(20);
     });
+
+    it('should return null when tracing.stackTraceLength is a non-numeric string', () => {
+      const config = {
+        tracing: {
+          stackTraceLength: 'not-a-number'
+        }
+      };
+      const result = stackTraceNormalizer.normalizeStackTraceLength(config);
+
+      expect(result).to.be.null;
+    });
+
+    it('should return null when tracing.stackTraceLength results in NaN after parsing', () => {
+      const config = {
+        tracing: {
+          stackTraceLength: 'abc123'
+        }
+      };
+      const result = stackTraceNormalizer.normalizeStackTraceLength(config);
+
+      expect(result).to.be.null;
+    });
   });
 
   describe('normalizeStackTraceModeFromAgent()', () => {

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -73,6 +73,11 @@ describe('config.normalizeConfig', () => {
       expect(config.serviceName).to.not.exist;
     });
 
+    it.skip('should use config when env not set', () => {
+      const config = coreConfig.normalize({ serviceName: 'config-service-name' });
+      expect(config.serviceName).to.equal('config-service-name');
+    });
+
     it.skip('should give precedence to INSTANA_SERVICE_NAME env var over config', () => {
       process.env.INSTANA_SERVICE_NAME = 'env-service';
       const config = coreConfig.normalize({ serviceName: 'config-service' });
@@ -607,6 +612,52 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.stackTraceLength).to.equal(10);
       });
 
+      it('should use default when INSTANA_STACK_TRACE passes validation but normalizer returns null', () => {
+        const stackTraceNormalizers = require('../../src/config/configNormalizers/stackTrace');
+        const original = stackTraceNormalizers.normalizeStackTraceModeFromEnv;
+        stackTraceNormalizers.normalizeStackTraceModeFromEnv = () => null;
+
+        process.env.INSTANA_STACK_TRACE = 'all';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTrace).to.equal('all');
+
+        stackTraceNormalizers.normalizeStackTraceModeFromEnv = original;
+      });
+
+      it('should use default when config stackTrace passes validation but normalizer returns null', () => {
+        const stackTraceNormalizers = require('../../src/config/configNormalizers/stackTrace');
+        const original = stackTraceNormalizers.normalizeStackTraceMode;
+        stackTraceNormalizers.normalizeStackTraceMode = () => null;
+
+        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'all' } } });
+        expect(config.tracing.stackTrace).to.equal('all');
+
+        stackTraceNormalizers.normalizeStackTraceMode = original;
+      });
+
+      it('should use default when INSTANA_STACK_TRACE_LENGTH passes validation but normalizer returns null', () => {
+        const stackTraceNormalizers = require('../../src/config/configNormalizers/stackTrace');
+        const original = stackTraceNormalizers.normalizeStackTraceLengthFromEnv;
+        stackTraceNormalizers.normalizeStackTraceLengthFromEnv = () => null;
+
+        process.env.INSTANA_STACK_TRACE_LENGTH = '10';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTraceLength).to.equal(10);
+
+        stackTraceNormalizers.normalizeStackTraceLengthFromEnv = original;
+      });
+
+      it('should use default when config stackTraceLength passes validation but normalizer returns null', () => {
+        const stackTraceNormalizers = require('../../src/config/configNormalizers/stackTrace');
+        const original = stackTraceNormalizers.normalizeStackTraceLength;
+        stackTraceNormalizers.normalizeStackTraceLength = () => null;
+
+        const config = coreConfig.normalize({ tracing: { global: { stackTraceLength: 20 } } });
+        expect(config.tracing.stackTraceLength).to.equal(10);
+
+        stackTraceNormalizers.normalizeStackTraceLength = original;
+      });
+
       it('should reject INSTANA_STACK_TRACE_LENGTH with only whitespace', () => {
         process.env.INSTANA_STACK_TRACE_LENGTH = '   ';
         const config = coreConfig.normalize();
@@ -617,6 +668,17 @@ describe('config.normalizeConfig', () => {
         process.env.INSTANA_STACK_TRACE_LENGTH = '15abc';
         const config = coreConfig.normalize();
         expect(config.tracing.stackTraceLength).to.equal(15);
+      });
+
+      it('should return null from normalizeStackTraceLength when value is valid but normalized is null', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            global: {
+              stackTraceLength: Infinity
+            }
+          }
+        });
+        expect(config.tracing.stackTraceLength).to.equal(10);
       });
 
       it('should handle both INSTANA_STACK_TRACE and INSTANA_STACK_TRACE_LENGTH together', () => {
@@ -1204,6 +1266,25 @@ describe('config.normalizeConfig', () => {
         });
         expect(config.tracing.ignoreEndpoints).to.deep.equal({});
       });
+
+      it('should handle ignoreEndpoints when config is an array instead of object', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            ignoreEndpoints: ['redis', 'kafka']
+          }
+        });
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({});
+      });
+
+      it('should handle ignoreEndpoints when config is a non-object type', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            ignoreEndpoints: 'invalid-string'
+          }
+        });
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({});
+      });
+
       it('should return false when INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION is not set', () => {
         const config = coreConfig.normalize();
         expect(config.tracing.ignoreEndpointsDisableSuppression).to.equal(false);

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -191,6 +191,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.enabled).to.be.true;
         expect(config.tracing.automaticTracingEnabled).to.be.false;
       });
+
       it('should not enable automatic tracing when tracing is disabled in general', () => {
         const config = coreConfig.normalize({
           userConfig: {
@@ -225,6 +226,12 @@ describe('config.normalizeConfig', () => {
         process.env.INSTANA_TRACING_DISABLE = 'true';
         const config = coreConfig.normalize({});
         expect(config.tracing.enabled).to.be.false;
+      });
+
+      it('should enable tracing if env var conatin non-boolean value', () => {
+        process.env.INSTANA_TRACING_DISABLE = 'redis';
+        const config = coreConfig.normalize({});
+        expect(config.tracing.enabled).to.be.true;
       });
 
       it('should use default (true) for automaticTracingEnabled when neither env nor config is set', () => {

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -1665,6 +1665,32 @@ describe('config.normalizeConfig', () => {
 
         expect(config.preloadOpentelemetry).to.be.true;
       });
+
+      it('should preserve existing tracing config when agent updates tracing partially', () => {
+        const config = coreConfig.normalize();
+
+        expect(config.tracing.kafka.traceCorrelation).to.be.true;
+        expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal([]);
+
+        coreConfig.update(
+          {
+            tracing: {
+              http: {
+                extraHttpHeadersToCapture: ['x-instana-test']
+              }
+            }
+          },
+          CONFIG_SOURCES.AGENT
+        );
+
+        expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal(['x-instana-test']);
+        expect(config.tracing.kafka).to.deep.equal({
+          traceCorrelation: true
+        });
+        expect(config.tracing.kafka.traceCorrelation).to.be.true;
+        expect(config.tracing.enabled).to.be.true;
+        expect(config.tracing.spanBatchingEnabled).to.be.false;
+      });
     });
   });
 

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -73,12 +73,12 @@ describe('config.normalizeConfig', () => {
       expect(config.serviceName).to.not.exist;
     });
 
-    it.skip('should use config when env not set', () => {
+    it('should use config when env not set', () => {
       const config = coreConfig.normalize({ userConfig: { serviceName: 'config-service-name' } });
       expect(config.serviceName).to.equal('config-service-name');
     });
 
-    it.skip('should give precedence to INSTANA_SERVICE_NAME env var over config', () => {
+    it('should give precedence to INSTANA_SERVICE_NAME env var over config', () => {
       process.env.INSTANA_SERVICE_NAME = 'env-service';
       const config = coreConfig.normalize({ userConfig: { serviceName: 'config-service' } });
       expect(config.serviceName).to.equal('env-service');
@@ -135,7 +135,7 @@ describe('config.normalizeConfig', () => {
       expect(config.metrics.transmissionDelay).to.equal(1000);
     });
 
-    it.skip('should give precedence to INSTANA_METRICS_TRANSMISSION_DELAY env var over config', () => {
+    it('should give precedence to INSTANA_METRICS_TRANSMISSION_DELAY env var over config', () => {
       process.env.INSTANA_METRICS_TRANSMISSION_DELAY = '3000';
       const config = coreConfig.normalize({ userConfig: { metrics: { transmissionDelay: 5000 } } });
       expect(config.metrics.transmissionDelay).to.equal(3000);
@@ -209,19 +209,19 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.enabled).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_TRACING_DISABLE env var set to true over config set to true', () => {
+      it('should give precedence to INSTANA_TRACING_DISABLE env var set to true over config set to true', () => {
         process.env.INSTANA_TRACING_DISABLE = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { enabled: true } } });
         expect(config.tracing.enabled).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_TRACING_DISABLE env var set to false over config set to false', () => {
+      it('should give precedence to INSTANA_TRACING_DISABLE env var set to false over config set to false', () => {
         process.env.INSTANA_TRACING_DISABLE = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { enabled: false } } });
         expect(config.tracing.enabled).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_TRACING_DISABLE env var over default', () => {
+      it('should give precedence to INSTANA_TRACING_DISABLE env var over default', () => {
         process.env.INSTANA_TRACING_DISABLE = 'true';
         const config = coreConfig.normalize({});
         expect(config.tracing.enabled).to.be.false;
@@ -232,19 +232,19 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.automaticTracingEnabled).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var set to true over config set to true', () => {
+      it('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var set to true over config set to true', () => {
         process.env.INSTANA_DISABLE_AUTO_INSTR = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { automaticTracingEnabled: true } } });
         expect(config.tracing.automaticTracingEnabled).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var set to false over config set to false', () => {
+      it('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var set to false over config set to false', () => {
         process.env.INSTANA_DISABLE_AUTO_INSTR = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { automaticTracingEnabled: false } } });
         expect(config.tracing.automaticTracingEnabled).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var over default', () => {
+      it('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var over default', () => {
         process.env.INSTANA_DISABLE_AUTO_INSTR = 'true';
         const config = coreConfig.normalize({});
         expect(config.tracing.automaticTracingEnabled).to.be.false;
@@ -281,13 +281,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.activateImmediately).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_TRACE_IMMEDIATELY env var set to true over config set to false', () => {
+      it('should give precedence to INSTANA_TRACE_IMMEDIATELY env var set to true over config set to false', () => {
         process.env.INSTANA_TRACE_IMMEDIATELY = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { activateImmediately: false } } });
         expect(config.tracing.activateImmediately).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_TRACE_IMMEDIATELY env var set to false over config set to true', () => {
+      it('should give precedence to INSTANA_TRACE_IMMEDIATELY env var set to false over config set to true', () => {
         process.env.INSTANA_TRACE_IMMEDIATELY = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { activateImmediately: true } } });
         expect(config.tracing.activateImmediately).to.be.false;
@@ -326,13 +326,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.transmissionDelay).to.equal(1000);
       });
 
-      it.skip('should give precedence to INSTANA_TRACING_TRANSMISSION_DELAY env var over config', () => {
+      it('should give precedence to INSTANA_TRACING_TRANSMISSION_DELAY env var over config', () => {
         process.env.INSTANA_TRACING_TRANSMISSION_DELAY = '4000';
         const config = coreConfig.normalize({ userConfig: { tracing: { transmissionDelay: 2000 } } });
         expect(config.tracing.transmissionDelay).to.equal(4000);
       });
 
-      it.skip('should give precedence to INSTANA_FORCE_TRANSMISSION_STARTING_AT env var over config', () => {
+      it('should give precedence to INSTANA_FORCE_TRANSMISSION_STARTING_AT env var over config', () => {
         process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT = '700';
         const config = coreConfig.normalize({ userConfig: { tracing: { forceTransmissionStartingAt: 300 } } });
         expect(config.tracing.forceTransmissionStartingAt).to.equal(700);
@@ -434,7 +434,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.stackTraceLength).to.equal(3);
       });
 
-      it.skip('should give precedence to INSTANA_STACK_TRACE_LENGTH over config', () => {
+      it('should give precedence to INSTANA_STACK_TRACE_LENGTH over config', () => {
         process.env.INSTANA_STACK_TRACE_LENGTH = '5';
         const normalizedConfig = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: 20 } } });
         expect(normalizedConfig.tracing.stackTraceLength).to.equal(5);
@@ -473,7 +473,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.stackTrace).to.equal('none');
       });
 
-      it.skip('should give precedence to env INSTANA_STACK_TRACE over config', () => {
+      it('should give precedence to env INSTANA_STACK_TRACE over config', () => {
         process.env.INSTANA_STACK_TRACE = 'none';
         const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: 'all' } } } });
         expect(config.tracing.stackTrace).to.equal('none');
@@ -720,7 +720,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.stackTraceLength).to.equal(30);
       });
 
-      it.skip('should give precedence to env vars for both stack trace settings over config', () => {
+      it('should give precedence to env vars for both stack trace settings over config', () => {
         process.env.INSTANA_STACK_TRACE = 'error';
         process.env.INSTANA_STACK_TRACE_LENGTH = '15';
         const config = coreConfig.normalize({
@@ -772,7 +772,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
       });
 
-      it('config should take precedence over INSTANA_TRACING_DISABLE_INSTRUMENTATIONS  for config', () => {
+      it('env var INSTANA_TRACING_DISABLE_INSTRUMENTATIONS over config', () => {
         process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'foo, bar';
         const config = coreConfig.normalize({
           userConfig: {
@@ -781,7 +781,7 @@ describe('config.normalizeConfig', () => {
             }
           }
         });
-        expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
+        expect(config.tracing.disable.instrumentations).to.deep.equal(['foo', 'bar']);
       });
 
       it('should disable multiple instrumentations via env var INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
@@ -819,7 +819,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.disable.groups).to.deep.equal(['frameworks', 'databases']);
       });
 
-      it('config should take precedence over INSTANA_TRACING_DISABLE_GROUPS when disabling groups', () => {
+      it('env var should take precedence over config when disabling groups', () => {
         process.env.INSTANA_TRACING_DISABLE_GROUPS = 'frameworks, databases';
         const config = coreConfig.normalize({
           userConfig: {
@@ -828,7 +828,7 @@ describe('config.normalizeConfig', () => {
             }
           }
         });
-        expect(config.tracing.disable.groups).to.deep.equal(['logging']);
+        expect(config.tracing.disable.groups).to.deep.equal(['frameworks', 'databases']);
       });
 
       it('should disable instrumentations and groups when both configured', () => {
@@ -911,13 +911,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.spanBatchingEnabled).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_SPANBATCHING_ENABLED env var set to true over config set to false', () => {
+      it('should give precedence to INSTANA_SPANBATCHING_ENABLED env var set to true over config set to false', () => {
         process.env.INSTANA_SPANBATCHING_ENABLED = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { spanBatchingEnabled: false } } });
         expect(config.tracing.spanBatchingEnabled).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_SPANBATCHING_ENABLED env var set to false over config set to true', () => {
+      it('should give precedence to INSTANA_SPANBATCHING_ENABLED env var set to false over config set to true', () => {
         process.env.INSTANA_SPANBATCHING_ENABLED = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { spanBatchingEnabled: true } } });
         expect(config.tracing.spanBatchingEnabled).to.be.false;
@@ -941,7 +941,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.disableW3cTraceCorrelation).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_DISABLE_W3C_TRACE_CORRELATION env var over config (truthy env)', () => {
+      it('should give precedence to INSTANA_DISABLE_W3C_TRACE_CORRELATION env var over config (truthy env)', () => {
         process.env.INSTANA_DISABLE_W3C_TRACE_CORRELATION = 'any-value';
         const config = coreConfig.normalize({ userConfig: { tracing: { disableW3cTraceCorrelation: false } } });
         expect(config.tracing.disableW3cTraceCorrelation).to.be.true;
@@ -965,13 +965,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.kafka.traceCorrelation).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_KAFKA_TRACE_CORRELATION env var set to false over config set to true', () => {
+      it('should give precedence to INSTANA_KAFKA_TRACE_CORRELATION env var set to false over config set to true', () => {
         process.env.INSTANA_KAFKA_TRACE_CORRELATION = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { kafka: { traceCorrelation: true } } } });
         expect(config.tracing.kafka.traceCorrelation).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_KAFKA_TRACE_CORRELATION env var set to true over config set to false', () => {
+      it('should give precedence to INSTANA_KAFKA_TRACE_CORRELATION env var set to true over config set to false', () => {
         process.env.INSTANA_KAFKA_TRACE_CORRELATION = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { kafka: { traceCorrelation: false } } } });
         expect(config.tracing.kafka.traceCorrelation).to.be.true;
@@ -1014,13 +1014,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.useOpentelemetry).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_DISABLE_USE_OPENTELEMETRY env var set to true over config set to true', () => {
+      it('should give precedence to INSTANA_DISABLE_USE_OPENTELEMETRY env var set to true over config set to true', () => {
         process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { useOpentelemetry: true } } });
         expect(config.tracing.useOpentelemetry).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_DISABLE_USE_OPENTELEMETRY env var set to false over config set to false', () => {
+      it('should give precedence to INSTANA_DISABLE_USE_OPENTELEMETRY env var set to false over config set to false', () => {
         process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { useOpentelemetry: false } } });
         expect(config.tracing.useOpentelemetry).to.be.true;
@@ -1117,12 +1117,12 @@ describe('config.normalizeConfig', () => {
         expect(config.packageJsonPath).to.equal('/my/path');
       });
 
-      it.skip('should use default (null) when neither env nor config is set', () => {
+      it('should use default (null) when neither env nor config is set', () => {
         const config = coreConfig.normalize({});
         expect(config.packageJsonPath).to.be.null;
       });
 
-      it.skip('should give precedence to INSTANA_PACKAGE_JSON_PATH env var over config', () => {
+      it('should give precedence to INSTANA_PACKAGE_JSON_PATH env var over config', () => {
         process.env.INSTANA_PACKAGE_JSON_PATH = '/env/path/package.json';
         const config = coreConfig.normalize({ userConfig: { packageJsonPath: '/config/path/package.json' } });
         expect(config.packageJsonPath).to.equal('/env/path/package.json');
@@ -1164,13 +1164,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.allowRootExitSpan).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_ALLOW_ROOT_EXIT_SPAN env var set to true over config set to false', () => {
+      it('should give precedence to INSTANA_ALLOW_ROOT_EXIT_SPAN env var set to true over config set to false', () => {
         process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { allowRootExitSpan: false } } });
         expect(config.tracing.allowRootExitSpan).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_ALLOW_ROOT_EXIT_SPAN env var set to false over config set to true', () => {
+      it('should give precedence to INSTANA_ALLOW_ROOT_EXIT_SPAN env var set to false over config set to true', () => {
         process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { allowRootExitSpan: true } } });
         expect(config.tracing.allowRootExitSpan).to.be.false;
@@ -1369,13 +1369,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.false;
       });
 
-      it.skip('should give precedence to INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION env var set to true over config set to false', () => {
+      it('should give precedence to INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION env var set to true over config set to false', () => {
         process.env.INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { ignoreEndpointsDisableSuppression: false } } });
         expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION env var set to false over config set to true', () => {
+      it('should give precedence to INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION env var set to false over config set to true', () => {
         process.env.INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { ignoreEndpointsDisableSuppression: true } } });
         expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.false;
@@ -1483,13 +1483,13 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.disableEOLEvents).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_TRACING_DISABLE_EOL_EVENTS env var set to true over config set to false', () => {
+      it('should give precedence to INSTANA_TRACING_DISABLE_EOL_EVENTS env var set to true over config set to false', () => {
         process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'true';
         const config = coreConfig.normalize({ userConfig: { tracing: { disableEOLEvents: false } } });
         expect(config.tracing.disableEOLEvents).to.be.true;
       });
 
-      it.skip('should give precedence to INSTANA_TRACING_DISABLE_EOL_EVENTS env var set to false over config set to true', () => {
+      it('should give precedence to INSTANA_TRACING_DISABLE_EOL_EVENTS env var set to false over config set to true', () => {
         process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'false';
         const config = coreConfig.normalize({ userConfig: { tracing: { disableEOLEvents: true } } });
         expect(config.tracing.disableEOLEvents).to.be.false;

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -1540,157 +1540,450 @@ describe('config.normalizeConfig', () => {
       const config = coreConfig.normalize({ userConfig: { serviceName: 'test' } });
       expect(config.serviceName).to.equal('test');
     });
+  });
 
-    describe('config.update', () => {
-      const { CONFIG_SOURCES } = require('../../src/util/constants');
+  describe('config.update', () => {
+    const { CONFIG_SOURCES } = require('../../src/util/constants');
 
-      it('should update config from agent when not previously set', () => {
-        const config = coreConfig.normalize({});
+    it('should update config from external source when not previously set', () => {
+      const config = coreConfig.normalize({});
 
-        coreConfig.update(
-          {
-            serviceName: 'agent-service'
-          },
-          CONFIG_SOURCES.AGENT
-        );
-
-        expect(config.serviceName).to.equal('agent-service');
+      coreConfig.update({
+        externalConfig: {
+          serviceName: 'agent-service'
+        },
+        source: CONFIG_SOURCES.AGENT
       });
 
-      it('should not update config from agent when ENV var is set', () => {
-        process.env.INSTANA_SERVICE_NAME = 'env-service';
-        const config = coreConfig.normalize({});
-        expect(config.serviceName).to.equal('env-service');
+      expect(config.serviceName).to.equal('agent-service');
+    });
 
-        coreConfig.update(
-          {
-            serviceName: 'agent-service'
-          },
-          CONFIG_SOURCES.AGENT
-        );
+    it('should not update config from external source when ENV var is set', () => {
+      process.env.INSTANA_SERVICE_NAME = 'env-service';
+      const config = coreConfig.normalize({});
+      expect(config.serviceName).to.equal('env-service');
 
-        expect(config.serviceName).to.equal('env-service');
+      coreConfig.update({
+        externalConfig: {
+          serviceName: 'agent-service'
+        },
+        source: CONFIG_SOURCES.AGENT
       });
 
-      it('should not update config from agent when in-code config is set', () => {
-        const config = coreConfig.normalize({
-          userConfig: {
-            serviceName: 'code-service'
-          }
-        });
-        expect(config.serviceName).to.equal('code-service');
+      expect(config.serviceName).to.equal('env-service');
+    });
 
-        coreConfig.update(
-          {
-            serviceName: 'agent-service'
-          },
-          CONFIG_SOURCES.AGENT
-        );
+    it('should not update config from external source when in-code config is set', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          serviceName: 'code-service'
+        }
+      });
+      expect(config.serviceName).to.equal('code-service');
 
-        expect(config.serviceName).to.equal('code-service');
+      coreConfig.update({
+        externalConfig: {
+          serviceName: 'agent-service'
+        },
+        source: CONFIG_SOURCES.AGENT
       });
 
-      it('should update multiple config values from agent', () => {
-        const config = coreConfig.normalize();
+      expect(config.serviceName).to.equal('code-service');
+    });
 
-        coreConfig.update(
-          {
-            serviceName: 'agent-service',
-            'metrics.transmissionDelay': 2000
-          },
-          CONFIG_SOURCES.AGENT
-        );
+    it('should update multiple config values from external source', () => {
+      const config = coreConfig.normalize();
 
-        expect(config.serviceName).to.equal('agent-service');
-        expect(config['metrics.transmissionDelay']).to.equal(2000);
+      coreConfig.update({
+        externalConfig: {
+          serviceName: 'agent-service',
+          'metrics.transmissionDelay': 2000
+        },
+        source: CONFIG_SOURCES.AGENT
       });
 
-      it('should handle empty agent config', () => {
-        const config = coreConfig.normalize();
-        const originalServiceName = config.serviceName;
+      expect(config.serviceName).to.equal('agent-service');
+      expect(config['metrics.transmissionDelay']).to.equal(2000);
+    });
 
-        coreConfig.update({}, CONFIG_SOURCES.AGENT);
+    it('should handle empty external config', () => {
+      const config = coreConfig.normalize();
+      const originalServiceName = config.serviceName;
 
-        expect(config.serviceName).to.equal(originalServiceName);
+      coreConfig.update({ externalConfig: {}, source: CONFIG_SOURCES.AGENT });
+
+      expect(config.serviceName).to.equal(originalServiceName);
+    });
+
+    it('should handle null external config', () => {
+      const config = coreConfig.normalize();
+      const originalServiceName = config.serviceName;
+
+      coreConfig.update({ externalConfig: null, source: CONFIG_SOURCES.AGENT });
+
+      expect(config.serviceName).to.equal(originalServiceName);
+    });
+
+    it('should update external config over default values', () => {
+      const config = coreConfig.normalize();
+
+      expect(config.serviceName).to.be.null;
+
+      coreConfig.update({
+        externalConfig: {
+          serviceName: 'agent-service'
+        },
+        source: CONFIG_SOURCES.AGENT
       });
 
-      it('should handle null agent config', () => {
-        const config = coreConfig.normalize();
-        const originalServiceName = config.serviceName;
+      expect(config.serviceName).to.equal('agent-service');
+    });
 
-        coreConfig.update(null, CONFIG_SOURCES.AGENT);
+    it('should respect precedence: ENV > IN_CODE > AGENT > DEFAULT', () => {
+      process.env.INSTANA_SERVICE_NAME = 'env-service';
 
-        expect(config.serviceName).to.equal(originalServiceName);
+      const config = coreConfig.normalize({
+        userConfig: {
+          packageJsonPath: '/custom/path'
+        }
       });
 
-      it('should update agent config over default values', () => {
-        const config = coreConfig.normalize();
+      expect(config.serviceName).to.equal('env-service');
+      expect(config.packageJsonPath).to.equal('/custom/path');
 
-        expect(config.serviceName).to.be.null;
-
-        coreConfig.update(
-          {
-            serviceName: 'agent-service'
-          },
-          CONFIG_SOURCES.AGENT
-        );
-
-        expect(config.serviceName).to.equal('agent-service');
+      coreConfig.update({
+        externalConfig: {
+          serviceName: 'agent-service',
+          packageJsonPath: '/agent/path',
+          preloadOpentelemetry: true
+        },
+        source: CONFIG_SOURCES.AGENT
       });
 
-      it('should respect precedence: ENV > IN_CODE > AGENT > DEFAULT', () => {
-        process.env.INSTANA_SERVICE_NAME = 'env-service';
+      expect(config.serviceName).to.equal('env-service');
 
-        const config = coreConfig.normalize({
-          userConfig: {
-            packageJsonPath: '/custom/path'
-          }
-        });
+      expect(config.packageJsonPath).to.equal('/custom/path');
 
-        expect(config.serviceName).to.equal('env-service');
-        expect(config.packageJsonPath).to.equal('/custom/path');
+      expect(config.preloadOpentelemetry).to.be.true;
+    });
 
-        coreConfig.update(
-          {
-            serviceName: 'agent-service',
-            packageJsonPath: '/agent/path',
-            preloadOpentelemetry: true
-          },
-          CONFIG_SOURCES.AGENT
-        );
+    it('should preserve existing tracing config when external source updates tracing partially', () => {
+      const config = coreConfig.normalize();
 
-        expect(config.serviceName).to.equal('env-service');
+      expect(config.tracing.kafka.traceCorrelation).to.be.true;
+      expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal([]);
 
-        expect(config.packageJsonPath).to.equal('/custom/path');
-
-        expect(config.preloadOpentelemetry).to.be.true;
-      });
-
-      it('should preserve existing tracing config when agent updates tracing partially', () => {
-        const config = coreConfig.normalize();
-
-        expect(config.tracing.kafka.traceCorrelation).to.be.true;
-        expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal([]);
-
-        coreConfig.update(
-          {
-            tracing: {
-              http: {
-                extraHttpHeadersToCapture: ['x-instana-test']
-              }
+      coreConfig.update({
+        externalConfig: {
+          tracing: {
+            http: {
+              extraHttpHeadersToCapture: ['x-instana-test']
             }
-          },
-          CONFIG_SOURCES.AGENT
-        );
-
-        expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal(['x-instana-test']);
-        expect(config.tracing.kafka).to.deep.equal({
-          traceCorrelation: true
-        });
-        expect(config.tracing.kafka.traceCorrelation).to.be.true;
-        expect(config.tracing.enabled).to.be.true;
-        expect(config.tracing.spanBatchingEnabled).to.be.false;
+          }
+        },
+        source: CONFIG_SOURCES.AGENT
       });
+
+      expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal(['x-instana-test']);
+      expect(config.tracing.kafka).to.deep.equal({
+        traceCorrelation: true
+      });
+      expect(config.tracing.kafka.traceCorrelation).to.be.true;
+      expect(config.tracing.enabled).to.be.true;
+      expect(config.tracing.spanBatchingEnabled).to.be.false;
+    });
+
+    it('should handle external source updating tracing.disable configuration', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          tracing: {
+            disable: {
+              'http-client': true
+            }
+          }
+        }
+      });
+
+      expect(config.tracing.disable).to.deep.equal({
+        'http-client': true
+      });
+
+      coreConfig.update({
+        externalConfig: {
+          tracing: {
+            disable: {
+              'http-server': true,
+              mongodb: true
+            }
+          }
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
+
+      expect(config.tracing.disable).to.deep.equal({
+        'http-client': true
+      });
+    });
+
+    it('should handle external source updating tracing.http.extraHttpHeadersToCapture', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          tracing: {
+            http: {
+              extraHttpHeadersToCapture: ['x-custom-header']
+            }
+          }
+        }
+      });
+
+      expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal(['x-custom-header']);
+
+      coreConfig.update({
+        externalConfig: {
+          tracing: {
+            http: {
+              extraHttpHeadersToCapture: ['x-agent-header', 'x-trace-id']
+            }
+          }
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
+
+      expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal(['x-custom-header']);
+    });
+
+    it('should handle external source updating secrets configuration', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          secrets: {
+            matcherMode: 'contains-ignore-case',
+            keywords: ['password', 'secret']
+          }
+        }
+      });
+
+      expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
+      expect(config.secrets.keywords).to.deep.equal(['password', 'secret']);
+
+      coreConfig.update({
+        externalConfig: {
+          secrets: {
+            keywords: ['token', 'apikey', 'auth']
+          }
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
+
+      expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
+      expect(config.secrets.keywords).to.deep.equal(['password', 'secret']);
+    });
+
+    it('should ignore external source updating tracing.ignoreEndpoints configuration when already set', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          tracing: {
+            ignoreEndpoints: {
+              redis: ['get', 'set']
+            }
+          }
+        }
+      });
+
+      expect(config.tracing.ignoreEndpoints).to.deep.equal({
+        redis: [{ methods: ['get', 'set'] }]
+      });
+
+      coreConfig.update({
+        externalConfig: {
+          tracing: {
+            ignoreEndpoints: {
+              dynamodb: [{ methods: ['query'] }],
+              mongodb: [{ methods: ['find'] }]
+            }
+          }
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
+
+      expect(config.tracing.ignoreEndpoints).to.deep.equal({
+        redis: [{ methods: ['get', 'set'] }]
+      });
+    });
+
+    it('should use external config value dor tracing.ignoreEndpoints configuration when not set', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          tracing: {}
+        }
+      });
+
+      coreConfig.update({
+        externalConfig: {
+          tracing: {
+            ignoreEndpoints: {
+              dynamodb: [{ methods: ['query'] }],
+              mongodb: [{ methods: ['find'] }]
+            }
+          }
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
+
+      expect(config.tracing.ignoreEndpoints).to.deep.equal({
+        dynamodb: [{ methods: ['query'] }],
+        mongodb: [{ methods: ['find'] }]
+      });
+    });
+
+    it('should handle external source updating stackTrace configuration when not set in-code', () => {
+      const config = coreConfig.normalize();
+
+      expect(config.tracing.stackTrace).to.equal('all');
+      expect(config.tracing.stackTraceLength).to.equal(10);
+
+      coreConfig.update({
+        externalConfig: {
+          tracing: {
+            stackTrace: 'on-error',
+            stackTraceLength: 15
+          }
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
+
+      expect(config.tracing.stackTrace).to.equal('on-error');
+      expect(config.tracing.stackTraceLength).to.equal(15);
+    });
+
+    it('should not override in-code config with external config when in-code has higher priority', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          tracing: {
+            enabled: false,
+            stackTrace: 'never'
+          }
+        }
+      });
+
+      expect(config.tracing.enabled).to.be.false;
+      expect(config.tracing.stackTrace).to.equal('all');
+
+      coreConfig.update({
+        externalConfig: {
+          tracing: {
+            enabled: true,
+            stackTrace: 'all'
+          }
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
+
+      expect(config.tracing.enabled).to.be.false;
+      expect(config.tracing.stackTrace).to.equal('all');
+    });
+
+    it('should handle complex nested config updates from external source', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          tracing: {
+            http: {
+              extraHttpHeadersToCapture: ['x-custom']
+            },
+            kafka: {
+              traceCorrelation: false
+            }
+          }
+        }
+      });
+
+      expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal(['x-custom']);
+      expect(config.tracing.kafka.traceCorrelation).to.be.false;
+
+      coreConfig.update({
+        externalConfig: {
+          tracing: {
+            http: {
+              extraHttpHeadersToCapture: ['x-agent-header']
+            },
+            stackTrace: 'on-error',
+            stackTraceLength: 25,
+            disable: {
+              redis: true
+            }
+          }
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
+
+      expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal(['x-custom']);
+      expect(config.tracing.stackTrace).to.equal('on-error');
+      expect(config.tracing.stackTraceLength).to.equal(25);
+      expect(config.tracing.disable.redis).to.be.true;
+
+      expect(config.tracing.kafka.traceCorrelation).to.be.false;
+    });
+
+    it('should handle external source disabling tracing when not set in-code', () => {
+      const config = coreConfig.normalize();
+
+      expect(config.tracing.enabled).to.be.true;
+
+      coreConfig.update({
+        externalConfig: {
+          tracing: {
+            enabled: false
+          }
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
+
+      expect(config.tracing.enabled).to.be.false;
+    });
+
+    it('should handle external source updating tracing.ignoreEndpointsDisableSuppression', () => {
+      const config = coreConfig.normalize();
+
+      expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.false;
+
+      coreConfig.update({
+        externalConfig: {
+          tracing: {
+            ignoreEndpointsDisableSuppression: true
+          }
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
+
+      expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.true;
+    });
+
+    it('should preserve existing tracing.ignoreEndpoints when external source updates disableSuppression', () => {
+      const config = coreConfig.normalize({
+        userConfig: {
+          tracing: {
+            ignoreEndpoints: {
+              redis: ['get'],
+              mongodb: ['find']
+            }
+          }
+        }
+      });
+
+      expect(config.tracing.ignoreEndpoints.redis).to.deep.equal([{ methods: ['get'] }]);
+      expect(config.tracing.ignoreEndpoints.mongodb).to.deep.equal([{ methods: ['find'] }]);
+
+      coreConfig.update({
+        externalConfig: {
+          tracing: {
+            ignoreEndpointsDisableSuppression: true
+          }
+        },
+        source: CONFIG_SOURCES.AGENT
+      });
+
+      expect(config.tracing.ignoreEndpoints.redis).to.deep.equal([{ methods: ['get'] }]);
+      expect(config.tracing.ignoreEndpoints.mongodb).to.deep.equal([{ methods: ['find'] }]);
+      expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.true;
     });
   });
 

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -44,1021 +44,1058 @@ describe('config.normalizeConfig', () => {
     delete process.env.INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION;
   }
 
-  it('should apply all defaults', () => {
-    checkDefaults(coreConfig.normalize());
-    checkDefaults(coreConfig.normalize({}));
-    checkDefaults(coreConfig.normalize({ tracing: {}, metrics: {} }));
-    checkDefaults(coreConfig.normalize({ unknowConfigOption: 13 }));
-  });
-
-  it('should accept service name', () => {
-    const config = coreConfig.normalize({ serviceName: 'custom-service-name' });
-    expect(config.serviceName).to.equal('custom-service-name');
-  });
-
-  it('should accept service name from env var', () => {
-    process.env.INSTANA_SERVICE_NAME = 'very-custom-service-name';
-    const config = coreConfig.normalize();
-    expect(config.serviceName).to.equal('very-custom-service-name');
-  });
-
-  it('should not accept non-string service name', () => {
-    const config = coreConfig.normalize({ serviceName: 42 });
-    expect(config.serviceName).to.not.exist;
-  });
-
-  it('should use custom metrics transmission settings from config', () => {
-    const config = coreConfig.normalize({
-      metrics: {
-        transmissionDelay: 753
-      }
-    });
-    expect(config.metrics.transmissionDelay).to.equal(753);
-  });
-
-  it('should use custom metrics transmission settings from env vars', () => {
-    process.env.INSTANA_METRICS_TRANSMISSION_DELAY = '2500';
-    const config = coreConfig.normalize();
-    expect(config.metrics.transmissionDelay).to.equal(2500);
-  });
-
-  it('should use default metrics transmission settings when env vars are non-numerical', () => {
-    process.env.INSTANA_METRICS_TRANSMISSION_DELAY = 'x2500';
-    const config = coreConfig.normalize();
-    expect(config.metrics.transmissionDelay).to.equal(1000);
-  });
-
-  it('should use max metrics transmission settings when value exceeds max of 5000', () => {
-    process.env.INSTANA_METRICS_TRANSMISSION_DELAY = '6000';
-    const normalizedConfig = coreConfig.normalize();
-    expect(normalizedConfig.metrics.transmissionDelay).to.equal(5000);
-  });
-
-  it('should accept metrics transmission delay at max value of 5000', () => {
-    process.env.INSTANA_METRICS_TRANSMISSION_DELAY = '5000';
-    const normalizedConfig = coreConfig.normalize();
-    expect(normalizedConfig.metrics.transmissionDelay).to.equal(5000);
-  });
-
-  it('should use max metrics transmission settings when value exceeds max 5000', () => {
-    const config = coreConfig.normalize({
-      metrics: {
-        transmissionDelay: 9753
-      }
-    });
-    expect(config.metrics.transmissionDelay).to.equal(5000);
-  });
-
-  it('should use custom config.metrics.timeBetweenHealthcheckCalls', () => {
-    const config = coreConfig.normalize({
-      metrics: {
-        timeBetweenHealthcheckCalls: 9876
-      }
-    });
-    expect(config.metrics.timeBetweenHealthcheckCalls).to.equal(9876);
-  });
-
-  it('should disable tracing with enabled: false', () => {
-    const config = coreConfig.normalize({ tracing: { enabled: false } });
-    expect(config.tracing.enabled).to.be.false;
-    expect(config.tracing.automaticTracingEnabled).to.be.false;
-  });
-
-  it('should disable tracing with disable: true', () => {
-    const config = coreConfig.normalize({ tracing: { enabled: false } });
-    expect(config.tracing.enabled).to.be.false;
-    expect(config.tracing.automaticTracingEnabled).to.be.false;
-  });
-
-  it('should disable automatic tracing', () => {
-    const config = coreConfig.normalize({ tracing: { automaticTracingEnabled: false } });
-    expect(config.tracing.enabled).to.be.true;
-    expect(config.tracing.automaticTracingEnabled).to.be.false;
-  });
-
-  it('should disable automatic tracing via INSTANA_DISABLE_AUTO_INSTR', () => {
-    process.env.INSTANA_DISABLE_AUTO_INSTR = 'true';
-    const config = coreConfig.normalize();
-    expect(config.tracing.enabled).to.be.true;
-    expect(config.tracing.automaticTracingEnabled).to.be.false;
-  });
-
-  it('should not enable automatic tracing when tracing is disabled in general', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        enabled: false,
-        automaticTracingEnabled: true
-      }
-    });
-    expect(config.tracing.enabled).to.be.false;
-    expect(config.tracing.automaticTracingEnabled).to.be.false;
-  });
-
-  it('should enable immediate tracing activation', () => {
-    const config = coreConfig.normalize({ tracing: { activateImmediately: true } });
-    expect(config.tracing.activateImmediately).to.be.true;
-  });
-
-  it('should enable immediate tracing activation via INSTANA_TRACE_IMMEDIATELY', () => {
-    process.env.INSTANA_TRACE_IMMEDIATELY = 'true';
-    const config = coreConfig.normalize();
-    expect(config.tracing.activateImmediately).to.be.true;
-  });
-
-  it('should not enable immediate tracing activation when tracing is disabled in general', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        enabled: false,
-        activateImmediately: true
-      }
-    });
-    expect(config.tracing.enabled).to.be.false;
-    expect(config.tracing.activateImmediately).to.be.false;
-  });
-
-  it('should use custom tracing transmission settings from config', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        maxBufferedSpans: 13,
-        forceTransmissionStartingAt: 2,
-        transmissionDelay: 9753
-      }
-    });
-    expect(config.tracing.maxBufferedSpans).to.equal(13);
-    expect(config.tracing.forceTransmissionStartingAt).to.equal(2);
-    expect(config.tracing.transmissionDelay).to.equal(9753);
-  });
-
-  it('should use custom tracing transmission settings from env vars', () => {
-    process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT = '2468';
-    process.env.INSTANA_TRACING_TRANSMISSION_DELAY = '2500';
-    const config = coreConfig.normalize();
-    expect(config.tracing.forceTransmissionStartingAt).to.equal(2468);
-    expect(config.tracing.transmissionDelay).to.equal(2500);
-  });
-
-  it('should use default tracing transmission settings when env vars are non-numerical', () => {
-    process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT = 'a2468';
-    process.env.INSTANA_TRACING_TRANSMISSION_DELAY = 'x2500';
-    const config = coreConfig.normalize();
-    expect(config.tracing.forceTransmissionStartingAt).to.equal(500);
-    expect(config.tracing.transmissionDelay).to.equal(1000);
-  });
-
-  it('should use extra http headers (and normalize to lower case)', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        http: {
-          extraHttpHeadersToCapture: ['yo', 'LO']
-        }
-      }
-    });
-    expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal(['yo', 'lo']);
-  });
-
-  it('should reject non-array extra http headers configuration value', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        http: {
-          extraHttpHeadersToCapture: 'yolo'
-        }
-      }
-    });
-    expect(config.tracing.http.extraHttpHeadersToCapture).to.be.an('array');
-    expect(config.tracing.http.extraHttpHeadersToCapture).to.be.empty;
-  });
-
-  it('should parse extra headers from env var', () => {
-    process.env.INSTANA_EXTRA_HTTP_HEADERS = ' X-Header-1 ; X-hEADer-2 , X-Whatever ';
-    const config = coreConfig.normalize();
-    expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal(['x-header-1', 'x-header-2', 'x-whatever']);
-  });
-
-  it('must use default extra headers (empty list) when INSTANA_EXTRA_HTTP_HEADERS is invalid', () => {
-    process.env.INSTANA_EXTRA_HTTP_HEADERS = ' \n \t ';
-    const config = coreConfig.normalize();
-    expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal([]);
-  });
-
-  it('should accept numerical custom stack trace length', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: 666 } });
-    expect(config.tracing.stackTraceLength).to.equal(500);
-  });
-
-  it('should normalize numbers for custom stack trace length', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: -28.08 } });
-    expect(config.tracing.stackTraceLength).to.be.a('number');
-    expect(config.tracing.stackTraceLength).to.equal(28);
-  });
-
-  it('should accept number-like strings for custom stack trace length', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: '1302' } });
-    expect(config.tracing.stackTraceLength).to.be.a('number');
-    expect(config.tracing.stackTraceLength).to.equal(500);
-  });
-
-  it('should normalize number-like strings for custom stack trace length', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: '-16.04' } });
-    expect(config.tracing.stackTraceLength).to.be.a('number');
-    expect(config.tracing.stackTraceLength).to.equal(16);
-  });
-
-  it('should reject non-numerical strings for custom stack trace length', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: 'three' } });
-    expect(config.tracing.stackTraceLength).to.be.a('number');
-    expect(config.tracing.stackTraceLength).to.equal(10);
-  });
-
-  it('should reject custom stack trace length which is neither a number nor a string', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: false } });
-    expect(config.tracing.stackTraceLength).to.be.a('number');
-    expect(config.tracing.stackTraceLength).to.equal(10);
-  });
-
-  it('should read stack trace length from INSTANA_STACK_TRACE_LENGTH', () => {
-    process.env.INSTANA_STACK_TRACE_LENGTH = '3';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTraceLength).to.equal(3);
-  });
-
-  it('should give precedence to INSTANA_STACK_TRACE_LENGTH over config', () => {
-    process.env.INSTANA_STACK_TRACE_LENGTH = '5';
-    const normalizedConfig = coreConfig.normalize({ tracing: { stackTraceLength: 20 } });
-    expect(normalizedConfig.tracing.stackTraceLength).to.equal(5);
-    delete process.env.INSTANA_STACK_TRACE_LENGTH;
-  });
-
-  it('should use default stack trace mode', () => {
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTrace).to.equal('all');
-  });
-
-  it('should accept valid stack trace mode from config', () => {
-    const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'error' } } });
-    expect(config.tracing.stackTrace).to.equal('error');
-  });
-
-  it('should accept "none" stack trace mode from config', () => {
-    const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'none' } } });
-    expect(config.tracing.stackTrace).to.equal('none');
-  });
-
-  it('should normalize stack trace mode to lowercase from config', () => {
-    const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'ERROR' } } });
-    expect(config.tracing.stackTrace).to.equal('error');
-  });
-
-  it('should read stack trace mode from INSTANA_STACK_TRACE', () => {
-    process.env.INSTANA_STACK_TRACE = 'error';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTrace).to.equal('error');
-  });
-
-  it('should normalize stack trace mode to lowercase from INSTANA_STACK_TRACE', () => {
-    process.env.INSTANA_STACK_TRACE = 'NONE';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTrace).to.equal('none');
-  });
-
-  it('should give precedence to env INSTANA_STACK_TRACE over config', () => {
-    process.env.INSTANA_STACK_TRACE = 'none';
-    const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'all' } } });
-    expect(config.tracing.stackTrace).to.equal('none');
-  });
-
-  it('should reject invalid stack trace mode from config and fallback to default', () => {
-    const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'invalid' } } });
-    expect(config.tracing.stackTrace).to.equal('all');
-  });
-
-  it('should reject invalid stack trace mode from INSTANA_STACK_TRACE and use default', () => {
-    process.env.INSTANA_STACK_TRACE = 'invalid';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTrace).to.equal('all');
-  });
-
-  it('should reject non-string stack trace mode from config', () => {
-    const config = coreConfig.normalize({ tracing: { global: { stackTrace: 123 } } });
-    expect(config.tracing.stackTrace).to.equal('all');
-  });
-
-  it('should handle null stack trace mode from config', () => {
-    const config = coreConfig.normalize({ tracing: { global: { stackTrace: null } } });
-    expect(config.tracing.stackTrace).to.equal('all');
-  });
-
-  it('should handle undefined stack trace mode from config', () => {
-    const config = coreConfig.normalize({ tracing: { global: { stackTrace: undefined } } });
-    expect(config.tracing.stackTrace).to.equal('all');
-  });
-
-  it('should handle empty string stack trace mode from config', () => {
-    const config = coreConfig.normalize({ tracing: { global: { stackTrace: '' } } });
-    expect(config.tracing.stackTrace).to.equal('all');
-  });
-
-  it('should handle boolean stack trace mode from config', () => {
-    const config = coreConfig.normalize({ tracing: { global: { stackTrace: true } } });
-    expect(config.tracing.stackTrace).to.equal('all');
-  });
-
-  it('should handle object stack trace mode from config', () => {
-    const config = coreConfig.normalize({ tracing: { global: { stackTrace: {} } } });
-    expect(config.tracing.stackTrace).to.equal('all');
-  });
-
-  it('should handle array stack trace mode from config', () => {
-    const config = coreConfig.normalize({ tracing: { global: { stackTrace: ['error'] } } });
-    expect(config.tracing.stackTrace).to.equal('all');
-  });
-
-  it('should accept zero as valid stack trace length', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: 0 } });
-    expect(config.tracing.stackTraceLength).to.equal(0);
-  });
-
-  it('should handle negative stack trace length', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: -10 } });
-    expect(config.tracing.stackTraceLength).to.equal(10);
-  });
-
-  it('should handle very large negative stack trace length', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: -100 } });
-    expect(config.tracing.stackTraceLength).to.equal(100);
-  });
-
-  it('should handle stack trace length as positive float', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: 15.9 } });
-    expect(config.tracing.stackTraceLength).to.equal(16);
-  });
-
-  it('should handle stack trace length as negative float', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: -15.9 } });
-    expect(config.tracing.stackTraceLength).to.equal(16);
-  });
-
-  it('should handle stack trace length as string with leading zeros', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: '007' } });
-    expect(config.tracing.stackTraceLength).to.equal(7);
-  });
-
-  it('should handle stack trace length as string with whitespace', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: '  25  ' } });
-    expect(config.tracing.stackTraceLength).to.equal(25);
-  });
-
-  it('should handle stack trace length as string with plus sign', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: '+30' } });
-    expect(config.tracing.stackTraceLength).to.equal(30);
-  });
-
-  it('should reject stack trace length as null', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: null } });
-    expect(config.tracing.stackTraceLength).to.equal(10);
-  });
-
-  it('should reject stack trace length as undefined', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: undefined } });
-    expect(config.tracing.stackTraceLength).to.equal(10);
-  });
-
-  it('should reject stack trace length as empty string', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: '' } });
-    expect(config.tracing.stackTraceLength).to.equal(10);
-  });
-
-  it('should reject stack trace length as object', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: {} } });
-    expect(config.tracing.stackTraceLength).to.equal(10);
-  });
-
-  it('should reject stack trace length as array', () => {
-    const config = coreConfig.normalize({ tracing: { stackTraceLength: [10] } });
-    expect(config.tracing.stackTraceLength).to.equal(10);
-  });
-
-  it('should handle stack trace length from INSTANA_STACK_TRACE_LENGTH as zero', () => {
-    process.env.INSTANA_STACK_TRACE_LENGTH = '0';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTraceLength).to.equal(0);
-  });
-
-  it('should handle stack trace length from INSTANA_STACK_TRACE_LENGTH with negative value', () => {
-    process.env.INSTANA_STACK_TRACE_LENGTH = '-20';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTraceLength).to.equal(20);
-  });
-
-  it('should handle stack trace length from INSTANA_STACK_TRACE_LENGTH exceeding max', () => {
-    process.env.INSTANA_STACK_TRACE_LENGTH = '1000';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTraceLength).to.equal(500);
-  });
-
-  it('should handle stack trace length from INSTANA_STACK_TRACE_LENGTH as float', () => {
-    process.env.INSTANA_STACK_TRACE_LENGTH = '12.3';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTraceLength).to.equal(12);
-  });
-
-  it('should reject invalid INSTANA_STACK_TRACE_LENGTH', () => {
-    process.env.INSTANA_STACK_TRACE_LENGTH = 'not-a-number';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTraceLength).to.equal(10);
-  });
-
-  it('should reject empty INSTANA_STACK_TRACE_LENGTH', () => {
-    process.env.INSTANA_STACK_TRACE_LENGTH = '';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTraceLength).to.equal(10);
-  });
-
-  it('should reject INSTANA_STACK_TRACE_LENGTH with only whitespace', () => {
-    process.env.INSTANA_STACK_TRACE_LENGTH = '   ';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTraceLength).to.equal(10);
-  });
-
-  it('should handle INSTANA_STACK_TRACE_LENGTH with mixed valid and invalid characters', () => {
-    process.env.INSTANA_STACK_TRACE_LENGTH = '15abc';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTraceLength).to.equal(15);
-  });
-
-  it('should handle both INSTANA_STACK_TRACE and INSTANA_STACK_TRACE_LENGTH together', () => {
-    process.env.INSTANA_STACK_TRACE = 'error';
-    process.env.INSTANA_STACK_TRACE_LENGTH = '25';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTrace).to.equal('error');
-    expect(config.tracing.stackTraceLength).to.equal(25);
-  });
-
-  it('should handle config with both stackTrace and stackTraceLength', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        global: {
-          stackTrace: 'none',
-          stackTraceLength: 30
-        }
-      }
-    });
-    expect(config.tracing.stackTrace).to.equal('none');
-    expect(config.tracing.stackTraceLength).to.equal(30);
-  });
-
-  it('should give precedence to env vars for both stack trace settings over config', () => {
-    process.env.INSTANA_STACK_TRACE = 'error';
-    process.env.INSTANA_STACK_TRACE_LENGTH = '15';
-    const config = coreConfig.normalize({
-      tracing: {
-        global: {
-          stackTrace: 'all',
-          stackTraceLength: 40
-        }
-      }
-    });
-    expect(config.tracing.stackTrace).to.equal('error');
-    expect(config.tracing.stackTraceLength).to.equal(15);
-  });
-
-  it('should use INSTANA_STACK_TRACE_LENGTH when STACK_TRACE_LENGTH is not set', () => {
-    process.env.INSTANA_STACK_TRACE_LENGTH = '18';
-    const config = coreConfig.normalize();
-    expect(config.tracing.stackTraceLength).to.equal(18);
-    delete process.env.INSTANA_STACK_TRACE_LENGTH;
-  });
-
-  it('should not disable individual instrumentations by default', () => {
-    const config = coreConfig.normalize();
-    expect(config.tracing.disable).to.deep.equal({});
-  });
-
-  it('should disable individual instrumentations via disable config', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        disable: ['graphQL', 'GRPC']
-      }
-    });
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
-  });
-
-  it('should disable individual instrumentations via disable.instrumentations config', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        disable: { instrumentations: ['graphQL', 'GRPC'] }
-      }
-    });
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
-  });
-
-  it('config should take precedence over INSTANA_TRACING_DISABLE_INSTRUMENTATIONS  for config', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'foo, bar';
-    const config = coreConfig.normalize({
-      tracing: {
-        disable: { instrumentations: ['baz', 'fizz'] }
-      }
-    });
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
-  });
-
-  it('should disable multiple instrumentations via env var INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'graphQL   , GRPC, http';
-    const config = coreConfig.normalize();
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc', 'http']);
-  });
-
-  it('should handle single instrumentations via INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'console';
-    const config = coreConfig.normalize();
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['console']);
-  });
-
-  it('should trim whitespace from tracer names', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = '  graphql  ,  grpc  ';
-    const config = coreConfig.normalize();
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
-  });
-
-  it('should disable individual groups via disable config', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        disable: { groups: ['logging'] }
-      }
-    });
-    expect(config.tracing.disable.groups).to.deep.equal(['logging']);
-  });
-
-  it('config should disable when env var INSTANA_TRACING_DISABLE_GROUPS is set', () => {
-    process.env.INSTANA_TRACING_DISABLE_GROUPS = 'frameworks, databases';
-    const config = coreConfig.normalize({});
-    expect(config.tracing.disable.groups).to.deep.equal(['frameworks', 'databases']);
-  });
-
-  it('config should take precedence over INSTANA_TRACING_DISABLE_GROUPS when disabling groups', () => {
-    process.env.INSTANA_TRACING_DISABLE_GROUPS = 'frameworks, databases';
-    const config = coreConfig.normalize({
-      tracing: {
-        disable: { groups: ['LOGGING'] }
-      }
-    });
-    expect(config.tracing.disable.groups).to.deep.equal(['logging']);
-  });
-
-  it('should disable instrumentations and groups when both configured', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        disable: { groups: ['LOGGING'], instrumentations: ['redis', 'kafka'] }
-      }
-    });
-    expect(config.tracing.disable.groups).to.deep.equal(['logging']);
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['redis', 'kafka']);
-  });
-
-  it('should disable instrumentations and groups when both env variables provided', () => {
-    process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'redis';
-    process.env.INSTANA_TRACING_DISABLE_GROUPS = 'logging';
-    const config = coreConfig.normalize();
-    expect(config.tracing.disable.instrumentations).to.deep.equal(['redis']);
-    expect(config.tracing.disable.groups).to.deep.equal(['logging']);
-  });
-
-  it('should disable all tracing via INSTANA_TRACING_DISABLE', () => {
-    process.env.INSTANA_TRACING_DISABLE = true;
-    const config = coreConfig.normalize();
-    expect(config.tracing.enabled).to.be.false;
-    expect(config.tracing.disable).to.deep.equal({});
-    expect(config.tracing.automaticTracingEnabled).to.be.false;
-  });
-
-  it('should disable all tracing via config tracing.disable', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        disable: true
-      }
-    });
-    expect(config.tracing.enabled).to.be.false;
-    expect(config.tracing.disable).to.deep.equal({});
-    expect(config.tracing.automaticTracingEnabled).to.be.false;
-  });
-
-  // delete this test when we switch to opt-out
-  it('should enable span batching via config in transition phase', () => {
-    const config = coreConfig.normalize({ tracing: { spanBatchingEnabled: true } });
-    expect(config.tracing.spanBatchingEnabled).to.be.true;
-  });
-
-  // delete this test when we switch to opt-out
-  it('should enable span batching via INSTANA_SPANBATCHING_ENABLED in transition phase', () => {
-    process.env.INSTANA_SPANBATCHING_ENABLED = 'true';
-    const config = coreConfig.normalize();
-    expect(config.tracing.spanBatchingEnabled).to.be.true;
-  });
-
-  it('should ignore non-boolean span batching config value', () => {
-    const config = coreConfig.normalize({ tracing: { spanBatchingEnabled: 73 } });
-    // test needs to be updated once we switch to opt-out
-    expect(config.tracing.spanBatchingEnabled).to.be.false;
-  });
-
-  it('should disable span batching', () => {
-    // test only becomes relevant once we switch to opt-out
-    const config = coreConfig.normalize({ tracing: { spanBatchingEnabled: false } });
-    expect(config.tracing.spanBatchingEnabled).to.be.false;
-  });
-
-  it('should disable span batching via INSTANA_DISABLE_SPANBATCHING', () => {
-    // test only becomes relevant once we switch to opt-out
-    process.env.INSTANA_DISABLE_SPANBATCHING = 'true';
-    const config = coreConfig.normalize();
-    expect(config.tracing.spanBatchingEnabled).to.be.false;
-  });
-
-  it('should disable W3C trace correlation', () => {
-    const config = coreConfig.normalize({ tracing: { disableW3cTraceCorrelation: true } });
-    expect(config.tracing.disableW3cTraceCorrelation).to.be.true;
-  });
-
-  it('should disable W3C trace correlation via INSTANA_DISABLE_W3C_TRACE_CORRELATION', () => {
-    process.env.INSTANA_DISABLE_W3C_TRACE_CORRELATION = 'false'; // any non-empty string will disable, even "false"!
-    const config = coreConfig.normalize();
-    expect(config.tracing.disableW3cTraceCorrelation).to.be.true;
-  });
-
-  it('should disable Kafka trace correlation', () => {
-    const config = coreConfig.normalize({ tracing: { kafka: { traceCorrelation: false } } });
-    expect(config.tracing.kafka.traceCorrelation).to.be.false;
-  });
-
-  it('should disable Kafka trace correlation via INSTANA_KAFKA_TRACE_CORRELATION', () => {
-    process.env.INSTANA_KAFKA_TRACE_CORRELATION = 'false';
-    const config = coreConfig.normalize();
-    expect(config.tracing.kafka.traceCorrelation).to.be.false;
-  });
-
-  it('should disable opentelemetry if config is set', () => {
-    const config = coreConfig.normalize({
-      tracing: { useOpentelemetry: false }
-    });
-    expect(config.tracing.useOpentelemetry).to.equal(false);
-  });
-
-  it('should enable opentelemetry if config is set', () => {
-    const config = coreConfig.normalize({
-      tracing: { useOpentelemetry: true }
-    });
-    expect(config.tracing.useOpentelemetry).to.equal(true);
-  });
-
-  it('should disable opentelemetry if INSTANA_DISABLE_USE_OPENTELEMETRY is set', () => {
-    process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'true';
-    const config = coreConfig.normalize();
-    expect(config.tracing.useOpentelemetry).to.equal(false);
-  });
-
-  it('should enable opentelemetry if INSTANA_DISABLE_USE_OPENTELEMETRY is set', () => {
-    process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'false';
-    const config = coreConfig.normalize();
-    expect(config.tracing.useOpentelemetry).to.equal(true);
-  });
-
-  it('should accept custom secrets config', () => {
-    const config = coreConfig.normalize({
-      secrets: {
-        matcherMode: 'equals',
-        keywords: ['custom-secret', 'sheesh']
-      }
-    });
-    expect(config.secrets.matcherMode).to.equal('equals');
-    expect(config.secrets.keywords).to.deep.equal(['custom-secret', 'sheesh']);
-  });
-
-  it("should set keywords to empty array for matcher mode 'none'", () => {
-    const config = coreConfig.normalize({
-      secrets: {
-        matcherMode: 'none'
-      }
-    });
-    expect(config.secrets.matcherMode).to.equal('none');
-    expect(config.secrets.keywords).to.deep.equal([]);
-  });
-
-  it('should reject non-string matcher mode', () => {
-    const config = coreConfig.normalize({ secrets: { matcherMode: 43 } });
-    expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
-    expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
-  });
-
-  it('should reject unknown matcher mode from config', () => {
-    const config = coreConfig.normalize({ secrets: { matcherMode: 'whatever' } });
-    expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
-    expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
-  });
-
-  it('should reject non-array keywords', () => {
-    const config = coreConfig.normalize({ secrets: { keywords: 'yes' } });
-    expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
-    expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
-  });
-
-  it('should parse secrets from env var', () => {
-    process.env.INSTANA_SECRETS = ' eQuaLs-igNore-case  :  concealed  ,  hush  ';
-    const config = coreConfig.normalize();
-    expect(config.secrets.matcherMode).to.equal('equals-ignore-case');
-    expect(config.secrets.keywords).to.deep.equal(['concealed', 'hush']);
-  });
-
-  it('must use default secrets when INSTANA_SECRETS is invalid', () => {
-    process.env.INSTANA_SECRETS = 'whatever';
-    const config = coreConfig.normalize();
-    expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
-    expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
-  });
-
-  it("must accept INSTANA_SECRETS without secrets list if matcher mode is 'none'", () => {
-    process.env.INSTANA_SECRETS = 'NONE';
-    const config = coreConfig.normalize();
-    expect(config.secrets.matcherMode).to.equal('none');
-    expect(config.secrets.keywords).to.deep.equal([]);
-  });
-
-  it('should reject unknown matcher mode from INSTANA_SECRETS', () => {
-    process.env.INSTANA_SECRETS = 'unknown-matcher:nope,never';
-    const config = coreConfig.normalize();
-    expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
-    expect(config.secrets.keywords).to.deep.equal(['nope', 'never']);
-  });
-
-  it('should accept packageJsonPath', () => {
-    const config = coreConfig.normalize({ packageJsonPath: './something' });
-    expect(config.packageJsonPath).to.equal('./something');
-  });
-
-  it('should not accept packageJsonPath', () => {
-    const config = coreConfig.normalize({ packageJsonPath: 1234 });
-    expect(config.packageJsonPath).to.not.exist;
-  });
-
-  it('should accept INSTANA_PACKAGE_JSON_PATH', () => {
-    process.env.INSTANA_PACKAGE_JSON_PATH = '/my/path';
-    const config = coreConfig.normalize({});
-    expect(config.packageJsonPath).to.equal('/my/path');
-  });
-
-  it('should disable allow root exit span if config is set to false', () => {
-    const config = coreConfig.normalize({
-      tracing: { allowRootExitSpan: false }
-    });
-    expect(config.tracing.allowRootExitSpan).to.equal(false);
-  });
-
-  it('should enable allow root exit span if config is set to true', () => {
-    const config = coreConfig.normalize({
-      tracing: { allowRootExitSpan: true }
-    });
-    expect(config.tracing.allowRootExitSpan).to.equal(true);
-  });
-
-  it('should disable allow root exit span if INSTANA_ALLOW_ROOT_EXIT_SPAN is not set', () => {
-    process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = false;
-    const config = coreConfig.normalize();
-    expect(config.tracing.allowRootExitSpan).to.equal(false);
-  });
-
-  it('should enable allow root exit span if INSTANA_ALLOW_ROOT_EXIT_SPAN is set', () => {
-    process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = true;
-    const config = coreConfig.normalize();
-    expect(config.tracing.allowRootExitSpan).to.equal(true);
-  });
-  it('should not set ignore endpoints tracers by default', () => {
-    const config = coreConfig.normalize();
-    expect(config.tracing.ignoreEndpoints).to.deep.equal({});
-  });
-
-  it('should apply ignore endpoints if the INSTANA_IGNORE_ENDPOINTS is set and valid', () => {
-    process.env.INSTANA_IGNORE_ENDPOINTS = 'redis:get,set;';
-    const config = coreConfig.normalize();
-
-    expect(config.tracing.ignoreEndpoints).to.deep.equal({ redis: [{ methods: ['get', 'set'] }] });
-  });
-
-  it('should correctly parse INSTANA_IGNORE_ENDPOINTS containing multiple services and endpoints', () => {
-    process.env.INSTANA_IGNORE_ENDPOINTS = 'redis:get,set; dynamodb:query';
-    const config = coreConfig.normalize();
-    expect(config.tracing.ignoreEndpoints).to.deep.equal({
-      redis: [{ methods: ['get', 'set'] }],
-      dynamodb: [{ methods: ['query'] }]
+  describe('default configuration', () => {
+    it('should apply all defaults', () => {
+      checkDefaults(coreConfig.normalize());
+      checkDefaults(coreConfig.normalize({}));
+      checkDefaults(coreConfig.normalize({ tracing: {}, metrics: {} }));
+      checkDefaults(coreConfig.normalize({ unknowConfigOption: 13 }));
     });
   });
 
-  it('should fallback to default if INSTANA_IGNORE_ENDPOINTS is set but has an invalid format', () => {
-    process.env.INSTANA_IGNORE_ENDPOINTS = '"redis=get,set"';
-    const config = coreConfig.normalize();
-    expect(config.tracing.ignoreEndpoints).to.deep.equal({});
-  });
-
-  it('should apply ignore endpoints via config', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        ignoreEndpoints: { redis: ['get'] }
-      }
-    });
-    expect(config.tracing.ignoreEndpoints).to.deep.equal({ redis: [{ methods: ['get'] }] });
-  });
-  it('should apply multiple ignore endpoints via config', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        ignoreEndpoints: { redis: ['GET', 'TYPE'] }
-      }
-    });
-    expect(config.tracing.ignoreEndpoints).to.deep.equal({ redis: [{ methods: ['get', 'type'] }] });
-  });
-  it('should apply ignore endpoints via config for multiple packages', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        ignoreEndpoints: { redis: ['get'], dynamodb: ['querey'] }
-      }
-    });
-    expect(config.tracing.ignoreEndpoints).to.deep.equal({
-      redis: [{ methods: ['get'] }],
-      dynamodb: [{ methods: ['querey'] }]
-    });
-  });
-
-  it('should normalize case and trim spaces in method names and endpoint paths', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        ignoreEndpoints: {
-          redis: ['  GET ', 'TyPe'],
-          kafka: [{ methods: ['  PUBLISH  '], endpoints: [' Topic1 ', 'TOPIC2 '] }]
-        }
-      }
-    });
-    expect(config.tracing.ignoreEndpoints).to.deep.equal({
-      redis: [{ methods: ['get', 'type'] }],
-      kafka: [{ methods: ['publish'], endpoints: ['topic1', 'topic2'] }]
-    });
-  });
-
-  it('should return an empty list if all configurations are invalid', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        ignoreEndpoints: { redis: {}, kafka: true, mysql: null }
-      }
-    });
-    expect(config.tracing.ignoreEndpoints).to.deep.equal({
-      redis: [],
-      kafka: [],
-      mysql: []
-    });
-  });
-
-  it('should normalize objects when unsupported additional fields applied', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        ignoreEndpoints: {
-          redis: [{ extra: 'data' }],
-          kafka: [{ methods: ['publish'], extra: 'info' }]
-        }
-      }
-    });
-    expect(config.tracing.ignoreEndpoints).to.deep.equal({
-      redis: [],
-      kafka: [{ methods: ['publish'] }]
-    });
-  });
-
-  it('should normalize objects with only methods and no endpoints', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        ignoreEndpoints: {
-          kafka: [{ methods: ['PUBLISH'] }]
-        }
-      }
-    });
-    expect(config.tracing.ignoreEndpoints).to.deep.equal({
-      kafka: [{ methods: ['publish'] }]
-    });
-  });
-
-  it('should normalize objects with only endpoints and no methods', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        ignoreEndpoints: {
-          kafka: [{ endpoints: ['Topic1'] }]
-        }
-      }
-    });
-    expect(config.tracing.ignoreEndpoints).to.deep.equal({
-      kafka: [{ endpoints: ['topic1'] }]
-    });
-  });
-
-  it('should normalize objects where methods or endpoints are invalid types', () => {
-    const config = coreConfig.normalize({
-      tracing: {
-        ignoreEndpoints: {
-          kafka: [{ methods: 123, endpoints: 'invalid' }]
-        }
-      }
-    });
-    expect(config.tracing.ignoreEndpoints).to.deep.equal({});
-  });
-
-  it('preloadOpentelemetry should default to false', () => {
-    const config = coreConfig.normalize({});
-    expect(config.preloadOpentelemetry).to.be.false;
-  });
-
-  it('preloadOpentelemetry should accept true value', () => {
-    const config = coreConfig.normalize({
-      preloadOpentelemetry: true
-    });
-    expect(config.preloadOpentelemetry).to.be.true;
-  });
-
-  it('preloadOpentelemetry should work with custom defaults', () => {
-    const customDefaults = {
-      preloadOpentelemetry: true,
-      tracing: {
-        forceTransmissionStartingAt: 25
-      }
-    };
-    const config = coreConfig.normalize({}, customDefaults);
-    expect(config.preloadOpentelemetry).to.be.true;
-    expect(config.tracing.forceTransmissionStartingAt).to.equal(25);
-  });
-
-  describe('when testing ignore endpoints reading from INSTANA_IGNORE_ENDPOINTS_PATH env variable', () => {
-    let filePaths;
-
-    before(() => {
-      filePaths = setupTestYamlFiles(__dirname);
+  describe('service name configuration', () => {
+    it('should accept service name', () => {
+      const config = coreConfig.normalize({ serviceName: 'custom-service-name' });
+      expect(config.serviceName).to.equal('custom-service-name');
     });
 
-    after(() => {
-      cleanupTestYamlFiles(filePaths);
-    });
-
-    it('should normalize YAML with "tracing" key', () => {
-      process.env.INSTANA_IGNORE_ENDPOINTS_PATH = filePaths.tracingYamlPath;
+    it('should accept service name from env var', () => {
+      process.env.INSTANA_SERVICE_NAME = 'very-custom-service-name';
       const config = coreConfig.normalize();
-      expect(config.tracing.ignoreEndpoints).to.deep.equal({
-        kafka: [{ methods: ['consume', 'publish'], endpoints: ['topic1', 'topic2'] }]
+      expect(config.serviceName).to.equal('very-custom-service-name');
+    });
+
+    it('should not accept non-string service name', () => {
+      const config = coreConfig.normalize({ serviceName: 42 });
+      expect(config.serviceName).to.not.exist;
+    });
+  });
+
+  describe('metrics configuration', () => {
+    it('should use custom metrics transmission settings from config', () => {
+      const config = coreConfig.normalize({
+        metrics: {
+          transmissionDelay: 9753
+        }
+      });
+      expect(config.metrics.transmissionDelay).to.equal(9753);
+    });
+
+    it('should use custom metrics transmission settings from env vars', () => {
+      process.env.INSTANA_METRICS_TRANSMISSION_DELAY = '2500';
+      const config = coreConfig.normalize();
+      expect(config.metrics.transmissionDelay).to.equal(2500);
+    });
+
+    it('should use default metrics transmission settings when env vars are non-numerical', () => {
+      process.env.INSTANA_METRICS_TRANSMISSION_DELAY = 'x2500';
+      const config = coreConfig.normalize();
+      expect(config.metrics.transmissionDelay).to.equal(1000);
+    });
+
+    it('should use max metrics transmission settings when value exceeds max of 5000', () => {
+      process.env.INSTANA_METRICS_TRANSMISSION_DELAY = '6000';
+      const normalizedConfig = coreConfig.normalize();
+      expect(normalizedConfig.metrics.transmissionDelay).to.equal(5000);
+    });
+
+    it('should accept metrics transmission delay at max value of 5000', () => {
+      process.env.INSTANA_METRICS_TRANSMISSION_DELAY = '5000';
+      const normalizedConfig = coreConfig.normalize();
+      expect(normalizedConfig.metrics.transmissionDelay).to.equal(5000);
+    });
+
+    it('should use max metrics transmission settings when value exceeds max 5000', () => {
+      const config = coreConfig.normalize({
+        metrics: {
+          transmissionDelay: 9753
+        }
+      });
+      expect(config.metrics.transmissionDelay).to.equal(5000);
+    });
+
+    it('should use custom config.metrics.timeBetweenHealthcheckCalls', () => {
+      const config = coreConfig.normalize({
+        metrics: {
+          timeBetweenHealthcheckCalls: 9876
+        }
+      });
+      expect(config.metrics.timeBetweenHealthcheckCalls).to.equal(9876);
+    });
+  });
+
+  describe('tracing configuration', () => {
+    describe('enabling and disabling tracing', () => {
+      it('should disable tracing with enabled: false', () => {
+        const config = coreConfig.normalize({ tracing: { enabled: false } });
+        expect(config.tracing.enabled).to.be.false;
+        expect(config.tracing.automaticTracingEnabled).to.be.false;
+      });
+
+      it('should disable tracing with disable: true', () => {
+        const config = coreConfig.normalize({ tracing: { enabled: false } });
+        expect(config.tracing.enabled).to.be.false;
+        expect(config.tracing.automaticTracingEnabled).to.be.false;
+      });
+
+      it('should disable automatic tracing', () => {
+        const config = coreConfig.normalize({ tracing: { automaticTracingEnabled: false } });
+        expect(config.tracing.enabled).to.be.true;
+        expect(config.tracing.automaticTracingEnabled).to.be.false;
+      });
+
+      it('should disable automatic tracing via INSTANA_DISABLE_AUTO_INSTR', () => {
+        process.env.INSTANA_DISABLE_AUTO_INSTR = 'true';
+        const config = coreConfig.normalize();
+        expect(config.tracing.enabled).to.be.true;
+        expect(config.tracing.automaticTracingEnabled).to.be.false;
+      });
+
+      it('should not enable automatic tracing when tracing is disabled in general', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            enabled: false,
+            automaticTracingEnabled: true
+          }
+        });
+        expect(config.tracing.enabled).to.be.false;
+        expect(config.tracing.automaticTracingEnabled).to.be.false;
       });
     });
 
-    it('should normalize YAML with "com.instana.tracing" key', () => {
-      process.env.INSTANA_IGNORE_ENDPOINTS_PATH = filePaths.comInstanaTracingYamlPath;
-      const config = coreConfig.normalize();
-      expect(config.tracing.ignoreEndpoints).to.deep.equal({
-        kafka: [{ methods: ['consume', 'publish'], endpoints: ['topic1', 'topic2'] }]
+    describe('immediate activation', () => {
+      it('should enable immediate tracing activation', () => {
+        const config = coreConfig.normalize({ tracing: { activateImmediately: true } });
+        expect(config.tracing.activateImmediately).to.be.true;
+      });
+
+      it('should enable immediate tracing activation via INSTANA_TRACE_IMMEDIATELY', () => {
+        process.env.INSTANA_TRACE_IMMEDIATELY = 'true';
+        const config = coreConfig.normalize();
+        expect(config.tracing.activateImmediately).to.be.true;
+      });
+
+      it('should not enable immediate tracing activation when tracing is disabled in general', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            enabled: false,
+            activateImmediately: true
+          }
+        });
+        expect(config.tracing.enabled).to.be.false;
+        expect(config.tracing.activateImmediately).to.be.false;
       });
     });
 
-    it('should return an empty object for invalid YAML content', () => {
-      process.env.INSTANA_IGNORE_ENDPOINTS_PATH = filePaths.invalidYamlPath;
-      const config = coreConfig.normalize();
-      expect(config.tracing.ignoreEndpoints).to.deep.equal({});
+    describe('transmission settings', () => {
+      it('should use custom tracing transmission settings from config', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            maxBufferedSpans: 13,
+            forceTransmissionStartingAt: 2,
+            transmissionDelay: 9753
+          }
+        });
+        expect(config.tracing.maxBufferedSpans).to.equal(13);
+        expect(config.tracing.forceTransmissionStartingAt).to.equal(2);
+        expect(config.tracing.transmissionDelay).to.equal(9753);
+      });
+
+      it('should use custom tracing transmission settings from env vars', () => {
+        process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT = '2468';
+        process.env.INSTANA_TRACING_TRANSMISSION_DELAY = '2500';
+        const config = coreConfig.normalize();
+        expect(config.tracing.forceTransmissionStartingAt).to.equal(2468);
+        expect(config.tracing.transmissionDelay).to.equal(2500);
+      });
+
+      it('should use default tracing transmission settings when env vars are non-numerical', () => {
+        process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT = 'a2468';
+        process.env.INSTANA_TRACING_TRANSMISSION_DELAY = 'x2500';
+        const config = coreConfig.normalize();
+        expect(config.tracing.forceTransmissionStartingAt).to.equal(500);
+        expect(config.tracing.transmissionDelay).to.equal(1000);
+      });
     });
 
-    it('should return an empty object for YAML with missing root keys', () => {
-      process.env.INSTANA_IGNORE_ENDPOINTS_PATH = filePaths.missingRootKeyYamlPath;
-      const config = coreConfig.normalize();
-      expect(config.tracing.ignoreEndpoints).to.deep.equal({});
+    describe('HTTP headers configuration', () => {
+      it('should use extra http headers (and normalize to lower case)', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            http: {
+              extraHttpHeadersToCapture: ['yo', 'LO']
+            }
+          }
+        });
+        expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal(['yo', 'lo']);
+      });
+
+      it('should reject non-array extra http headers configuration value', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            http: {
+              extraHttpHeadersToCapture: 'yolo'
+            }
+          }
+        });
+        expect(config.tracing.http.extraHttpHeadersToCapture).to.be.an('array');
+        expect(config.tracing.http.extraHttpHeadersToCapture).to.be.empty;
+      });
+
+      it('should parse extra headers from env var', () => {
+        process.env.INSTANA_EXTRA_HTTP_HEADERS = ' X-Header-1 ; X-hEADer-2 , X-Whatever ';
+        const config = coreConfig.normalize();
+        expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal(['x-header-1', 'x-header-2', 'x-whatever']);
+      });
+
+      it('must use default extra headers (empty list) when INSTANA_EXTRA_HTTP_HEADERS is invalid', () => {
+        process.env.INSTANA_EXTRA_HTTP_HEADERS = ' \n \t ';
+        const config = coreConfig.normalize();
+        expect(config.tracing.http.extraHttpHeadersToCapture).to.deep.equal([]);
+      });
     });
 
-    it('should return false when INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION is not set', () => {
-      const config = coreConfig.normalize();
-      expect(config.tracing.ignoreEndpointsDisableSuppression).to.equal(false);
+    describe('stack trace configuration', () => {
+      it('should accept numerical custom stack trace length', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: 666 } });
+        expect(config.tracing.stackTraceLength).to.equal(500);
+      });
+      it('should normalize numbers for custom stack trace length', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: -28.08 } });
+
+        expect(config.tracing.stackTraceLength).to.be.a('number');
+        expect(config.tracing.stackTraceLength).to.equal(28);
+      });
+
+      it('should accept number-like strings for custom stack trace length', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: '1302' } });
+        expect(config.tracing.stackTraceLength).to.be.a('number');
+        expect(config.tracing.stackTraceLength).to.equal(500);
+      });
+
+      it('should normalize number-like strings for custom stack trace length', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: '-16.04' } });
+        expect(config.tracing.stackTraceLength).to.be.a('number');
+        expect(config.tracing.stackTraceLength).to.equal(16);
+      });
+
+      it('should reject non-numerical strings for custom stack trace length', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: 'three' } });
+        expect(config.tracing.stackTraceLength).to.be.a('number');
+        expect(config.tracing.stackTraceLength).to.equal(10);
+      });
+
+      it('should reject custom stack trace length which is neither a number nor a string', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: false } });
+        expect(config.tracing.stackTraceLength).to.be.a('number');
+        expect(config.tracing.stackTraceLength).to.equal(10);
+      });
+
+      it('should read stack trace length from INSTANA_STACK_TRACE_LENGTH', () => {
+        process.env.INSTANA_STACK_TRACE_LENGTH = '3';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTraceLength).to.equal(3);
+      });
+
+      it('should give precedence to INSTANA_STACK_TRACE_LENGTH over config', () => {
+        process.env.INSTANA_STACK_TRACE_LENGTH = '5';
+        const normalizedConfig = coreConfig.normalize({ tracing: { stackTraceLength: 20 } });
+        expect(normalizedConfig.tracing.stackTraceLength).to.equal(5);
+        delete process.env.INSTANA_STACK_TRACE_LENGTH;
+      });
+
+      it('should use default stack trace mode', () => {
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTrace).to.equal('all');
+      });
+
+      it('should accept valid stack trace mode from config', () => {
+        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'error' } } });
+        expect(config.tracing.stackTrace).to.equal('error');
+      });
+
+      it('should accept "none" stack trace mode from config', () => {
+        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'none' } } });
+        expect(config.tracing.stackTrace).to.equal('none');
+      });
+
+      it('should normalize stack trace mode to lowercase from config', () => {
+        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'ERROR' } } });
+        expect(config.tracing.stackTrace).to.equal('error');
+      });
+
+      it('should read stack trace mode from INSTANA_STACK_TRACE', () => {
+        process.env.INSTANA_STACK_TRACE = 'error';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTrace).to.equal('error');
+      });
+
+      it('should normalize stack trace mode to lowercase from INSTANA_STACK_TRACE', () => {
+        process.env.INSTANA_STACK_TRACE = 'NONE';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTrace).to.equal('none');
+      });
+
+      it('should give precedence to env INSTANA_STACK_TRACE over config', () => {
+        process.env.INSTANA_STACK_TRACE = 'none';
+        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'all' } } });
+        expect(config.tracing.stackTrace).to.equal('none');
+      });
+
+      it('should reject invalid stack trace mode from config and fallback to default', () => {
+        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'invalid' } } });
+        expect(config.tracing.stackTrace).to.equal('all');
+      });
+
+      it('should reject invalid stack trace mode from INSTANA_STACK_TRACE and use default', () => {
+        process.env.INSTANA_STACK_TRACE = 'invalid';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTrace).to.equal('all');
+      });
+
+      it('should reject non-string stack trace mode from config', () => {
+        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 123 } } });
+        expect(config.tracing.stackTrace).to.equal('all');
+      });
+
+      it('should handle null stack trace mode from config', () => {
+        const config = coreConfig.normalize({ tracing: { global: { stackTrace: null } } });
+        expect(config.tracing.stackTrace).to.equal('all');
+      });
+
+      it('should handle undefined stack trace mode from config', () => {
+        const config = coreConfig.normalize({ tracing: { global: { stackTrace: undefined } } });
+        expect(config.tracing.stackTrace).to.equal('all');
+      });
+
+      it('should handle empty string stack trace mode from config', () => {
+        const config = coreConfig.normalize({ tracing: { global: { stackTrace: '' } } });
+        expect(config.tracing.stackTrace).to.equal('all');
+      });
+
+      it('should handle boolean stack trace mode from config', () => {
+        const config = coreConfig.normalize({ tracing: { global: { stackTrace: true } } });
+        expect(config.tracing.stackTrace).to.equal('all');
+      });
+
+      it('should handle object stack trace mode from config', () => {
+        const config = coreConfig.normalize({ tracing: { global: { stackTrace: {} } } });
+        expect(config.tracing.stackTrace).to.equal('all');
+      });
+
+      it('should handle array stack trace mode from config', () => {
+        const config = coreConfig.normalize({ tracing: { global: { stackTrace: ['error'] } } });
+        expect(config.tracing.stackTrace).to.equal('all');
+      });
+
+      it('should accept zero as valid stack trace length', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: 0 } });
+        expect(config.tracing.stackTraceLength).to.equal(0);
+      });
+
+      it('should handle negative stack trace length', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: -10 } });
+        expect(config.tracing.stackTraceLength).to.equal(10);
+      });
+
+      it('should handle very large negative stack trace length', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: -100 } });
+        expect(config.tracing.stackTraceLength).to.equal(100);
+      });
+
+      it('should handle stack trace length as positive float', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: 15.9 } });
+        expect(config.tracing.stackTraceLength).to.equal(16);
+      });
+
+      it('should handle stack trace length as negative float', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: -15.9 } });
+        expect(config.tracing.stackTraceLength).to.equal(16);
+      });
+
+      it('should handle stack trace length as string with leading zeros', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: '007' } });
+        expect(config.tracing.stackTraceLength).to.equal(7);
+      });
+
+      it('should handle stack trace length as string with whitespace', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: '  25  ' } });
+        expect(config.tracing.stackTraceLength).to.equal(25);
+      });
+
+      it('should handle stack trace length as string with plus sign', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: '+30' } });
+        expect(config.tracing.stackTraceLength).to.equal(30);
+      });
+
+      it('should reject stack trace length as null', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: null } });
+        expect(config.tracing.stackTraceLength).to.equal(10);
+      });
+
+      it('should reject stack trace length as undefined', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: undefined } });
+        expect(config.tracing.stackTraceLength).to.equal(10);
+      });
+
+      it('should reject stack trace length as empty string', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: '' } });
+        expect(config.tracing.stackTraceLength).to.equal(10);
+      });
+
+      it('should reject stack trace length as object', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: {} } });
+        expect(config.tracing.stackTraceLength).to.equal(10);
+      });
+
+      it('should reject stack trace length as array', () => {
+        const config = coreConfig.normalize({ tracing: { stackTraceLength: [10] } });
+        expect(config.tracing.stackTraceLength).to.equal(10);
+      });
+
+      it('should handle stack trace length from INSTANA_STACK_TRACE_LENGTH as zero', () => {
+        process.env.INSTANA_STACK_TRACE_LENGTH = '0';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTraceLength).to.equal(0);
+      });
+
+      it('should handle stack trace length from INSTANA_STACK_TRACE_LENGTH with negative value', () => {
+        process.env.INSTANA_STACK_TRACE_LENGTH = '-20';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTraceLength).to.equal(20);
+      });
+
+      it('should handle stack trace length from INSTANA_STACK_TRACE_LENGTH exceeding max', () => {
+        process.env.INSTANA_STACK_TRACE_LENGTH = '1000';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTraceLength).to.equal(500);
+      });
+
+      it('should handle stack trace length from INSTANA_STACK_TRACE_LENGTH as float', () => {
+        process.env.INSTANA_STACK_TRACE_LENGTH = '12.3';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTraceLength).to.equal(12);
+      });
+
+      it('should reject invalid INSTANA_STACK_TRACE_LENGTH', () => {
+        process.env.INSTANA_STACK_TRACE_LENGTH = 'not-a-number';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTraceLength).to.equal(10);
+      });
+
+      it('should reject empty INSTANA_STACK_TRACE_LENGTH', () => {
+        process.env.INSTANA_STACK_TRACE_LENGTH = '';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTraceLength).to.equal(10);
+      });
+
+      it('should reject INSTANA_STACK_TRACE_LENGTH with only whitespace', () => {
+        process.env.INSTANA_STACK_TRACE_LENGTH = '   ';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTraceLength).to.equal(10);
+      });
+
+      it('should handle INSTANA_STACK_TRACE_LENGTH with mixed valid and invalid characters', () => {
+        process.env.INSTANA_STACK_TRACE_LENGTH = '15abc';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTraceLength).to.equal(15);
+      });
+
+      it('should handle both INSTANA_STACK_TRACE and INSTANA_STACK_TRACE_LENGTH together', () => {
+        process.env.INSTANA_STACK_TRACE = 'error';
+        process.env.INSTANA_STACK_TRACE_LENGTH = '25';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTrace).to.equal('error');
+        expect(config.tracing.stackTraceLength).to.equal(25);
+      });
+
+      it('should handle config with both stackTrace and stackTraceLength', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            global: {
+              stackTrace: 'none',
+              stackTraceLength: 30
+            }
+          }
+        });
+        expect(config.tracing.stackTrace).to.equal('none');
+        expect(config.tracing.stackTraceLength).to.equal(30);
+      });
+
+      it('should give precedence to env vars for both stack trace settings over config', () => {
+        process.env.INSTANA_STACK_TRACE = 'error';
+        process.env.INSTANA_STACK_TRACE_LENGTH = '15';
+        const config = coreConfig.normalize({
+          tracing: {
+            global: {
+              stackTrace: 'all',
+              stackTraceLength: 40
+            }
+          }
+        });
+        expect(config.tracing.stackTrace).to.equal('error');
+        expect(config.tracing.stackTraceLength).to.equal(15);
+      });
+
+      it('should use INSTANA_STACK_TRACE_LENGTH when STACK_TRACE_LENGTH is not set', () => {
+        process.env.INSTANA_STACK_TRACE_LENGTH = '18';
+        const config = coreConfig.normalize();
+        expect(config.tracing.stackTraceLength).to.equal(18);
+        delete process.env.INSTANA_STACK_TRACE_LENGTH;
+      });
     });
 
-    it('should return true when INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION is set', () => {
-      process.env.INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION = true;
-      const config = coreConfig.normalize();
-      expect(config.tracing.ignoreEndpointsDisableSuppression).to.equal(true);
+    describe('disabling instrumentations and groups', () => {
+      it('should not disable individual instrumentations by default', () => {
+        const config = coreConfig.normalize();
+        expect(config.tracing.disable).to.deep.equal({});
+      });
+      it('should disable individual instrumentations via disable config', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            disable: ['graphQL', 'GRPC']
+          }
+        });
+        expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
+      });
+
+      it('should disable individual instrumentations via disable.instrumentations config', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            disable: { instrumentations: ['graphQL', 'GRPC'] }
+          }
+        });
+        expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
+      });
+
+      it('config should take precedence over INSTANA_TRACING_DISABLE_INSTRUMENTATIONS  for config', () => {
+        process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'foo, bar';
+        const config = coreConfig.normalize({
+          tracing: {
+            disable: { instrumentations: ['baz', 'fizz'] }
+          }
+        });
+        expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
+      });
+
+      it('should disable multiple instrumentations via env var INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
+        process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'graphQL   , GRPC, http';
+        const config = coreConfig.normalize();
+        expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc', 'http']);
+      });
+
+      it('should handle single instrumentations via INSTANA_TRACING_DISABLE_INSTRUMENTATIONS', () => {
+        process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'console';
+        const config = coreConfig.normalize();
+        expect(config.tracing.disable.instrumentations).to.deep.equal(['console']);
+      });
+
+      it('should trim whitespace from tracer names', () => {
+        process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = '  graphql  ,  grpc  ';
+        const config = coreConfig.normalize();
+        expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
+      });
+
+      it('should disable individual groups via disable config', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            disable: { groups: ['logging'] }
+          }
+        });
+        expect(config.tracing.disable.groups).to.deep.equal(['logging']);
+      });
+
+      it('config should disable when env var INSTANA_TRACING_DISABLE_GROUPS is set', () => {
+        process.env.INSTANA_TRACING_DISABLE_GROUPS = 'frameworks, databases';
+        const config = coreConfig.normalize({});
+        expect(config.tracing.disable.groups).to.deep.equal(['frameworks', 'databases']);
+      });
+
+      it('config should take precedence over INSTANA_TRACING_DISABLE_GROUPS when disabling groups', () => {
+        process.env.INSTANA_TRACING_DISABLE_GROUPS = 'frameworks, databases';
+        const config = coreConfig.normalize({
+          tracing: {
+            disable: { groups: ['LOGGING'] }
+          }
+        });
+        expect(config.tracing.disable.groups).to.deep.equal(['logging']);
+      });
+
+      it('should disable instrumentations and groups when both configured', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            disable: { groups: ['LOGGING'], instrumentations: ['redis', 'kafka'] }
+          }
+        });
+        expect(config.tracing.disable.groups).to.deep.equal(['logging']);
+        expect(config.tracing.disable.instrumentations).to.deep.equal(['redis', 'kafka']);
+      });
+
+      it('should disable instrumentations and groups when both env variables provided', () => {
+        process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'redis';
+        process.env.INSTANA_TRACING_DISABLE_GROUPS = 'logging';
+        const config = coreConfig.normalize();
+        expect(config.tracing.disable.instrumentations).to.deep.equal(['redis']);
+        expect(config.tracing.disable.groups).to.deep.equal(['logging']);
+      });
+
+      it('should disable all tracing via INSTANA_TRACING_DISABLE', () => {
+        process.env.INSTANA_TRACING_DISABLE = true;
+        const config = coreConfig.normalize();
+        expect(config.tracing.enabled).to.be.false;
+        expect(config.tracing.disable).to.deep.equal({});
+        expect(config.tracing.automaticTracingEnabled).to.be.false;
+      });
+
+      it('should disable all tracing via config tracing.disable', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            disable: true
+          }
+        });
+        expect(config.tracing.enabled).to.be.false;
+        expect(config.tracing.disable).to.deep.equal({});
+        expect(config.tracing.automaticTracingEnabled).to.be.false;
+      });
     });
 
-    it('should return false when INSTANA_TRACING_DISABLE_EOL_EVENTS is not set', () => {
-      const config = coreConfig.normalize();
-      expect(config.tracing.disableEOLEvents).to.equal(false);
+    describe('span batching', () => {
+      // delete this test when we switch to opt-out
+      it('should enable span batching via config in transition phase', () => {
+        const config = coreConfig.normalize({ tracing: { spanBatchingEnabled: true } });
+        expect(config.tracing.spanBatchingEnabled).to.be.true;
+      });
+
+      // delete this test when we switch to opt-out
+      it('should enable span batching via INSTANA_SPANBATCHING_ENABLED in transition phase', () => {
+        process.env.INSTANA_SPANBATCHING_ENABLED = 'true';
+        const config = coreConfig.normalize();
+        expect(config.tracing.spanBatchingEnabled).to.be.true;
+      });
+
+      it('should ignore non-boolean span batching config value', () => {
+        const config = coreConfig.normalize({ tracing: { spanBatchingEnabled: 73 } });
+        // test needs to be updated once we switch to opt-out
+        expect(config.tracing.spanBatchingEnabled).to.be.false;
+      });
+
+      it('should disable span batching', () => {
+        // test only becomes relevant once we switch to opt-out
+        const config = coreConfig.normalize({ tracing: { spanBatchingEnabled: false } });
+        expect(config.tracing.spanBatchingEnabled).to.be.false;
+      });
+
+      it('should disable span batching via INSTANA_DISABLE_SPANBATCHING', () => {
+        // test only becomes relevant once we switch to opt-out
+        process.env.INSTANA_DISABLE_SPANBATCHING = 'true';
+        const config = coreConfig.normalize();
+        expect(config.tracing.spanBatchingEnabled).to.be.false;
+      });
     });
 
-    it('should return true when INSTANA_TRACING_DISABLE_EOL_EVENTS is set to true', () => {
-      process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'true';
-      const config = coreConfig.normalize();
-      expect(config.tracing.disableEOLEvents).to.equal(true);
+    describe('W3C trace correlation', () => {
+      it('should disable W3C trace correlation', () => {
+        const config = coreConfig.normalize({ tracing: { disableW3cTraceCorrelation: true } });
+        expect(config.tracing.disableW3cTraceCorrelation).to.be.true;
+      });
+
+      it('should disable W3C trace correlation via INSTANA_DISABLE_W3C_TRACE_CORRELATION', () => {
+        process.env.INSTANA_DISABLE_W3C_TRACE_CORRELATION = 'false'; // any non-empty string will disable, even "false"!
+        const config = coreConfig.normalize();
+        expect(config.tracing.disableW3cTraceCorrelation).to.be.true;
+      });
     });
 
-    it('should return false when INSTANA_TRACING_DISABLE_EOL_EVENTS is set to false', () => {
-      process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'false';
-      const config = coreConfig.normalize();
-      expect(config.tracing.disableEOLEvents).to.equal(false);
+    describe('Kafka trace correlation', () => {
+      it('should disable Kafka trace correlation', () => {
+        const config = coreConfig.normalize({ tracing: { kafka: { traceCorrelation: false } } });
+        expect(config.tracing.kafka.traceCorrelation).to.be.false;
+      });
+
+      it('should disable Kafka trace correlation via INSTANA_KAFKA_TRACE_CORRELATION', () => {
+        process.env.INSTANA_KAFKA_TRACE_CORRELATION = 'false';
+        const config = coreConfig.normalize();
+        expect(config.tracing.kafka.traceCorrelation).to.be.false;
+      });
     });
 
-    it('should return false when INSTANA_TRACING_DISABLE_EOL_EVENTS is set to any other value', () => {
-      process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'test';
-      const config = coreConfig.normalize();
-      expect(config.tracing.disableEOLEvents).to.equal(false);
+    describe('OpenTelemetry configuration', () => {
+      it('should disable opentelemetry if config is set', () => {
+        const config = coreConfig.normalize({
+          tracing: { useOpentelemetry: false }
+        });
+        expect(config.tracing.useOpentelemetry).to.equal(false);
+      });
+
+      it('should enable opentelemetry if config is set', () => {
+        const config = coreConfig.normalize({
+          tracing: { useOpentelemetry: true }
+        });
+        expect(config.tracing.useOpentelemetry).to.equal(true);
+      });
+
+      it('should disable opentelemetry if INSTANA_DISABLE_USE_OPENTELEMETRY is set', () => {
+        process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'true';
+        const config = coreConfig.normalize();
+        expect(config.tracing.useOpentelemetry).to.equal(false);
+      });
+
+      it('should enable opentelemetry if INSTANA_DISABLE_USE_OPENTELEMETRY is set', () => {
+        process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'false';
+        const config = coreConfig.normalize();
+        expect(config.tracing.useOpentelemetry).to.equal(true);
+      });
+    });
+
+    describe('secrets configuration', () => {
+      it('should accept custom secrets config', () => {
+        const config = coreConfig.normalize({
+          secrets: {
+            matcherMode: 'equals',
+            keywords: ['custom-secret', 'sheesh']
+          }
+        });
+        expect(config.secrets.matcherMode).to.equal('equals');
+        expect(config.secrets.keywords).to.deep.equal(['custom-secret', 'sheesh']);
+      });
+
+      it("should set keywords to empty array for matcher mode 'none'", () => {
+        const config = coreConfig.normalize({
+          secrets: {
+            matcherMode: 'none'
+          }
+        });
+        expect(config.secrets.matcherMode).to.equal('none');
+        expect(config.secrets.keywords).to.deep.equal([]);
+      });
+
+      it('should reject non-string matcher mode', () => {
+        const config = coreConfig.normalize({ secrets: { matcherMode: 43 } });
+        expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
+        expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
+      });
+
+      it('should reject unknown matcher mode from config', () => {
+        const config = coreConfig.normalize({ secrets: { matcherMode: 'whatever' } });
+        expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
+        expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
+      });
+
+      it('should reject non-array keywords', () => {
+        const config = coreConfig.normalize({ secrets: { keywords: 'yes' } });
+        expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
+        expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
+      });
+
+      it('should parse secrets from env var', () => {
+        process.env.INSTANA_SECRETS = ' eQuaLs-igNore-case  :  concealed  ,  hush  ';
+        const config = coreConfig.normalize();
+        expect(config.secrets.matcherMode).to.equal('equals-ignore-case');
+        expect(config.secrets.keywords).to.deep.equal(['concealed', 'hush']);
+      });
+
+      it('must use default secrets when INSTANA_SECRETS is invalid', () => {
+        process.env.INSTANA_SECRETS = 'whatever';
+        const config = coreConfig.normalize();
+        expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
+        expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
+      });
+
+      it("must accept INSTANA_SECRETS without secrets list if matcher mode is 'none'", () => {
+        process.env.INSTANA_SECRETS = 'NONE';
+        const config = coreConfig.normalize();
+        expect(config.secrets.matcherMode).to.equal('none');
+        expect(config.secrets.keywords).to.deep.equal([]);
+      });
+
+      it('should reject unknown matcher mode from INSTANA_SECRETS', () => {
+        process.env.INSTANA_SECRETS = 'unknown-matcher:nope,never';
+        const config = coreConfig.normalize();
+        expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
+        expect(config.secrets.keywords).to.deep.equal(['nope', 'never']);
+      });
+    });
+
+    describe('package.json path configuration', () => {
+      it('should accept packageJsonPath', () => {
+        const config = coreConfig.normalize({ packageJsonPath: './something' });
+        expect(config.packageJsonPath).to.equal('./something');
+      });
+
+      it('should not accept packageJsonPath', () => {
+        const config = coreConfig.normalize({ packageJsonPath: 1234 });
+        expect(config.packageJsonPath).to.not.exist;
+      });
+
+      it('should accept INSTANA_PACKAGE_JSON_PATH', () => {
+        process.env.INSTANA_PACKAGE_JSON_PATH = '/my/path';
+        const config = coreConfig.normalize({});
+        expect(config.packageJsonPath).to.equal('/my/path');
+      });
+    });
+
+    describe('allow root exit span', () => {
+      it('should disable allow root exit span if config is set to false', () => {
+        const config = coreConfig.normalize({
+          tracing: { allowRootExitSpan: false }
+        });
+        expect(config.tracing.allowRootExitSpan).to.equal(false);
+      });
+
+      it('should enable allow root exit span if config is set to true', () => {
+        const config = coreConfig.normalize({
+          tracing: { allowRootExitSpan: true }
+        });
+        expect(config.tracing.allowRootExitSpan).to.equal(true);
+      });
+      it('should disable allow root exit span if INSTANA_ALLOW_ROOT_EXIT_SPAN is not set', () => {
+        process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = false;
+        const config = coreConfig.normalize();
+        expect(config.tracing.allowRootExitSpan).to.equal(false);
+      });
+
+      it('should enable allow root exit span if INSTANA_ALLOW_ROOT_EXIT_SPAN is set', () => {
+        process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = true;
+        const config = coreConfig.normalize();
+        expect(config.tracing.allowRootExitSpan).to.equal(true);
+      });
+    });
+
+    describe('ignore endpoints configuration', () => {
+      it('should not set ignore endpoints tracers by default', () => {
+        const config = coreConfig.normalize();
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({});
+      });
+
+      it('should apply ignore endpoints if the INSTANA_IGNORE_ENDPOINTS is set and valid', () => {
+        process.env.INSTANA_IGNORE_ENDPOINTS = 'redis:get,set;';
+        const config = coreConfig.normalize();
+
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({ redis: [{ methods: ['get', 'set'] }] });
+      });
+
+      it('should correctly parse INSTANA_IGNORE_ENDPOINTS containing multiple services and endpoints', () => {
+        process.env.INSTANA_IGNORE_ENDPOINTS = 'redis:get,set; dynamodb:query';
+        const config = coreConfig.normalize();
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({
+          redis: [{ methods: ['get', 'set'] }],
+          dynamodb: [{ methods: ['query'] }]
+        });
+      });
+
+      it('should fallback to default if INSTANA_IGNORE_ENDPOINTS is set but has an invalid format', () => {
+        process.env.INSTANA_IGNORE_ENDPOINTS = '"redis=get,set"';
+        const config = coreConfig.normalize();
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({});
+      });
+
+      it('should apply ignore endpoints via config', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            ignoreEndpoints: { redis: ['get'] }
+          }
+        });
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({ redis: [{ methods: ['get'] }] });
+      });
+      it('should apply multiple ignore endpoints via config', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            ignoreEndpoints: { redis: ['GET', 'TYPE'] }
+          }
+        });
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({ redis: [{ methods: ['get', 'type'] }] });
+      });
+      it('should apply ignore endpoints via config for multiple packages', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            ignoreEndpoints: { redis: ['get'], dynamodb: ['querey'] }
+          }
+        });
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({
+          redis: [{ methods: ['get'] }],
+          dynamodb: [{ methods: ['querey'] }]
+        });
+      });
+
+      it('should normalize case and trim spaces in method names and endpoint paths', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            ignoreEndpoints: {
+              redis: ['  GET ', 'TyPe'],
+              kafka: [{ methods: ['  PUBLISH  '], endpoints: [' Topic1 ', 'TOPIC2 '] }]
+            }
+          }
+        });
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({
+          redis: [{ methods: ['get', 'type'] }],
+          kafka: [{ methods: ['publish'], endpoints: ['topic1', 'topic2'] }]
+        });
+      });
+
+      it('should return an empty list if all configurations are invalid', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            ignoreEndpoints: { redis: {}, kafka: true, mysql: null }
+          }
+        });
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({
+          redis: [],
+          kafka: [],
+          mysql: []
+        });
+      });
+
+      it('should normalize objects when unsupported additional fields applied', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            ignoreEndpoints: {
+              redis: [{ extra: 'data' }],
+              kafka: [{ methods: ['publish'], extra: 'info' }]
+            }
+          }
+        });
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({
+          redis: [],
+          kafka: [{ methods: ['publish'] }]
+        });
+      });
+
+      it('should normalize objects with only methods and no endpoints', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            ignoreEndpoints: {
+              kafka: [{ methods: ['PUBLISH'] }]
+            }
+          }
+        });
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({
+          kafka: [{ methods: ['publish'] }]
+        });
+      });
+
+      it('should normalize objects with only endpoints and no methods', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            ignoreEndpoints: {
+              kafka: [{ endpoints: ['Topic1'] }]
+            }
+          }
+        });
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({
+          kafka: [{ endpoints: ['topic1'] }]
+        });
+      });
+
+      it('should normalize objects where methods or endpoints are invalid types', () => {
+        const config = coreConfig.normalize({
+          tracing: {
+            ignoreEndpoints: {
+              kafka: [{ methods: 123, endpoints: 'invalid' }]
+            }
+          }
+        });
+        expect(config.tracing.ignoreEndpoints).to.deep.equal({});
+      });
+      it('should return false when INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION is not set', () => {
+        const config = coreConfig.normalize();
+        expect(config.tracing.ignoreEndpointsDisableSuppression).to.equal(false);
+      });
+
+      it('should return true when INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION is set', () => {
+        process.env.INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION = true;
+        const config = coreConfig.normalize();
+        expect(config.tracing.ignoreEndpointsDisableSuppression).to.equal(true);
+      });
+
+      describe('when testing ignore endpoints reading from INSTANA_IGNORE_ENDPOINTS_PATH env variable', () => {
+        let filePaths;
+
+        before(() => {
+          filePaths = setupTestYamlFiles(__dirname);
+        });
+
+        after(() => {
+          cleanupTestYamlFiles(filePaths);
+        });
+
+        it('should normalize YAML with "tracing" key', () => {
+          process.env.INSTANA_IGNORE_ENDPOINTS_PATH = filePaths.tracingYamlPath;
+          const config = coreConfig.normalize();
+          expect(config.tracing.ignoreEndpoints).to.deep.equal({
+            kafka: [{ methods: ['consume', 'publish'], endpoints: ['topic1', 'topic2'] }]
+          });
+        });
+
+        it('should normalize YAML with "com.instana.tracing" key', () => {
+          process.env.INSTANA_IGNORE_ENDPOINTS_PATH = filePaths.comInstanaTracingYamlPath;
+          const config = coreConfig.normalize();
+          expect(config.tracing.ignoreEndpoints).to.deep.equal({
+            kafka: [{ methods: ['consume', 'publish'], endpoints: ['topic1', 'topic2'] }]
+          });
+        });
+
+        it('should return an empty object for invalid YAML content', () => {
+          process.env.INSTANA_IGNORE_ENDPOINTS_PATH = filePaths.invalidYamlPath;
+          const config = coreConfig.normalize();
+          expect(config.tracing.ignoreEndpoints).to.deep.equal({});
+        });
+
+        it('should return an empty object for YAML with missing root keys', () => {
+          process.env.INSTANA_IGNORE_ENDPOINTS_PATH = filePaths.missingRootKeyYamlPath;
+          const config = coreConfig.normalize();
+          expect(config.tracing.ignoreEndpoints).to.deep.equal({});
+        });
+      });
+    });
+
+    describe('preloadOpentelemetry', () => {
+      it('preloadOpentelemetry should default to false', () => {
+        const config = coreConfig.normalize({});
+        expect(config.preloadOpentelemetry).to.be.false;
+      });
+
+      it('preloadOpentelemetry should accept true value', () => {
+        const config = coreConfig.normalize({
+          preloadOpentelemetry: true
+        });
+        expect(config.preloadOpentelemetry).to.be.true;
+      });
+
+      it('preloadOpentelemetry should work with custom defaults', () => {
+        const customDefaults = {
+          preloadOpentelemetry: true,
+          tracing: {
+            forceTransmissionStartingAt: 25
+          }
+        };
+        const config = coreConfig.normalize({}, customDefaults);
+        expect(config.preloadOpentelemetry).to.be.true;
+        expect(config.tracing.forceTransmissionStartingAt).to.equal(25);
+      });
+    });
+
+    describe('EOL events configuration', () => {
+      it('should return false when INSTANA_TRACING_DISABLE_EOL_EVENTS is not set', () => {
+        const config = coreConfig.normalize();
+        expect(config.tracing.disableEOLEvents).to.equal(false);
+      });
+
+      it('should return true when INSTANA_TRACING_DISABLE_EOL_EVENTS is set to true', () => {
+        process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'true';
+        const config = coreConfig.normalize();
+        expect(config.tracing.disableEOLEvents).to.equal(true);
+      });
+
+      it('should return false when INSTANA_TRACING_DISABLE_EOL_EVENTS is set to false', () => {
+        process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'false';
+        const config = coreConfig.normalize();
+        expect(config.tracing.disableEOLEvents).to.equal(false);
+      });
+      it('should return false when INSTANA_TRACING_DISABLE_EOL_EVENTS is set to any other value', () => {
+        process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'test';
+        const config = coreConfig.normalize();
+        expect(config.tracing.disableEOLEvents).to.equal(false);
+      });
     });
   });
 

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -1107,6 +1107,104 @@ describe('config.normalizeConfig', () => {
         expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
         expect(config.secrets.keywords).to.deep.equal(['nope', 'never']);
       });
+
+      it('should prioritize ENV over in-code for matcherMode', () => {
+        process.env.INSTANA_SECRETS = 'equals:env-secret';
+        const config = coreConfig.normalize({
+          userConfig: {
+            secrets: {
+              matcherMode: 'regex',
+              keywords: ['incode-secret']
+            }
+          }
+        });
+        expect(config.secrets.matcherMode).to.equal('equals');
+        expect(config.secrets.keywords).to.deep.equal(['env-secret']);
+      });
+
+      it('should prioritize ENV over in-code for keywords', () => {
+        process.env.INSTANA_SECRETS = 'contains:env-keyword1,env-keyword2';
+        const config = coreConfig.normalize({
+          userConfig: {
+            secrets: {
+              matcherMode: 'equals',
+              keywords: ['incode-keyword']
+            }
+          }
+        });
+        expect(config.secrets.keywords).to.deep.equal(['env-keyword1', 'env-keyword2']);
+      });
+
+      it('should use in-code when ENV is not set', () => {
+        delete process.env.INSTANA_SECRETS;
+        const config = coreConfig.normalize({
+          userConfig: {
+            secrets: {
+              matcherMode: 'regex',
+              keywords: ['incode-secret']
+            }
+          }
+        });
+        expect(config.secrets.matcherMode).to.equal('regex');
+        expect(config.secrets.keywords).to.deep.equal(['incode-secret']);
+      });
+
+      it('should use DEFAULT when neither ENV nor in-code is set', () => {
+        delete process.env.INSTANA_SECRETS;
+        const config = coreConfig.normalize({
+          userConfig: {}
+        });
+        expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
+        expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
+      });
+
+      it('should track DEFAULT source when invalid matcherMode is provided', () => {
+        const config = coreConfig.normalize({
+          userConfig: {
+            secrets: {
+              matcherMode: 'invalid-matcher'
+            }
+          }
+        });
+        expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
+      });
+
+      it('should track DEFAULT source when invalid keywords are provided', () => {
+        const config = coreConfig.normalize({
+          userConfig: {
+            secrets: {
+              keywords: 'not-an-array'
+            }
+          }
+        });
+        expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
+      });
+
+      it('should handle matcherMode=none', () => {
+        const config = coreConfig.normalize({
+          userConfig: {
+            secrets: {
+              matcherMode: 'none'
+            }
+          }
+        });
+        expect(config.secrets.matcherMode).to.equal('none');
+        expect(config.secrets.keywords).to.deep.equal([]);
+      });
+
+      it('should handle ENV matcherMode=none', () => {
+        process.env.INSTANA_SECRETS = 'none';
+        const config = coreConfig.normalize({
+          userConfig: {
+            secrets: {
+              matcherMode: 'equals',
+              keywords: ['should-be-ignored']
+            }
+          }
+        });
+        expect(config.secrets.matcherMode).to.equal('none');
+        expect(config.secrets.keywords).to.deep.equal([]);
+      });
     });
 
     describe('package.json path configuration', () => {

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -1540,6 +1540,132 @@ describe('config.normalizeConfig', () => {
       const config = coreConfig.normalize({ userConfig: { serviceName: 'test' } });
       expect(config.serviceName).to.equal('test');
     });
+
+    describe('config.update', () => {
+      const { CONFIG_SOURCES } = require('../../src/util/constants');
+
+      it('should update config from agent when not previously set', () => {
+        const config = coreConfig.normalize({});
+
+        coreConfig.update(
+          {
+            serviceName: 'agent-service'
+          },
+          CONFIG_SOURCES.AGENT
+        );
+
+        expect(config.serviceName).to.equal('agent-service');
+      });
+
+      it('should not update config from agent when ENV var is set', () => {
+        process.env.INSTANA_SERVICE_NAME = 'env-service';
+        const config = coreConfig.normalize({});
+        expect(config.serviceName).to.equal('env-service');
+
+        coreConfig.update(
+          {
+            serviceName: 'agent-service'
+          },
+          CONFIG_SOURCES.AGENT
+        );
+
+        expect(config.serviceName).to.equal('env-service');
+      });
+
+      it('should not update config from agent when in-code config is set', () => {
+        const config = coreConfig.normalize({
+          userConfig: {
+            serviceName: 'code-service'
+          }
+        });
+        expect(config.serviceName).to.equal('code-service');
+
+        coreConfig.update(
+          {
+            serviceName: 'agent-service'
+          },
+          CONFIG_SOURCES.AGENT
+        );
+
+        expect(config.serviceName).to.equal('code-service');
+      });
+
+      it('should update multiple config values from agent', () => {
+        const config = coreConfig.normalize();
+
+        coreConfig.update(
+          {
+            serviceName: 'agent-service',
+            'metrics.transmissionDelay': 2000
+          },
+          CONFIG_SOURCES.AGENT
+        );
+
+        expect(config.serviceName).to.equal('agent-service');
+        expect(config['metrics.transmissionDelay']).to.equal(2000);
+      });
+
+      it('should handle empty agent config', () => {
+        const config = coreConfig.normalize();
+        const originalServiceName = config.serviceName;
+
+        coreConfig.update({}, CONFIG_SOURCES.AGENT);
+
+        expect(config.serviceName).to.equal(originalServiceName);
+      });
+
+      it('should handle null agent config', () => {
+        const config = coreConfig.normalize();
+        const originalServiceName = config.serviceName;
+
+        coreConfig.update(null, CONFIG_SOURCES.AGENT);
+
+        expect(config.serviceName).to.equal(originalServiceName);
+      });
+
+      it('should update agent config over default values', () => {
+        const config = coreConfig.normalize();
+
+        expect(config.serviceName).to.be.null;
+
+        coreConfig.update(
+          {
+            serviceName: 'agent-service'
+          },
+          CONFIG_SOURCES.AGENT
+        );
+
+        expect(config.serviceName).to.equal('agent-service');
+      });
+
+      it('should respect precedence: ENV > IN_CODE > AGENT > DEFAULT', () => {
+        process.env.INSTANA_SERVICE_NAME = 'env-service';
+
+        const config = coreConfig.normalize({
+          userConfig: {
+            packageJsonPath: '/custom/path'
+          }
+        });
+
+        expect(config.serviceName).to.equal('env-service');
+        expect(config.packageJsonPath).to.equal('/custom/path');
+
+        coreConfig.update(
+          {
+            serviceName: 'agent-service',
+            packageJsonPath: '/agent/path',
+            preloadOpentelemetry: true
+          },
+          CONFIG_SOURCES.AGENT
+        );
+
+        expect(config.serviceName).to.equal('env-service');
+
+        expect(config.packageJsonPath).to.equal('/custom/path');
+
+        expect(config.preloadOpentelemetry).to.be.true;
+      });
+    });
   });
 
   function checkDefaults(config) {

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -50,15 +50,15 @@ describe('config.normalizeConfig', () => {
   describe('default configuration', () => {
     it('should apply all defaults', () => {
       checkDefaults(coreConfig.normalize());
-      checkDefaults(coreConfig.normalize({}));
-      checkDefaults(coreConfig.normalize({ tracing: {}, metrics: {} }));
-      checkDefaults(coreConfig.normalize({ unknowConfigOption: 13 }));
+      checkDefaults(coreConfig.normalize({ userConfig: { userConfig: {} } }));
+      checkDefaults(coreConfig.normalize({ userConfig: { userConfig: { tracing: {}, metrics: {} } } }));
+      checkDefaults(coreConfig.normalize({ userConfig: { userConfig: { unknowConfigOption: 13 } } }));
     });
   });
 
   describe('service name configuration', () => {
     it('should accept service name', () => {
-      const config = coreConfig.normalize({ serviceName: 'custom-service-name' });
+      const config = coreConfig.normalize({ userConfig: { serviceName: 'custom-service-name' } });
       expect(config.serviceName).to.equal('custom-service-name');
     });
 
@@ -69,18 +69,18 @@ describe('config.normalizeConfig', () => {
     });
 
     it('should not accept non-string service name', () => {
-      const config = coreConfig.normalize({ serviceName: 42 });
+      const config = coreConfig.normalize({ userConfig: { serviceName: 42 } });
       expect(config.serviceName).to.not.exist;
     });
 
     it.skip('should use config when env not set', () => {
-      const config = coreConfig.normalize({ serviceName: 'config-service-name' });
+      const config = coreConfig.normalize({ userConfig: { serviceName: 'config-service-name' } });
       expect(config.serviceName).to.equal('config-service-name');
     });
 
     it.skip('should give precedence to INSTANA_SERVICE_NAME env var over config', () => {
       process.env.INSTANA_SERVICE_NAME = 'env-service';
-      const config = coreConfig.normalize({ serviceName: 'config-service' });
+      const config = coreConfig.normalize({ userConfig: { serviceName: 'config-service' } });
       expect(config.serviceName).to.equal('env-service');
     });
   });
@@ -88,8 +88,10 @@ describe('config.normalizeConfig', () => {
   describe('metrics configuration', () => {
     it('should use custom metrics transmission settings from config', () => {
       const config = coreConfig.normalize({
-        metrics: {
-          transmissionDelay: 9753
+        userConfig: {
+          metrics: {
+            transmissionDelay: 9753
+          }
         }
       });
       expect(config.metrics.transmissionDelay).to.equal(9753);
@@ -135,26 +137,28 @@ describe('config.normalizeConfig', () => {
 
     it.skip('should give precedence to INSTANA_METRICS_TRANSMISSION_DELAY env var over config', () => {
       process.env.INSTANA_METRICS_TRANSMISSION_DELAY = '3000';
-      const config = coreConfig.normalize({ metrics: { transmissionDelay: 5000 } });
+      const config = coreConfig.normalize({ userConfig: { metrics: { transmissionDelay: 5000 } } });
       expect(config.metrics.transmissionDelay).to.equal(3000);
     });
 
     it('should fall back to config when env var is invalid', () => {
       process.env.INSTANA_METRICS_TRANSMISSION_DELAY = 'invalid';
-      const config = coreConfig.normalize({ metrics: { transmissionDelay: 5000 } });
+      const config = coreConfig.normalize({ userConfig: { metrics: { transmissionDelay: 5000 } } });
       expect(config.metrics.transmissionDelay).to.equal(5000);
     });
 
     it('should fall back to default when both env and config are invalid', () => {
       process.env.INSTANA_METRICS_TRANSMISSION_DELAY = 'invalid';
-      const config = coreConfig.normalize({ metrics: { transmissionDelay: 'also-invalid' } });
+      const config = coreConfig.normalize({ userConfig: { metrics: { transmissionDelay: 'also-invalid' } } });
       expect(config.metrics.transmissionDelay).to.equal(1000);
     });
 
     it('should use custom config.metrics.timeBetweenHealthcheckCalls', () => {
       const config = coreConfig.normalize({
-        metrics: {
-          timeBetweenHealthcheckCalls: 9876
+        userConfig: {
+          metrics: {
+            timeBetweenHealthcheckCalls: 9876
+          }
         }
       });
       expect(config.metrics.timeBetweenHealthcheckCalls).to.equal(9876);
@@ -164,19 +168,19 @@ describe('config.normalizeConfig', () => {
   describe('tracing configuration', () => {
     describe('enabling and disabling tracing', () => {
       it('should disable tracing with enabled: false', () => {
-        const config = coreConfig.normalize({ tracing: { enabled: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { enabled: false } } });
         expect(config.tracing.enabled).to.be.false;
         expect(config.tracing.automaticTracingEnabled).to.be.false;
       });
 
       it('should disable tracing with disable: true', () => {
-        const config = coreConfig.normalize({ tracing: { enabled: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { enabled: false } } });
         expect(config.tracing.enabled).to.be.false;
         expect(config.tracing.automaticTracingEnabled).to.be.false;
       });
 
       it('should disable automatic tracing', () => {
-        const config = coreConfig.normalize({ tracing: { automaticTracingEnabled: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { automaticTracingEnabled: false } } });
         expect(config.tracing.enabled).to.be.true;
         expect(config.tracing.automaticTracingEnabled).to.be.false;
       });
@@ -189,9 +193,11 @@ describe('config.normalizeConfig', () => {
       });
       it('should not enable automatic tracing when tracing is disabled in general', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            enabled: false,
-            automaticTracingEnabled: true
+          userConfig: {
+            tracing: {
+              enabled: false,
+              automaticTracingEnabled: true
+            }
           }
         });
         expect(config.tracing.enabled).to.be.false;
@@ -205,13 +211,13 @@ describe('config.normalizeConfig', () => {
 
       it.skip('should give precedence to INSTANA_TRACING_DISABLE env var set to true over config set to true', () => {
         process.env.INSTANA_TRACING_DISABLE = 'true';
-        const config = coreConfig.normalize({ tracing: { enabled: true } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { enabled: true } } });
         expect(config.tracing.enabled).to.be.false;
       });
 
       it.skip('should give precedence to INSTANA_TRACING_DISABLE env var set to false over config set to false', () => {
         process.env.INSTANA_TRACING_DISABLE = 'false';
-        const config = coreConfig.normalize({ tracing: { enabled: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { enabled: false } } });
         expect(config.tracing.enabled).to.be.true;
       });
 
@@ -228,13 +234,13 @@ describe('config.normalizeConfig', () => {
 
       it.skip('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var set to true over config set to true', () => {
         process.env.INSTANA_DISABLE_AUTO_INSTR = 'true';
-        const config = coreConfig.normalize({ tracing: { automaticTracingEnabled: true } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { automaticTracingEnabled: true } } });
         expect(config.tracing.automaticTracingEnabled).to.be.false;
       });
 
       it.skip('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var set to false over config set to false', () => {
         process.env.INSTANA_DISABLE_AUTO_INSTR = 'false';
-        const config = coreConfig.normalize({ tracing: { automaticTracingEnabled: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { automaticTracingEnabled: false } } });
         expect(config.tracing.automaticTracingEnabled).to.be.true;
       });
 
@@ -247,7 +253,7 @@ describe('config.normalizeConfig', () => {
 
     describe('immediate activation', () => {
       it('should enable immediate tracing activation', () => {
-        const config = coreConfig.normalize({ tracing: { activateImmediately: true } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { activateImmediately: true } } });
         expect(config.tracing.activateImmediately).to.be.true;
       });
 
@@ -259,9 +265,11 @@ describe('config.normalizeConfig', () => {
 
       it('should not enable immediate tracing activation when tracing is disabled in general', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            enabled: false,
-            activateImmediately: true
+          userConfig: {
+            tracing: {
+              enabled: false,
+              activateImmediately: true
+            }
           }
         });
         expect(config.tracing.enabled).to.be.false;
@@ -275,13 +283,13 @@ describe('config.normalizeConfig', () => {
 
       it.skip('should give precedence to INSTANA_TRACE_IMMEDIATELY env var set to true over config set to false', () => {
         process.env.INSTANA_TRACE_IMMEDIATELY = 'true';
-        const config = coreConfig.normalize({ tracing: { activateImmediately: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { activateImmediately: false } } });
         expect(config.tracing.activateImmediately).to.be.true;
       });
 
       it.skip('should give precedence to INSTANA_TRACE_IMMEDIATELY env var set to false over config set to true', () => {
         process.env.INSTANA_TRACE_IMMEDIATELY = 'false';
-        const config = coreConfig.normalize({ tracing: { activateImmediately: true } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { activateImmediately: true } } });
         expect(config.tracing.activateImmediately).to.be.false;
       });
     });
@@ -289,10 +297,12 @@ describe('config.normalizeConfig', () => {
     describe('transmission settings', () => {
       it('should use custom tracing transmission settings from config', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            maxBufferedSpans: 13,
-            forceTransmissionStartingAt: 2,
-            transmissionDelay: 9753
+          userConfig: {
+            tracing: {
+              maxBufferedSpans: 13,
+              forceTransmissionStartingAt: 2,
+              transmissionDelay: 9753
+            }
           }
         });
         expect(config.tracing.maxBufferedSpans).to.equal(13);
@@ -318,25 +328,25 @@ describe('config.normalizeConfig', () => {
 
       it.skip('should give precedence to INSTANA_TRACING_TRANSMISSION_DELAY env var over config', () => {
         process.env.INSTANA_TRACING_TRANSMISSION_DELAY = '4000';
-        const config = coreConfig.normalize({ tracing: { transmissionDelay: 2000 } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { transmissionDelay: 2000 } } });
         expect(config.tracing.transmissionDelay).to.equal(4000);
       });
 
       it.skip('should give precedence to INSTANA_FORCE_TRANSMISSION_STARTING_AT env var over config', () => {
         process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT = '700';
-        const config = coreConfig.normalize({ tracing: { forceTransmissionStartingAt: 300 } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { forceTransmissionStartingAt: 300 } } });
         expect(config.tracing.forceTransmissionStartingAt).to.equal(700);
       });
 
       it('should fall back to config when env var is invalid for transmissionDelay', () => {
         process.env.INSTANA_TRACING_TRANSMISSION_DELAY = 'invalid';
-        const config = coreConfig.normalize({ tracing: { transmissionDelay: 5000 } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { transmissionDelay: 5000 } } });
         expect(config.tracing.transmissionDelay).to.equal(5000);
       });
 
       it('should fall back to default when both env and config are invalid for transmissionDelay', () => {
         process.env.INSTANA_TRACING_TRANSMISSION_DELAY = 'invalid';
-        const config = coreConfig.normalize({ tracing: { transmissionDelay: 'also-invalid' } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { transmissionDelay: 'also-invalid' } } });
         expect(config.tracing.transmissionDelay).to.equal(1000);
       });
     });
@@ -344,9 +354,11 @@ describe('config.normalizeConfig', () => {
     describe('HTTP headers configuration', () => {
       it('should use extra http headers (and normalize to lower case)', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            http: {
-              extraHttpHeadersToCapture: ['yo', 'LO']
+          userConfig: {
+            tracing: {
+              http: {
+                extraHttpHeadersToCapture: ['yo', 'LO']
+              }
             }
           }
         });
@@ -355,9 +367,11 @@ describe('config.normalizeConfig', () => {
 
       it('should reject non-array extra http headers configuration value', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            http: {
-              extraHttpHeadersToCapture: 'yolo'
+          userConfig: {
+            tracing: {
+              http: {
+                extraHttpHeadersToCapture: 'yolo'
+              }
             }
           }
         });
@@ -380,36 +394,36 @@ describe('config.normalizeConfig', () => {
 
     describe('stack trace configuration', () => {
       it('should accept numerical custom stack trace length', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: 666 } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: 666 } } });
         expect(config.tracing.stackTraceLength).to.equal(500);
       });
       it('should normalize numbers for custom stack trace length', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: -28.08 } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: -28.08 } } });
 
         expect(config.tracing.stackTraceLength).to.be.a('number');
         expect(config.tracing.stackTraceLength).to.equal(28);
       });
 
       it('should accept number-like strings for custom stack trace length', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: '1302' } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: '1302' } } });
         expect(config.tracing.stackTraceLength).to.be.a('number');
         expect(config.tracing.stackTraceLength).to.equal(500);
       });
 
       it('should normalize number-like strings for custom stack trace length', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: '-16.04' } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: '-16.04' } } });
         expect(config.tracing.stackTraceLength).to.be.a('number');
         expect(config.tracing.stackTraceLength).to.equal(16);
       });
 
       it('should reject non-numerical strings for custom stack trace length', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: 'three' } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: 'three' } } });
         expect(config.tracing.stackTraceLength).to.be.a('number');
         expect(config.tracing.stackTraceLength).to.equal(10);
       });
 
       it('should reject custom stack trace length which is neither a number nor a string', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: false } } });
         expect(config.tracing.stackTraceLength).to.be.a('number');
         expect(config.tracing.stackTraceLength).to.equal(10);
       });
@@ -422,7 +436,7 @@ describe('config.normalizeConfig', () => {
 
       it.skip('should give precedence to INSTANA_STACK_TRACE_LENGTH over config', () => {
         process.env.INSTANA_STACK_TRACE_LENGTH = '5';
-        const normalizedConfig = coreConfig.normalize({ tracing: { stackTraceLength: 20 } });
+        const normalizedConfig = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: 20 } } });
         expect(normalizedConfig.tracing.stackTraceLength).to.equal(5);
         delete process.env.INSTANA_STACK_TRACE_LENGTH;
       });
@@ -433,17 +447,17 @@ describe('config.normalizeConfig', () => {
       });
 
       it('should accept valid stack trace mode from config', () => {
-        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'error' } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: 'error' } } } });
         expect(config.tracing.stackTrace).to.equal('error');
       });
 
       it('should accept "none" stack trace mode from config', () => {
-        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'none' } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: 'none' } } } });
         expect(config.tracing.stackTrace).to.equal('none');
       });
 
       it('should normalize stack trace mode to lowercase from config', () => {
-        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'ERROR' } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: 'ERROR' } } } });
         expect(config.tracing.stackTrace).to.equal('error');
       });
 
@@ -461,12 +475,12 @@ describe('config.normalizeConfig', () => {
 
       it.skip('should give precedence to env INSTANA_STACK_TRACE over config', () => {
         process.env.INSTANA_STACK_TRACE = 'none';
-        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'all' } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: 'all' } } } });
         expect(config.tracing.stackTrace).to.equal('none');
       });
 
       it('should reject invalid stack trace mode from config and fallback to default', () => {
-        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'invalid' } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: 'invalid' } } } });
         expect(config.tracing.stackTrace).to.equal('all');
       });
 
@@ -477,102 +491,102 @@ describe('config.normalizeConfig', () => {
       });
 
       it('should reject non-string stack trace mode from config', () => {
-        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 123 } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: 123 } } } });
         expect(config.tracing.stackTrace).to.equal('all');
       });
 
       it('should handle null stack trace mode from config', () => {
-        const config = coreConfig.normalize({ tracing: { global: { stackTrace: null } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: null } } } });
         expect(config.tracing.stackTrace).to.equal('all');
       });
 
       it('should handle undefined stack trace mode from config', () => {
-        const config = coreConfig.normalize({ tracing: { global: { stackTrace: undefined } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: undefined } } } });
         expect(config.tracing.stackTrace).to.equal('all');
       });
 
       it('should handle empty string stack trace mode from config', () => {
-        const config = coreConfig.normalize({ tracing: { global: { stackTrace: '' } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: '' } } } });
         expect(config.tracing.stackTrace).to.equal('all');
       });
 
       it('should handle boolean stack trace mode from config', () => {
-        const config = coreConfig.normalize({ tracing: { global: { stackTrace: true } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: true } } } });
         expect(config.tracing.stackTrace).to.equal('all');
       });
 
       it('should handle object stack trace mode from config', () => {
-        const config = coreConfig.normalize({ tracing: { global: { stackTrace: {} } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: {} } } } });
         expect(config.tracing.stackTrace).to.equal('all');
       });
 
       it('should handle array stack trace mode from config', () => {
-        const config = coreConfig.normalize({ tracing: { global: { stackTrace: ['error'] } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: ['error'] } } } });
         expect(config.tracing.stackTrace).to.equal('all');
       });
 
       it('should accept zero as valid stack trace length', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: 0 } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: 0 } } });
         expect(config.tracing.stackTraceLength).to.equal(0);
       });
 
       it('should handle negative stack trace length', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: -10 } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: -10 } } });
         expect(config.tracing.stackTraceLength).to.equal(10);
       });
 
       it('should handle very large negative stack trace length', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: -100 } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: -100 } } });
         expect(config.tracing.stackTraceLength).to.equal(100);
       });
 
       it('should handle stack trace length as positive float', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: 15.9 } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: 15.9 } } });
         expect(config.tracing.stackTraceLength).to.equal(16);
       });
 
       it('should handle stack trace length as negative float', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: -15.9 } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: -15.9 } } });
         expect(config.tracing.stackTraceLength).to.equal(16);
       });
 
       it('should handle stack trace length as string with leading zeros', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: '007' } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: '007' } } });
         expect(config.tracing.stackTraceLength).to.equal(7);
       });
 
       it('should handle stack trace length as string with whitespace', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: '  25  ' } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: '  25  ' } } });
         expect(config.tracing.stackTraceLength).to.equal(25);
       });
 
       it('should handle stack trace length as string with plus sign', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: '+30' } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: '+30' } } });
         expect(config.tracing.stackTraceLength).to.equal(30);
       });
 
       it('should reject stack trace length as null', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: null } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: null } } });
         expect(config.tracing.stackTraceLength).to.equal(10);
       });
 
       it('should reject stack trace length as undefined', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: undefined } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: undefined } } });
         expect(config.tracing.stackTraceLength).to.equal(10);
       });
 
       it('should reject stack trace length as empty string', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: '' } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: '' } } });
         expect(config.tracing.stackTraceLength).to.equal(10);
       });
 
       it('should reject stack trace length as object', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: {} } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: {} } } });
         expect(config.tracing.stackTraceLength).to.equal(10);
       });
 
       it('should reject stack trace length as array', () => {
-        const config = coreConfig.normalize({ tracing: { stackTraceLength: [10] } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { stackTraceLength: [10] } } });
         expect(config.tracing.stackTraceLength).to.equal(10);
       });
 
@@ -629,7 +643,7 @@ describe('config.normalizeConfig', () => {
         const original = stackTraceNormalizers.normalizeStackTraceMode;
         stackTraceNormalizers.normalizeStackTraceMode = () => null;
 
-        const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'all' } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: 'all' } } } });
         expect(config.tracing.stackTrace).to.equal('all');
 
         stackTraceNormalizers.normalizeStackTraceMode = original;
@@ -652,7 +666,7 @@ describe('config.normalizeConfig', () => {
         const original = stackTraceNormalizers.normalizeStackTraceLength;
         stackTraceNormalizers.normalizeStackTraceLength = () => null;
 
-        const config = coreConfig.normalize({ tracing: { global: { stackTraceLength: 20 } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTraceLength: 20 } } } });
         expect(config.tracing.stackTraceLength).to.equal(10);
 
         stackTraceNormalizers.normalizeStackTraceLength = original;
@@ -672,9 +686,11 @@ describe('config.normalizeConfig', () => {
 
       it('should return null from normalizeStackTraceLength when value is valid but normalized is null', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            global: {
-              stackTraceLength: Infinity
+          userConfig: {
+            tracing: {
+              global: {
+                stackTraceLength: Infinity
+              }
             }
           }
         });
@@ -691,10 +707,12 @@ describe('config.normalizeConfig', () => {
 
       it('should handle config with both stackTrace and stackTraceLength', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            global: {
-              stackTrace: 'none',
-              stackTraceLength: 30
+          userConfig: {
+            tracing: {
+              global: {
+                stackTrace: 'none',
+                stackTraceLength: 30
+              }
             }
           }
         });
@@ -706,10 +724,12 @@ describe('config.normalizeConfig', () => {
         process.env.INSTANA_STACK_TRACE = 'error';
         process.env.INSTANA_STACK_TRACE_LENGTH = '15';
         const config = coreConfig.normalize({
-          tracing: {
-            global: {
-              stackTrace: 'all',
-              stackTraceLength: 40
+          userConfig: {
+            tracing: {
+              global: {
+                stackTrace: 'all',
+                stackTraceLength: 40
+              }
             }
           }
         });
@@ -732,8 +752,10 @@ describe('config.normalizeConfig', () => {
       });
       it('should disable individual instrumentations via disable config', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            disable: ['graphQL', 'GRPC']
+          userConfig: {
+            tracing: {
+              disable: ['graphQL', 'GRPC']
+            }
           }
         });
         expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
@@ -741,8 +763,10 @@ describe('config.normalizeConfig', () => {
 
       it('should disable individual instrumentations via disable.instrumentations config', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            disable: { instrumentations: ['graphQL', 'GRPC'] }
+          userConfig: {
+            tracing: {
+              disable: { instrumentations: ['graphQL', 'GRPC'] }
+            }
           }
         });
         expect(config.tracing.disable.instrumentations).to.deep.equal(['graphql', 'grpc']);
@@ -751,8 +775,10 @@ describe('config.normalizeConfig', () => {
       it('config should take precedence over INSTANA_TRACING_DISABLE_INSTRUMENTATIONS  for config', () => {
         process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'foo, bar';
         const config = coreConfig.normalize({
-          tracing: {
-            disable: { instrumentations: ['baz', 'fizz'] }
+          userConfig: {
+            tracing: {
+              disable: { instrumentations: ['baz', 'fizz'] }
+            }
           }
         });
         expect(config.tracing.disable.instrumentations).to.deep.equal(['baz', 'fizz']);
@@ -778,8 +804,10 @@ describe('config.normalizeConfig', () => {
 
       it('should disable individual groups via disable config', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            disable: { groups: ['logging'] }
+          userConfig: {
+            tracing: {
+              disable: { groups: ['logging'] }
+            }
           }
         });
         expect(config.tracing.disable.groups).to.deep.equal(['logging']);
@@ -794,8 +822,10 @@ describe('config.normalizeConfig', () => {
       it('config should take precedence over INSTANA_TRACING_DISABLE_GROUPS when disabling groups', () => {
         process.env.INSTANA_TRACING_DISABLE_GROUPS = 'frameworks, databases';
         const config = coreConfig.normalize({
-          tracing: {
-            disable: { groups: ['LOGGING'] }
+          userConfig: {
+            tracing: {
+              disable: { groups: ['LOGGING'] }
+            }
           }
         });
         expect(config.tracing.disable.groups).to.deep.equal(['logging']);
@@ -803,8 +833,10 @@ describe('config.normalizeConfig', () => {
 
       it('should disable instrumentations and groups when both configured', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            disable: { groups: ['LOGGING'], instrumentations: ['redis', 'kafka'] }
+          userConfig: {
+            tracing: {
+              disable: { groups: ['LOGGING'], instrumentations: ['redis', 'kafka'] }
+            }
           }
         });
         expect(config.tracing.disable.groups).to.deep.equal(['logging']);
@@ -829,8 +861,10 @@ describe('config.normalizeConfig', () => {
 
       it('should disable all tracing via config tracing.disable', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            disable: true
+          userConfig: {
+            tracing: {
+              disable: true
+            }
           }
         });
         expect(config.tracing.enabled).to.be.false;
@@ -842,7 +876,7 @@ describe('config.normalizeConfig', () => {
     describe('span batching', () => {
       // delete this test when we switch to opt-out
       it('should enable span batching via config in transition phase', () => {
-        const config = coreConfig.normalize({ tracing: { spanBatchingEnabled: true } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { spanBatchingEnabled: true } } });
         expect(config.tracing.spanBatchingEnabled).to.be.true;
       });
 
@@ -854,14 +888,14 @@ describe('config.normalizeConfig', () => {
       });
 
       it('should ignore non-boolean span batching config value', () => {
-        const config = coreConfig.normalize({ tracing: { spanBatchingEnabled: 73 } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { spanBatchingEnabled: 73 } } });
         // test needs to be updated once we switch to opt-out
         expect(config.tracing.spanBatchingEnabled).to.be.false;
       });
 
       it('should disable span batching', () => {
         // test only becomes relevant once we switch to opt-out
-        const config = coreConfig.normalize({ tracing: { spanBatchingEnabled: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { spanBatchingEnabled: false } } });
         expect(config.tracing.spanBatchingEnabled).to.be.false;
       });
 
@@ -879,20 +913,20 @@ describe('config.normalizeConfig', () => {
 
       it.skip('should give precedence to INSTANA_SPANBATCHING_ENABLED env var set to true over config set to false', () => {
         process.env.INSTANA_SPANBATCHING_ENABLED = 'true';
-        const config = coreConfig.normalize({ tracing: { spanBatchingEnabled: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { spanBatchingEnabled: false } } });
         expect(config.tracing.spanBatchingEnabled).to.be.true;
       });
 
       it.skip('should give precedence to INSTANA_SPANBATCHING_ENABLED env var set to false over config set to true', () => {
         process.env.INSTANA_SPANBATCHING_ENABLED = 'false';
-        const config = coreConfig.normalize({ tracing: { spanBatchingEnabled: true } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { spanBatchingEnabled: true } } });
         expect(config.tracing.spanBatchingEnabled).to.be.false;
       });
     });
 
     describe('W3C trace correlation', () => {
       it('should disable W3C trace correlation', () => {
-        const config = coreConfig.normalize({ tracing: { disableW3cTraceCorrelation: true } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { disableW3cTraceCorrelation: true } } });
         expect(config.tracing.disableW3cTraceCorrelation).to.be.true;
       });
 
@@ -909,14 +943,14 @@ describe('config.normalizeConfig', () => {
 
       it.skip('should give precedence to INSTANA_DISABLE_W3C_TRACE_CORRELATION env var over config (truthy env)', () => {
         process.env.INSTANA_DISABLE_W3C_TRACE_CORRELATION = 'any-value';
-        const config = coreConfig.normalize({ tracing: { disableW3cTraceCorrelation: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { disableW3cTraceCorrelation: false } } });
         expect(config.tracing.disableW3cTraceCorrelation).to.be.true;
       });
     });
 
     describe('Kafka trace correlation', () => {
       it('should disable Kafka trace correlation', () => {
-        const config = coreConfig.normalize({ tracing: { kafka: { traceCorrelation: false } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { kafka: { traceCorrelation: false } } } });
         expect(config.tracing.kafka.traceCorrelation).to.be.false;
       });
 
@@ -933,13 +967,13 @@ describe('config.normalizeConfig', () => {
 
       it.skip('should give precedence to INSTANA_KAFKA_TRACE_CORRELATION env var set to false over config set to true', () => {
         process.env.INSTANA_KAFKA_TRACE_CORRELATION = 'false';
-        const config = coreConfig.normalize({ tracing: { kafka: { traceCorrelation: true } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { kafka: { traceCorrelation: true } } } });
         expect(config.tracing.kafka.traceCorrelation).to.be.false;
       });
 
       it.skip('should give precedence to INSTANA_KAFKA_TRACE_CORRELATION env var set to true over config set to false', () => {
         process.env.INSTANA_KAFKA_TRACE_CORRELATION = 'true';
-        const config = coreConfig.normalize({ tracing: { kafka: { traceCorrelation: false } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { kafka: { traceCorrelation: false } } } });
         expect(config.tracing.kafka.traceCorrelation).to.be.true;
       });
     });
@@ -947,14 +981,18 @@ describe('config.normalizeConfig', () => {
     describe('OpenTelemetry configuration', () => {
       it('should disable opentelemetry if config is set', () => {
         const config = coreConfig.normalize({
-          tracing: { useOpentelemetry: false }
+          userConfig: {
+            tracing: { useOpentelemetry: false }
+          }
         });
         expect(config.tracing.useOpentelemetry).to.equal(false);
       });
 
       it('should enable opentelemetry if config is set', () => {
         const config = coreConfig.normalize({
-          tracing: { useOpentelemetry: true }
+          userConfig: {
+            tracing: { useOpentelemetry: true }
+          }
         });
         expect(config.tracing.useOpentelemetry).to.equal(true);
       });
@@ -978,13 +1016,13 @@ describe('config.normalizeConfig', () => {
 
       it.skip('should give precedence to INSTANA_DISABLE_USE_OPENTELEMETRY env var set to true over config set to true', () => {
         process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'true';
-        const config = coreConfig.normalize({ tracing: { useOpentelemetry: true } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { useOpentelemetry: true } } });
         expect(config.tracing.useOpentelemetry).to.be.false;
       });
 
       it.skip('should give precedence to INSTANA_DISABLE_USE_OPENTELEMETRY env var set to false over config set to false', () => {
         process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'false';
-        const config = coreConfig.normalize({ tracing: { useOpentelemetry: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { useOpentelemetry: false } } });
         expect(config.tracing.useOpentelemetry).to.be.true;
       });
     });
@@ -992,9 +1030,11 @@ describe('config.normalizeConfig', () => {
     describe('secrets configuration', () => {
       it('should accept custom secrets config', () => {
         const config = coreConfig.normalize({
-          secrets: {
-            matcherMode: 'equals',
-            keywords: ['custom-secret', 'sheesh']
+          userConfig: {
+            secrets: {
+              matcherMode: 'equals',
+              keywords: ['custom-secret', 'sheesh']
+            }
           }
         });
         expect(config.secrets.matcherMode).to.equal('equals');
@@ -1003,8 +1043,10 @@ describe('config.normalizeConfig', () => {
 
       it("should set keywords to empty array for matcher mode 'none'", () => {
         const config = coreConfig.normalize({
-          secrets: {
-            matcherMode: 'none'
+          userConfig: {
+            secrets: {
+              matcherMode: 'none'
+            }
           }
         });
         expect(config.secrets.matcherMode).to.equal('none');
@@ -1012,19 +1054,19 @@ describe('config.normalizeConfig', () => {
       });
 
       it('should reject non-string matcher mode', () => {
-        const config = coreConfig.normalize({ secrets: { matcherMode: 43 } });
+        const config = coreConfig.normalize({ userConfig: { secrets: { matcherMode: 43 } } });
         expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
         expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
       });
 
       it('should reject unknown matcher mode from config', () => {
-        const config = coreConfig.normalize({ secrets: { matcherMode: 'whatever' } });
+        const config = coreConfig.normalize({ userConfig: { secrets: { matcherMode: 'whatever' } } });
         expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
         expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
       });
 
       it('should reject non-array keywords', () => {
-        const config = coreConfig.normalize({ secrets: { keywords: 'yes' } });
+        const config = coreConfig.normalize({ userConfig: { secrets: { keywords: 'yes' } } });
         expect(config.secrets.matcherMode).to.equal('contains-ignore-case');
         expect(config.secrets.keywords).to.deep.equal(['key', 'pass', 'secret']);
       });
@@ -1060,12 +1102,12 @@ describe('config.normalizeConfig', () => {
 
     describe('package.json path configuration', () => {
       it('should accept packageJsonPath', () => {
-        const config = coreConfig.normalize({ packageJsonPath: './something' });
+        const config = coreConfig.normalize({ userConfig: { packageJsonPath: './something' } });
         expect(config.packageJsonPath).to.equal('./something');
       });
 
       it('should not accept packageJsonPath', () => {
-        const config = coreConfig.normalize({ packageJsonPath: 1234 });
+        const config = coreConfig.normalize({ userConfig: { packageJsonPath: 1234 } });
         expect(config.packageJsonPath).to.not.exist;
       });
 
@@ -1082,7 +1124,7 @@ describe('config.normalizeConfig', () => {
 
       it.skip('should give precedence to INSTANA_PACKAGE_JSON_PATH env var over config', () => {
         process.env.INSTANA_PACKAGE_JSON_PATH = '/env/path/package.json';
-        const config = coreConfig.normalize({ packageJsonPath: '/config/path/package.json' });
+        const config = coreConfig.normalize({ userConfig: { packageJsonPath: '/config/path/package.json' } });
         expect(config.packageJsonPath).to.equal('/env/path/package.json');
       });
     });
@@ -1090,14 +1132,18 @@ describe('config.normalizeConfig', () => {
     describe('allow root exit span', () => {
       it('should disable allow root exit span if config is set to false', () => {
         const config = coreConfig.normalize({
-          tracing: { allowRootExitSpan: false }
+          userConfig: {
+            tracing: { allowRootExitSpan: false }
+          }
         });
         expect(config.tracing.allowRootExitSpan).to.equal(false);
       });
 
       it('should enable allow root exit span if config is set to true', () => {
         const config = coreConfig.normalize({
-          tracing: { allowRootExitSpan: true }
+          userConfig: {
+            tracing: { allowRootExitSpan: true }
+          }
         });
         expect(config.tracing.allowRootExitSpan).to.equal(true);
       });
@@ -1120,13 +1166,13 @@ describe('config.normalizeConfig', () => {
 
       it.skip('should give precedence to INSTANA_ALLOW_ROOT_EXIT_SPAN env var set to true over config set to false', () => {
         process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = 'true';
-        const config = coreConfig.normalize({ tracing: { allowRootExitSpan: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { allowRootExitSpan: false } } });
         expect(config.tracing.allowRootExitSpan).to.be.true;
       });
 
       it.skip('should give precedence to INSTANA_ALLOW_ROOT_EXIT_SPAN env var set to false over config set to true', () => {
         process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = 'false';
-        const config = coreConfig.normalize({ tracing: { allowRootExitSpan: true } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { allowRootExitSpan: true } } });
         expect(config.tracing.allowRootExitSpan).to.be.false;
       });
     });
@@ -1161,24 +1207,30 @@ describe('config.normalizeConfig', () => {
 
       it('should apply ignore endpoints via config', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            ignoreEndpoints: { redis: ['get'] }
+          userConfig: {
+            tracing: {
+              ignoreEndpoints: { redis: ['get'] }
+            }
           }
         });
         expect(config.tracing.ignoreEndpoints).to.deep.equal({ redis: [{ methods: ['get'] }] });
       });
       it('should apply multiple ignore endpoints via config', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            ignoreEndpoints: { redis: ['GET', 'TYPE'] }
+          userConfig: {
+            tracing: {
+              ignoreEndpoints: { redis: ['GET', 'TYPE'] }
+            }
           }
         });
         expect(config.tracing.ignoreEndpoints).to.deep.equal({ redis: [{ methods: ['get', 'type'] }] });
       });
       it('should apply ignore endpoints via config for multiple packages', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            ignoreEndpoints: { redis: ['get'], dynamodb: ['querey'] }
+          userConfig: {
+            tracing: {
+              ignoreEndpoints: { redis: ['get'], dynamodb: ['querey'] }
+            }
           }
         });
         expect(config.tracing.ignoreEndpoints).to.deep.equal({
@@ -1189,10 +1241,12 @@ describe('config.normalizeConfig', () => {
 
       it('should normalize case and trim spaces in method names and endpoint paths', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            ignoreEndpoints: {
-              redis: ['  GET ', 'TyPe'],
-              kafka: [{ methods: ['  PUBLISH  '], endpoints: [' Topic1 ', 'TOPIC2 '] }]
+          userConfig: {
+            tracing: {
+              ignoreEndpoints: {
+                redis: ['  GET ', 'TyPe'],
+                kafka: [{ methods: ['  PUBLISH  '], endpoints: [' Topic1 ', 'TOPIC2 '] }]
+              }
             }
           }
         });
@@ -1204,8 +1258,10 @@ describe('config.normalizeConfig', () => {
 
       it('should return an empty list if all configurations are invalid', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            ignoreEndpoints: { redis: {}, kafka: true, mysql: null }
+          userConfig: {
+            tracing: {
+              ignoreEndpoints: { redis: {}, kafka: true, mysql: null }
+            }
           }
         });
         expect(config.tracing.ignoreEndpoints).to.deep.equal({
@@ -1217,10 +1273,12 @@ describe('config.normalizeConfig', () => {
 
       it('should normalize objects when unsupported additional fields applied', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            ignoreEndpoints: {
-              redis: [{ extra: 'data' }],
-              kafka: [{ methods: ['publish'], extra: 'info' }]
+          userConfig: {
+            tracing: {
+              ignoreEndpoints: {
+                redis: [{ extra: 'data' }],
+                kafka: [{ methods: ['publish'], extra: 'info' }]
+              }
             }
           }
         });
@@ -1232,9 +1290,11 @@ describe('config.normalizeConfig', () => {
 
       it('should normalize objects with only methods and no endpoints', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            ignoreEndpoints: {
-              kafka: [{ methods: ['PUBLISH'] }]
+          userConfig: {
+            tracing: {
+              ignoreEndpoints: {
+                kafka: [{ methods: ['PUBLISH'] }]
+              }
             }
           }
         });
@@ -1245,9 +1305,11 @@ describe('config.normalizeConfig', () => {
 
       it('should normalize objects with only endpoints and no methods', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            ignoreEndpoints: {
-              kafka: [{ endpoints: ['Topic1'] }]
+          userConfig: {
+            tracing: {
+              ignoreEndpoints: {
+                kafka: [{ endpoints: ['Topic1'] }]
+              }
             }
           }
         });
@@ -1258,9 +1320,11 @@ describe('config.normalizeConfig', () => {
 
       it('should normalize objects where methods or endpoints are invalid types', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            ignoreEndpoints: {
-              kafka: [{ methods: 123, endpoints: 'invalid' }]
+          userConfig: {
+            tracing: {
+              ignoreEndpoints: {
+                kafka: [{ methods: 123, endpoints: 'invalid' }]
+              }
             }
           }
         });
@@ -1269,8 +1333,10 @@ describe('config.normalizeConfig', () => {
 
       it('should handle ignoreEndpoints when config is an array instead of object', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            ignoreEndpoints: ['redis', 'kafka']
+          userConfig: {
+            tracing: {
+              ignoreEndpoints: ['redis', 'kafka']
+            }
           }
         });
         expect(config.tracing.ignoreEndpoints).to.deep.equal({});
@@ -1278,8 +1344,10 @@ describe('config.normalizeConfig', () => {
 
       it('should handle ignoreEndpoints when config is a non-object type', () => {
         const config = coreConfig.normalize({
-          tracing: {
-            ignoreEndpoints: 'invalid-string'
+          userConfig: {
+            tracing: {
+              ignoreEndpoints: 'invalid-string'
+            }
           }
         });
         expect(config.tracing.ignoreEndpoints).to.deep.equal({});
@@ -1303,13 +1371,13 @@ describe('config.normalizeConfig', () => {
 
       it.skip('should give precedence to INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION env var set to true over config set to false', () => {
         process.env.INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION = 'true';
-        const config = coreConfig.normalize({ tracing: { ignoreEndpointsDisableSuppression: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { ignoreEndpointsDisableSuppression: false } } });
         expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.true;
       });
 
       it.skip('should give precedence to INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION env var set to false over config set to true', () => {
         process.env.INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION = 'false';
-        const config = coreConfig.normalize({ tracing: { ignoreEndpointsDisableSuppression: true } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { ignoreEndpointsDisableSuppression: true } } });
         expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.false;
       });
 
@@ -1362,7 +1430,9 @@ describe('config.normalizeConfig', () => {
 
       it('preloadOpentelemetry should accept true value', () => {
         const config = coreConfig.normalize({
-          preloadOpentelemetry: true
+          userConfig: {
+            preloadOpentelemetry: true
+          }
         });
         expect(config.preloadOpentelemetry).to.be.true;
       });
@@ -1374,7 +1444,7 @@ describe('config.normalizeConfig', () => {
             forceTransmissionStartingAt: 25
           }
         };
-        const config = coreConfig.normalize({}, customDefaults);
+        const config = coreConfig.normalize({ defaultsOverride: customDefaults });
         expect(config.preloadOpentelemetry).to.be.true;
         expect(config.tracing.forceTransmissionStartingAt).to.equal(25);
       });
@@ -1409,21 +1479,66 @@ describe('config.normalizeConfig', () => {
       });
 
       it('should use config value when env is not set', () => {
-        const config = coreConfig.normalize({ tracing: { disableEOLEvents: true } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { disableEOLEvents: true } } });
         expect(config.tracing.disableEOLEvents).to.be.true;
       });
 
       it.skip('should give precedence to INSTANA_TRACING_DISABLE_EOL_EVENTS env var set to true over config set to false', () => {
         process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'true';
-        const config = coreConfig.normalize({ tracing: { disableEOLEvents: false } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { disableEOLEvents: false } } });
         expect(config.tracing.disableEOLEvents).to.be.true;
       });
 
       it.skip('should give precedence to INSTANA_TRACING_DISABLE_EOL_EVENTS env var set to false over config set to true', () => {
         process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'false';
-        const config = coreConfig.normalize({ tracing: { disableEOLEvents: true } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { disableEOLEvents: true } } });
         expect(config.tracing.disableEOLEvents).to.be.false;
       });
+    });
+  });
+
+  describe('finalConfigBase parameter', () => {
+    it('should always preserve finalConfigBase', () => {
+      const finalConfigBase = {
+        agentHost: '192.168.1.100',
+        agentPort: 3000,
+        agentRequestTimeout: 10000
+      };
+      const config = coreConfig.normalize({ finalConfigBase });
+      expect(config.agentHost).to.equal('192.168.1.100');
+      expect(config.agentPort).to.equal(3000);
+      expect(config.agentRequestTimeout).to.equal(10000);
+    });
+
+    it('should merge finalConfigBase with userConfig', () => {
+      const finalConfigBase = {
+        agentHost: '192.168.1.100',
+        agentPort: 3000,
+        agentRequestTimeout: 5000
+      };
+      const userConfig = {
+        serviceName: 'my-app',
+        tracing: {
+          enabled: true
+        }
+      };
+      const config = coreConfig.normalize({ userConfig, finalConfigBase });
+      expect(config.agentHost).to.equal('192.168.1.100');
+      expect(config.agentPort).to.equal(3000);
+      expect(config.agentRequestTimeout).to.equal(5000);
+      expect(config.serviceName).to.equal('my-app');
+      expect(config.tracing.enabled).to.be.true;
+    });
+
+    it('should work with empty finalConfigBase', () => {
+      const config = coreConfig.normalize({ finalConfigBase: {} });
+      expect(config.serviceName).to.be.null;
+      expect(config.tracing.enabled).to.be.true;
+    });
+
+    it('should work without finalConfigBase parameter', () => {
+      const config = coreConfig.normalize({ userConfig: { serviceName: 'test' } });
+      expect(config.serviceName).to.equal('test');
     });
   });
 

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -90,11 +90,11 @@ describe('config.normalizeConfig', () => {
       const config = coreConfig.normalize({
         userConfig: {
           metrics: {
-            transmissionDelay: 9753
+            transmissionDelay: 4753
           }
         }
       });
-      expect(config.metrics.transmissionDelay).to.equal(9753);
+      expect(config.metrics.transmissionDelay).to.equal(4753);
     });
 
     it('should use custom metrics transmission settings from env vars', () => {
@@ -123,8 +123,10 @@ describe('config.normalizeConfig', () => {
 
     it('should use max metrics transmission settings when value exceeds max 5000', () => {
       const config = coreConfig.normalize({
-        metrics: {
-          transmissionDelay: 9753
+        userConfig: {
+          metrics: {
+            transmissionDelay: 9753
+          }
         }
       });
       expect(config.metrics.transmissionDelay).to.equal(5000);

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -20,6 +20,7 @@ describe('config.normalizeConfig', () => {
   afterEach(resetEnv);
 
   function resetEnv() {
+    delete process.env.INSTANA_TRACING_DISABLE;
     delete process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS;
     delete process.env.INSTANA_TRACING_DISABLE_GROUPS;
     delete process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS;
@@ -33,9 +34,11 @@ describe('config.normalizeConfig', () => {
     delete process.env.INSTANA_STACK_TRACE;
     delete process.env.INSTANA_STACK_TRACE_LENGTH;
     delete process.env.INSTANA_TRACING_TRANSMISSION_DELAY;
+    delete process.env.INSTANA_TRACING_INITIAL_TRANSMISSION_DELAY;
     delete process.env.INSTANA_SPANBATCHING_ENABLED;
     delete process.env.INSTANA_DISABLE_SPANBATCHING;
     delete process.env.INSTANA_DISABLE_W3C_TRACE_CORRELATION;
+    delete process.env.INSTANA_DISABLE_USE_OPENTELEMETRY;
     delete process.env.INSTANA_KAFKA_TRACE_CORRELATION;
     delete process.env.INSTANA_PACKAGE_JSON_PATH;
     delete process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN;
@@ -68,6 +71,12 @@ describe('config.normalizeConfig', () => {
     it('should not accept non-string service name', () => {
       const config = coreConfig.normalize({ serviceName: 42 });
       expect(config.serviceName).to.not.exist;
+    });
+
+    it.skip('should give precedence to INSTANA_SERVICE_NAME env var over config', () => {
+      process.env.INSTANA_SERVICE_NAME = 'env-service';
+      const config = coreConfig.normalize({ serviceName: 'config-service' });
+      expect(config.serviceName).to.equal('env-service');
     });
   });
 
@@ -114,6 +123,29 @@ describe('config.normalizeConfig', () => {
       expect(config.metrics.transmissionDelay).to.equal(5000);
     });
 
+    it('should use default (1000) for transmissionDelay when neither env nor config is set', () => {
+      const config = coreConfig.normalize({});
+      expect(config.metrics.transmissionDelay).to.equal(1000);
+    });
+
+    it.skip('should give precedence to INSTANA_METRICS_TRANSMISSION_DELAY env var over config', () => {
+      process.env.INSTANA_METRICS_TRANSMISSION_DELAY = '3000';
+      const config = coreConfig.normalize({ metrics: { transmissionDelay: 5000 } });
+      expect(config.metrics.transmissionDelay).to.equal(3000);
+    });
+
+    it('should fall back to config when env var is invalid', () => {
+      process.env.INSTANA_METRICS_TRANSMISSION_DELAY = 'invalid';
+      const config = coreConfig.normalize({ metrics: { transmissionDelay: 5000 } });
+      expect(config.metrics.transmissionDelay).to.equal(5000);
+    });
+
+    it('should fall back to default when both env and config are invalid', () => {
+      process.env.INSTANA_METRICS_TRANSMISSION_DELAY = 'invalid';
+      const config = coreConfig.normalize({ metrics: { transmissionDelay: 'also-invalid' } });
+      expect(config.metrics.transmissionDelay).to.equal(1000);
+    });
+
     it('should use custom config.metrics.timeBetweenHealthcheckCalls', () => {
       const config = coreConfig.normalize({
         metrics: {
@@ -150,7 +182,6 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.enabled).to.be.true;
         expect(config.tracing.automaticTracingEnabled).to.be.false;
       });
-
       it('should not enable automatic tracing when tracing is disabled in general', () => {
         const config = coreConfig.normalize({
           tracing: {
@@ -159,6 +190,52 @@ describe('config.normalizeConfig', () => {
           }
         });
         expect(config.tracing.enabled).to.be.false;
+        expect(config.tracing.automaticTracingEnabled).to.be.false;
+      });
+
+      it('should use default (true) for tracing.enabled when neither env nor config is set', () => {
+        const config = coreConfig.normalize({});
+        expect(config.tracing.enabled).to.be.true;
+      });
+
+      it.skip('should give precedence to INSTANA_TRACING_DISABLE env var set to true over config set to true', () => {
+        process.env.INSTANA_TRACING_DISABLE = 'true';
+        const config = coreConfig.normalize({ tracing: { enabled: true } });
+        expect(config.tracing.enabled).to.be.false;
+      });
+
+      it.skip('should give precedence to INSTANA_TRACING_DISABLE env var set to false over config set to false', () => {
+        process.env.INSTANA_TRACING_DISABLE = 'false';
+        const config = coreConfig.normalize({ tracing: { enabled: false } });
+        expect(config.tracing.enabled).to.be.true;
+      });
+
+      it.skip('should give precedence to INSTANA_TRACING_DISABLE env var over default', () => {
+        process.env.INSTANA_TRACING_DISABLE = 'true';
+        const config = coreConfig.normalize({});
+        expect(config.tracing.enabled).to.be.false;
+      });
+
+      it('should use default (true) for automaticTracingEnabled when neither env nor config is set', () => {
+        const config = coreConfig.normalize({});
+        expect(config.tracing.automaticTracingEnabled).to.be.true;
+      });
+
+      it.skip('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var set to true over config set to true', () => {
+        process.env.INSTANA_DISABLE_AUTO_INSTR = 'true';
+        const config = coreConfig.normalize({ tracing: { automaticTracingEnabled: true } });
+        expect(config.tracing.automaticTracingEnabled).to.be.false;
+      });
+
+      it.skip('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var set to false over config set to false', () => {
+        process.env.INSTANA_DISABLE_AUTO_INSTR = 'false';
+        const config = coreConfig.normalize({ tracing: { automaticTracingEnabled: false } });
+        expect(config.tracing.automaticTracingEnabled).to.be.true;
+      });
+
+      it.skip('should give precedence to INSTANA_DISABLE_AUTO_INSTR env var over default', () => {
+        process.env.INSTANA_DISABLE_AUTO_INSTR = 'true';
+        const config = coreConfig.normalize({});
         expect(config.tracing.automaticTracingEnabled).to.be.false;
       });
     });
@@ -183,6 +260,23 @@ describe('config.normalizeConfig', () => {
           }
         });
         expect(config.tracing.enabled).to.be.false;
+        expect(config.tracing.activateImmediately).to.be.false;
+      });
+
+      it('should use default (false) for activateImmediately when neither env nor config is set', () => {
+        const config = coreConfig.normalize({});
+        expect(config.tracing.activateImmediately).to.be.false;
+      });
+
+      it.skip('should give precedence to INSTANA_TRACE_IMMEDIATELY env var set to true over config set to false', () => {
+        process.env.INSTANA_TRACE_IMMEDIATELY = 'true';
+        const config = coreConfig.normalize({ tracing: { activateImmediately: false } });
+        expect(config.tracing.activateImmediately).to.be.true;
+      });
+
+      it.skip('should give precedence to INSTANA_TRACE_IMMEDIATELY env var set to false over config set to true', () => {
+        process.env.INSTANA_TRACE_IMMEDIATELY = 'false';
+        const config = coreConfig.normalize({ tracing: { activateImmediately: true } });
         expect(config.tracing.activateImmediately).to.be.false;
       });
     });
@@ -214,6 +308,30 @@ describe('config.normalizeConfig', () => {
         process.env.INSTANA_TRACING_TRANSMISSION_DELAY = 'x2500';
         const config = coreConfig.normalize();
         expect(config.tracing.forceTransmissionStartingAt).to.equal(500);
+        expect(config.tracing.transmissionDelay).to.equal(1000);
+      });
+
+      it.skip('should give precedence to INSTANA_TRACING_TRANSMISSION_DELAY env var over config', () => {
+        process.env.INSTANA_TRACING_TRANSMISSION_DELAY = '4000';
+        const config = coreConfig.normalize({ tracing: { transmissionDelay: 2000 } });
+        expect(config.tracing.transmissionDelay).to.equal(4000);
+      });
+
+      it.skip('should give precedence to INSTANA_FORCE_TRANSMISSION_STARTING_AT env var over config', () => {
+        process.env.INSTANA_FORCE_TRANSMISSION_STARTING_AT = '700';
+        const config = coreConfig.normalize({ tracing: { forceTransmissionStartingAt: 300 } });
+        expect(config.tracing.forceTransmissionStartingAt).to.equal(700);
+      });
+
+      it('should fall back to config when env var is invalid for transmissionDelay', () => {
+        process.env.INSTANA_TRACING_TRANSMISSION_DELAY = 'invalid';
+        const config = coreConfig.normalize({ tracing: { transmissionDelay: 5000 } });
+        expect(config.tracing.transmissionDelay).to.equal(5000);
+      });
+
+      it('should fall back to default when both env and config are invalid for transmissionDelay', () => {
+        process.env.INSTANA_TRACING_TRANSMISSION_DELAY = 'invalid';
+        const config = coreConfig.normalize({ tracing: { transmissionDelay: 'also-invalid' } });
         expect(config.tracing.transmissionDelay).to.equal(1000);
       });
     });
@@ -297,7 +415,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.stackTraceLength).to.equal(3);
       });
 
-      it('should give precedence to INSTANA_STACK_TRACE_LENGTH over config', () => {
+      it.skip('should give precedence to INSTANA_STACK_TRACE_LENGTH over config', () => {
         process.env.INSTANA_STACK_TRACE_LENGTH = '5';
         const normalizedConfig = coreConfig.normalize({ tracing: { stackTraceLength: 20 } });
         expect(normalizedConfig.tracing.stackTraceLength).to.equal(5);
@@ -336,7 +454,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.stackTrace).to.equal('none');
       });
 
-      it('should give precedence to env INSTANA_STACK_TRACE over config', () => {
+      it.skip('should give precedence to env INSTANA_STACK_TRACE over config', () => {
         process.env.INSTANA_STACK_TRACE = 'none';
         const config = coreConfig.normalize({ tracing: { global: { stackTrace: 'all' } } });
         expect(config.tracing.stackTrace).to.equal('none');
@@ -522,7 +640,7 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.stackTraceLength).to.equal(30);
       });
 
-      it('should give precedence to env vars for both stack trace settings over config', () => {
+      it.skip('should give precedence to env vars for both stack trace settings over config', () => {
         process.env.INSTANA_STACK_TRACE = 'error';
         process.env.INSTANA_STACK_TRACE_LENGTH = '15';
         const config = coreConfig.normalize({
@@ -691,6 +809,23 @@ describe('config.normalizeConfig', () => {
         const config = coreConfig.normalize();
         expect(config.tracing.spanBatchingEnabled).to.be.false;
       });
+
+      it('should use default (false) for spanBatchingEnabled when neither env nor config is set', () => {
+        const config = coreConfig.normalize({});
+        expect(config.tracing.spanBatchingEnabled).to.be.false;
+      });
+
+      it.skip('should give precedence to INSTANA_SPANBATCHING_ENABLED env var set to true over config set to false', () => {
+        process.env.INSTANA_SPANBATCHING_ENABLED = 'true';
+        const config = coreConfig.normalize({ tracing: { spanBatchingEnabled: false } });
+        expect(config.tracing.spanBatchingEnabled).to.be.true;
+      });
+
+      it.skip('should give precedence to INSTANA_SPANBATCHING_ENABLED env var set to false over config set to true', () => {
+        process.env.INSTANA_SPANBATCHING_ENABLED = 'false';
+        const config = coreConfig.normalize({ tracing: { spanBatchingEnabled: true } });
+        expect(config.tracing.spanBatchingEnabled).to.be.false;
+      });
     });
 
     describe('W3C trace correlation', () => {
@@ -702,6 +837,17 @@ describe('config.normalizeConfig', () => {
       it('should disable W3C trace correlation via INSTANA_DISABLE_W3C_TRACE_CORRELATION', () => {
         process.env.INSTANA_DISABLE_W3C_TRACE_CORRELATION = 'false'; // any non-empty string will disable, even "false"!
         const config = coreConfig.normalize();
+        expect(config.tracing.disableW3cTraceCorrelation).to.be.true;
+      });
+
+      it('should use default (false) for disableW3cTraceCorrelation when neither env nor config is set', () => {
+        const config = coreConfig.normalize({});
+        expect(config.tracing.disableW3cTraceCorrelation).to.be.false;
+      });
+
+      it.skip('should give precedence to INSTANA_DISABLE_W3C_TRACE_CORRELATION env var over config (truthy env)', () => {
+        process.env.INSTANA_DISABLE_W3C_TRACE_CORRELATION = 'any-value';
+        const config = coreConfig.normalize({ tracing: { disableW3cTraceCorrelation: false } });
         expect(config.tracing.disableW3cTraceCorrelation).to.be.true;
       });
     });
@@ -716,6 +862,23 @@ describe('config.normalizeConfig', () => {
         process.env.INSTANA_KAFKA_TRACE_CORRELATION = 'false';
         const config = coreConfig.normalize();
         expect(config.tracing.kafka.traceCorrelation).to.be.false;
+      });
+
+      it('should use default (true) for kafka.traceCorrelation when neither env nor config is set', () => {
+        const config = coreConfig.normalize({});
+        expect(config.tracing.kafka.traceCorrelation).to.be.true;
+      });
+
+      it.skip('should give precedence to INSTANA_KAFKA_TRACE_CORRELATION env var set to false over config set to true', () => {
+        process.env.INSTANA_KAFKA_TRACE_CORRELATION = 'false';
+        const config = coreConfig.normalize({ tracing: { kafka: { traceCorrelation: true } } });
+        expect(config.tracing.kafka.traceCorrelation).to.be.false;
+      });
+
+      it.skip('should give precedence to INSTANA_KAFKA_TRACE_CORRELATION env var set to true over config set to false', () => {
+        process.env.INSTANA_KAFKA_TRACE_CORRELATION = 'true';
+        const config = coreConfig.normalize({ tracing: { kafka: { traceCorrelation: false } } });
+        expect(config.tracing.kafka.traceCorrelation).to.be.true;
       });
     });
 
@@ -744,6 +907,23 @@ describe('config.normalizeConfig', () => {
         process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'false';
         const config = coreConfig.normalize();
         expect(config.tracing.useOpentelemetry).to.equal(true);
+      });
+
+      it('should use default (true) for useOpentelemetry when neither env nor config is set', () => {
+        const config = coreConfig.normalize({});
+        expect(config.tracing.useOpentelemetry).to.be.true;
+      });
+
+      it.skip('should give precedence to INSTANA_DISABLE_USE_OPENTELEMETRY env var set to true over config set to true', () => {
+        process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'true';
+        const config = coreConfig.normalize({ tracing: { useOpentelemetry: true } });
+        expect(config.tracing.useOpentelemetry).to.be.false;
+      });
+
+      it.skip('should give precedence to INSTANA_DISABLE_USE_OPENTELEMETRY env var set to false over config set to false', () => {
+        process.env.INSTANA_DISABLE_USE_OPENTELEMETRY = 'false';
+        const config = coreConfig.normalize({ tracing: { useOpentelemetry: false } });
+        expect(config.tracing.useOpentelemetry).to.be.true;
       });
     });
 
@@ -832,6 +1012,17 @@ describe('config.normalizeConfig', () => {
         const config = coreConfig.normalize({});
         expect(config.packageJsonPath).to.equal('/my/path');
       });
+
+      it.skip('should use default (null) when neither env nor config is set', () => {
+        const config = coreConfig.normalize({});
+        expect(config.packageJsonPath).to.be.null;
+      });
+
+      it.skip('should give precedence to INSTANA_PACKAGE_JSON_PATH env var over config', () => {
+        process.env.INSTANA_PACKAGE_JSON_PATH = '/env/path/package.json';
+        const config = coreConfig.normalize({ packageJsonPath: '/config/path/package.json' });
+        expect(config.packageJsonPath).to.equal('/env/path/package.json');
+      });
     });
 
     describe('allow root exit span', () => {
@@ -854,10 +1045,27 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.allowRootExitSpan).to.equal(false);
       });
 
-      it('should enable allow root exit span if INSTANA_ALLOW_ROOT_EXIT_SPAN is set', () => {
+      it('should enable allow root exit span if INSTANA_ALLOW_ROOT_EXIT_SPAN is set to true', () => {
         process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = true;
         const config = coreConfig.normalize();
         expect(config.tracing.allowRootExitSpan).to.equal(true);
+      });
+
+      it('should use default (false) for allowRootExitSpan when neither env nor config is set', () => {
+        const config = coreConfig.normalize({});
+        expect(config.tracing.allowRootExitSpan).to.be.false;
+      });
+
+      it.skip('should give precedence to INSTANA_ALLOW_ROOT_EXIT_SPAN env var set to true over config set to false', () => {
+        process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = 'true';
+        const config = coreConfig.normalize({ tracing: { allowRootExitSpan: false } });
+        expect(config.tracing.allowRootExitSpan).to.be.true;
+      });
+
+      it.skip('should give precedence to INSTANA_ALLOW_ROOT_EXIT_SPAN env var set to false over config set to true', () => {
+        process.env.INSTANA_ALLOW_ROOT_EXIT_SPAN = 'false';
+        const config = coreConfig.normalize({ tracing: { allowRootExitSpan: true } });
+        expect(config.tracing.allowRootExitSpan).to.be.false;
       });
     });
 
@@ -1001,10 +1209,27 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.ignoreEndpointsDisableSuppression).to.equal(false);
       });
 
-      it('should return true when INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION is set', () => {
+      it('should return true when INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION is set to true', () => {
         process.env.INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION = true;
         const config = coreConfig.normalize();
         expect(config.tracing.ignoreEndpointsDisableSuppression).to.equal(true);
+      });
+
+      it('should use default (false) for ignoreEndpointsDisableSuppression when neither env nor config is set', () => {
+        const config = coreConfig.normalize({});
+        expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.false;
+      });
+
+      it.skip('should give precedence to INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION env var set to true over config set to false', () => {
+        process.env.INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION = 'true';
+        const config = coreConfig.normalize({ tracing: { ignoreEndpointsDisableSuppression: false } });
+        expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.true;
+      });
+
+      it.skip('should give precedence to INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION env var set to false over config set to true', () => {
+        process.env.INSTANA_IGNORE_ENDPOINTS_DISABLE_SUPPRESSION = 'false';
+        const config = coreConfig.normalize({ tracing: { ignoreEndpointsDisableSuppression: true } });
+        expect(config.tracing.ignoreEndpointsDisableSuppression).to.be.false;
       });
 
       describe('when testing ignore endpoints reading from INSTANA_IGNORE_ENDPOINTS_PATH env variable', () => {
@@ -1075,7 +1300,7 @@ describe('config.normalizeConfig', () => {
     });
 
     describe('EOL events configuration', () => {
-      it('should return false when INSTANA_TRACING_DISABLE_EOL_EVENTS is not set', () => {
+      it('should return false when INSTANA_TRACING_DISABLE_EOL_EVENTS is set to false', () => {
         const config = coreConfig.normalize();
         expect(config.tracing.disableEOLEvents).to.equal(false);
       });
@@ -1095,6 +1320,28 @@ describe('config.normalizeConfig', () => {
         process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'test';
         const config = coreConfig.normalize();
         expect(config.tracing.disableEOLEvents).to.equal(false);
+      });
+
+      it('should use default (false) for disableEOLEvents when neither env nor config is set', () => {
+        const config = coreConfig.normalize({});
+        expect(config.tracing.disableEOLEvents).to.be.false;
+      });
+
+      it('should use config value when env is not set', () => {
+        const config = coreConfig.normalize({ tracing: { disableEOLEvents: true } });
+        expect(config.tracing.disableEOLEvents).to.be.true;
+      });
+
+      it.skip('should give precedence to INSTANA_TRACING_DISABLE_EOL_EVENTS env var set to true over config set to false', () => {
+        process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'true';
+        const config = coreConfig.normalize({ tracing: { disableEOLEvents: false } });
+        expect(config.tracing.disableEOLEvents).to.be.true;
+      });
+
+      it.skip('should give precedence to INSTANA_TRACING_DISABLE_EOL_EVENTS env var set to false over config set to true', () => {
+        process.env.INSTANA_TRACING_DISABLE_EOL_EVENTS = 'false';
+        const config = coreConfig.normalize({ tracing: { disableEOLEvents: true } });
+        expect(config.tracing.disableEOLEvents).to.be.false;
       });
     });
   });

--- a/packages/core/test/config/util_test.js
+++ b/packages/core/test/config/util_test.js
@@ -581,4 +581,111 @@ describe('config.util', () => {
       expect(result).to.equal(false);
     });
   });
+
+  describe('resolveStringConfig', () => {
+    beforeEach(() => {
+      delete process.env.TEST_STRING_VAR;
+    });
+
+    afterEach(() => {
+      delete process.env.TEST_STRING_VAR;
+    });
+
+    it('should return the default value when no env var or config value is provided', () => {
+      const result = util.resolveStringConfig({
+        envVar: 'TEST_STRING_VAR',
+        configValue: undefined,
+        defaultValue: 'default-value',
+        configPath: 'config.test.string'
+      });
+
+      expect(result).to.equal('default-value');
+    });
+
+    it.skip('should prioritize env var over config value', () => {
+      process.env.TEST_STRING_VAR = 'env-value';
+
+      const result = util.resolveStringConfig({
+        envVar: 'TEST_STRING_VAR',
+        configValue: 'config-value',
+        defaultValue: 'default-value',
+        configPath: 'config.test.string'
+      });
+
+      expect(result).to.equal('env-value');
+    });
+
+    it('should use env var when config value is not set', () => {
+      process.env.TEST_STRING_VAR = 'env-value';
+
+      const result = util.resolveStringConfig({
+        envVar: 'TEST_STRING_VAR',
+        configValue: undefined,
+        defaultValue: 'default-value',
+        configPath: 'config.test.string'
+      });
+
+      expect(result).to.equal('env-value');
+    });
+
+    it('should use config value when env var is not set', () => {
+      const result = util.resolveStringConfig({
+        envVar: 'TEST_STRING_VAR',
+        configValue: 'config-value',
+        defaultValue: 'default-value',
+        configPath: 'config.test.string'
+      });
+
+      expect(result).to.equal('config-value');
+    });
+
+    it('should handle empty string as a valid config value', () => {
+      const result = util.resolveStringConfig({
+        envVar: 'TEST_STRING_VAR',
+        configValue: '',
+        defaultValue: 'default-value',
+        configPath: 'config.test.string'
+      });
+
+      expect(result).to.equal('');
+    });
+
+    it('should handle empty string as a valid env var value', () => {
+      process.env.TEST_STRING_VAR = '';
+
+      const result = util.resolveStringConfig({
+        envVar: 'TEST_STRING_VAR',
+        configValue: undefined,
+        defaultValue: 'default-value',
+        configPath: 'config.test.string'
+      });
+
+      expect(result).to.equal('');
+    });
+
+    it('should handle undefined config value as not set', () => {
+      process.env.TEST_STRING_VAR = 'env-value';
+
+      const result = util.resolveStringConfig({
+        envVar: 'TEST_STRING_VAR',
+        configValue: undefined,
+        defaultValue: 'default-value',
+        configPath: 'config.test.string'
+      });
+
+      expect(result).to.equal('env-value');
+    });
+
+    it('should handle multiline string values', () => {
+      const multilineValue = 'line1\nline2\nline3';
+      const result = util.resolveStringConfig({
+        envVar: undefined,
+        configValue: multilineValue,
+        defaultValue: 'default-value',
+        configPath: 'config.test.string'
+      });
+
+      expect(result).to.equal(multilineValue);
+    });
+  });
 });

--- a/packages/core/test/config/util_test.js
+++ b/packages/core/test/config/util_test.js
@@ -479,6 +479,17 @@ describe('config.util', () => {
 
       expect(result).to.equal(false);
     });
+
+    it('should return default when configValue and env var are not boolean', () => {
+      const result = util.resolveBooleanConfigWithInvertedEnv({
+        envVar: 'TEST_INVERTED_VAR',
+        configValue: 'not-a-boolean',
+        defaultValue: true,
+        configPath: 'config.test.inverted'
+      });
+
+      expect(result).to.equal(true);
+    });
   });
 
   describe('resolveBooleanConfigWithTruthyEnv', () => {

--- a/packages/core/test/config/util_test.js
+++ b/packages/core/test/config/util_test.js
@@ -35,7 +35,7 @@ describe('config.util', () => {
       expect(result).to.equal(1000);
     });
 
-    it('should prioritize env var over config value', () => {
+    it.skip('should prioritize env var over config value', () => {
       process.env.TEST_ENV_VAR = '2000';
 
       const result = util.resolveNumericConfig({
@@ -236,6 +236,338 @@ describe('config.util', () => {
       });
 
       expect(result).to.equal(0);
+    });
+  });
+
+  describe('resolveBooleanConfig', () => {
+    beforeEach(() => {
+      delete process.env.TEST_BOOL_VAR;
+    });
+
+    afterEach(() => {
+      delete process.env.TEST_BOOL_VAR;
+    });
+
+    it('should return the default value when no env var or config value is provided', () => {
+      const result = util.resolveBooleanConfig({
+        envVar: 'TEST_BOOL_VAR',
+        configValue: undefined,
+        defaultValue: false,
+        configPath: 'config.test.bool'
+      });
+
+      expect(result).to.equal(false);
+    });
+
+    it.skip('should prioritize env var over config value', () => {
+      process.env.TEST_BOOL_VAR = 'true';
+
+      const result = util.resolveBooleanConfig({
+        envVar: 'TEST_BOOL_VAR',
+        configValue: false,
+        defaultValue: false,
+        configPath: 'config.test.bool'
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should use config value when env var is not set', () => {
+      const result = util.resolveBooleanConfig({
+        envVar: 'TEST_BOOL_VAR',
+        configValue: true,
+        defaultValue: false,
+        configPath: 'config.test.bool'
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should parse "true" from env var', () => {
+      process.env.TEST_BOOL_VAR = 'true';
+
+      const result = util.resolveBooleanConfig({
+        envVar: 'TEST_BOOL_VAR',
+        configValue: undefined,
+        defaultValue: false,
+        configPath: 'config.test.bool'
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should parse "false" from env var', () => {
+      process.env.TEST_BOOL_VAR = 'false';
+
+      const result = util.resolveBooleanConfig({
+        envVar: 'TEST_BOOL_VAR',
+        configValue: undefined,
+        defaultValue: true,
+        configPath: 'config.test.bool'
+      });
+
+      expect(result).to.equal(false);
+    });
+
+    it('should parse "1" from env var as true', () => {
+      process.env.TEST_BOOL_VAR = '1';
+
+      const result = util.resolveBooleanConfig({
+        envVar: 'TEST_BOOL_VAR',
+        configValue: undefined,
+        defaultValue: false,
+        configPath: 'config.test.bool'
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should parse "0" from env var as false', () => {
+      process.env.TEST_BOOL_VAR = '0';
+
+      const result = util.resolveBooleanConfig({
+        envVar: 'TEST_BOOL_VAR',
+        configValue: undefined,
+        defaultValue: true,
+        configPath: 'config.test.bool'
+      });
+
+      expect(result).to.equal(false);
+    });
+
+    it('should handle case-insensitive "TRUE" from env var', () => {
+      process.env.TEST_BOOL_VAR = 'TRUE';
+
+      const result = util.resolveBooleanConfig({
+        envVar: 'TEST_BOOL_VAR',
+        configValue: undefined,
+        defaultValue: false,
+        configPath: 'config.test.bool'
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should handle case-insensitive "FALSE" from env var', () => {
+      process.env.TEST_BOOL_VAR = 'FALSE';
+
+      const result = util.resolveBooleanConfig({
+        envVar: 'TEST_BOOL_VAR',
+        configValue: undefined,
+        defaultValue: true,
+        configPath: 'config.test.bool'
+      });
+
+      expect(result).to.equal(false);
+    });
+
+    it.skip('should fall back to config value when env var is invalid', () => {
+      process.env.TEST_BOOL_VAR = 'invalid';
+
+      const result = util.resolveBooleanConfig({
+        envVar: 'TEST_BOOL_VAR',
+        configValue: true,
+        defaultValue: false,
+        configPath: 'config.test.bool'
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should fall back to default when both env var and config value are invalid', () => {
+      process.env.TEST_BOOL_VAR = 'invalid';
+
+      const result = util.resolveBooleanConfig({
+        envVar: 'TEST_BOOL_VAR',
+        configValue: 'not-a-boolean',
+        defaultValue: true,
+        configPath: 'config.test.bool'
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should handle null config value', () => {
+      const result = util.resolveBooleanConfig({
+        envVar: 'TEST_BOOL_VAR',
+        configValue: null,
+        defaultValue: true,
+        configPath: 'config.test.bool'
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should handle undefined config value', () => {
+      const result = util.resolveBooleanConfig({
+        envVar: 'TEST_BOOL_VAR',
+        configValue: undefined,
+        defaultValue: false,
+        configPath: 'config.test.bool'
+      });
+
+      expect(result).to.equal(false);
+    });
+  });
+
+  describe('resolveBooleanConfigWithInvertedEnv', () => {
+    beforeEach(() => {
+      delete process.env.TEST_DISABLE_VAR;
+    });
+
+    afterEach(() => {
+      delete process.env.TEST_DISABLE_VAR;
+    });
+
+    it('should return false when env var is "true" (inverted logic)', () => {
+      process.env.TEST_DISABLE_VAR = 'true';
+
+      const result = util.resolveBooleanConfigWithInvertedEnv({
+        envVar: 'TEST_DISABLE_VAR',
+        configValue: undefined,
+        defaultValue: true,
+        configPath: 'config.test.disable'
+      });
+
+      expect(result).to.equal(false);
+    });
+
+    it.skip('should prioritize env var over config value', () => {
+      process.env.TEST_DISABLE_VAR = 'true';
+
+      const result = util.resolveBooleanConfigWithInvertedEnv({
+        envVar: 'TEST_DISABLE_VAR',
+        configValue: true,
+        defaultValue: true,
+        configPath: 'config.test.disable'
+      });
+
+      expect(result).to.equal(false);
+    });
+
+    it('should use config value when env var is not set', () => {
+      const result = util.resolveBooleanConfigWithInvertedEnv({
+        envVar: 'TEST_DISABLE_VAR',
+        configValue: false,
+        defaultValue: true,
+        configPath: 'config.test.disable'
+      });
+
+      expect(result).to.equal(false);
+    });
+
+    it('should use default when env var is not "true" and config is not set', () => {
+      process.env.TEST_DISABLE_VAR = 'false';
+
+      const result = util.resolveBooleanConfigWithInvertedEnv({
+        envVar: 'TEST_DISABLE_VAR',
+        configValue: undefined,
+        defaultValue: true,
+        configPath: 'config.test.disable'
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should handle null config value', () => {
+      const result = util.resolveBooleanConfigWithInvertedEnv({
+        envVar: 'TEST_DISABLE_VAR',
+        configValue: null,
+        defaultValue: false,
+        configPath: 'config.test.disable'
+      });
+
+      expect(result).to.equal(false);
+    });
+  });
+
+  describe('resolveBooleanConfigWithTruthyEnv', () => {
+    beforeEach(() => {
+      delete process.env.TEST_TRUTHY_VAR;
+    });
+
+    afterEach(() => {
+      delete process.env.TEST_TRUTHY_VAR;
+    });
+
+    it('should return true when env var exists and is truthy', () => {
+      process.env.TEST_TRUTHY_VAR = 'any-value';
+
+      const result = util.resolveBooleanConfigWithTruthyEnv({
+        envVar: 'TEST_TRUTHY_VAR',
+        configValue: undefined,
+        defaultValue: false
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should return true when env var is "true"', () => {
+      process.env.TEST_TRUTHY_VAR = 'true';
+
+      const result = util.resolveBooleanConfigWithTruthyEnv({
+        envVar: 'TEST_TRUTHY_VAR',
+        configValue: undefined,
+        defaultValue: false
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should return true when env var is "1"', () => {
+      process.env.TEST_TRUTHY_VAR = '1';
+
+      const result = util.resolveBooleanConfigWithTruthyEnv({
+        envVar: 'TEST_TRUTHY_VAR',
+        configValue: undefined,
+        defaultValue: false
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it.skip('should prioritize env var over config value', () => {
+      process.env.TEST_TRUTHY_VAR = 'yes';
+
+      const result = util.resolveBooleanConfigWithTruthyEnv({
+        envVar: 'TEST_TRUTHY_VAR',
+        configValue: false,
+        defaultValue: false
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should use config value when env var is not set', () => {
+      const result = util.resolveBooleanConfigWithTruthyEnv({
+        envVar: 'TEST_TRUTHY_VAR',
+        configValue: true,
+        defaultValue: false
+      });
+
+      expect(result).to.equal(true);
+    });
+
+    it('should use default when env var is not set and config is not boolean', () => {
+      const result = util.resolveBooleanConfigWithTruthyEnv({
+        envVar: 'TEST_TRUTHY_VAR',
+        configValue: undefined,
+        defaultValue: false
+      });
+
+      expect(result).to.equal(false);
+    });
+
+    it('should handle empty string env var as falsy', () => {
+      process.env.TEST_TRUTHY_VAR = '';
+
+      const result = util.resolveBooleanConfigWithTruthyEnv({
+        envVar: 'TEST_TRUTHY_VAR',
+        configValue: undefined,
+        defaultValue: false
+      });
+
+      expect(result).to.equal(false);
     });
   });
 });

--- a/packages/core/test/config/util_test.js
+++ b/packages/core/test/config/util_test.js
@@ -1,0 +1,241 @@
+/*
+ * (c) Copyright IBM Corp. 2026
+ */
+
+'use strict';
+
+const expect = require('chai').expect;
+const { createFakeLogger } = require('../test_util');
+const util = require('../../src/config/util');
+
+describe('config.util', () => {
+  let logger;
+
+  before(() => {
+    logger = createFakeLogger();
+    util.init(logger);
+  });
+
+  beforeEach(resetEnv);
+  afterEach(resetEnv);
+
+  function resetEnv() {
+    delete process.env.TEST_ENV_VAR;
+  }
+
+  describe('resolveNumericConfig', () => {
+    it('should return the default value when no env var or config value is provided', () => {
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: undefined,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(1000);
+    });
+
+    it('should prioritize env var over config value', () => {
+      process.env.TEST_ENV_VAR = '2000';
+
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: 3000,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(2000);
+    });
+
+    it('should use config value when env var is not set', () => {
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: 3000,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(3000);
+    });
+
+    it('should handle numeric config value', () => {
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: 5000,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(5000);
+    });
+
+    it('should handle string config value that can be parsed as number', () => {
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: '5000',
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(5000);
+    });
+
+    it('should handle string env var that can be parsed as number', () => {
+      process.env.TEST_ENV_VAR = '7500';
+
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: undefined,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(7500);
+    });
+
+    it('should fall back to default when env var is invalid', () => {
+      process.env.TEST_ENV_VAR = 'not-a-number';
+
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: undefined,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(1000);
+    });
+
+    it('should fall back to default when config value is invalid', () => {
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: 'invalid',
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(1000);
+    });
+
+    it('should use config value when env var is invalid', () => {
+      process.env.TEST_ENV_VAR = 'not-a-number';
+
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: 3000,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(3000);
+    });
+
+    it('should handle zero as a valid value from env var', () => {
+      process.env.TEST_ENV_VAR = '0';
+
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: undefined,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(0);
+    });
+
+    it('should handle zero as a valid value from config', () => {
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: 0,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(0);
+    });
+
+    it('should handle negative numbers from env var', () => {
+      process.env.TEST_ENV_VAR = '-500';
+
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: undefined,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(-500);
+    });
+
+    it('should handle negative numbers from config', () => {
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: -500,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(-500);
+    });
+
+    it('should handle floating point numbers from env var', () => {
+      process.env.TEST_ENV_VAR = '123.45';
+
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: undefined,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(123.45);
+    });
+
+    it('should handle floating point numbers from config', () => {
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: 123.45,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(123.45);
+    });
+
+    it('should handle null config value', () => {
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: null,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(1000);
+    });
+
+    it('should handle empty string env var as 0', () => {
+      process.env.TEST_ENV_VAR = '';
+
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: undefined,
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(0);
+    });
+
+    it('should handle empty string config value as 0', () => {
+      const result = util.resolveNumericConfig({
+        envVar: 'TEST_ENV_VAR',
+        configValue: '',
+        defaultValue: 1000,
+        configPath: 'config.test.value'
+      });
+
+      expect(result).to.equal(0);
+    });
+  });
+});

--- a/packages/core/test/config/util_test.js
+++ b/packages/core/test/config/util_test.js
@@ -35,7 +35,7 @@ describe('config.util', () => {
       expect(result).to.equal(1000);
     });
 
-    it.skip('should prioritize env var over config value', () => {
+    it('should prioritize env var over config value', () => {
       process.env.TEST_ENV_VAR = '2000';
 
       const result = util.resolveNumericConfig({
@@ -259,7 +259,7 @@ describe('config.util', () => {
       expect(result).to.equal(false);
     });
 
-    it.skip('should prioritize env var over config value', () => {
+    it('should prioritize env var over config value', () => {
       process.env.TEST_BOOL_VAR = 'true';
 
       const result = util.resolveBooleanConfig({
@@ -361,7 +361,7 @@ describe('config.util', () => {
       expect(result).to.equal(false);
     });
 
-    it.skip('should fall back to config value when env var is invalid', () => {
+    it('should fall back to config value when env var is invalid', () => {
       process.env.TEST_BOOL_VAR = 'invalid';
 
       const result = util.resolveBooleanConfig({
@@ -432,7 +432,7 @@ describe('config.util', () => {
       expect(result).to.equal(false);
     });
 
-    it.skip('should prioritize env var over config value', () => {
+    it('should prioritize env var over config value', () => {
       process.env.TEST_DISABLE_VAR = 'true';
 
       const result = util.resolveBooleanConfigWithInvertedEnv({
@@ -537,7 +537,7 @@ describe('config.util', () => {
       expect(result).to.equal(true);
     });
 
-    it.skip('should prioritize env var over config value', () => {
+    it('should prioritize env var over config value', () => {
       process.env.TEST_TRUTHY_VAR = 'yes';
 
       const result = util.resolveBooleanConfigWithTruthyEnv({
@@ -602,7 +602,7 @@ describe('config.util', () => {
       expect(result).to.equal('default-value');
     });
 
-    it.skip('should prioritize env var over config value', () => {
+    it('should prioritize env var over config value', () => {
       process.env.TEST_STRING_VAR = 'env-value';
 
       const result = util.resolveStringConfig({

--- a/packages/core/test/config/util_test.js
+++ b/packages/core/test/config/util_test.js
@@ -7,8 +7,9 @@
 const expect = require('chai').expect;
 const { createFakeLogger } = require('../test_util');
 const util = require('../../src/config/util');
+const { CONFIG_SOURCES } = require('../../src/util/constants');
 
-describe('config.util', () => {
+describe.skip('config.util', () => {
   let logger;
 
   before(() => {
@@ -32,7 +33,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(1000);
+      expect(result).to.deep.equal({
+        value: 1000,
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should prioritize env var over config value', () => {
@@ -45,7 +50,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(2000);
+      expect(result).to.deep.equal({
+        value: 2000,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should use config value when env var is not set', () => {
@@ -56,7 +65,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(3000);
+      expect(result).to.deep.equal({
+        value: 3000,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle numeric config value', () => {
@@ -67,7 +80,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(5000);
+      expect(result).to.deep.equal({
+        value: 5000,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle string config value that can be parsed as number', () => {
@@ -78,7 +95,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(5000);
+      expect(result).to.deep.equal({
+        value: 5000,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle string env var that can be parsed as number', () => {
@@ -91,7 +112,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(7500);
+      expect(result).to.deep.equal({
+        value: 7500,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should fall back to default when env var is invalid', () => {
@@ -104,7 +129,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(1000);
+      expect(result).to.deep.equal({
+        value: 1000,
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should fall back to default when config value is invalid', () => {
@@ -115,7 +144,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(1000);
+      expect(result).to.deep.equal({
+        value: 1000,
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should use config value when env var is invalid', () => {
@@ -128,7 +161,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(3000);
+      expect(result).to.deep.equal({
+        value: 3000,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle zero as a valid value from env var', () => {
@@ -141,7 +178,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(0);
+      expect(result).to.deep.equal({
+        value: 0,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle zero as a valid value from config', () => {
@@ -152,7 +193,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(0);
+      expect(result).to.deep.equal({
+        value: 0,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle negative numbers from env var', () => {
@@ -165,7 +210,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(-500);
+      expect(result).to.deep.equal({
+        value: -500,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle negative numbers from config', () => {
@@ -176,7 +225,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(-500);
+      expect(result).to.deep.equal({
+        value: -500,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle floating point numbers from env var', () => {
@@ -189,7 +242,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(123.45);
+      expect(result).to.deep.equal({
+        value: 123.45,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle floating point numbers from config', () => {
@@ -200,7 +257,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(123.45);
+      expect(result).to.deep.equal({
+        value: 123.45,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle null config value', () => {
@@ -211,7 +272,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(1000);
+      expect(result).to.deep.equal({
+        value: 1000,
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle empty string env var as 0', () => {
@@ -224,7 +289,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(0);
+      expect(result).to.deep.equal({
+        value: 0,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle empty string config value as 0', () => {
@@ -235,7 +304,11 @@ describe('config.util', () => {
         configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(0);
+      expect(result).to.deep.equal({
+        value: 0,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
   });
 
@@ -253,10 +326,14 @@ describe('config.util', () => {
         envVar: 'TEST_BOOL_VAR',
         configValue: undefined,
         defaultValue: false,
-        configPath: 'config.test.bool'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(false);
+      expect(result).to.deep.equal({
+        value: false,
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should prioritize env var over config value', () => {
@@ -266,10 +343,14 @@ describe('config.util', () => {
         envVar: 'TEST_BOOL_VAR',
         configValue: false,
         defaultValue: false,
-        configPath: 'config.test.bool'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should use config value when env var is not set', () => {
@@ -277,10 +358,14 @@ describe('config.util', () => {
         envVar: 'TEST_BOOL_VAR',
         configValue: true,
         defaultValue: false,
-        configPath: 'config.test.bool'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should parse "true" from env var', () => {
@@ -290,10 +375,14 @@ describe('config.util', () => {
         envVar: 'TEST_BOOL_VAR',
         configValue: undefined,
         defaultValue: false,
-        configPath: 'config.test.bool'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should parse "false" from env var', () => {
@@ -303,10 +392,14 @@ describe('config.util', () => {
         envVar: 'TEST_BOOL_VAR',
         configValue: undefined,
         defaultValue: true,
-        configPath: 'config.test.bool'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(false);
+      expect(result).to.deep.equal({
+        value: false,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should parse "1" from env var as true', () => {
@@ -315,11 +408,14 @@ describe('config.util', () => {
       const result = util.resolveBooleanConfig({
         envVar: 'TEST_BOOL_VAR',
         configValue: undefined,
-        defaultValue: false,
-        configPath: 'config.test.bool'
+        defaultValue: false
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.ENV,
+        configPath: undefined
+      });
     });
 
     it('should parse "0" from env var as false', () => {
@@ -329,10 +425,13 @@ describe('config.util', () => {
         envVar: 'TEST_BOOL_VAR',
         configValue: undefined,
         defaultValue: true,
-        configPath: 'config.test.bool'
+        configPath: 'config.test.value'
       });
-
-      expect(result).to.equal(false);
+      expect(result).to.deep.equal({
+        value: false,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle case-insensitive "TRUE" from env var', () => {
@@ -342,10 +441,14 @@ describe('config.util', () => {
         envVar: 'TEST_BOOL_VAR',
         configValue: undefined,
         defaultValue: false,
-        configPath: 'config.test.bool'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle case-insensitive "FALSE" from env var', () => {
@@ -355,10 +458,14 @@ describe('config.util', () => {
         envVar: 'TEST_BOOL_VAR',
         configValue: undefined,
         defaultValue: true,
-        configPath: 'config.test.bool'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(false);
+      expect(result).to.deep.equal({
+        value: false,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should fall back to config value when env var is invalid', () => {
@@ -368,10 +475,14 @@ describe('config.util', () => {
         envVar: 'TEST_BOOL_VAR',
         configValue: true,
         defaultValue: false,
-        configPath: 'config.test.bool'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should fall back to default when both env var and config value are invalid', () => {
@@ -381,10 +492,14 @@ describe('config.util', () => {
         envVar: 'TEST_BOOL_VAR',
         configValue: 'not-a-boolean',
         defaultValue: true,
-        configPath: 'config.test.bool'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle null config value', () => {
@@ -392,10 +507,14 @@ describe('config.util', () => {
         envVar: 'TEST_BOOL_VAR',
         configValue: null,
         defaultValue: true,
-        configPath: 'config.test.bool'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle undefined config value', () => {
@@ -403,10 +522,14 @@ describe('config.util', () => {
         envVar: 'TEST_BOOL_VAR',
         configValue: undefined,
         defaultValue: false,
-        configPath: 'config.test.bool'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(false);
+      expect(result).to.deep.equal({
+        value: false,
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.test.value'
+      });
     });
   });
 
@@ -426,10 +549,14 @@ describe('config.util', () => {
         envVar: 'TEST_DISABLE_VAR',
         configValue: undefined,
         defaultValue: true,
-        configPath: 'config.test.disable'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(false);
+      expect(result).to.deep.equal({
+        value: false,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should prioritize env var over config value', () => {
@@ -439,10 +566,14 @@ describe('config.util', () => {
         envVar: 'TEST_DISABLE_VAR',
         configValue: true,
         defaultValue: true,
-        configPath: 'config.test.disable'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(false);
+      expect(result).to.deep.equal({
+        value: false,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should use config value when env var is not set', () => {
@@ -450,10 +581,14 @@ describe('config.util', () => {
         envVar: 'TEST_DISABLE_VAR',
         configValue: false,
         defaultValue: true,
-        configPath: 'config.test.disable'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(false);
+      expect(result).to.deep.equal({
+        value: false,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should use default when env var is not "true" and config is not set', () => {
@@ -463,10 +598,14 @@ describe('config.util', () => {
         envVar: 'TEST_DISABLE_VAR',
         configValue: undefined,
         defaultValue: true,
-        configPath: 'config.test.disable'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle null config value', () => {
@@ -474,10 +613,14 @@ describe('config.util', () => {
         envVar: 'TEST_DISABLE_VAR',
         configValue: null,
         defaultValue: false,
-        configPath: 'config.test.disable'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(false);
+      expect(result).to.deep.equal({
+        value: false,
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should return default when configValue and env var are not boolean', () => {
@@ -485,10 +628,14 @@ describe('config.util', () => {
         envVar: 'TEST_INVERTED_VAR',
         configValue: 'not-a-boolean',
         defaultValue: true,
-        configPath: 'config.test.inverted'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.test.value'
+      });
     });
   });
 
@@ -507,10 +654,15 @@ describe('config.util', () => {
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
         configValue: undefined,
-        defaultValue: false
+        defaultValue: false,
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should return true when env var is "true"', () => {
@@ -519,10 +671,15 @@ describe('config.util', () => {
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
         configValue: undefined,
-        defaultValue: false
+        defaultValue: false,
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should return true when env var is "1"', () => {
@@ -531,10 +688,15 @@ describe('config.util', () => {
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
         configValue: undefined,
-        defaultValue: false
+        defaultValue: false,
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should prioritize env var over config value', () => {
@@ -543,30 +705,45 @@ describe('config.util', () => {
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
         configValue: false,
-        defaultValue: false
+        defaultValue: false,
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should use config value when env var is not set', () => {
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
         configValue: true,
-        defaultValue: false
+        defaultValue: false,
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(true);
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should use default when env var is not set and config is not boolean', () => {
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
         configValue: undefined,
-        defaultValue: false
+        defaultValue: false,
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(false);
+      expect(result).to.deep.equal({
+        value: false,
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle empty string env var as falsy', () => {
@@ -575,10 +752,15 @@ describe('config.util', () => {
       const result = util.resolveBooleanConfigWithTruthyEnv({
         envVar: 'TEST_TRUTHY_VAR',
         configValue: undefined,
-        defaultValue: false
+        defaultValue: false,
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(false);
+      expect(result).to.deep.equal({
+        value: false,
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.test.value'
+      });
     });
   });
 
@@ -596,10 +778,14 @@ describe('config.util', () => {
         envVar: 'TEST_STRING_VAR',
         configValue: undefined,
         defaultValue: 'default-value',
-        configPath: 'config.test.string'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal('default-value');
+      expect(result).to.deep.equal({
+        value: 'default-value',
+        source: CONFIG_SOURCES.DEFAULT,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should prioritize env var over config value', () => {
@@ -609,10 +795,14 @@ describe('config.util', () => {
         envVar: 'TEST_STRING_VAR',
         configValue: 'config-value',
         defaultValue: 'default-value',
-        configPath: 'config.test.string'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal('env-value');
+      expect(result).to.deep.equal({
+        value: 'env-value',
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should use env var when config value is not set', () => {
@@ -622,10 +812,14 @@ describe('config.util', () => {
         envVar: 'TEST_STRING_VAR',
         configValue: undefined,
         defaultValue: 'default-value',
-        configPath: 'config.test.string'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal('env-value');
+      expect(result).to.deep.equal({
+        value: 'env-value',
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should use config value when env var is not set', () => {
@@ -633,10 +827,14 @@ describe('config.util', () => {
         envVar: 'TEST_STRING_VAR',
         configValue: 'config-value',
         defaultValue: 'default-value',
-        configPath: 'config.test.string'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal('config-value');
+      expect(result).to.deep.equal({
+        value: 'config-value',
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle empty string as a valid config value', () => {
@@ -644,10 +842,14 @@ describe('config.util', () => {
         envVar: 'TEST_STRING_VAR',
         configValue: '',
         defaultValue: 'default-value',
-        configPath: 'config.test.string'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal('');
+      expect(result).to.deep.equal({
+        value: '',
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle empty string as a valid env var value', () => {
@@ -657,10 +859,14 @@ describe('config.util', () => {
         envVar: 'TEST_STRING_VAR',
         configValue: undefined,
         defaultValue: 'default-value',
-        configPath: 'config.test.string'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal('');
+      expect(result).to.deep.equal({
+        value: '',
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle undefined config value as not set', () => {
@@ -670,10 +876,14 @@ describe('config.util', () => {
         envVar: 'TEST_STRING_VAR',
         configValue: undefined,
         defaultValue: 'default-value',
-        configPath: 'config.test.string'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal('env-value');
+      expect(result).to.deep.equal({
+        value: 'env-value',
+        source: CONFIG_SOURCES.ENV,
+        configPath: 'config.test.value'
+      });
     });
 
     it('should handle multiline string values', () => {
@@ -682,10 +892,14 @@ describe('config.util', () => {
         envVar: undefined,
         configValue: multilineValue,
         defaultValue: 'default-value',
-        configPath: 'config.test.string'
+        configPath: 'config.test.value'
       });
 
-      expect(result).to.equal(multilineValue);
+      expect(result).to.deep.equal({
+        value: multilineValue,
+        source: CONFIG_SOURCES.INCODE,
+        configPath: 'config.test.value'
+      });
     });
   });
 });

--- a/packages/core/test/config/util_test.js
+++ b/packages/core/test/config/util_test.js
@@ -7,9 +7,10 @@
 const expect = require('chai').expect;
 const { createFakeLogger } = require('../test_util');
 const util = require('../../src/config/util');
+const validate = require('../../src/config/validator');
 const { CONFIG_SOURCES } = require('../../src/util/constants');
 
-describe.skip('config.util', () => {
+describe('config.util', () => {
   let logger;
 
   before(() => {
@@ -22,883 +23,594 @@ describe.skip('config.util', () => {
 
   function resetEnv() {
     delete process.env.TEST_ENV_VAR;
+    delete process.env.TEST_BOOL_VAR;
+    delete process.env.TEST_STRING_VAR;
+    delete process.env.TEST_TRUTHY_VAR;
   }
 
-  describe('resolveNumericConfig', () => {
-    it('should return the default value when no env var or config value is provided', () => {
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
+  describe('resolve - priority order (env > inCode > agent > default)', () => {
+    it('should prioritize env over inCode, agent, and default', () => {
+      process.env.TEST_ENV_VAR = '100';
+
+      const result = util.resolve(
+        {
+          envValue: 'TEST_ENV_VAR',
+          inCodeValue: 200,
+          agentValue: 300,
+          defaultValue: 400
+        },
+        validate.numberValidator
+      );
 
       expect(result).to.deep.equal({
-        value: 1000,
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.test.value'
+        value: 100,
+        source: CONFIG_SOURCES.ENV
       });
     });
 
-    it('should prioritize env var over config value', () => {
-      process.env.TEST_ENV_VAR = '2000';
-
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: 3000,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
+    it('should prioritize inCode over agent and default when env is not set', () => {
+      const result = util.resolve(
+        {
+          inCodeValue: 200,
+          agentValue: 300,
+          defaultValue: 400
+        },
+        validate.numberValidator
+      );
 
       expect(result).to.deep.equal({
-        value: 2000,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
+        value: 200,
+        source: CONFIG_SOURCES.INCODE
       });
     });
 
-    it('should use config value when env var is not set', () => {
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: 3000,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
+    it('should prioritize agent over default when env and inCode are not set', () => {
+      const result = util.resolve(
+        {
+          agentValue: 300,
+          defaultValue: 400
+        },
+        validate.numberValidator
+      );
 
       expect(result).to.deep.equal({
-        value: 3000,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
+        value: 300,
+        source: CONFIG_SOURCES.AGENT
       });
     });
 
-    it('should handle numeric config value', () => {
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: 5000,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
+    it('should use default when env, inCode, and agent are not set', () => {
+      const result = util.resolve(
+        {
+          defaultValue: 400
+        },
+        validate.numberValidator
+      );
 
       expect(result).to.deep.equal({
-        value: 5000,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle string config value that can be parsed as number', () => {
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: '5000',
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 5000,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle string env var that can be parsed as number', () => {
-      process.env.TEST_ENV_VAR = '7500';
-
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 7500,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should fall back to default when env var is invalid', () => {
-      process.env.TEST_ENV_VAR = 'not-a-number';
-
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 1000,
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should fall back to default when config value is invalid', () => {
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: 'invalid',
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 1000,
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should use config value when env var is invalid', () => {
-      process.env.TEST_ENV_VAR = 'not-a-number';
-
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: 3000,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 3000,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle zero as a valid value from env var', () => {
-      process.env.TEST_ENV_VAR = '0';
-
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 0,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle zero as a valid value from config', () => {
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: 0,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 0,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle negative numbers from env var', () => {
-      process.env.TEST_ENV_VAR = '-500';
-
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: -500,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle negative numbers from config', () => {
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: -500,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: -500,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle floating point numbers from env var', () => {
-      process.env.TEST_ENV_VAR = '123.45';
-
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 123.45,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle floating point numbers from config', () => {
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: 123.45,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 123.45,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle null config value', () => {
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: null,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 1000,
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle empty string env var as 0', () => {
-      process.env.TEST_ENV_VAR = '';
-
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: undefined,
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 0,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle empty string config value as 0', () => {
-      const result = util.resolveNumericConfig({
-        envVar: 'TEST_ENV_VAR',
-        configValue: '',
-        defaultValue: 1000,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 0,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
+        value: 400,
+        source: CONFIG_SOURCES.DEFAULT
       });
     });
   });
 
-  describe('resolveBooleanConfig', () => {
-    beforeEach(() => {
-      delete process.env.TEST_BOOL_VAR;
-    });
+  describe('resolve with numberValidator', () => {
+    it('should parse numeric string from env var', () => {
+      process.env.TEST_ENV_VAR = '7500';
 
-    afterEach(() => {
-      delete process.env.TEST_BOOL_VAR;
-    });
-
-    it('should return the default value when no env var or config value is provided', () => {
-      const result = util.resolveBooleanConfig({
-        envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
+      const result = util.resolve(
+        {
+          envValue: 'TEST_ENV_VAR',
+          inCodeValue: undefined,
+          defaultValue: 1000
+        },
+        validate.numberValidator
+      );
 
       expect(result).to.deep.equal({
-        value: false,
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.test.value'
+        value: 7500,
+        source: CONFIG_SOURCES.ENV
       });
     });
 
-    it('should prioritize env var over config value', () => {
-      process.env.TEST_BOOL_VAR = 'true';
-
-      const result = util.resolveBooleanConfig({
-        envVar: 'TEST_BOOL_VAR',
-        configValue: false,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
+    it('should parse numeric string from inCode value', () => {
+      const result = util.resolve(
+        {
+          envValue: 'TEST_ENV_VAR',
+          inCodeValue: '5000',
+          defaultValue: 1000
+        },
+        validate.numberValidator
+      );
 
       expect(result).to.deep.equal({
-        value: true,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
+        value: 5000,
+        source: CONFIG_SOURCES.INCODE
       });
     });
 
-    it('should use config value when env var is not set', () => {
-      const result = util.resolveBooleanConfig({
-        envVar: 'TEST_BOOL_VAR',
-        configValue: true,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
+    it('should handle zero as valid value', () => {
+      const result = util.resolve(
+        {
+          envValue: 'TEST_ENV_VAR',
+          inCodeValue: 0,
+          defaultValue: 1000
+        },
+        validate.numberValidator
+      );
 
       expect(result).to.deep.equal({
-        value: true,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
+        value: 0,
+        source: CONFIG_SOURCES.INCODE
       });
     });
 
+    it('should handle negative numbers', () => {
+      process.env.TEST_ENV_VAR = '-500';
+
+      const result = util.resolve(
+        {
+          envValue: 'TEST_ENV_VAR',
+          inCodeValue: undefined,
+          defaultValue: 1000
+        },
+        validate.numberValidator
+      );
+
+      expect(result).to.deep.equal({
+        value: -500,
+        source: CONFIG_SOURCES.ENV
+      });
+    });
+
+    it('should handle floating point numbers', () => {
+      const result = util.resolve(
+        {
+          envValue: 'TEST_ENV_VAR',
+          inCodeValue: 123.45,
+          defaultValue: 1000
+        },
+        validate.numberValidator
+      );
+
+      expect(result).to.deep.equal({
+        value: 123.45,
+        source: CONFIG_SOURCES.INCODE
+      });
+    });
+
+    it('should handle empty string as 0', () => {
+      process.env.TEST_ENV_VAR = '';
+
+      const result = util.resolve(
+        {
+          envValue: 'TEST_ENV_VAR',
+          inCodeValue: undefined,
+          defaultValue: 1000
+        },
+        validate.numberValidator
+      );
+
+      expect(result).to.deep.equal({
+        value: 0,
+        source: CONFIG_SOURCES.ENV
+      });
+    });
+
+    it('should fall back to next priority when env var is invalid', () => {
+      process.env.TEST_ENV_VAR = 'not-a-number';
+
+      const result = util.resolve(
+        {
+          envValue: 'TEST_ENV_VAR',
+          inCodeValue: 3000,
+          defaultValue: 1000
+        },
+        validate.numberValidator
+      );
+
+      expect(result).to.deep.equal({
+        value: 3000,
+        source: CONFIG_SOURCES.INCODE
+      });
+    });
+
+    it('should fall back to default when all values are invalid', () => {
+      process.env.TEST_ENV_VAR = 'not-a-number';
+
+      const result = util.resolve(
+        {
+          envValue: 'TEST_ENV_VAR',
+          inCodeValue: 'invalid',
+          defaultValue: 1000
+        },
+        validate.numberValidator
+      );
+
+      expect(result).to.deep.equal({
+        value: 1000,
+        source: CONFIG_SOURCES.DEFAULT
+      });
+    });
+
+    it('should treat null as undefined', () => {
+      const result = util.resolve(
+        {
+          envValue: 'TEST_ENV_VAR',
+          inCodeValue: null,
+          defaultValue: 1000
+        },
+        validate.numberValidator
+      );
+
+      expect(result).to.deep.equal({
+        value: 1000,
+        source: CONFIG_SOURCES.DEFAULT
+      });
+    });
+  });
+
+  describe('resolve with booleanValidator', () => {
     it('should parse "true" from env var', () => {
       process.env.TEST_BOOL_VAR = 'true';
 
-      const result = util.resolveBooleanConfig({
-        envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
+      const result = util.resolve(
+        {
+          envValue: 'TEST_BOOL_VAR',
+          inCodeValue: undefined,
+          defaultValue: false
+        },
+        validate.booleanValidator
+      );
 
       expect(result).to.deep.equal({
         value: true,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
+        source: CONFIG_SOURCES.ENV
       });
     });
 
     it('should parse "false" from env var', () => {
       process.env.TEST_BOOL_VAR = 'false';
 
-      const result = util.resolveBooleanConfig({
-        envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
-        defaultValue: true,
-        configPath: 'config.test.value'
-      });
+      const result = util.resolve(
+        {
+          envValue: 'TEST_BOOL_VAR',
+          inCodeValue: undefined,
+          defaultValue: true
+        },
+        validate.booleanValidator
+      );
 
       expect(result).to.deep.equal({
         value: false,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
+        source: CONFIG_SOURCES.ENV
       });
     });
 
-    it('should parse "1" from env var as true', () => {
+    it('should parse "1" as true', () => {
       process.env.TEST_BOOL_VAR = '1';
 
-      const result = util.resolveBooleanConfig({
-        envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
-        defaultValue: false
-      });
+      const result = util.resolve(
+        {
+          envValue: 'TEST_BOOL_VAR',
+          inCodeValue: undefined,
+          defaultValue: false
+        },
+        validate.booleanValidator
+      );
 
       expect(result).to.deep.equal({
         value: true,
-        source: CONFIG_SOURCES.ENV,
-        configPath: undefined
+        source: CONFIG_SOURCES.ENV
       });
     });
 
-    it('should parse "0" from env var as false', () => {
+    it('should parse "0" as false', () => {
       process.env.TEST_BOOL_VAR = '0';
 
-      const result = util.resolveBooleanConfig({
-        envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
-        defaultValue: true,
-        configPath: 'config.test.value'
-      });
+      const result = util.resolve(
+        {
+          envValue: 'TEST_BOOL_VAR',
+          inCodeValue: undefined,
+          defaultValue: true
+        },
+        validate.booleanValidator
+      );
+
       expect(result).to.deep.equal({
         value: false,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
+        source: CONFIG_SOURCES.ENV
       });
     });
 
-    it('should handle case-insensitive "TRUE" from env var', () => {
+    it('should handle case-insensitive values', () => {
       process.env.TEST_BOOL_VAR = 'TRUE';
 
-      const result = util.resolveBooleanConfig({
-        envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
+      const result = util.resolve(
+        {
+          envValue: 'TEST_BOOL_VAR',
+          inCodeValue: undefined,
+          defaultValue: false
+        },
+        validate.booleanValidator
+      );
 
       expect(result).to.deep.equal({
         value: true,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
+        source: CONFIG_SOURCES.ENV
       });
     });
 
-    it('should handle case-insensitive "FALSE" from env var', () => {
-      process.env.TEST_BOOL_VAR = 'FALSE';
-
-      const result = util.resolveBooleanConfig({
-        envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
-        defaultValue: true,
-        configPath: 'config.test.value'
-      });
+    it('should handle boolean inCode values', () => {
+      const result = util.resolve(
+        {
+          envValue: 'TEST_BOOL_VAR',
+          inCodeValue: true,
+          defaultValue: false
+        },
+        validate.booleanValidator
+      );
 
       expect(result).to.deep.equal({
-        value: false,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
+        value: true,
+        source: CONFIG_SOURCES.INCODE
       });
     });
 
-    it('should fall back to config value when env var is invalid', () => {
+    it('should fall back to next priority when env var is invalid', () => {
       process.env.TEST_BOOL_VAR = 'invalid';
 
-      const result = util.resolveBooleanConfig({
-        envVar: 'TEST_BOOL_VAR',
-        configValue: true,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
+      const result = util.resolve(
+        {
+          envValue: 'TEST_BOOL_VAR',
+          inCodeValue: true,
+          defaultValue: false
+        },
+        validate.booleanValidator
+      );
 
       expect(result).to.deep.equal({
         value: true,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
+        source: CONFIG_SOURCES.INCODE
       });
     });
 
-    it('should fall back to default when both env var and config value are invalid', () => {
+    it('should fall back to default when all values are invalid', () => {
       process.env.TEST_BOOL_VAR = 'invalid';
 
-      const result = util.resolveBooleanConfig({
-        envVar: 'TEST_BOOL_VAR',
-        configValue: 'not-a-boolean',
-        defaultValue: true,
-        configPath: 'config.test.value'
-      });
+      const result = util.resolve(
+        {
+          envValue: 'TEST_BOOL_VAR',
+          inCodeValue: 'not-a-boolean',
+          defaultValue: true
+        },
+        validate.booleanValidator
+      );
 
       expect(result).to.deep.equal({
         value: true,
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle null config value', () => {
-      const result = util.resolveBooleanConfig({
-        envVar: 'TEST_BOOL_VAR',
-        configValue: null,
-        defaultValue: true,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: true,
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle undefined config value', () => {
-      const result = util.resolveBooleanConfig({
-        envVar: 'TEST_BOOL_VAR',
-        configValue: undefined,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: false,
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.test.value'
+        source: CONFIG_SOURCES.DEFAULT
       });
     });
   });
 
-  describe('resolveBooleanConfigWithInvertedEnv', () => {
-    beforeEach(() => {
-      delete process.env.TEST_DISABLE_VAR;
-    });
-
-    afterEach(() => {
-      delete process.env.TEST_DISABLE_VAR;
-    });
-
-    it('should return false when env var is "true" (inverted logic)', () => {
-      process.env.TEST_DISABLE_VAR = 'true';
-
-      const result = util.resolveBooleanConfigWithInvertedEnv({
-        envVar: 'TEST_DISABLE_VAR',
-        configValue: undefined,
-        defaultValue: true,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: false,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should prioritize env var over config value', () => {
-      process.env.TEST_DISABLE_VAR = 'true';
-
-      const result = util.resolveBooleanConfigWithInvertedEnv({
-        envVar: 'TEST_DISABLE_VAR',
-        configValue: true,
-        defaultValue: true,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: false,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should use config value when env var is not set', () => {
-      const result = util.resolveBooleanConfigWithInvertedEnv({
-        envVar: 'TEST_DISABLE_VAR',
-        configValue: false,
-        defaultValue: true,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: false,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should use default when env var is not "true" and config is not set', () => {
-      process.env.TEST_DISABLE_VAR = 'false';
-
-      const result = util.resolveBooleanConfigWithInvertedEnv({
-        envVar: 'TEST_DISABLE_VAR',
-        configValue: undefined,
-        defaultValue: true,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: true,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle null config value', () => {
-      const result = util.resolveBooleanConfigWithInvertedEnv({
-        envVar: 'TEST_DISABLE_VAR',
-        configValue: null,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: false,
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should return default when configValue and env var are not boolean', () => {
-      const result = util.resolveBooleanConfigWithInvertedEnv({
-        envVar: 'TEST_INVERTED_VAR',
-        configValue: 'not-a-boolean',
-        defaultValue: true,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: true,
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.test.value'
-      });
-    });
-  });
-
-  describe('resolveBooleanConfigWithTruthyEnv', () => {
-    beforeEach(() => {
-      delete process.env.TEST_TRUTHY_VAR;
-    });
-
-    afterEach(() => {
-      delete process.env.TEST_TRUTHY_VAR;
-    });
-
-    it('should return true when env var exists and is truthy', () => {
+  describe('resolve with validateTruthyBoolean', () => {
+    it('should return true for any truthy env var value', () => {
       process.env.TEST_TRUTHY_VAR = 'any-value';
 
-      const result = util.resolveBooleanConfigWithTruthyEnv({
-        envVar: 'TEST_TRUTHY_VAR',
-        configValue: undefined,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
+      const result = util.resolve(
+        {
+          envValue: 'TEST_TRUTHY_VAR',
+          inCodeValue: undefined,
+          defaultValue: false
+        },
+        validate.validateTruthyBoolean
+      );
 
       expect(result).to.deep.equal({
         value: true,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
+        source: CONFIG_SOURCES.ENV
       });
     });
 
-    it('should return true when env var is "true"', () => {
-      process.env.TEST_TRUTHY_VAR = 'true';
-
-      const result = util.resolveBooleanConfigWithTruthyEnv({
-        envVar: 'TEST_TRUTHY_VAR',
-        configValue: undefined,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
+    it('should return true for truthy inCode value', () => {
+      const result = util.resolve(
+        {
+          envValue: 'TEST_TRUTHY_VAR',
+          inCodeValue: true,
+          defaultValue: false
+        },
+        validate.validateTruthyBoolean
+      );
 
       expect(result).to.deep.equal({
         value: true,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
+        source: CONFIG_SOURCES.INCODE
       });
     });
 
-    it('should return true when env var is "1"', () => {
-      process.env.TEST_TRUTHY_VAR = '1';
-
-      const result = util.resolveBooleanConfigWithTruthyEnv({
-        envVar: 'TEST_TRUTHY_VAR',
-        configValue: undefined,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: true,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should prioritize env var over config value', () => {
-      process.env.TEST_TRUTHY_VAR = 'yes';
-
-      const result = util.resolveBooleanConfigWithTruthyEnv({
-        envVar: 'TEST_TRUTHY_VAR',
-        configValue: false,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: true,
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should use config value when env var is not set', () => {
-      const result = util.resolveBooleanConfigWithTruthyEnv({
-        envVar: 'TEST_TRUTHY_VAR',
-        configValue: true,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: true,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should use default when env var is not set and config is not boolean', () => {
-      const result = util.resolveBooleanConfigWithTruthyEnv({
-        envVar: 'TEST_TRUTHY_VAR',
-        configValue: undefined,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: false,
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle empty string env var as falsy', () => {
+    it('should fall back to default for empty string env var', () => {
       process.env.TEST_TRUTHY_VAR = '';
 
-      const result = util.resolveBooleanConfigWithTruthyEnv({
-        envVar: 'TEST_TRUTHY_VAR',
-        configValue: undefined,
-        defaultValue: false,
-        configPath: 'config.test.value'
-      });
+      const result = util.resolve(
+        {
+          envValue: 'TEST_TRUTHY_VAR',
+          inCodeValue: undefined,
+          defaultValue: false
+        },
+        validate.validateTruthyBoolean
+      );
 
       expect(result).to.deep.equal({
         value: false,
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.test.value'
+        source: CONFIG_SOURCES.DEFAULT
+      });
+    });
+
+    it('should fall back to default for falsy inCode value', () => {
+      const result = util.resolve(
+        {
+          envValue: 'TEST_TRUTHY_VAR',
+          inCodeValue: false,
+          defaultValue: true
+        },
+        validate.validateTruthyBoolean
+      );
+
+      expect(result).to.deep.equal({
+        value: true,
+        source: CONFIG_SOURCES.DEFAULT
       });
     });
   });
 
-  describe('resolveStringConfig', () => {
-    beforeEach(() => {
-      delete process.env.TEST_STRING_VAR;
-    });
-
-    afterEach(() => {
-      delete process.env.TEST_STRING_VAR;
-    });
-
-    it('should return the default value when no env var or config value is provided', () => {
-      const result = util.resolveStringConfig({
-        envVar: 'TEST_STRING_VAR',
-        configValue: undefined,
-        defaultValue: 'default-value',
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 'default-value',
-        source: CONFIG_SOURCES.DEFAULT,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should prioritize env var over config value', () => {
+  describe('resolve with stringValidator', () => {
+    it('should use string from env var', () => {
       process.env.TEST_STRING_VAR = 'env-value';
 
-      const result = util.resolveStringConfig({
-        envVar: 'TEST_STRING_VAR',
-        configValue: 'config-value',
-        defaultValue: 'default-value',
-        configPath: 'config.test.value'
-      });
+      const result = util.resolve(
+        {
+          envValue: 'TEST_STRING_VAR',
+          inCodeValue: undefined,
+          defaultValue: 'default-value'
+        },
+        validate.stringValidator
+      );
 
       expect(result).to.deep.equal({
         value: 'env-value',
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
+        source: CONFIG_SOURCES.ENV
       });
     });
 
-    it('should use env var when config value is not set', () => {
-      process.env.TEST_STRING_VAR = 'env-value';
-
-      const result = util.resolveStringConfig({
-        envVar: 'TEST_STRING_VAR',
-        configValue: undefined,
-        defaultValue: 'default-value',
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 'env-value',
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should use config value when env var is not set', () => {
-      const result = util.resolveStringConfig({
-        envVar: 'TEST_STRING_VAR',
-        configValue: 'config-value',
-        defaultValue: 'default-value',
-        configPath: 'config.test.value'
-      });
+    it('should use string from inCode value', () => {
+      const result = util.resolve(
+        {
+          envValue: 'TEST_STRING_VAR',
+          inCodeValue: 'config-value',
+          defaultValue: 'default-value'
+        },
+        validate.stringValidator
+      );
 
       expect(result).to.deep.equal({
         value: 'config-value',
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
+        source: CONFIG_SOURCES.INCODE
       });
     });
 
-    it('should handle empty string as a valid config value', () => {
-      const result = util.resolveStringConfig({
-        envVar: 'TEST_STRING_VAR',
-        configValue: '',
-        defaultValue: 'default-value',
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: '',
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle empty string as a valid env var value', () => {
+    it('should handle empty string as valid value', () => {
       process.env.TEST_STRING_VAR = '';
 
-      const result = util.resolveStringConfig({
-        envVar: 'TEST_STRING_VAR',
-        configValue: undefined,
-        defaultValue: 'default-value',
-        configPath: 'config.test.value'
-      });
+      const result = util.resolve(
+        {
+          envValue: 'TEST_STRING_VAR',
+          inCodeValue: undefined,
+          defaultValue: 'default-value'
+        },
+        validate.stringValidator
+      );
 
       expect(result).to.deep.equal({
         value: '',
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
+        source: CONFIG_SOURCES.ENV
       });
     });
 
-    it('should handle undefined config value as not set', () => {
-      process.env.TEST_STRING_VAR = 'env-value';
-
-      const result = util.resolveStringConfig({
-        envVar: 'TEST_STRING_VAR',
-        configValue: undefined,
-        defaultValue: 'default-value',
-        configPath: 'config.test.value'
-      });
-
-      expect(result).to.deep.equal({
-        value: 'env-value',
-        source: CONFIG_SOURCES.ENV,
-        configPath: 'config.test.value'
-      });
-    });
-
-    it('should handle multiline string values', () => {
+    it('should handle multiline strings', () => {
       const multilineValue = 'line1\nline2\nline3';
-      const result = util.resolveStringConfig({
-        envVar: undefined,
-        configValue: multilineValue,
-        defaultValue: 'default-value',
-        configPath: 'config.test.value'
-      });
+      const result = util.resolve(
+        {
+          envValue: 'TEST_STRING_VAR',
+          inCodeValue: multilineValue,
+          defaultValue: 'default-value'
+        },
+        validate.stringValidator
+      );
 
       expect(result).to.deep.equal({
         value: multilineValue,
-        source: CONFIG_SOURCES.INCODE,
-        configPath: 'config.test.value'
+        source: CONFIG_SOURCES.INCODE
+      });
+    });
+
+    it('should reject non-string values and fall back', () => {
+      const result = util.resolve(
+        {
+          envValue: 'TEST_STRING_VAR',
+          inCodeValue: 123,
+          defaultValue: 'default-value'
+        },
+        validate.stringValidator
+      );
+
+      expect(result).to.deep.equal({
+        value: 'default-value',
+        source: CONFIG_SOURCES.DEFAULT
+      });
+    });
+
+    it('should treat null as undefined', () => {
+      const result = util.resolve(
+        {
+          envValue: 'TEST_STRING_VAR',
+          inCodeValue: null,
+          defaultValue: 'default-value'
+        },
+        validate.stringValidator
+      );
+
+      expect(result).to.deep.equal({
+        value: 'default-value',
+        source: CONFIG_SOURCES.DEFAULT
+      });
+    });
+  });
+
+  describe('resolve with multiple validators', () => {
+    it('should apply validators in sequence', () => {
+      const customValidator = value => {
+        if (typeof value === 'number' && value > 100) {
+          return value;
+        }
+        return undefined;
+      };
+
+      const result = util.resolve(
+        {
+          envValue: 'TEST_ENV_VAR',
+          inCodeValue: 150,
+          defaultValue: 50
+        },
+        [validate.numberValidator, customValidator]
+      );
+
+      expect(result).to.deep.equal({
+        value: 150,
+        source: CONFIG_SOURCES.INCODE
+      });
+    });
+
+    it('should fall back when any validator in chain fails', () => {
+      const customValidator = value => {
+        if (typeof value === 'number' && value > 100) {
+          return value;
+        }
+        return undefined;
+      };
+
+      const result = util.resolve(
+        {
+          envValue: 'TEST_ENV_VAR',
+          inCodeValue: 50,
+          defaultValue: 200
+        },
+        [validate.numberValidator, customValidator]
+      );
+
+      expect(result).to.deep.equal({
+        value: 200,
+        source: CONFIG_SOURCES.DEFAULT
       });
     });
   });

--- a/packages/core/test/config/validator_test.js
+++ b/packages/core/test/config/validator_test.js
@@ -1,0 +1,175 @@
+/*
+ * (c) Copyright IBM Corp. 2026
+ */
+
+'use strict';
+
+const expect = require('chai').expect;
+const validator = require('../../src/config/validator');
+
+describe('config.validator', () => {
+  describe('numberValidator', () => {
+    it('should return number for valid numeric input', () => {
+      expect(validator.numberValidator(123)).to.equal(123);
+      expect(validator.numberValidator(0)).to.equal(0);
+      expect(validator.numberValidator(-456)).to.equal(-456);
+      expect(validator.numberValidator(123.45)).to.equal(123.45);
+    });
+
+    it('should parse numeric strings', () => {
+      expect(validator.numberValidator('123')).to.equal(123);
+      expect(validator.numberValidator('0')).to.equal(0);
+      expect(validator.numberValidator('-456')).to.equal(-456);
+      expect(validator.numberValidator('123.45')).to.equal(123.45);
+    });
+
+    it('should handle empty string as 0', () => {
+      expect(validator.numberValidator('')).to.equal(0);
+    });
+
+    it('should return undefined for null', () => {
+      expect(validator.numberValidator(null)).to.be.undefined;
+    });
+
+    it('should return undefined for undefined', () => {
+      expect(validator.numberValidator(undefined)).to.be.undefined;
+    });
+
+    it('should return undefined for non-numeric strings', () => {
+      expect(validator.numberValidator('abc')).to.be.undefined;
+      expect(validator.numberValidator('12abc')).to.be.undefined;
+      expect(validator.numberValidator('not-a-number')).to.be.undefined;
+    });
+
+    it('should return undefined for NaN', () => {
+      expect(validator.numberValidator(NaN)).to.be.undefined;
+    });
+
+    it('should handle Infinity', () => {
+      expect(validator.numberValidator(Infinity)).to.equal(Infinity);
+      expect(validator.numberValidator(-Infinity)).to.equal(-Infinity);
+    });
+  });
+
+  describe('booleanValidator', () => {
+    it('should return boolean for valid boolean input', () => {
+      expect(validator.booleanValidator(true)).to.equal(true);
+      expect(validator.booleanValidator(false)).to.equal(false);
+    });
+
+    it('should parse "true" string as true', () => {
+      expect(validator.booleanValidator('true')).to.equal(true);
+      expect(validator.booleanValidator('TRUE')).to.equal(true);
+      expect(validator.booleanValidator('True')).to.equal(true);
+    });
+
+    it('should parse "false" string as false', () => {
+      expect(validator.booleanValidator('false')).to.equal(false);
+      expect(validator.booleanValidator('FALSE')).to.equal(false);
+      expect(validator.booleanValidator('False')).to.equal(false);
+    });
+
+    it('should parse "1" as true', () => {
+      expect(validator.booleanValidator('1')).to.equal(true);
+    });
+
+    it('should parse "0" as false', () => {
+      expect(validator.booleanValidator('0')).to.equal(false);
+    });
+
+    it('should return undefined for null', () => {
+      expect(validator.booleanValidator(null)).to.be.undefined;
+    });
+
+    it('should return undefined for undefined', () => {
+      expect(validator.booleanValidator(undefined)).to.be.undefined;
+    });
+
+    it('should return undefined for invalid strings', () => {
+      expect(validator.booleanValidator('yes')).to.be.undefined;
+      expect(validator.booleanValidator('no')).to.be.undefined;
+      expect(validator.booleanValidator('invalid')).to.be.undefined;
+      expect(validator.booleanValidator('')).to.be.undefined;
+    });
+
+    it('should return undefined for numbers other than 0 and 1', () => {
+      expect(validator.booleanValidator(2)).to.be.undefined;
+      expect(validator.booleanValidator(-1)).to.be.undefined;
+      expect(validator.booleanValidator(123)).to.be.undefined;
+    });
+
+    it('should return undefined for objects', () => {
+      expect(validator.booleanValidator({})).to.be.undefined;
+      expect(validator.booleanValidator([])).to.be.undefined;
+    });
+  });
+
+  describe('stringValidator', () => {
+    it('should return string for valid string input', () => {
+      expect(validator.stringValidator('hello')).to.equal('hello');
+      expect(validator.stringValidator('world')).to.equal('world');
+      expect(validator.stringValidator('')).to.equal('');
+    });
+
+    it('should handle empty string', () => {
+      expect(validator.stringValidator('')).to.equal('');
+    });
+
+    it('should handle multiline strings', () => {
+      const multiline = 'line1\nline2\nline3';
+      expect(validator.stringValidator(multiline)).to.equal(multiline);
+    });
+
+    it('should handle strings with special characters', () => {
+      expect(validator.stringValidator('hello@world.com')).to.equal('hello@world.com');
+      expect(validator.stringValidator('path/to/file')).to.equal('path/to/file');
+      expect(validator.stringValidator('key=value')).to.equal('key=value');
+    });
+
+    it('should return undefined for null', () => {
+      expect(validator.stringValidator(null)).to.be.undefined;
+    });
+
+    it('should return undefined for undefined', () => {
+      expect(validator.stringValidator(undefined)).to.be.undefined;
+    });
+
+    it('should return undefined for numbers', () => {
+      expect(validator.stringValidator(123)).to.be.undefined;
+      expect(validator.stringValidator(0)).to.be.undefined;
+      expect(validator.stringValidator(-456)).to.be.undefined;
+    });
+
+    it('should return undefined for booleans', () => {
+      expect(validator.stringValidator(true)).to.be.undefined;
+      expect(validator.stringValidator(false)).to.be.undefined;
+    });
+
+    it('should return undefined for objects', () => {
+      expect(validator.stringValidator({})).to.be.undefined;
+      expect(validator.stringValidator([])).to.be.undefined;
+    });
+  });
+
+  describe('validateTruthyBoolean', () => {
+    it('should return true for truthy values', () => {
+      expect(validator.validateTruthyBoolean(true)).to.equal(true);
+      expect(validator.validateTruthyBoolean(1)).to.equal(true);
+      expect(validator.validateTruthyBoolean('any-string')).to.equal(true);
+      expect(validator.validateTruthyBoolean('true')).to.equal(true);
+      expect(validator.validateTruthyBoolean('false')).to.equal(true);
+      expect(validator.validateTruthyBoolean({})).to.equal(true);
+      expect(validator.validateTruthyBoolean([])).to.equal(true);
+      expect(validator.validateTruthyBoolean(123)).to.equal(true);
+    });
+
+    it('should return undefined for falsy values', () => {
+      expect(validator.validateTruthyBoolean(false)).to.be.undefined;
+      expect(validator.validateTruthyBoolean(0)).to.be.undefined;
+      expect(validator.validateTruthyBoolean('')).to.be.undefined;
+      expect(validator.validateTruthyBoolean(null)).to.be.undefined;
+      expect(validator.validateTruthyBoolean(undefined)).to.be.undefined;
+      expect(validator.validateTruthyBoolean(NaN)).to.be.undefined;
+    });
+  });
+});

--- a/packages/core/test/secrets_test.js
+++ b/packages/core/test/secrets_test.js
@@ -304,4 +304,74 @@ describe('secrets with matcher mode', () => {
       expect(matcher('pass')).to.be.false;
     });
   });
+
+  describe('activate', () => {
+    it('should update matcher and keywords when config changes', () => {
+      secrets.init({
+        logger: testUtil.createFakeLogger(),
+        secrets: {
+          matcherMode: 'equals',
+          keywords: ['initialSecret']
+        }
+      });
+
+      expect(secrets.isSecret('initialSecret')).to.be.true;
+      expect(secrets.isSecret('newSecret')).to.be.false;
+
+      secrets.activate({
+        secrets: {
+          matcherMode: 'equals',
+          keywords: ['newSecret', 'anotherSecret']
+        }
+      });
+
+      expect(secrets.isSecret('initialSecret')).to.be.false;
+      expect(secrets.isSecret('newSecret')).to.be.true;
+      expect(secrets.isSecret('anotherSecret')).to.be.true;
+    });
+
+    it('should update matcher mode when config changes', () => {
+      secrets.init({
+        logger: testUtil.createFakeLogger(),
+        secrets: {
+          matcherMode: 'equals',
+          keywords: ['secret']
+        }
+      });
+
+      expect(secrets.isSecret('secret')).to.be.true;
+      expect(secrets.isSecret('SECRET')).to.be.false;
+
+      secrets.activate({
+        secrets: {
+          matcherMode: 'equals-ignore-case',
+          keywords: ['secret']
+        }
+      });
+
+      expect(secrets.isSecret('secret')).to.be.true;
+      expect(secrets.isSecret('SECRET')).to.be.true;
+    });
+
+    it('should not update when only partial config provided', () => {
+      secrets.init({
+        logger: testUtil.createFakeLogger(),
+        secrets: {
+          matcherMode: 'contains-ignore-case',
+          keywords: ['password']
+        }
+      });
+
+      expect(secrets.isSecret('mypassword')).to.be.true;
+
+      secrets.activate({
+        secrets: {
+          keywords: ['token']
+        }
+      });
+
+      expect(secrets.isSecret('mypassword')).to.be.true;
+      expect(secrets.isSecret('mytoken')).to.be.false;
+    });
+  });
 });

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -273,7 +273,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     function initAndActivate(initConfig, extraConfigForActivate) {
       const logger = testUtils.createFakeLogger();
       coreConfig.init(logger);
-      const config = coreConfig.normalize(initConfig);
+      const config = coreConfig.normalize({ userConfig: initConfig });
       util.init(config);
       tracing.init(config);
       tracing.activate(extraConfigForActivate);

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -193,7 +193,7 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           expect(activateStubRdKafka).to.have.been.called;
         });
 
-        it.skip('should prefer env vars over config.tracing.disable', () => {
+        it('should prefer env vars over config.tracing.disable', () => {
           process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'grpc,kafkajs';
           initAndActivate({ tracing: { disable: { instrumentations: ['aws-sdk/v2'] } } });
 

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -155,8 +155,8 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
             }
           };
           initAndActivate({}, extraConfigFromAgent);
-          expect(activateStubKafkaJs).to.have.been.calledWith(extraConfigFromAgent);
-          expect(activateStubRdKafka).to.have.been.calledWith(extraConfigFromAgent);
+          expect(activateStubKafkaJs).to.have.been.called;
+          expect(activateStubRdKafka).to.have.been.called;
         });
 
         it('should disable aws-sdk/v3 via config', () => {
@@ -273,10 +273,12 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
     function initAndActivate(initConfig, extraConfigForActivate) {
       const logger = testUtils.createFakeLogger();
       coreConfig.init(logger);
-      const config = coreConfig.normalize({ userConfig: initConfig });
+      let config = coreConfig.normalize({ userConfig: initConfig });
       util.init(config);
       tracing.init(config);
-      tracing.activate(extraConfigForActivate);
+
+      config = coreConfig.update(extraConfigForActivate, 3);
+      tracing.activate(config);
     }
   });
 });

--- a/packages/core/test/tracing/index_test.js
+++ b/packages/core/test/tracing/index_test.js
@@ -193,18 +193,18 @@ mochaSuiteFn('[UNIT] tracing/index', function () {
           expect(activateStubRdKafka).to.have.been.called;
         });
 
-        it('should prefer config.tracing.disable over env vars', () => {
+        it.skip('should prefer env vars over config.tracing.disable', () => {
           process.env.INSTANA_TRACING_DISABLE_INSTRUMENTATIONS = 'grpc,kafkajs';
           initAndActivate({ tracing: { disable: { instrumentations: ['aws-sdk/v2'] } } });
 
-          expect(initAwsSdkv2).not.to.have.been.called;
-          expect(activateAwsSdkv2).not.to.have.been.called;
+          expect(initAwsSdkv2).to.have.been.called;
+          expect(activateAwsSdkv2).to.have.been.called;
 
           expect(initStubGrpcJs).to.have.been.called;
           expect(activateStubGrpcJs).to.have.been.called;
 
-          expect(initStubKafkaJs).to.have.been.called;
-          expect(activateStubKafkaJs).to.have.been.called;
+          expect(initStubKafkaJs).not.to.have.been.called;
+          expect(activateStubKafkaJs).not.to.have.been.called;
         });
 
         it('should disable all instrumentations in specified groups', () => {

--- a/packages/core/test/tracing/spanBuffer_test.js
+++ b/packages/core/test/tracing/spanBuffer_test.js
@@ -46,7 +46,13 @@ describe('tracing/spanBuffer', () => {
     });
 
     beforeEach(() => {
-      spanBuffer.activate();
+      downstreamConnectionStub.sendSpans.resetHistory();
+      spanBuffer.setTransmitImmediate(false);
+      spanBuffer.activate({
+        tracing: {
+          spanBatchingEnabled: false
+        }
+      });
       expect(global.setTimeout.called).to.be.false;
 
       global.setTimeout.resetHistory();
@@ -124,7 +130,13 @@ describe('tracing/spanBuffer', () => {
     });
 
     beforeEach(() => {
-      spanBuffer.activate();
+      downstreamConnectionStub.sendSpans.resetHistory();
+      spanBuffer.setTransmitImmediate(false);
+      spanBuffer.activate({
+        tracing: {
+          spanBatchingEnabled: false
+        }
+      });
       expect(global.setTimeout.called).to.be.true;
       global.setTimeout.resetHistory();
     });
@@ -217,7 +229,14 @@ describe('tracing/spanBuffer', () => {
         spanBuffer.addBatchableSpanName('batchable');
       });
 
-      beforeEach(() => spanBuffer.activate());
+      beforeEach(() => {
+        spanBuffer.setTransmitImmediate(false);
+        spanBuffer.activate({
+          tracing: {
+            spanBatchingEnabled: true
+          }
+        });
+      });
 
       afterEach(() => spanBuffer.deactivate());
 
@@ -563,7 +582,14 @@ describe('tracing/spanBuffer', () => {
         spanBuffer.addBatchableSpanName('batchable');
       });
 
-      beforeEach(() => spanBuffer.activate());
+      beforeEach(() => {
+        spanBuffer.setTransmitImmediate(false);
+        spanBuffer.activate({
+          tracing: {
+            spanBatchingEnabled: false
+          }
+        });
+      });
 
       afterEach(() => spanBuffer.deactivate());
 
@@ -574,7 +600,14 @@ describe('tracing/spanBuffer', () => {
     });
 
     describe('when applying span transformations', () => {
-      beforeEach(() => spanBuffer.activate());
+      beforeEach(() => {
+        spanBuffer.setTransmitImmediate(false);
+        spanBuffer.activate({
+          tracing: {
+            spanBatchingEnabled: false
+          }
+        });
+      });
 
       afterEach(() => spanBuffer.deactivate());
       const span = {

--- a/packages/core/test/util/disableInstrumentation_test.js
+++ b/packages/core/test/util/disableInstrumentation_test.js
@@ -387,31 +387,6 @@ describe('util.disableInstrumentation', () => {
       expect(consoleResult).to.be.true;
     });
 
-    it('should accept service configuration and agent configuration when both are present', () => {
-      disableInstrumentation.init({
-        tracing: {
-          disable: { instrumentations: ['console'] }
-        }
-      });
-      disableInstrumentation.activate({
-        tracing: {
-          disable: { instrumentations: ['bunyan'] }
-        }
-      });
-
-      const consoleResult = disableInstrumentation.isInstrumentationDisabled({
-        instrumentationKey: './instrumentation/logging/console',
-        instrumentationModules: testInstrumentationModules
-      });
-      const bunyanResult = disableInstrumentation.isInstrumentationDisabled({
-        instrumentationKey: './instrumentation/logging/bunyan',
-        instrumentationModules: testInstrumentationModules
-      });
-
-      expect(consoleResult).to.be.true;
-      expect(bunyanResult).to.be.true;
-    });
-
     it('should use agent configuration when service configuration is empty', () => {
       disableInstrumentation.init({});
       disableInstrumentation.activate({


### PR DESCRIPTION
BREAKING CHANGES:

- The configuration precedence is updated. The new configuration precedence order is:

  `environment variables > in-code configuration > agent configuration > default values`

see: https://github.com/instana/nodejs/pull/2432

- The environment variable **`INSTANA_DEV_MIN_DELAY_BEFORE_SENDING_SPANS`** is removed. Use **`INSTANA_TRACING_TRANSMISSION_DELAY`** instead.

public docs any updates: https://github.ibm.com/instana/docs/pull/19776/files


ref https://jsw.ibm.com/browse/INSTA-82558

Before release

- [x] Test config precedence maunally e2e
- [x] merge https://github.com/instana/nodejs/pull/2432
- [x] create v5 branch from main
- [x] Merge this PR to main

After release

- [x]  Public doc release
- [x]  Prepare Release notes

