### PR TITLE
revert: make agent data port configurable independently from the agent connection port

### DIFF
--- a/packages/collector/src/agent/opts.js
+++ b/packages/collector/src/agent/opts.js
@@ -12,8 +12,6 @@ exports.requestTimeout = 5000;
 exports.host = '127.0.0.1';
 // @ts-ignore - Cannot redeclare exported variable
 exports.port = 42699;
-// @ts-ignore - Cannot redeclare exported variable
-exports.dataPort = 42699;
 /** @type {string} */
 exports.agentUuid = undefined;
 // @ts-ignore - Cannot redeclare exported variable
@@ -32,8 +30,6 @@ exports.init = function init(config) {
   exports.host = config.agentHost;
   // @ts-ignore - Cannot redeclare exported variable
   exports.port = config.agentPort;
-  // @ts-ignore - Cannot redeclare exported variable
-  exports.dataPort = config.agentDataPort;
 
   // TODO: Why is autoProfile part of agentOpts? O_o
   // @ts-ignore - Cannot redeclare exported variable

--- a/packages/collector/src/agentConnection.js
+++ b/packages/collector/src/agentConnection.js
@@ -133,7 +133,6 @@ exports.announceNodeCollector = function announceNodeCollector(callback) {
 
   logger.debug(`Announcing the Node.js collector to the Instana host agent at ${agentOpts.host}:${agentOpts.port}`);
 
-  // Agent announcement uses agentOpts.port (agent connection port)
   const req = http.request(
     {
       host: agentOpts.host,
@@ -236,8 +235,6 @@ exports.sendLogToAgent = function sendLogToAgent(logLevel, message, stackTrace) 
 
   const payload = Buffer.from(JSON.stringify(payloadObject), 'utf8');
 
-  // Log forwarding uses agentOpts.port (agent connection port) for now
-  // this can be customized if we use OTLP transformation for logs in the future
   const req = http.request(
     {
       host: agentOpts.host,
@@ -274,7 +271,6 @@ exports.sendLogToAgent = function sendLogToAgent(logLevel, message, stackTrace) 
 function checkWhetherResponseForPathIsOkay(path, cb) {
   cb = util.atMostOnce('callback for checkWhetherResponseForPathIsOkay', cb);
 
-  // Agent readiness check uses agentOpts.port (agent connection port)
   const req = http.request(
     {
       host: agentOpts.host,
@@ -456,12 +452,10 @@ function sendData(path, data, cb, ignore404 = false) {
     return setImmediate(cb.bind(null, error));
   }
 
-  // Use dataPort for sending all telemetry data (metrics, spans, profiles, events, etc.)
-  // dataPort defaults to agentPort but can be configured separately for future use cases (e.g., OTel format)
   const req = http.request(
     {
       host: agentOpts.host,
-      port: agentOpts.dataPort,
+      port: agentOpts.port,
       path,
       method: 'POST',
       agent: http.agent,

--- a/packages/collector/src/types/collector.d.ts
+++ b/packages/collector/src/types/collector.d.ts
@@ -24,7 +24,6 @@ export interface AgentConfig {
 export interface CollectorConfig {
   agentPort?: number;
   agentHost?: string;
-  agentDataPort?: number;
   agentRequestTimeout?: number;
   tracing?: {
     stackTraceLength?: number;

--- a/packages/collector/src/util/normalizeConfig.js
+++ b/packages/collector/src/util/normalizeConfig.js
@@ -30,7 +30,6 @@ module.exports = function normalizeConfig(userConfig = {}) {
   // as extraFinalConfig to core's normalize function.
   finalConfig.agentHost = normalizeAgentHost(userConfig, defaults);
   finalConfig.agentPort = normalizeAgentPort(userConfig, defaults);
-  finalConfig.agentDataPort = normalizeAgentDataPort(userConfig, defaults);
   finalConfig.agentRequestTimeout = normalizeAgentRequestTimeout(userConfig, defaults);
   finalConfig.autoProfile = normalizeAutoProfile(userConfig, defaults);
   finalConfig.reportUnhandledPromiseRejections = normalizeUnhandledRejections(userConfig);
@@ -72,20 +71,6 @@ function normalizeAgentPort(userConfig, defaultConfig) {
     [validate.numberValidator]
   );
   return value;
-}
-
-/**
- * @param {import('../types/collector').CollectorConfig} userConfig
- * @param {{ agentPort: number }} defaultConfig
- * @returns {number}
- */
-function normalizeAgentDataPort(userConfig, defaultConfig) {
-  // Future logic for OTLP enabled check can be added here to determine which port to use
-  // if (userConfig.otlpEnabled) {
-  //   return defaultConfig.otlpPort; // 4317 or 4318
-  // }
-
-  return normalizeAgentPort(userConfig, defaultConfig);
 }
 
 /**

--- a/packages/collector/test/apps/agentStubControls.js
+++ b/packages/collector/test/apps/agentStubControls.js
@@ -101,12 +101,6 @@ class AgentStubControls {
     return this.agentPort;
   }
 
-  getDataPort() {
-    // For now, the agent stub uses the same port for both control and data
-    // In the future, this could be configured separately if needed
-    return this.agentPort;
-  }
-
   async waitUntilAgentHasStarted() {
     const url = `http://127.0.0.1:${this.agentPort}`;
 

--- a/packages/collector/test/integration/misc/agent_connection/test_base.js
+++ b/packages/collector/test/integration/misc/agent_connection/test_base.js
@@ -75,7 +75,6 @@ module.exports = function () {
 
   beforeEach(async () => {
     agentOpts.port = agentControls.getPort();
-    agentOpts.dataPort = agentControls.getPort();
     agentConnection = require('@_local/collector/src/agentConnection');
     pidStore.init(config);
     agentConnection.init(config, pidStore);
@@ -86,7 +85,6 @@ module.exports = function () {
 
   afterEach(() => {
     agentOpts.port = originalPort;
-    agentOpts.dataPort = originalPort;
   });
 
   it('should send traces to agent', done => {


### PR DESCRIPTION
This reverts commit df36f4afd727ce0c2b1f6a9897a0c6e0935f241b.

This change is no longer required. 