### PR TITLE
test: added node constraint for native esm test

### DIFF
--- a/packages/collector/test/integration/misc/native_esm/test_base.js
+++ b/packages/collector/test/integration/misc/native_esm/test_base.js
@@ -4,16 +4,20 @@
 
 'use strict';
 
+const semver = require('semver');
 const expect = require('chai').expect;
 const config = require('@_local/core/test/config');
 const { retry, verifyEntrySpan } = require('@_local/core/test/test_util');
 const ProcessControls = require('@_local/collector/test/test_util/ProcessControls');
 const globalAgent = require('@_local/collector/test/globalAgent');
 const constants = require('@_local/core').tracing.constants;
+const { supportedVersion } = require('@instana/core').tracing;
 const path = require('path');
 
 module.exports = function () {
-  describe('tracing/native-esm modules', function () {
+  const supportsRequireESM = semver.gte(process.versions.node, '20.19.0');
+  const mochaSuiteFn = supportedVersion(process.versions.node) && supportsRequireESM ? describe : describe.skip;
+  mochaSuiteFn('tracing/native-esm modules', function () {
     this.timeout(config.getTestTimeout());
 
     globalAgent.setUpCleanUpHooks();


### PR DESCRIPTION
v18 tests failing

```
@instana/collector: node:internal/modules/cjs/loader:1200
@instana/collector:     throw new ERR_REQUIRE_ESM(filename, true);
@instana/collector:     ^
@instana/collector: Error [ERR_REQUIRE_ESM]: require() of ES Module /artifacts/node_modules/square-calc/index.mjs not supported.
@instana/collector: Instead change the require of /artifacts/node_modules/square-calc/index.mjs to a dynamic import() which is available in all CommonJS modules.
@instana/collector:     at Function.patchedModuleLoad [as _load] (/artifacts/packages/collector/test/integration/misc/native_esm/_v1.0.0/node_modules/@instana/core/src/util/requireHook.js:94:34)
@instana/collector:     at Object.<anonymous> (/artifacts/packages/collector/test/integration/misc/native_esm/_v1.0.0/app.js:18:25) {
@instana/collector:   code: 'ERR_REQUIRE_ESM'
@instana/collector: }
@instana/collector: Node.js v18.20.8
```

require(esm) support from v20.19. Added the constraint.