### PR TITLE
fix(winston): avoid wrapping error logger method twice

### DIFF
--- a/packages/core/src/tracing/instrumentation/logging/winston.js
+++ b/packages/core/src/tracing/instrumentation/logging/winston.js
@@ -50,7 +50,6 @@ function instrumentWinston3(createLogger) {
     shimLevelMethod(derivedLogger, 'emerg', true);
     shimLevelMethod(derivedLogger, 'alert', true);
     shimLevelMethod(derivedLogger, 'crit', true);
-    shimLevelMethod(derivedLogger, 'error', true);
     shimLevelMethod(derivedLogger, 'warning', false);
 
     shimLogMethod(derivedLogger);


### PR DESCRIPTION
Removed the duplicate `error` shim registration from the Winston instrumentation to avoid wrapping the same method twice.