### PR TITLE
test: renamed internal agent stub environment variables

### DIFF
--- a/example-apps/collector/README.md
+++ b/example-apps/collector/README.md
@@ -16,7 +16,7 @@ If you want to use the agent stub instead of an actual agent, do this:
 ```
 # start the agent stub
 cd nodejs/packages/collector
-DROP_DATA=true npm run agent-stub
+AGENT_STUB_DROP_DATA=true npm run agent-stub
 
 # start the app (in a separate terminal)
 cd nodejs/example-apps/collector

--- a/example-apps/collector/README.md
+++ b/example-apps/collector/README.md
@@ -7,7 +7,7 @@ This is a trivial Node.js application suitable for quick experiments with the @i
 The app can be started via `node .` or `npm start`.
 
 It is configured via environment variables. The default values for the environment variables are in the `.env` file.
-The defaults can be overwritten like this `AGENT_PORT=3210 node .`.
+The defaults can be overwritten like this `AGENT_STUB_PORT=3210 node .`.
 
 ## Using The Agent Stub
 

--- a/packages/collector/package.json
+++ b/packages/collector/package.json
@@ -42,7 +42,7 @@
     "test:ci:long-running": "mocha --config=test/.mocharc.js --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json --require test/hooks.js 'test/integration/misc/long_*/**/*.test.js'",
     "lint": "eslint src test",
     "verify": "npm run lint && npm test",
-    "agent-stub": "AGENT_PORT=3210 node test/apps/agentStub.js",
+    "agent-stub": "AGENT_STUB_PORT=3210 node test/apps/agentStub.js",
     "prettier": "prettier --write 'src/**/*.js' 'test/**/*.js'"
   },
   "keywords": [

--- a/packages/collector/test/apps/agentStub.js
+++ b/packages/collector/test/apps/agentStub.js
@@ -26,7 +26,7 @@ if (process.env.INSTANA_DEBUG === 'true') {
 }
 
 // NOTE: we can leave the hardcoded port here as this file is not used in the test env!
-const port = process.env.AGENT_PORT || 42699;
+const port = process.env.AGENT_STUB_PORT || 42699;
 const uniqueAgentUuids = process.env.AGENT_STUB_AGENT_UNIQUE_UUIDS === 'true';
 const slowHostResponse = process.env.AGENT_STUB_SLOW_HOST_RESPONSE === 'true';
 const extraHeaders = process.env.AGENT_STUB_EXTRA_HEADERS ? process.env.AGENT_STUB_EXTRA_HEADERS.split(',') : [];

--- a/packages/collector/test/apps/agentStub.js
+++ b/packages/collector/test/apps/agentStub.js
@@ -27,26 +27,31 @@ if (process.env.INSTANA_DEBUG === 'true') {
 
 // NOTE: we can leave the hardcoded port here as this file is not used in the test env!
 const port = process.env.AGENT_PORT || 42699;
-const uniqueAgentUuids = process.env.AGENT_UNIQUE_UUIDS === 'true';
-const slowHostResponse = process.env.SLOW_HOST_RESPONSE === 'true';
-const extraHeaders = process.env.EXTRA_HEADERS ? process.env.EXTRA_HEADERS.split(',') : [];
-const secretsMatcher = process.env.SECRETS_MATCHER ? process.env.SECRETS_MATCHER : 'contains-ignore-case';
-const secretsList = process.env.SECRETS_LIST ? process.env.SECRETS_LIST.split(',') : ['pass', 'secret', 'token'];
-const dropAllData = process.env.DROP_DATA === 'true';
-const logTraces = process.env.LOG_TRACES === 'true';
-const logProfiles = process.env.LOG_PROFILES === 'true';
-const rejectTraces = process.env.REJECT_TRACES === 'true';
-const doesntHandleProfiles = process.env.DOESNT_HANDLE_PROFILES === 'true';
-const tracingMetrics = process.env.TRACING_METRICS !== 'false';
-let slowMetricsReply = process.env.SLOW_METRICS_REPLY === 'true';
-const enableSpanBatching = process.env.ENABLE_SPANBATCHING === 'true';
-const kafkaTraceCorrelation = process.env.KAFKA_TRACE_CORRELATION
-  ? process.env.KAFKA_TRACE_CORRELATION === 'true'
+const uniqueAgentUuids = process.env.AGENT_STUB_AGENT_UNIQUE_UUIDS === 'true';
+const slowHostResponse = process.env.AGENT_STUB_SLOW_HOST_RESPONSE === 'true';
+const extraHeaders = process.env.AGENT_STUB_EXTRA_HEADERS ? process.env.AGENT_STUB_EXTRA_HEADERS.split(',') : [];
+const secretsMatcher = process.env.AGENT_STUB_SECRETS_MATCHER
+  ? process.env.AGENT_STUB_SECRETS_MATCHER
+  : 'contains-ignore-case';
+const secretsList = process.env.AGENT_STUB_SECRETS_LIST
+  ? process.env.AGENT_STUB_SECRETS_LIST.split(',')
+  : ['pass', 'secret', 'token'];
+const dropAllData = process.env.AGENT_STUB_DROP_DATA === 'true';
+const logTraces = process.env.AGENT_STUB_LOG_TRACES === 'true';
+const logProfiles = process.env.AGENT_STUB_LOG_PROFILES === 'true';
+const rejectTraces = process.env.AGENT_STUB_REJECT_TRACES === 'true';
+const doesntHandleProfiles = process.env.AGENT_STUB_DOESNT_HANDLE_PROFILES === 'true';
+const tracingMetrics = process.env.AGENT_STUB_TRACING_METRICS !== 'false';
+let slowMetricsReply = process.env.AGENT_STUB_SLOW_METRICS_REPLY === 'true';
+const enableSpanBatching = process.env.AGENT_STUB_ENABLE_SPANBATCHING === 'true';
+const kafkaTraceCorrelation = process.env.AGENT_STUB_KAFKA_TRACE_CORRELATION
+  ? process.env.AGENT_STUB_KAFKA_TRACE_CORRELATION === 'true'
   : null;
-const ignoreEndpoints = process.env.IGNORE_ENDPOINTS && JSON.parse(process.env.IGNORE_ENDPOINTS);
-const disable = process.env.AGENT_DISABLE_TRACING && JSON.parse(process.env.AGENT_DISABLE_TRACING);
-const stackTraceConfig = process.env.STACK_TRACE_CONFIG && JSON.parse(process.env.STACK_TRACE_CONFIG);
-const otlpExporter = process.env.OTLP_EXPORTER && JSON.parse(process.env.OTLP_EXPORTER);
+const ignoreEndpoints = process.env.AGENT_STUB_IGNORE_ENDPOINTS && JSON.parse(process.env.AGENT_STUB_IGNORE_ENDPOINTS);
+const disable = process.env.AGENT_STUB_DISABLE_TRACING && JSON.parse(process.env.AGENT_STUB_DISABLE_TRACING);
+const stackTraceConfig =
+  process.env.AGENT_STUB_STACK_TRACE_CONFIG && JSON.parse(process.env.AGENT_STUB_STACK_TRACE_CONFIG);
+const otlpExporter = process.env.AGENT_STUB_OTLP_EXPORTER && JSON.parse(process.env.AGENT_STUB_OTLP_EXPORTER);
 const httpExitConfig = process.env.AGENT_STUB_HTTP_EXIT_CONFIG && JSON.parse(process.env.AGENT_STUB_HTTP_EXIT_CONFIG);
 
 const uuids = {};

--- a/packages/collector/test/apps/agentStubControls.js
+++ b/packages/collector/test/apps/agentStubControls.js
@@ -22,54 +22,52 @@ class AgentStubControls {
   async startAgent(opts = {}) {
     const env = Object.create(process.env);
     env.AGENT_PORT = this.agentPort;
-    env.EXTRA_HEADERS = (opts.extraHeaders || []).join(',');
-    env.SECRETS_MATCHER = opts.secretsMatcher || 'contains-ignore-case';
-    env.SECRETS_LIST = (opts.secretsList || []).join(',');
-    env.SECRETS_LIST = (opts.secretsList || []).join(',');
-    env.AGENT_UNIQUE_UUIDS = opts.uniqueAgentUuids === true;
+    env.AGENT_STUB_EXTRA_HEADERS = (opts.extraHeaders || []).join(',');
+    env.AGENT_STUB_SECRETS_MATCHER = opts.secretsMatcher || 'contains-ignore-case';
+    env.AGENT_STUB_SECRETS_LIST = (opts.secretsList || []).join(',');
+    env.AGENT_STUB_SECRETS_LIST = (opts.secretsList || []).join(',');
+    env.AGENT_STUB_AGENT_UNIQUE_UUIDS = opts.uniqueAgentUuids === true;
 
     if (opts.rejectTraces) {
-      env.REJECT_TRACES = 'true';
+      env.AGENT_STUB_REJECT_TRACES = 'true';
     }
     if (opts.doesntHandleProfiles) {
-      env.DOESNT_HANDLE_PROFILES = 'true';
+      env.AGENT_STUB_DOESNT_HANDLE_PROFILES = 'true';
     }
     if (typeof opts.tracingMetrics === 'boolean') {
-      env.TRACING_METRICS = opts.tracingMetrics.toString();
+      env.AGENT_STUB_TRACING_METRICS = opts.tracingMetrics.toString();
     }
 
     if (opts.slowMetricsReply) {
-      env.SLOW_METRICS_REPLY = opts.slowMetricsReply.toString();
+      env.AGENT_STUB_SLOW_METRICS_REPLY = opts.slowMetricsReply.toString();
     }
 
     if (opts.slowHostResponse) {
-      env.SLOW_HOST_RESPONSE = opts.slowHostResponse.toString();
+      env.AGENT_STUB_SLOW_HOST_RESPONSE = opts.slowHostResponse.toString();
     }
 
     if (opts.enableSpanBatching) {
-      env.ENABLE_SPANBATCHING = 'true';
+      env.AGENT_STUB_ENABLE_SPANBATCHING = 'true';
     }
     if (opts.kafkaConfig) {
       if (opts.kafkaConfig.traceCorrelation != null) {
-        env.KAFKA_TRACE_CORRELATION = opts.kafkaConfig.traceCorrelation.toString();
+        env.AGENT_STUB_KAFKA_TRACE_CORRELATION = opts.kafkaConfig.traceCorrelation.toString();
       }
     }
-    // This is not the INSTANA_IGNORE_ENDPOINTS env. We  use this "IGNORE_ENDPOINTS" env for the fake agent to
-    // serve the ignore endpoints config to our tracer.
     if (opts.ignoreEndpoints) {
-      env.IGNORE_ENDPOINTS = JSON.stringify(opts.ignoreEndpoints);
+      env.AGENT_STUB_IGNORE_ENDPOINTS = JSON.stringify(opts.ignoreEndpoints);
     }
 
     if (opts.disable) {
-      env.AGENT_DISABLE_TRACING = JSON.stringify(opts.disable);
+      env.AGENT_STUB_DISABLE_TRACING = JSON.stringify(opts.disable);
     }
 
     if (opts.stackTraceConfig) {
-      env.STACK_TRACE_CONFIG = JSON.stringify(opts.stackTraceConfig);
+      env.AGENT_STUB_STACK_TRACE_CONFIG = JSON.stringify(opts.stackTraceConfig);
     }
 
     if (opts.otlpExporter) {
-      env.OTLP_EXPORTER = JSON.stringify(opts.otlpExporter);
+      env.AGENT_STUB_OTLP_EXPORTER = JSON.stringify(opts.otlpExporter);
     }
     if (opts.httpExitConfig) {
       env.AGENT_STUB_HTTP_EXIT_CONFIG = JSON.stringify(opts.httpExitConfig);

--- a/packages/collector/test/apps/agentStubControls.js
+++ b/packages/collector/test/apps/agentStubControls.js
@@ -21,7 +21,7 @@ class AgentStubControls {
 
   async startAgent(opts = {}) {
     const env = Object.create(process.env);
-    env.AGENT_PORT = this.agentPort;
+    env.AGENT_STUB_PORT = this.agentPort;
     env.AGENT_STUB_EXTRA_HEADERS = (opts.extraHeaders || []).join(',');
     env.AGENT_STUB_SECRETS_MATCHER = opts.secretsMatcher || 'contains-ignore-case';
     env.AGENT_STUB_SECRETS_LIST = (opts.secretsList || []).join(',');

--- a/packages/collector/test/apps/express.js
+++ b/packages/collector/test/apps/express.js
@@ -15,7 +15,7 @@ process.on('SIGTERM', () => {
 // latency and response codes. This can be used a baselines for many tests, e.g.
 // to test distributed tracing.
 const instana = require('../..')({
-  agentPort: process.env.AGENT_PORT,
+  agentPort: process.env.AGENT_STUB_PORT,
   tracing: {
     metrics: {
       timeBetweenHealthcheckCalls: 1000

--- a/packages/collector/test/apps/expressControls.js
+++ b/packages/collector/test/apps/expressControls.js
@@ -22,7 +22,7 @@ let appPort;
 // TODO: transform into class
 exports.start = function start(opts = {}, retryTime = null) {
   const env = Object.create(process.env);
-  env.AGENT_PORT = opts.useGlobalAgent ? agentControls.getPort() : opts.agentControls.getPort();
+  env.AGENT_STUB_PORT = opts.useGlobalAgent ? agentControls.getPort() : opts.agentControls.getPort();
   env.APP_PORT = portfinder();
   appPort = env.APP_PORT;
 
@@ -45,7 +45,7 @@ exports.start = function start(opts = {}, retryTime = null) {
   // eslint-disable-next-line no-console
   console.log(
     // eslint-disable-next-line max-len
-    `[ExpressControls:start] starting with port: ${appPort}  and agentPort: ${env.AGENT_PORT}`
+    `[ExpressControls:start] starting with port: ${appPort}  and agentPort: ${env.AGENT_STUB_PORT}`
   );
 
   expressApp = spawn('node', [path.join(__dirname, 'express.js')], {

--- a/packages/collector/test/integration/currencies/async/await/app.js
+++ b/packages/collector/test/integration/currencies/async/await/app.js
@@ -12,7 +12,7 @@ process.on('SIGTERM', () => {
 });
 
 require('@instana/collector')({
-  agentPort: process.env.AGENT_PORT,
+  agentPort: process.env.AGENT_STUB_PORT,
   level: 'warn',
   tracing: {
     forceTransmissionStartingAt: 1

--- a/packages/collector/test/integration/currencies/async/await/controls.js
+++ b/packages/collector/test/integration/currencies/async/await/controls.js
@@ -22,7 +22,7 @@ exports.start = opts => {
   opts = opts || {};
 
   const env = Object.create(process.env);
-  env.AGENT_PORT = opts.useGlobalAgent ? agentControls.getPort() : opts.agentControls.getPort();
+  env.AGENT_STUB_PORT = opts.useGlobalAgent ? agentControls.getPort() : opts.agentControls.getPort();
   env.APP_PORT = portfinder();
 
   appPort = env.APP_PORT;
@@ -33,7 +33,7 @@ exports.start = opts => {
   // eslint-disable-next-line no-console
   console.log(
     // eslint-disable-next-line max-len
-    `[AsyncAwaitControls] starting with port: ${appPort}, upstreamPort: ${env.UPSTREAM_PORT} and agentPort: ${env.AGENT_PORT}`
+    `[AsyncAwaitControls] starting with port: ${appPort}, upstreamPort: ${env.UPSTREAM_PORT} and agentPort: ${env.AGENT_STUB_PORT}`
   );
 
   expressApp = spawn('node', [path.join(__dirname, 'app.js')], {

--- a/packages/collector/test/integration/currencies/messaging/amqplib/consumerCallbacks.js
+++ b/packages/collector/test/integration/currencies/messaging/amqplib/consumerCallbacks.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_STUB_PORT;
 const instana = require('@instana/collector')({
   agentPort,
   level: 'warn',

--- a/packages/collector/test/integration/currencies/messaging/amqplib/consumerControls.js
+++ b/packages/collector/test/integration/currencies/messaging/amqplib/consumerControls.js
@@ -18,7 +18,7 @@ exports.registerTestHooks = opts => {
     opts = opts || {};
 
     const env = Object.create(process.env);
-    env.AGENT_PORT = agentPort;
+    env.AGENT_STUB_PORT = agentPort;
     env.TRACING_ENABLED = 'enableTracing' in opts ? opts.enableTracing : true;
     env.INSTANA_RETRY_AGENT_CONNECTION_IN_MS = 100;
 

--- a/packages/collector/test/integration/currencies/messaging/amqplib/consumerPromises.js
+++ b/packages/collector/test/integration/currencies/messaging/amqplib/consumerPromises.js
@@ -9,7 +9,7 @@
 
 const expect = require('chai').expect;
 
-const agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_STUB_PORT;
 const instana = require('@instana/collector')({
   agentPort,
   level: 'warn',

--- a/packages/collector/test/integration/currencies/messaging/amqplib/publisherCallbacks.js
+++ b/packages/collector/test/integration/currencies/messaging/amqplib/publisherCallbacks.js
@@ -13,7 +13,7 @@ process.on('SIGTERM', () => {
   process.exit(0);
 });
 
-const agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_STUB_PORT;
 require('@instana/collector')({
   agentPort,
   level: 'warn',

--- a/packages/collector/test/integration/currencies/messaging/amqplib/publisherControls.js
+++ b/packages/collector/test/integration/currencies/messaging/amqplib/publisherControls.js
@@ -22,7 +22,7 @@ exports.registerTestHooks = opts => {
     opts = opts || {};
 
     const env = Object.create(process.env);
-    env.AGENT_PORT = agentControls.getPort();
+    env.AGENT_STUB_PORT = agentControls.getPort();
     env.APP_PORT = portfinder();
     appPort = env.APP_PORT;
     env.TRACING_ENABLED = 'enableTracing' in opts ? opts.enableTracing : true;

--- a/packages/collector/test/integration/currencies/messaging/amqplib/publisherPromises.js
+++ b/packages/collector/test/integration/currencies/messaging/amqplib/publisherPromises.js
@@ -13,7 +13,7 @@ process.on('SIGTERM', () => {
   process.exit(0);
 });
 
-const agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_STUB_PORT;
 require('@instana/collector')({
   agentPort,
   level: 'warn',

--- a/packages/collector/test/integration/currencies/protocols/http/proxy/expressProxy.js
+++ b/packages/collector/test/integration/currencies/protocols/http/proxy/expressProxy.js
@@ -16,7 +16,7 @@ process.on('SIGTERM', () => {
 // to test distributed tracing.
 
 const instanaConfig = {
-  agentPort: process.env.AGENT_PORT,
+  agentPort: process.env.AGENT_STUB_PORT,
   level: 'warn',
   tracing: {
     enabled: true,

--- a/packages/collector/test/integration/currencies/protocols/http/proxy/expressProxyControls.js
+++ b/packages/collector/test/integration/currencies/protocols/http/proxy/expressProxyControls.js
@@ -48,7 +48,7 @@ exports.getPort = () => appPort;
 
 exports.start = async (opts = {}) => {
   const env = Object.create(process.env);
-  env.AGENT_PORT = opts.useGlobalAgent ? agentControls.getPort() : opts.agentControls.getPort();
+  env.AGENT_STUB_PORT = opts.useGlobalAgent ? agentControls.getPort() : opts.agentControls.getPort();
   env.APP_PORT = portfinder();
   appPort = env.APP_PORT;
 

--- a/packages/collector/test/integration/misc/logger_spans/app-receives-bunyan-logger.js
+++ b/packages/collector/test/integration/misc/logger_spans/app-receives-bunyan-logger.js
@@ -13,7 +13,7 @@ process.on('SIGTERM', () => {
   process.exit(0);
 });
 
-const agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_STUB_PORT;
 const instana = require('@instana/collector')({
   agentPort,
   level: 'info',

--- a/packages/collector/test/integration/misc/logger_spans/app-receives-custom-dummy-logger.js
+++ b/packages/collector/test/integration/misc/logger_spans/app-receives-custom-dummy-logger.js
@@ -13,7 +13,7 @@ process.on('SIGTERM', () => {
   process.exit(0);
 });
 
-const agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_STUB_PORT;
 
 const instana = require('@instana/collector')({
   agentPort,

--- a/packages/collector/test/integration/misc/logger_spans/app-receives-log4js-logger.js
+++ b/packages/collector/test/integration/misc/logger_spans/app-receives-log4js-logger.js
@@ -12,7 +12,7 @@ process.on('SIGTERM', () => {
   process.exit(0);
 });
 
-const agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_STUB_PORT;
 const instana = require('@instana/collector')({
   agentPort,
   level: 'info',

--- a/packages/collector/test/integration/misc/logger_spans/app-receives-pino-logger.js
+++ b/packages/collector/test/integration/misc/logger_spans/app-receives-pino-logger.js
@@ -12,7 +12,7 @@ process.on('SIGTERM', () => {
   process.exit(0);
 });
 
-const agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_STUB_PORT;
 const createCustomLogSpans = process.env.CREATE_CUSTOM_LOG_SPANS === 'true';
 const extendedLoggerConfig = process.env.EXTENDED_LOGGER_CONFIG === 'true';
 const pinoExtendedFormat = require('@elastic/ecs-pino-format');

--- a/packages/collector/test/integration/misc/logger_spans/app-receives-winston-logger.js
+++ b/packages/collector/test/integration/misc/logger_spans/app-receives-winston-logger.js
@@ -12,7 +12,7 @@ process.on('SIGTERM', () => {
   process.exit(0);
 });
 
-const agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_STUB_PORT;
 const instana = require('@instana/collector')({
   agentPort,
   level: 'info',

--- a/packages/collector/test/integration/misc/logger_spans/app-uses-default-logger.js
+++ b/packages/collector/test/integration/misc/logger_spans/app-uses-default-logger.js
@@ -13,7 +13,7 @@ process.on('SIGTERM', () => {
   process.exit(0);
 });
 
-const agentPort = process.env.AGENT_PORT;
+const agentPort = process.env.AGENT_STUB_PORT;
 
 const instana = require('@instana/collector');
 instana({

--- a/packages/collector/test/integration/misc/logger_spans/controls.js
+++ b/packages/collector/test/integration/misc/logger_spans/controls.js
@@ -64,7 +64,7 @@ class AppControls {
   async start(opts = {}) {
     let env = Object.create(process.env);
 
-    env.AGENT_PORT = agentControls.getPort();
+    env.AGENT_STUB_PORT = agentControls.getPort();
     env.APP_PORT = this.appPort;
     env.UPSTREAM_PORT = expressControls.getPort();
     env.STACK_TRACE_LENGTH = opts.stackTraceLength || 0;

--- a/packages/collector/test/integration/misc/open_tracing/app.js
+++ b/packages/collector/test/integration/misc/open_tracing/app.js
@@ -14,7 +14,7 @@ process.on('SIGTERM', () => {
 const instana = require('@instana/collector');
 
 instana({
-  agentPort: process.env.AGENT_PORT,
+  agentPort: process.env.AGENT_STUB_PORT,
   level: 'warn',
   serviceName: 'theFancyServiceYouWouldntBelieveActuallyExists',
   tracing: {

--- a/packages/collector/test/integration/misc/open_tracing/controls.js
+++ b/packages/collector/test/integration/misc/open_tracing/controls.js
@@ -21,7 +21,7 @@ exports.registerTestHooks = opts => {
     opts = opts || {};
 
     const env = Object.create(process.env);
-    env.AGENT_PORT = agentControls.getPort();
+    env.AGENT_STUB_PORT = agentControls.getPort();
     env.APP_PORT = portfinder();
     appPort = env.APP_PORT;
     env.TRACING_ENABLED = opts.enableTracing !== false;

--- a/packages/collector/test/integration/misc/sdk/examples/README.md
+++ b/packages/collector/test/integration/misc/sdk/examples/README.md
@@ -20,7 +20,7 @@ The SDK will only actually create spans when `@instana/collector` has establishe
 
 If you are not interested in inspecting the reported data in Instana, you can start
 ```
-DROP_DATA=true node packages/collector/test/apps/agentStub
+AGENT_STUB_DROP_DATA=true node packages/collector/test/apps/agentStub
 ```
 
 in a separate shell. Otherwise, start an Instana agent locally. Be aware that the examples will create a lot of spans very quickly, though. (This can be controlled with the `DELAY` environment variable, see below.`)

--- a/packages/serverless/test/backend_stub/index.js
+++ b/packages/serverless/test/backend_stub/index.js
@@ -40,7 +40,7 @@ let unresponsive = process.env.BACKEND_UNRESPONSIVE === 'true';
 
 const app = express();
 
-const dropAllData = process.env.DROP_DATA === 'true';
+const dropAllData = process.env.AGENT_STUB_DROP_DATA === 'true';
 let receivedData = resetReceivedData();
 
 if (process.env.WITH_STDOUT) {


### PR DESCRIPTION
The environment variable names were confusing and did not clearly indicate that they are specific to the agent configuration used by the internal agent stub in the test setup.

Renamed all agent stub environment variables to make their scope clearer.