### PR TITLE
feat(bunyan): added option to capture info logs

### DIFF
--- a/packages/collector/test/integration/currencies/logging/bunyan/bunyanApp.js
+++ b/packages/collector/test/integration/currencies/logging/bunyan/bunyanApp.js
@@ -40,7 +40,7 @@ app.get('/', (req, res) => {
 });
 
 app.get('/info', (req, res) => {
-  logger.info('Info message - must not be traced.');
+  logger.info('Info message - must not be traced by default.');
   finish(res);
 });
 

--- a/packages/collector/test/integration/currencies/logging/bunyan/bunyanApp.mjs
+++ b/packages/collector/test/integration/currencies/logging/bunyan/bunyanApp.mjs
@@ -41,7 +41,7 @@ app.get('/', (req, res) => {
 });
 
 app.get('/info', (req, res) => {
-  logger.info('Info message - must not be traced.');
+  logger.info('Info message - must not be traced by default.');
   finish(res);
 });
 

--- a/packages/collector/test/integration/currencies/logging/bunyan/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/bunyan/test_base.js
@@ -154,7 +154,7 @@ module.exports = function (name, version, isLatest) {
         });
     });
 
-    describe('log span capture respects INSTANA_LOG_LEVEL_CAPTURE', () => {
+    describe('log span capture respects INSTANA_TRACING_CAPTURE_LOG_LEVEL', () => {
       let customControls;
 
       async function start(level) {
@@ -163,7 +163,7 @@ module.exports = function (name, version, isLatest) {
           appName: 'bunyanApp',
           useGlobalAgent: true,
           env: {
-            INSTANA_LOG_LEVEL_CAPTURE: level,
+            INSTANA_TRACING_CAPTURE_LOG_LEVEL: level,
             LIBRARY_LATEST: isLatest,
             LIBRARY_VERSION: version,
             LIBRARY_NAME: name

--- a/packages/collector/test/integration/currencies/logging/bunyan/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/bunyan/test_base.js
@@ -153,6 +153,133 @@ module.exports = function (name, version, isLatest) {
           }
         });
     });
+
+    describe('log span capture respects INSTANA_LOG_LEVEL_CAPTURE', () => {
+      let customControls;
+
+      async function start(level) {
+        customControls = new ProcessControls({
+          dirname: __dirname,
+          appName: 'bunyanApp',
+          useGlobalAgent: true,
+          env: {
+            INSTANA_LOG_LEVEL_CAPTURE: level,
+            LIBRARY_LATEST: isLatest,
+            LIBRARY_VERSION: version,
+            LIBRARY_NAME: name
+          }
+        });
+
+        await customControls.startAndWaitForAgentConnection();
+      }
+
+      beforeEach(async () => {
+        await agentControls.clearReceivedTraceData();
+      });
+
+      afterEach(async () => {
+        if (customControls) {
+          await customControls.stop();
+          customControls = null;
+        }
+      });
+
+      describe('when the minimum log level is ERROR', () => {
+        beforeEach(async () => {
+          await start('error');
+        });
+
+        afterEach(async () => {
+          await customControls.stop();
+        });
+
+        it('should not trace warn', () =>
+          trigger('warn', customControls).then(() =>
+            retry(async () => {
+              const spans = await agentControls.getSpans();
+
+              const entrySpan = expectAtLeastOneMatching(spans, [
+                span => expect(span.n).to.equal('node.http.server'),
+                span => expect(span.f.e).to.equal(String(customControls.getPid())),
+                span => expect(span.f.h).to.equal('agent-stub-uuid')
+              ]);
+
+              expectAtLeastOneMatching(spans, span => {
+                checkNextExitSpan(span, entrySpan, customControls);
+              });
+
+              expect(getSpansByName(spans, 'log.bunyan')).to.be.empty;
+            })
+          ));
+
+        it('should trace error', () => runTest('error', true, 'Error message - should be traced.', customControls));
+      });
+
+      describe('when the minimum log level is INFO', () => {
+        beforeEach(async () => {
+          await start('info');
+        });
+
+        afterEach(async () => {
+          await customControls.stop();
+        });
+
+        it('should trace info', () =>
+          runTest('info', false, 'Info message - must not be traced by default.', customControls));
+
+        it('should trace warn', () => runTest('warn', false, 'Warn message - should be traced.', customControls));
+
+        it('should trace error', () => runTest('error', true, 'Error message - should be traced.', customControls));
+      });
+
+      describe('when the minimum log level is OFF', () => {
+        beforeEach(async () => {
+          await start('off');
+        });
+
+        afterEach(async () => {
+          await customControls.stop();
+        });
+
+        it('should not trace warn', () =>
+          trigger('warn', customControls).then(() =>
+            retry(async () => {
+              const spans = await agentControls.getSpans();
+
+              const entrySpan = expectAtLeastOneMatching(spans, [
+                span => expect(span.n).to.equal('node.http.server'),
+                span => expect(span.f.e).to.equal(String(customControls.getPid())),
+                span => expect(span.f.h).to.equal('agent-stub-uuid')
+              ]);
+
+              expectAtLeastOneMatching(spans, span => {
+                checkNextExitSpan(span, entrySpan, customControls);
+              });
+
+              expect(getSpansByName(spans, 'log.bunyan')).to.be.empty;
+            })
+          ));
+
+        it('should not trace error', () =>
+          trigger('error', customControls).then(() =>
+            retry(async () => {
+              const spans = await agentControls.getSpans();
+
+              const entrySpan = expectAtLeastOneMatching(spans, [
+                span => expect(span.n).to.equal('node.http.server'),
+                span => expect(span.f.e).to.equal(String(customControls.getPid())),
+                span => expect(span.f.h).to.equal('agent-stub-uuid')
+              ]);
+
+              expectAtLeastOneMatching(spans, span => {
+                checkNextExitSpan(span, entrySpan, customControls);
+              });
+
+              expect(getSpansByName(spans, 'log.bunyan')).to.be.empty;
+            })
+          ));
+      });
+    });
   });
 
   function runTest(url, expectErroneous, message, controls, lengthOfMessage, numberOfSpans) {

--- a/packages/core/src/tracing/instrumentation/logging/bunyan.js
+++ b/packages/core/src/tracing/instrumentation/logging/bunyan.js
@@ -13,6 +13,7 @@ const hook = require('../../../util/hook');
 const tracingUtil = require('../../tracingUtil');
 const constants = require('../../constants');
 const cls = require('../../cls');
+const { LOG_LEVEL } = require('../../../util/constants');
 
 let isActive = false;
 
@@ -21,12 +22,13 @@ exports.init = function init() {
 };
 
 function instrument(Logger) {
-  shimmer.wrap(Logger.prototype, 'warn', shimLog(false));
-  shimmer.wrap(Logger.prototype, 'error', shimLog(true));
-  shimmer.wrap(Logger.prototype, 'fatal', shimLog(true));
+  shimmer.wrap(Logger.prototype, 'info', shimLog(LOG_LEVEL.INFO));
+  shimmer.wrap(Logger.prototype, 'warn', shimLog(LOG_LEVEL.WARN));
+  shimmer.wrap(Logger.prototype, 'error', shimLog(LOG_LEVEL.ERROR));
+  shimmer.wrap(Logger.prototype, 'fatal', shimLog(LOG_LEVEL.FATAL));
 }
 
-function shimLog(markAsError) {
+function shimLog(level) {
   return originalLog =>
     function () {
       // CASE: Customer is using a custom bunyan logger (instana.setLogger(bunyanLogger)).
@@ -42,6 +44,10 @@ function shimLog(markAsError) {
         return originalLog.apply(this, arguments);
       }
 
+      if (!tracingUtil.shouldCaptureLogSpan(level)) {
+        return originalLog.apply(this, arguments);
+      }
+
       if (cls.skipExitTracing({ isActive, skipAllowRootExitSpanPresence: true })) {
         return originalLog.apply(this, arguments);
       }
@@ -50,11 +56,11 @@ function shimLog(markAsError) {
       for (let i = 0; i < arguments.length; i++) {
         originalArgs[i] = arguments[i];
       }
-      instrumentedLog(this, originalLog, originalArgs, markAsError);
+      instrumentedLog(this, originalLog, originalArgs, level);
     };
 }
 
-function instrumentedLog(ctx, originalLog, originalArgs, markAsError) {
+function instrumentedLog(ctx, originalLog, originalArgs, level) {
   return cls.ns.runAndReturn(() => {
     const span = cls.startSpan({
       spanName: 'log.bunyan',
@@ -114,7 +120,7 @@ function instrumentedLog(ctx, originalLog, originalArgs, markAsError) {
     span.data.log = {
       message
     };
-    if (markAsError) {
+    if (isError(level)) {
       span.ec = 1;
     }
     try {
@@ -124,6 +130,10 @@ function instrumentedLog(ctx, originalLog, originalArgs, markAsError) {
       span.transmit();
     }
   });
+}
+
+function isError(level) {
+  return level === LOG_LEVEL.ERROR || level === LOG_LEVEL.FATAL;
 }
 
 exports.activate = function activate() {

--- a/packages/core/src/tracing/instrumentation/logging/bunyan.js
+++ b/packages/core/src/tracing/instrumentation/logging/bunyan.js
@@ -121,7 +121,7 @@ function instrumentedLog(ctx, originalLog, originalArgs, level) {
       message
     };
 
-    if (tracingUtil.shouldMarkErrorForLogLevel(level)) {
+    if (tracingUtil.isLogLevelAnError(level)) {
       span.ec = 1;
     }
 

--- a/packages/core/src/tracing/instrumentation/logging/bunyan.js
+++ b/packages/core/src/tracing/instrumentation/logging/bunyan.js
@@ -120,9 +120,11 @@ function instrumentedLog(ctx, originalLog, originalArgs, level) {
     span.data.log = {
       message
     };
-    if (isError(level)) {
+
+    if (tracingUtil.shouldMarkErrorForLogLevel(level)) {
       span.ec = 1;
     }
+
     try {
       return originalLog.apply(ctx, originalArgs);
     } finally {
@@ -130,10 +132,6 @@ function instrumentedLog(ctx, originalLog, originalArgs, level) {
       span.transmit();
     }
   });
-}
-
-function isError(level) {
-  return level === LOG_LEVEL.ERROR || level === LOG_LEVEL.FATAL;
 }
 
 exports.activate = function activate() {


### PR DESCRIPTION
## Summary

This PR adds support for capturing **info**-level logs for Bunyan. By default, log capture starts at **WARN** and above. When configured, **INFO** logs can also be captured.

Reference: https://www.npmjs.com/package/bunyan#levels

## Configuration

The log capture level can be configured using either:

- Environment variable: `INSTANA_TRACING_CAPTURE_LOG_LEVEL`
- In-code configuration: `tracing.captureLogLevel`

Supported values:

- `INFO`
- `WARN` (default)
- `ERROR`
- `OFF`

## Log capture behavior

| Configuration | Captured log levels        |
| ------------- | -------------------------- |
| `INFO`        | INFO, WARN, ERROR, FATAL   |
| `WARN`        | WARN, ERROR, FATAL         |
| `ERROR`       | ERROR, FATAL               |
| `OFF`         | No log spans are captured. |



## TODO

- [x] config support  https://github.com/instana/nodejs/pull/2657
- [x] pino  #2661
- [ ] winston #2662
- [ ] log4js #2659
- [x] console https://github.com/instana/nodejs/pull/2658
- [ ] bunyan #2651
- [ ] public docs

ref: https://jsw.ibm.com/browse/INSTA-101942
tech spec: https://github.ibm.com/instana/technical-documentation/blob/master/tracing/specification/README.md#log-spans