### PR TITLE
chore: removed latest tag from v5

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,10 +81,10 @@ jobs:
             git --no-pager diff --cached
             git --no-pager diff
           elif [[ $FROM_PACKAGE = true ]]; then
-            npx lerna publish --yes --no-verify-access from-package
+            npx lerna publish  --dist-tag v5 --yes --no-verify-access from-package
             git log -p -n1
           else
-            npx lerna publish --yes --no-verify-access
+            npx lerna publish  --dist-tag v5 --yes --no-verify-access
             git log -p -n1
           fi
 

--- a/packages/serverless/ci/pipeline.yaml
+++ b/packages/serverless/ci/pipeline.yaml
@@ -27,7 +27,8 @@ resources:
     icon: docker
     source:
       repository: us.icr.io/instana-tracer-nodejs/concourse-dind-nodejs-aws-jq
-      tag: latest
+      # NOTE: Deliberately omitting `tag: latest` here on the branch for 5.x so
+      # we do not accidentally tag 5.x image versions with `latest`.
       username: iamapikey
       password: ((team-nodejs-ibm-cloud-icr-api-key))
 
@@ -47,7 +48,8 @@ resources:
       repository: icr.io/instana/aws-fargate-nodejs
       username: ((concourse-icr-containers-public.apikey))
       password: ((concourse-icr-containers-public.password))
-      tag: latest
+     # NOTE: Deliberately omitting `tag: latest` here on the branch for 5.x so
+      # we do not accidentally tag 5.x image versions with `latest`.
 
   - name: instana-google-cloud-run-npm-package
     type: npm-resource
@@ -65,7 +67,8 @@ resources:
       repository: icr.io/instana/google-cloud-run-nodejs
       username: ((concourse-icr-containers-public.apikey))
       password: ((concourse-icr-containers-public.password))
-      tag: latest
+      # NOTE: Deliberately omitting `tag: latest` here on the branch for 5.x so 
+      # we do not accidentally tag 5.x image versions with `latest`.
 
   - name: instana-aws-lambda-npm-package
     type: npm-resource
@@ -98,7 +101,8 @@ resources:
       repository: icr.io/instana/azure-container-services-nodejs
       username: ((concourse-icr-containers-public.apikey))
       password: ((concourse-icr-containers-public.password))
-      tag: latest
+      # NOTE: Deliberately omitting `tag: latest` here on the branch for 5.x so 
+      # we do not accidentally tag 5.x image versions with `latest`.
 
 resource_types:
 
@@ -171,6 +175,7 @@ jobs:
       - put: aws-fargate-nodejs-image-icr
         params:
           image: image/image.tar
+          # In fact, on the branch for 5.x, this will be the only tag, not an _additional_ tag.
           additional_tags: instana-aws-fargate-npm-package/version
         get_params:
           skip_download: true
@@ -258,6 +263,7 @@ jobs:
       - put: google-cloud-run-nodejs-image-icr
         params:
           image: image/image.tar
+          # In fact, on the branch for 5.x, this will be the only tag, not an _additional_ tag.
           additional_tags: instana-google-cloud-run-npm-package/version
         get_params:
           skip_download: true
@@ -345,13 +351,15 @@ jobs:
             platform: linux
             inputs:
               - name: nodejs-repository
+            # Passing in PACKAGE_VERSION=5 will use the latest 5.x package and also avoid tagging the resulting
+            # container image as latest.
             run:
               path: entrypoint.sh
               args:
               - bash
               - -ceux
               - |
-                  BUILD_LAYER_WITH=npm \
+                  PACKAGE_VERSION=5 \
                   NO_PROMPT=true \
                   CONTAINER_REGISTRY_USER=iamapikey \
                   CONTAINER_REGISTRY_PASSWORD=((concourse-icr-containers-public.password)) \
@@ -385,13 +393,15 @@ jobs:
             platform: linux
             inputs:
               - name: nodejs-repository
+            # Passing in PACKAGE_VERSION=5 will use the latest 5.x package and also avoid tagging the resulting
+            # container image as latest.
             run:
               path: entrypoint.sh
               args:
               - bash
               - -ceux
               - |
-                  BUILD_LAYER_WITH=npm \
+                  PACKAGE_VERSION=5 \
                   NO_PROMPT=true \
                   SKIP_DOCKER_IMAGE=true \
                   LAMBDA_ARCHITECTURE=arm64 \
@@ -427,13 +437,15 @@ jobs:
             platform: linux
             inputs:
               - name: nodejs-repository
+            # Passing in PACKAGE_VERSION=5 will use the latest 5.x package and also avoid tagging the resulting
+            # container image as latest.
             run:
               path: entrypoint.sh
               args:
               - bash
               - -ceux
               - |
-                  BUILD_LAYER_WITH=npm \
+                  PACKAGE_VERSION=5 \
                   NO_PROMPT=true \
                   SKIP_DOCKER_IMAGE=true \
                   PUBLISH_TO_CHINA_REGIONS=true \
@@ -469,13 +481,15 @@ jobs:
             platform: linux
             inputs:
               - name: nodejs-repository
+            # Passing in PACKAGE_VERSION=5 will use the latest 5.x package and also avoid tagging the resulting
+            # container image as latest.
             run:
               path: entrypoint.sh
               args:
               - bash
               - -ceux
               - |
-                  BUILD_LAYER_WITH=npm \
+                  PACKAGE_VERSION=5 \
                   NO_PROMPT=true \
                   SKIP_DOCKER_IMAGE=true \
                   LAMBDA_ARCHITECTURE=arm64 \
@@ -549,6 +563,7 @@ jobs:
       - put: azure-container-services-nodejs-image-icr
         params:
           image: image/image.tar
+          # In fact, on the branch for 5.x, this will be the only tag, not an _additional_ tag.
           additional_tags: instana-azure-container-services-npm-package/version
         get_params:
           skip_download: true


### PR DESCRIPTION
This change prevents 5.x releases being tagged as latest.

ref: https://github.com/instana/nodejs/pull/2232