### PR TITLE
refactor: renamed kafka-node span attributes to use internal format

### DIFF
--- a/packages/core/src/tracing/instrumentation/messaging/kafkaNode.js
+++ b/packages/core/src/tracing/instrumentation/messaging/kafkaNode.js
@@ -73,8 +73,8 @@ function instrumentedSend(ctx, originalSend, produceRequests, cb) {
     span.b = { s: produceRequests.length };
     span.stack = tracingUtil.getStackTrace(instrumentedSend);
     span.data.kafka = {
-      service: produceRequest.topic,
-      access: 'send'
+      endpoints: produceRequest.topic,
+      operation: 'send'
     };
 
     args.push(
@@ -124,8 +124,8 @@ function shimEmit(original) {
       });
       span.stack = [];
       span.data.kafka = {
-        access: 'consume',
-        service: message.topic
+        operation: 'consume',
+        endpoints: message.topic
       };
 
       try {


### PR DESCRIPTION
This refactor is needed for the OTLP mapper so that the mapper can rely on internal format

We already have the backend mapper in place, so the end-user functionality is not affected