### PR TITLE
chore: updated memory for sonar

### DIFF
--- a/.tekton/tasks/tasks-results.yaml
+++ b/.tekton/tasks/tasks-results.yaml
@@ -27,6 +27,13 @@ spec:
     - name: print-all-results
       image: public.ecr.aws/docker/library/node:$(params.node-version)
       imagePullPolicy: IfNotPresent
+      resources:
+        requests:
+          cpu: "1000m"
+          memory: "4Gi"
+        limits:
+          cpu: "2000m"
+          memory: "8Gi"
       env:
         - name: PROPERTIES_FILE
           value: $(params.properties-file)
@@ -35,6 +42,10 @@ spec:
             secretKeyRef:
               name: $(params.continuous-delivery-context-secret)
               key: "SONAR_TOKEN"
+        - name: NODE_OPTIONS
+          value: "--max-old-space-size=6144"
+        - name: SONAR_SCANNER_OPTS
+          value: "-Xmx4g"
       script: |
         #!/bin/bash
 

--- a/.tekton/tasks/tasks-results.yaml
+++ b/.tekton/tasks/tasks-results.yaml
@@ -30,9 +30,6 @@ spec:
       resources:
         requests:
           cpu: "1000m"
-          memory: "4Gi"
-        limits:
-          cpu: "2000m"
           memory: "8Gi"
       env:
         - name: PROPERTIES_FILE

--- a/.tekton/tasks/tasks-results.yaml
+++ b/.tekton/tasks/tasks-results.yaml
@@ -35,10 +35,6 @@ spec:
             secretKeyRef:
               name: $(params.continuous-delivery-context-secret)
               key: "SONAR_TOKEN"
-        - name: NODE_OPTIONS
-          value: "--max-old-space-size=6144"
-        - name: SONAR_SCANNER_OPTS
-          value: "-Xmx4g"
       script: |
         #!/bin/bash
 

--- a/.tekton/tasks/tasks-results.yaml
+++ b/.tekton/tasks/tasks-results.yaml
@@ -27,10 +27,6 @@ spec:
     - name: print-all-results
       image: public.ecr.aws/docker/library/node:$(params.node-version)
       imagePullPolicy: IfNotPresent
-      resources:
-        requests:
-          cpu: "1000m"
-          memory: "8Gi"
       env:
         - name: PROPERTIES_FILE
           value: $(params.properties-file)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -28,7 +28,9 @@ sonar.javascript.lcov.reportPaths=coverage/**/lcov.info
 # ESLint configuration
 sonar.eslint.reportPaths=eslint-report.json
 
-# Code analysis parameters  
+# Code analysis parameters
 sonar.inclusions=**/src/**,**/lib/**
 sonar.exclusions=**/test/**,**/precompile/**,**lcov-report**,node_modules,example-apps/**
 sonar.coverage.exclusions=**/test/**,**/precompile/**,misc/**,example-apps/**
+
+sonar.javascript.node.maxspace=8192

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -28,7 +28,7 @@ sonar.javascript.lcov.reportPaths=coverage/**/lcov.info
 # ESLint configuration
 sonar.eslint.reportPaths=eslint-report.json
 
-# Code analysis parameters
+# Code analysis parameters 
 sonar.inclusions=**/src/**,**/lib/**
 sonar.exclusions=**/test/**,**/precompile/**,**lcov-report**,node_modules,example-apps/**
 sonar.coverage.exclusions=**/test/**,**/precompile/**,misc/**,example-apps/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -33,4 +33,4 @@ sonar.inclusions=**/src/**,**/lib/**
 sonar.exclusions=**/test/**,**/precompile/**,**lcov-report**,node_modules,example-apps/**
 sonar.coverage.exclusions=**/test/**,**/precompile/**,misc/**,example-apps/**
 
-sonar.javascript.node.maxspace=6144
+sonar.javascript.node.maxspace=8192

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -33,4 +33,4 @@ sonar.inclusions=**/src/**,**/lib/**
 sonar.exclusions=**/test/**,**/precompile/**,**lcov-report**,node_modules,example-apps/**
 sonar.coverage.exclusions=**/test/**,**/precompile/**,misc/**,example-apps/**
 
-sonar.javascript.node.maxspace=8192
+sonar.javascript.node.maxspace= 4096

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -33,4 +33,4 @@ sonar.inclusions=**/src/**,**/lib/**
 sonar.exclusions=**/test/**,**/precompile/**,**lcov-report**,node_modules,example-apps/**
 sonar.coverage.exclusions=**/test/**,**/precompile/**,misc/**,example-apps/**
 
-sonar.javascript.node.maxspace= 4096
+sonar.javascript.node.maxspace=6144


### PR DESCRIPTION
We're seeing an issue with SonarCloud coverage. PRs that have coverage enabled may fail with the following error:
`The bridge server is unresponsive. It might be because you don't have enough memory.`

Increases the memory available to the SonarCloud analysis step by:

Increasing the pod memory request to 6 GiB.

- Setting NODE_OPTIONS=--max-old-space-size=6144 to increase the maximum heap size available to the Node.js process used by the Sonar scanner.

- Setting SONAR_SCANNER_OPTS=-Xmx4g to increase the JVM heap size available to the Sonar Scanner.

These changes are intended to prevent out-of-memory conditions during analysis and improve the reliability of SonarCloud coverage processing.