### PR TITLE
fix(opentelemetry-exporter): updated otel sdk-trace-base and resource packages to 2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12090,41 +12090,6 @@
         "node": "^18.19.0 || >=20.6.0"
       }
     },
-    "node_modules/@opentelemetry/resources": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.3.0.tgz",
-      "integrity": "sha512-shlr2l5g+87J8wqYlsLyaUsgKVRO7RtX70Ckd5CtDOWtImZgaUDmf4Z2ozuSKQLM2wPDR0TE/3bPVBNJtRm/cQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.3.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.3.0.tgz",
-      "integrity": "sha512-B0TQ2e9h0ETjpI+eGmCz8Ojb+lnYms0SE3jFwEKrN/PK4aSVHU28AAmnOoBmfub+I3jfgPwvDJgomBA5a7QehQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.3.0",
-        "@opentelemetry/resources": "2.3.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.39.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
@@ -33954,9 +33919,9 @@
       },
       "devDependencies": {
         "@opentelemetry/auto-instrumentations-node": "^0.67.3",
-        "@opentelemetry/resources": "^2.3.0",
+        "@opentelemetry/resources": "^2.8.0",
         "@opentelemetry/sdk-node": "^0.209.0",
-        "@opentelemetry/sdk-trace-base": "^2.3.0",
+        "@opentelemetry/sdk-trace-base": "^2.8.0",
         "@opentelemetry/semantic-conventions": "^1.38.0"
       },
       "engines": {
@@ -35689,6 +35654,23 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "packages/opentelemetry-exporter/node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "packages/opentelemetry-exporter/node_modules/@opentelemetry/sdk-node": {
       "version": "0.209.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.209.0.tgz",
@@ -36458,6 +36440,23 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "packages/opentelemetry-exporter/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.3.0.tgz",
+      "integrity": "sha512-shlr2l5g+87J8wqYlsLyaUsgKVRO7RtX70Ckd5CtDOWtImZgaUDmf4Z2ozuSKQLM2wPDR0TE/3bPVBNJtRm/cQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.3.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "packages/opentelemetry-exporter/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-logs": {
       "version": "0.209.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.209.0.tgz",
@@ -36491,6 +36490,24 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "packages/opentelemetry-exporter/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.3.0.tgz",
+      "integrity": "sha512-B0TQ2e9h0ETjpI+eGmCz8Ojb+lnYms0SE3jFwEKrN/PK4aSVHU28AAmnOoBmfub+I3jfgPwvDJgomBA5a7QehQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.3.0",
+        "@opentelemetry/resources": "2.3.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "packages/opentelemetry-exporter/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-node": {
@@ -36534,6 +36551,24 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "packages/opentelemetry-exporter/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "packages/opentelemetry-exporter/node_modules/@types/connect": {

--- a/packages/opentelemetry-exporter/package.json
+++ b/packages/opentelemetry-exporter/package.json
@@ -62,9 +62,9 @@
   },
   "devDependencies": {
     "@opentelemetry/auto-instrumentations-node": "^0.67.3",
-    "@opentelemetry/resources": "^2.3.0",
+    "@opentelemetry/resources": "^2.8.0",
     "@opentelemetry/sdk-node": "^0.209.0",
-    "@opentelemetry/sdk-trace-base": "^2.3.0",
+    "@opentelemetry/sdk-trace-base": "^2.8.0",
     "@opentelemetry/semantic-conventions": "^1.38.0"
   }
 }


### PR DESCRIPTION
Recently we updated some OTEL core packages, including sdk-trace-base and resources packages for npm audit fix.

The current changes updates the same packages in opentelemetry-exporter dependencies
