### PR TITLE
Revert "fix: bumped @opentelemetry/instrumentation-tedious from 0.28.0 to 0.37.0 (#2594)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11863,7 +11863,6 @@
       "version": "0.208.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
       "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -12026,7 +12025,6 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.28.0.tgz",
       "integrity": "sha512-nQ9k1Bdk2yG4SPRuHZ+QVcc3YMm2sfsBV1MQIc/Y/OcN83Q+jA7gXgYgYIblQ1wI+/RtKlJpdl6hobAXuj+pSA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.208.0",
@@ -12044,7 +12042,6 @@
       "version": "0.208.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.208.0.tgz",
       "integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.208.0",
@@ -33740,7 +33737,7 @@
         "@opentelemetry/instrumentation-oracledb": "0.43.0",
         "@opentelemetry/instrumentation-restify": "0.63.0",
         "@opentelemetry/instrumentation-socket.io": "0.65.0",
-        "@opentelemetry/instrumentation-tedious": "0.37.0",
+        "@opentelemetry/instrumentation-tedious": "0.28.0",
         "@opentelemetry/sdk-trace-base": "2.8.0",
         "cls-bluebird": "^2.1.0",
         "import-in-the-middle": "2.0.5",
@@ -33853,23 +33850,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.218.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "packages/core/node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.37.0.tgz",
-      "integrity": "sha512-cGLF46UsgeI1334atJxLO36yQlV7WXKg35Mp+e2NXo2vOTfIZTVqoKOzExVOTOwT4AQjfGVEDxyq5wXybUYXIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.218.0",
-        "@opentelemetry/semantic-conventions": "^1.33.0",
-        "@types/tedious": "^4.0.14"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,7 +65,7 @@
     "@opentelemetry/instrumentation-oracledb": "0.43.0",
     "@opentelemetry/instrumentation-restify": "0.63.0",
     "@opentelemetry/instrumentation-socket.io": "0.65.0",
-    "@opentelemetry/instrumentation-tedious": "0.37.0",
+    "@opentelemetry/instrumentation-tedious": "0.28.0",
     "@opentelemetry/sdk-trace-base": "2.8.0",
     "cls-bluebird": "^2.1.0",
     "import-in-the-middle": "2.0.5",


### PR DESCRIPTION
## Current Status

While investigating, it also appears that `@opentelemetry/instrumentation-tedious@0.37` may have an issue affecting ESM tracing. This requires additional analysis and will be tracked separately under **[[JIRA](https://jsw.ibm.com/browse/INSTA-97288)]**.

To avoid introducing potential regressions, this PR reverts `@opentelemetry/instrumentation-tedious` to version `0.28` for now. A follow-up effort will revisit the upgrade once the ESM compatibility issue has been fully understood and addressed.



## Summary

The ESM test started failing after upgrading `@opentelemetry/instrumentation-tedious` from `0.28` to `0.37`.

During the investigation, the primary issue was identified as a package-lock inconsistency combined with duplicate instrumentation loading. The same package was being resolved from both:

* `node_modules/@opentelemetry/instrumentation-tedious`
* `core/node_modules/@opentelemetry/instrumentation-tedious`

As a result, multiple versions of the instrumentation were installed and loaded simultaneously, leading to unexpected behavior in the ESM tests.

After correcting the dependency resolution and updating the lock file, the original test failure appeared to be resolved. But it was a false positive!