### PR TITLE
test: enabled Prisma >v4.x tests for Node.js v26

### DIFF
--- a/currencies.json
+++ b/currencies.json
@@ -1165,22 +1165,19 @@
     "versions": [
       {
         "v": "7.8.0",
-        "node": ">=20.19.0 <23 || >=24 <26",
+        "node": ">=20.19.0 <23 || >=24",
         "skipValidation": true
       },
       {
         "v": "6.19.0",
-        "node": "<26",
         "skipValidation": true
       },
       {
         "v": "4.16.2",
-        "node": "<26",
         "skipValidation": true
       },
       {
         "v": "4.5.0",
-        "node": "<26",
         "skipValidation": true
       }
     ]

--- a/currencies.json
+++ b/currencies.json
@@ -1174,10 +1174,12 @@
       },
       {
         "v": "4.16.2",
+        "node": "<26",
         "skipValidation": true
       },
       {
         "v": "4.5.0",
+        "node": "<26",
         "skipValidation": true
       }
     ]


### PR DESCRIPTION
As part of v26 support, we didabled all prisma versions test against v26.

Prisma v4.x tests fail on CI with Node.js v26 with the following error:
```
Error: Unknown binaryTarget debian-openssl-3.5.x and no custom engine files were provided
```

Node.js v26 ships with OpenSSL 3.5.x. Prisma v4.x  does not include precompiled binaries for the `debian-openssl-3.5.x` platform target. The issue only affects Debian-based Linux, Linux requires exact OpenSSL version matches in binary target names (e.g., `debian-openssl-3.0.x`, `debian-openssl-3.5.x`).


ref https://jsw.ibm.com/browse/INSTA-89970