### PR TITLE
fix: preserved trace headers in aws4-axios package triggered calls

### DIFF
--- a/packages/collector/test/integration/currencies/protocols/http/client/clientApp.js
+++ b/packages/collector/test/integration/currencies/protocols/http/client/clientApp.js
@@ -367,9 +367,6 @@ app.get('/request-shared-headers', (req, res) => {
   });
 });
 
-// Simulates an outgoing request signed by aws4-axios:
-//   - Authorization: AWS4-HMAC-SHA256 (SigV4-signed)
-//   - User-Agent: axios/1.18.1
 app.get('/aws4-axios-signed-request', (req, res) => {
   httpModule
     .request(
@@ -398,9 +395,6 @@ app.get('/aws4-axios-signed-request', (req, res) => {
     .end();
 });
 
-// Simulates an outgoing request from the aws-sdk (v3):
-//   - Authorization: AWS4-HMAC-SHA256 (SigV4-signed)
-//   - User-Agent: aws-sdk-js/3.400.0 ... (identifies this as a real aws-sdk call)
 app.get('/aws-sdk-signed-request', (req, res) => {
   httpModule
     .request(

--- a/packages/collector/test/integration/currencies/protocols/http/client/clientApp.js
+++ b/packages/collector/test/integration/currencies/protocols/http/client/clientApp.js
@@ -367,6 +367,68 @@ app.get('/request-shared-headers', (req, res) => {
   });
 });
 
+// Simulates an outgoing request signed by aws4-axios:
+//   - Authorization: AWS4-HMAC-SHA256 (SigV4-signed)
+//   - User-Agent: axios/1.18.1
+app.get('/aws4-axios-signed-request', (req, res) => {
+  httpModule
+    .request(
+      {
+        hostname: 'localhost',
+        port: process.env.SERVER_PORT,
+        method: 'GET',
+        path: '/aws4-axios-target',
+        ca: cert,
+        headers: {
+          Authorization: 'AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1/execute-api/aws4_request',
+          'X-Amz-Date': '20240101T000000Z',
+          'User-Agent': 'axios/1.18.1'
+        }
+      },
+      downstreamRes => {
+        let body = '';
+        downstreamRes.on('data', chunk => {
+          body += chunk;
+        });
+        downstreamRes.on('end', () => {
+          res.status(200).json(JSON.parse(body));
+        });
+      }
+    )
+    .end();
+});
+
+// Simulates an outgoing request from the aws-sdk (v3):
+//   - Authorization: AWS4-HMAC-SHA256 (SigV4-signed)
+//   - User-Agent: aws-sdk-js/3.400.0 ... (identifies this as a real aws-sdk call)
+app.get('/aws-sdk-signed-request', (req, res) => {
+  httpModule
+    .request(
+      {
+        hostname: 'localhost',
+        port: process.env.SERVER_PORT,
+        method: 'GET',
+        path: '/aws4-axios-target',
+        ca: cert,
+        headers: {
+          Authorization: 'AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1/execute-api/aws4_request',
+          'X-Amz-Date': '20240101T000000Z',
+          'User-Agent': 'aws-sdk-js/3.400.0 os/darwin lang/js md/nodejs/18.17.0 api/execute-api/3.400.0'
+        }
+      },
+      downstreamRes => {
+        let body = '';
+        downstreamRes.on('data', chunk => {
+          body += chunk;
+        });
+        downstreamRes.on('end', () => {
+          res.status(200).json(JSON.parse(body));
+        });
+      }
+    )
+    .end();
+});
+
 app.get('/without-port', (req, res) => {
   const options = {
     hostname: 'www.google.com',

--- a/packages/collector/test/integration/currencies/protocols/http/client/serverApp.js
+++ b/packages/collector/test/integration/currencies/protocols/http/client/serverApp.js
@@ -65,6 +65,14 @@ app.all('/fetch-with-status', (req, res) => {
   res.status(status).json({ status });
 });
 
+app.get('/aws4-axios-target', (req, res) => {
+  res.status(200).json({
+    'x-instana-t': req.headers['x-instana-t'] || null,
+    'x-instana-s': req.headers['x-instana-s'] || null,
+    traceparent: req.headers.traceparent || null
+  });
+});
+
 app.put('/continue', (req, res) => {
   // Node http server will automatically send 100 Continue when it receives a request with an "Expect: 100-continue"
   // header present, unless we override the 'checkContinue' listener. For our test case, the default behaviour is just

--- a/packages/collector/test/integration/currencies/protocols/http/client/test_base.js
+++ b/packages/collector/test/integration/currencies/protocols/http/client/test_base.js
@@ -1418,50 +1418,55 @@ module.exports = function (name, version, isLatest) {
           )
         ));
 
-    if (!appUsesHttps) {
-      // Verifies that Instana trace headers are propagated through requests signed by aws4-axios.
-      // aws4-axios sets `Authorization: AWS4-HMAC-SHA256` + `User-Agent: axios/1.18.1`.
-      it('must propagate X-INSTANA and traceparent headers through an aws4-axios signed request', () =>
-        clientControls
-          .sendRequest({
-            method: 'GET',
-            path: '/aws4-axios-signed-request'
-          })
-          .then(body => {
-            expect(body['x-instana-t'], 'X-INSTANA-T must reach the downstream service').to.be.a('string');
-            expect(body['x-instana-s'], 'X-INSTANA-S must reach the downstream service').to.be.a('string');
-            expect(body.traceparent, 'traceparent must reach the downstream service').to.be.a('string');
+    it('must propagate X-INSTANA and traceparent headers through an external package signed request', () =>
+      clientControls
+        .sendRequest({
+          method: 'GET',
+          path: '/aws4-axios-signed-request'
+        })
+        .then(body => {
+          expect(body['x-instana-t'], 'X-INSTANA-T must reach the downstream service').to.be.a('string');
+          expect(body['x-instana-s'], 'X-INSTANA-S must reach the downstream service').to.be.a('string');
+          expect(body.traceparent, 'traceparent must reach the downstream service').to.be.a('string');
 
-            return retry(() =>
-              globalAgent.instance.getSpans().then(spans => {
-                const exitSpan = expectExactlyOneMatching(spans, [
-                  span => expect(span.n).to.equal('node.http.client'),
-                  span => expect(span.k).to.equal(constants.EXIT),
-                  span => expect(span.data.http.url).to.match(/\/aws4-axios-target/)
-                ]);
+          return retry(() =>
+            globalAgent.instance.getSpans().then(spans => {
+              const exitSpan = expectExactlyOneMatching(spans, [
+                span => expect(span.n).to.equal('node.http.client'),
+                span => expect(span.k).to.equal(constants.EXIT),
+                span => expect(span.data.http.url).to.match(/\/aws4-axios-target/)
+              ]);
 
-                expect(body['x-instana-t']).to.equal(exitSpan.t);
-                expect(body['x-instana-s']).to.equal(exitSpan.s);
-                expect(body.traceparent).to.include(exitSpan.t);
-              })
-            );
-          }));
+              expect(body['x-instana-t']).to.equal(exitSpan.t);
+              expect(body['x-instana-s']).to.equal(exitSpan.s);
+              expect(body.traceparent).to.include(exitSpan.t);
 
-      it('must NOT create http client EXIT span for an aws-sdk signed request', () =>
-        clientControls
-          .sendRequest({
-            method: 'GET',
-            path: '/aws-sdk-signed-request'
-          })
-          .then(() => {
-            return delay(500).then(() =>
-              globalAgent.instance.getSpans().then(spans => {
-                const exitSpans = spans.filter(span => span.n === 'node.http.client' && span.k === constants.EXIT);
-                expect(exitSpans, 'must not create a node.http.client exit span').to.have.length(0);
-              })
-            );
-          }));
-    }
+              // 1 x http server
+              // 1 x http client
+              // 1 x http server
+              expect(spans).to.have.lengthOf(3);
+            })
+          );
+        }));
+
+    it('must NOT create http client EXIT span for an aws-sdk signed request', () =>
+      clientControls
+        .sendRequest({
+          method: 'GET',
+          path: '/aws-sdk-signed-request'
+        })
+        .then(() => {
+          return delay(500).then(() =>
+            globalAgent.instance.getSpans().then(spans => {
+              const exitSpans = spans.filter(span => span.n === 'node.http.client' && span.k === constants.EXIT);
+              expect(exitSpans, 'must not create a node.http.client exit span').to.have.length(0);
+
+              // 1 x http server
+              // 1 x http server
+              expect(spans).to.have.lengthOf(2);
+            })
+          );
+        }));
   }
 
   function registerConnectionRefusalTest(appUsesHttps) {

--- a/packages/collector/test/integration/currencies/protocols/http/client/test_base.js
+++ b/packages/collector/test/integration/currencies/protocols/http/client/test_base.js
@@ -1428,8 +1428,6 @@ module.exports = function (name, version, isLatest) {
             path: '/aws4-axios-signed-request'
           })
           .then(body => {
-            // The downstream server echoes back whatever trace headers it received.
-            // All three must be present — none should have been swallowed by the AWS-signed-request guard.
             expect(body['x-instana-t'], 'X-INSTANA-T must reach the downstream service').to.be.a('string');
             expect(body['x-instana-s'], 'X-INSTANA-S must reach the downstream service').to.be.a('string');
             expect(body.traceparent, 'traceparent must reach the downstream service').to.be.a('string');
@@ -1442,52 +1440,24 @@ module.exports = function (name, version, isLatest) {
                   span => expect(span.data.http.url).to.match(/\/aws4-axios-target/)
                 ]);
 
-                // The trace ID the server received must be the same one the exit span carries,
-                // proving end-to-end trace context continuity.
                 expect(body['x-instana-t']).to.equal(exitSpan.t);
-
-                // The span ID the server received as X-INSTANA-S must equal the exit span's own span ID.
                 expect(body['x-instana-s']).to.equal(exitSpan.s);
-
-                // traceparent must encode the same trace ID (last 16 hex chars of the 32-char trace ID field).
                 expect(body.traceparent).to.include(exitSpan.t);
               })
             );
           }));
 
-      // Verifies that Instana trace headers are NOT injected into requests from the aws-sdk.
-      // aws-sdk sets `Authorization: AWS4-HMAC-SHA256` + `User-Agent: aws-sdk-js/...`.
-      it('must NOT inject X-INSTANA or traceparent headers into an aws-sdk signed request', () =>
+      it('must NOT create http client EXIT span for an aws-sdk signed request', () =>
         clientControls
           .sendRequest({
             method: 'GET',
             path: '/aws-sdk-signed-request'
           })
-          .then(body => {
-            return retry(() =>
+          .then(() => {
+            return delay(500).then(() =>
               globalAgent.instance.getSpans().then(spans => {
-                // A node.http.client exit span is still created — the guard only suppresses header
-                // injection, not span creation.
-                const exitSpan = expectExactlyOneMatching(spans, [
-                  span => expect(span.n).to.equal('node.http.client'),
-                  span => expect(span.k).to.equal(constants.EXIT),
-                  span => expect(span.data.http.url).to.match(/\/aws4-axios-target/)
-                ]);
-
-                // The downstream service must NOT have received the exit span's trace ID as X-INSTANA-T.
-                // body['x-instana-t'] is either null (not sent) or a parent span's value — either way
-                // it must differ from the exit span's own trace ID.
-                expect(body['x-instana-t']).to.not.equal(exitSpan.t);
-
-                // Same for X-INSTANA-S: the exit span's span ID must not have been forwarded.
-                expect(body['x-instana-s']).to.not.equal(exitSpan.s);
-
-                // traceparent must not carry the exit span's trace ID.
-                // When null (not sent at all), that already satisfies the requirement.
-                // When present (e.g. a parent span's traceparent), it must not reference this exit span.
-                if (body.traceparent !== null) {
-                  expect(body.traceparent).to.not.include(exitSpan.t);
-                }
+                const exitSpans = spans.filter(span => span.n === 'node.http.client' && span.k === constants.EXIT);
+                expect(exitSpans, 'must not create a node.http.client exit span').to.have.length(0);
               })
             );
           }));

--- a/packages/collector/test/integration/currencies/protocols/http/client/test_base.js
+++ b/packages/collector/test/integration/currencies/protocols/http/client/test_base.js
@@ -1417,6 +1417,81 @@ module.exports = function (name, version, isLatest) {
             })
           )
         ));
+
+    if (!appUsesHttps) {
+      // Verifies that Instana trace headers are propagated through requests signed by aws4-axios.
+      // aws4-axios sets `Authorization: AWS4-HMAC-SHA256` + `User-Agent: axios/1.18.1`.
+      it('must propagate X-INSTANA and traceparent headers through an aws4-axios signed request', () =>
+        clientControls
+          .sendRequest({
+            method: 'GET',
+            path: '/aws4-axios-signed-request'
+          })
+          .then(body => {
+            // The downstream server echoes back whatever trace headers it received.
+            // All three must be present — none should have been swallowed by the AWS-signed-request guard.
+            expect(body['x-instana-t'], 'X-INSTANA-T must reach the downstream service').to.be.a('string');
+            expect(body['x-instana-s'], 'X-INSTANA-S must reach the downstream service').to.be.a('string');
+            expect(body.traceparent, 'traceparent must reach the downstream service').to.be.a('string');
+
+            return retry(() =>
+              globalAgent.instance.getSpans().then(spans => {
+                const exitSpan = expectExactlyOneMatching(spans, [
+                  span => expect(span.n).to.equal('node.http.client'),
+                  span => expect(span.k).to.equal(constants.EXIT),
+                  span => expect(span.data.http.url).to.match(/\/aws4-axios-target/)
+                ]);
+
+                // The trace ID the server received must be the same one the exit span carries,
+                // proving end-to-end trace context continuity.
+                expect(body['x-instana-t']).to.equal(exitSpan.t);
+
+                // The span ID the server received as X-INSTANA-S must equal the exit span's own span ID.
+                expect(body['x-instana-s']).to.equal(exitSpan.s);
+
+                // traceparent must encode the same trace ID (last 16 hex chars of the 32-char trace ID field).
+                expect(body.traceparent).to.include(exitSpan.t);
+              })
+            );
+          }));
+
+      // Verifies that Instana trace headers are NOT injected into requests from the aws-sdk.
+      // aws-sdk sets `Authorization: AWS4-HMAC-SHA256` + `User-Agent: aws-sdk-js/...`.
+      it('must NOT inject X-INSTANA or traceparent headers into an aws-sdk signed request', () =>
+        clientControls
+          .sendRequest({
+            method: 'GET',
+            path: '/aws-sdk-signed-request'
+          })
+          .then(body => {
+            return retry(() =>
+              globalAgent.instance.getSpans().then(spans => {
+                // A node.http.client exit span is still created — the guard only suppresses header
+                // injection, not span creation.
+                const exitSpan = expectExactlyOneMatching(spans, [
+                  span => expect(span.n).to.equal('node.http.client'),
+                  span => expect(span.k).to.equal(constants.EXIT),
+                  span => expect(span.data.http.url).to.match(/\/aws4-axios-target/)
+                ]);
+
+                // The downstream service must NOT have received the exit span's trace ID as X-INSTANA-T.
+                // body['x-instana-t'] is either null (not sent) or a parent span's value — either way
+                // it must differ from the exit span's own trace ID.
+                expect(body['x-instana-t']).to.not.equal(exitSpan.t);
+
+                // Same for X-INSTANA-S: the exit span's span ID must not have been forwarded.
+                expect(body['x-instana-s']).to.not.equal(exitSpan.s);
+
+                // traceparent must not carry the exit span's trace ID.
+                // When null (not sent at all), that already satisfies the requirement.
+                // When present (e.g. a parent span's traceparent), it must not reference this exit span.
+                if (body.traceparent !== null) {
+                  expect(body.traceparent).to.not.include(exitSpan.t);
+                }
+              })
+            );
+          }));
+    }
   }
 
   function registerConnectionRefusalTest(appUsesHttps) {

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -83,7 +83,7 @@ function evaluateHeaderValue(headerValue, validator) {
  * @param {Object} options
  * @returns {boolean}
  */
-function isAWSdkHeader(options) {
+function isAwsSdkRequest(options) {
   const headers = options && options.headers;
   const userAgent = (headers && headers['User-Agent']) || (headers && headers['user-agent']);
   return evaluateHeaderValue(
@@ -186,7 +186,7 @@ function instrument(coreModule, forceHttps) {
 
     const parentSpan = skipTracingResult.parentSpan;
 
-    const awsSdkRequest = isAWSdkHeader(options);
+    const awsSdkRequest = isAwsSdkRequest(options);
 
     if (skipTracingResult.skip || shouldBeBypassed(skipTracingResult.parentSpan, options, awsSdkRequest)) {
       let traceLevelHeaderHasBeenAdded = false;
@@ -204,7 +204,7 @@ function instrument(coreModule, forceHttps) {
       return clientRequest;
     }
 
-    // Note: The aws sdk instr will create its own span, so no need to create again an http client span
+    // "Note: There is no need to create http EXIT spans for AWS SDK created events"
     if (awsSdkRequest) {
       return originalRequest.apply(coreModule, arguments);
     }

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -113,11 +113,9 @@ function isAWSdkHeader(options) {
   );
 }
 
-function shouldBeBypassed(parentSpan, options) {
+function shouldBeBypassed(parentSpan, options, awsSdkRequest) {
   const headers = options && options.headers;
   const userAgent = (headers && headers['User-Agent']) || (headers && headers['user-agent']);
-
-  const awsSdkHeader = isAWSdkHeader(options);
 
   const hostInfo = (headers && headers.Host) || (headers && headers.host);
 
@@ -127,7 +125,7 @@ function shouldBeBypassed(parentSpan, options) {
   // 'user-agent': 'aws-sdk-js/3.329.0 os/darwin/22.5.0 lang/js md/nodejs/18.14.2 api/sqs/3.329.0'
   const agentMatchesSQS = evaluateHeaderValue(userAgent, header => header.toLowerCase().indexOf('api/sqs') > -1);
 
-  if (parentSpan && parentSpan.n === 'sqs' && awsSdkHeader && (hostMatchesSQS || agentMatchesSQS)) {
+  if (parentSpan && parentSpan.n === 'sqs' && awsSdkRequest && (hostMatchesSQS || agentMatchesSQS)) {
     return true;
   }
 

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -84,8 +84,8 @@ function evaluateHeaderValue(headerValue, validator) {
  * @returns {boolean}
  */
 function isAwsSdkRequest(options) {
-  const headers = options && options.headers;
-  const userAgent = (headers && headers['User-Agent']) || (headers && headers['user-agent']);
+  const headers = options?.headers;
+  const userAgent = headers?.['User-Agent'] ?? headers?.['user-agent'];
   return evaluateHeaderValue(
     userAgent,
     header => header.toLowerCase().indexOf('aws-sdk-nodejs') > -1 || header.toLowerCase().indexOf('aws-sdk-js') > -1
@@ -120,9 +120,8 @@ function shouldBeBypassed(parentSpan, options) {
   );
 
   const hostMatchesGPC = options && options.host && options.host === 'storage.googleapis.com';
-  if (isGCPNodeJSHeader && hostMatchesGPC) return true;
 
-  return false;
+  return isGCPNodeJSHeader && hostMatchesGPC;
 }
 
 function instrument(coreModule, forceHttps) {

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -98,14 +98,34 @@ function evaluateHeaderValue(headerValue, validator) {
  * https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_http_request_options_callback
  * @return {boolean} true, if the HTTP request that is about to happen should _not_ create a span.
  */
+/**
+ * Returns true if the User-Agent identifies the request as originating from the aws-sdk (v2 or v3).
+ * Used both to bypass span creation and to skip Instana header injection for AWS SigV4-signed requests.
+ * @param {Object} options
+ * @returns {boolean}
+ */
+function isAwsSdkRequest(options) {
+  const headers = options && options.headers;
+  const userAgent = (headers && headers['User-Agent']) || (headers && headers['user-agent']);
+  return isAWSNodeJSHeader(userAgent);
+}
+
+/**
+ * @param {string | string[] | undefined} userAgent
+ * @returns {boolean}
+ */
+function isAWSNodeJSHeader(userAgent) {
+  return evaluateHeaderValue(
+    userAgent,
+    header => header.toLowerCase().indexOf('aws-sdk-nodejs') > -1 || header.toLowerCase().indexOf('aws-sdk-js') > -1
+  );
+}
+
 function shouldBeBypassed(parentSpan, options) {
   const headers = options && options.headers;
   const userAgent = (headers && headers['User-Agent']) || (headers && headers['user-agent']);
 
-  const isAWSNodeJSHeader = evaluateHeaderValue(
-    userAgent,
-    header => header.toLowerCase().indexOf('aws-sdk-nodejs') > -1 || header.toLowerCase().indexOf('aws-sdk-js') > -1
-  );
+  const awsSdkHeader = isAWSNodeJSHeader(userAgent);
 
   const hostInfo = (headers && headers.Host) || (headers && headers.host);
 
@@ -115,7 +135,7 @@ function shouldBeBypassed(parentSpan, options) {
   // 'user-agent': 'aws-sdk-js/3.329.0 os/darwin/22.5.0 lang/js md/nodejs/18.14.2 api/sqs/3.329.0'
   const agentMatchesSQS = evaluateHeaderValue(userAgent, header => header.toLowerCase().indexOf('api/sqs') > -1);
 
-  if (parentSpan && parentSpan.n === 'sqs' && isAWSNodeJSHeader && (hostMatchesSQS || agentMatchesSQS)) {
+  if (parentSpan && parentSpan.n === 'sqs' && awsSdkHeader && (hostMatchesSQS || agentMatchesSQS)) {
     return true;
   }
 
@@ -178,7 +198,20 @@ function instrument(coreModule, forceHttps) {
 
     const parentSpan = skipTracingResult.parentSpan;
 
-    if (skipTracingResult.skip || shouldBeBypassed(skipTracingResult.parentSpan, options)) {
+    // aws-sdk requests (identified by User-Agent) must not have Instana headers injected —
+    // the request is already SigV4-signed and adding headers would cause SignatureDoesNotMatch on retries.
+    // A node.http.client span is still created for observability; only header injection is skipped.
+    const awsSdkRequest = isAwsSdkRequest(options);
+
+    // CASE 1: skip due to tracing being inactive / reduced span / etc.
+    // CASE 2: shouldBeBypassed covers special cases like SQS polling from an SQS entry span.
+    // For aws-sdk requests in either case: return the original request completely untouched
+    // (no suppression headers, no W3C headers — nothing must disturb the signed request).
+    if (skipTracingResult.skip || shouldBeBypassed(skipTracingResult.parentSpan, options, awsSdkRequest)) {
+      if (awsSdkRequest) {
+        return originalRequest.apply(coreModule, arguments);
+      }
+
       let traceLevelHeaderHasBeenAdded = false;
       if (skipTracingResult.suppressed) {
         traceLevelHeaderHasBeenAdded = tryToAddTraceLevelAddHeaderToOpts(options, '0', w3cTraceContext);
@@ -255,7 +288,7 @@ function instrument(coreModule, forceHttps) {
 
       let instanaHeadersHaveBeenAdded = false;
       try {
-        instanaHeadersHaveBeenAdded = tryToAddHeadersToOpts(options, span, w3cTraceContext);
+        instanaHeadersHaveBeenAdded = tryToAddHeadersToOpts(options, span, w3cTraceContext, awsSdkRequest);
         clientRequest = originalRequest.apply(coreModule, originalArgs);
         removeInstanaHeadersFromOpts(options);
       } catch (e) {
@@ -273,7 +306,7 @@ function instrument(coreModule, forceHttps) {
 
       cls.ns.bindEmitter(clientRequest);
       if (!instanaHeadersHaveBeenAdded) {
-        instanaHeadersHaveBeenAdded = setHeadersOnRequest(clientRequest, span, w3cTraceContext);
+        instanaHeadersHaveBeenAdded = setHeadersOnRequest(clientRequest, span, w3cTraceContext, awsSdkRequest);
       }
 
       let isTimeout = false;
@@ -368,7 +401,7 @@ function isUrlObject(argument) {
   return URL && argument instanceof url.URL;
 }
 
-function tryToAddHeadersToOpts(options, span, w3cTraceContext) {
+function tryToAddHeadersToOpts(options, span, w3cTraceContext, awsSdkRequest) {
   // Some HTTP spec background: If the request has a header Expect: 100-continue, the client will first send the
   // request headers, without the body. The client is then ought to wait for the server to send a first, preliminary
   // response with the status code 100 Continue (if all is well). Only then will the client send the actual request
@@ -388,7 +421,9 @@ function tryToAddHeadersToOpts(options, span, w3cTraceContext) {
   // (see setHeadersOnRequest).
 
   if (hasHeadersOption(options)) {
-    if (!isItSafeToModifiyHeadersInOptions(options)) {
+    // Do not inject headers into aws-sdk requests: the request is SigV4-signed and adding headers
+    // would cause SignatureDoesNotMatch errors on retries.
+    if (awsSdkRequest) {
       return true;
     }
     options.headers[constants.spanIdHeaderName] = span.s;
@@ -403,11 +438,6 @@ function tryToAddHeadersToOpts(options, span, w3cTraceContext) {
 
 function tryToAddTraceLevelAddHeaderToOpts(options, level, w3cTraceContext) {
   if (hasHeadersOption(options)) {
-    if (!isItSafeToModifiyHeadersInOptions(options)) {
-      // Return true to convince the caller that headers have been added although we have in fact not added them. This
-      // will result in no headers being added. See isItSafeToModifiyHeadersInOptions for the motivation behind this.
-      return true;
-    }
     options.headers[constants.traceLevelHeaderName] = level;
     tryToAddW3cHeaderToOpts(options, w3cTraceContext);
     return true;
@@ -443,8 +473,9 @@ function removeInstanaHeadersFromOpts(options) {
   delete options.headers[constants.w3cTraceState];
 }
 
-function setHeadersOnRequest(clientRequest, span, w3cTraceContext) {
-  if (!isItSafeToModifiyHeadersForRequest(clientRequest)) {
+function setHeadersOnRequest(clientRequest, span, w3cTraceContext, awsSdkRequest) {
+  // Do not inject headers into aws-sdk requests — same reasoning as in tryToAddHeadersToOpts.
+  if (awsSdkRequest) {
     return;
   }
 
@@ -471,70 +502,6 @@ function setW3cHeadersOnRequest(clientRequest, w3cTraceContext) {
       clientRequest.setHeader(constants.w3cTraceState, w3cTraceContext.renderTraceState());
     }
   }
-}
-
-function isItSafeToModifiyHeadersInOptions(options) {
-  const keys = Object.keys(options.headers);
-  let key;
-  for (let i = 0; i < keys.length; i++) {
-    key = keys[i];
-    if (
-      'authorization' === key.toLowerCase() &&
-      typeof options.headers[key] === 'string' &&
-      options.headers[key].indexOf('AWS') === 0
-    ) {
-      // This is a signed AWS API request (probably from the aws-sdk package).
-      // Adding our headers too this request would trigger a SignatureDoesNotMatch error in case the request will be
-      // retried:
-      // "SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided.
-      // Check your key and signing method."
-      // See https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
-      //
-      // Additionally, adding our headers to this request would not have any benefit - the receiving end will be an AWS
-      // service like S3 and those are not instrumented. (There is a very small chance that the receiving end is an
-      // instrumented Lambda function behind an API gateway and the user is using
-      // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/APIGateway.html to invoke this Gateway/Lambda
-      // combination, which _would_ benefit from tracing headers.)
-
-      // Exception: when the request comes from axios (e.g. via aws4-axios), the signing library re-signs
-      // the request fresh on every call, so adding trace headers is safe. The receiving end is also likely
-      // an instrumented service (e.g. a Lambda behind API Gateway) that benefits from receiving trace headers.
-      if (!isAxiosRequest(options.headers)) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
-function isItSafeToModifiyHeadersForRequest(clientRequest) {
-  const authHeader = clientRequest.getHeader('Authorization');
-  if (!authHeader || authHeader.indexOf('AWS') !== 0) {
-    return true;
-  }
-  // See comment in isItSafeToModifiyHeadersInOptions. Allow header injection only for axios requests.
-  const userAgent = clientRequest.getHeader('User-Agent');
-  return isAxiosUserAgent(userAgent);
-}
-
-/**
- * Returns true if the headers object contains a User-Agent indicating the request was made by axios
- * (e.g. via the aws4-axios interceptor). Only the presence of "axios" in the User-Agent is checked;
- * no version matching is performed.
- * @param {Object} headers
- * @returns {boolean}
- */
-function isAxiosRequest(headers) {
-  const userAgent = headers['User-Agent'] || headers['user-agent'];
-  return isAxiosUserAgent(userAgent);
-}
-
-/**
- * @param {string | string[] | undefined} userAgent
- * @returns {boolean}
- */
-function isAxiosUserAgent(userAgent) {
-  return evaluateHeaderValue(userAgent, header => header.toLowerCase().indexOf('axios') > -1);
 }
 
 function captureRequestHeaders(options, clientRequest, response) {

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -80,6 +80,19 @@ function evaluateHeaderValue(headerValue, validator) {
 }
 
 /**
+ * @param {Object} options
+ * @returns {boolean}
+ */
+function isAWSdkHeader(options) {
+  const headers = options && options.headers;
+  const userAgent = (headers && headers['User-Agent']) || (headers && headers['user-agent']);
+  return evaluateHeaderValue(
+    userAgent,
+    header => header.toLowerCase().indexOf('aws-sdk-nodejs') > -1 || header.toLowerCase().indexOf('aws-sdk-js') > -1
+  );
+}
+
+/**
  * Checks whether an outgoing HTTP request should not be traced. This is intended to suppress the creation of HTTP exits
  * for which a higher level instrumentation exists, for example, HTTP requests made by AWS SQS that represent the queue
  * polling when we already created an SQS entry span for it.
@@ -98,21 +111,6 @@ function evaluateHeaderValue(headerValue, validator) {
  * https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_http_request_options_callback
  * @return {boolean} true, if the HTTP request that is about to happen should _not_ create a span.
  */
-/**
- * Returns true if the request options originate from the aws-sdk (v2 or v3), identified by the
- * User-Agent header. Used to skip Instana header injection for SigV4-signed requests.
- * @param {Object} options
- * @returns {boolean}
- */
-function isAWSdkHeader(options) {
-  const headers = options && options.headers;
-  const userAgent = (headers && headers['User-Agent']) || (headers && headers['user-agent']);
-  return evaluateHeaderValue(
-    userAgent,
-    header => header.toLowerCase().indexOf('aws-sdk-nodejs') > -1 || header.toLowerCase().indexOf('aws-sdk-js') > -1
-  );
-}
-
 function shouldBeBypassed(parentSpan, options, awsSdkRequest) {
   const headers = options && options.headers;
   const userAgent = (headers && headers['User-Agent']) || (headers && headers['user-agent']);
@@ -190,9 +188,6 @@ function instrument(coreModule, forceHttps) {
 
     const awsSdkRequest = isAWSdkHeader(options);
 
-    // aws-sdk requests that are being skipped/bypassed must be returned completely untouched —
-    // no suppression or W3C headers either, as nothing must disturb the signed request because
-    // adding headers would cause SignatureDoesNotMatch on retries.
     if (skipTracingResult.skip || shouldBeBypassed(skipTracingResult.parentSpan, options, awsSdkRequest)) {
       if (awsSdkRequest) {
         return originalRequest.apply(coreModule, arguments);
@@ -407,19 +402,14 @@ function tryToAddHeadersToOpts(options, span, w3cTraceContext, awsSdkRequest) {
   // (see setHeadersOnRequest).
 
   if (hasHeadersOption(options)) {
-    // This is a signed AWS API request (from the aws-sdk package, identified by its User-Agent).
-    // Adding our headers to this request would trigger a SignatureDoesNotMatch error in case the request
-    // will be retried:
-    // "SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided.
-    // Check your key and signing method."
-    // See https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
-    //
-    // Additionally, adding our headers to this request would not have any benefit — the receiving end will
-    // be an AWS service like S3 and those are not instrumented. (There is a very small chance that the
-    // receiving end is an instrumented Lambda function behind an API gateway and the user is using
-    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/APIGateway.html to invoke this
-    // Gateway/Lambda combination, which _would_ benefit from tracing headers.)
     if (awsSdkRequest) {
+      // This is a signed AWS API request (from the aws-sdk package, identified by its User-Agent).
+      // Adding our headers to this request would trigger a SignatureDoesNotMatch error in case the request
+      // will be retried:
+      // "SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided.
+      // Check your key and signing method."
+      // See https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
+
       return true;
     }
     options.headers[constants.spanIdHeaderName] = span.s;
@@ -470,9 +460,6 @@ function removeInstanaHeadersFromOpts(options) {
 }
 
 function setHeadersOnRequest(clientRequest, span, w3cTraceContext, awsSdkRequest) {
-  // This is a signed AWS API request (from the aws-sdk package, identified by its User-Agent).
-  // Adding our headers to this request would trigger a SignatureDoesNotMatch error in case the request
-  // will be retried. See the comment in tryToAddHeadersToOpts for the full explanation.
   if (awsSdkRequest) {
     return;
   }

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -421,8 +421,18 @@ function tryToAddHeadersToOpts(options, span, w3cTraceContext, awsSdkRequest) {
   // (see setHeadersOnRequest).
 
   if (hasHeadersOption(options)) {
-    // Do not inject headers into aws-sdk requests: the request is SigV4-signed and adding headers
-    // would cause SignatureDoesNotMatch errors on retries.
+    // This is a signed AWS API request (from the aws-sdk package, identified by its User-Agent).
+    // Adding our headers to this request would trigger a SignatureDoesNotMatch error in case the request
+    // will be retried:
+    // "SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided.
+    // Check your key and signing method."
+    // See https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
+    //
+    // Additionally, adding our headers to this request would not have any benefit — the receiving end will
+    // be an AWS service like S3 and those are not instrumented. (There is a very small chance that the
+    // receiving end is an instrumented Lambda function behind an API gateway and the user is using
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/APIGateway.html to invoke this
+    // Gateway/Lambda combination, which _would_ benefit from tracing headers.)
     if (awsSdkRequest) {
       return true;
     }
@@ -474,7 +484,9 @@ function removeInstanaHeadersFromOpts(options) {
 }
 
 function setHeadersOnRequest(clientRequest, span, w3cTraceContext, awsSdkRequest) {
-  // Do not inject headers into aws-sdk requests — same reasoning as in tryToAddHeadersToOpts.
+  // This is a signed AWS API request (from the aws-sdk package, identified by its User-Agent).
+  // Adding our headers to this request would trigger a SignatureDoesNotMatch error in case the request
+  // will be retried. See the comment in tryToAddHeadersToOpts for the full explanation.
   if (awsSdkRequest) {
     return;
   }

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -94,8 +94,7 @@ function isAwsSdkRequest(options) {
 
 /**
  * Checks whether an outgoing HTTP request should not be traced. This is intended to suppress the creation of HTTP exits
- * for which a higher level instrumentation exists, for example, HTTP requests made by AWS SQS that represent the queue
- * polling when we already created an SQS entry span for it.
+ * for which a higher level instrumentation exists.
  *
  * When using GCP storage library, the default way to upload a file is the resumable strategy.
  * This strategy uses google-auth-library -> gaxios -> http/https node core libs, which create http exit spans.
@@ -111,21 +110,9 @@ function isAwsSdkRequest(options) {
  * https://nodejs.org/dist/latest-v14.x/docs/api/http.html#http_http_request_options_callback
  * @return {boolean} true, if the HTTP request that is about to happen should _not_ create a span.
  */
-function shouldBeBypassed(parentSpan, options, awsSdkRequest) {
+function shouldBeBypassed(parentSpan, options) {
   const headers = options && options.headers;
   const userAgent = (headers && headers['User-Agent']) || (headers && headers['user-agent']);
-
-  const hostInfo = (headers && headers.Host) || (headers && headers.host);
-
-  // Same regex used by AWS SDK at /lib/services/sqs.js
-  const hostMatchesSQS = evaluateHeaderValue(hostInfo, header => header.match(/^sqs\.(?:.+?)\./) !== null);
-
-  // 'user-agent': 'aws-sdk-js/3.329.0 os/darwin/22.5.0 lang/js md/nodejs/18.14.2 api/sqs/3.329.0'
-  const agentMatchesSQS = evaluateHeaderValue(userAgent, header => header.toLowerCase().indexOf('api/sqs') > -1);
-
-  if (parentSpan && parentSpan.n === 'sqs' && awsSdkRequest && (hostMatchesSQS || agentMatchesSQS)) {
-    return true;
-  }
 
   const isGCPNodeJSHeader = evaluateHeaderValue(
     userAgent,
@@ -186,9 +173,12 @@ function instrument(coreModule, forceHttps) {
 
     const parentSpan = skipTracingResult.parentSpan;
 
-    const awsSdkRequest = isAwsSdkRequest(options);
+    // Note: There is no need to create http EXIT spans for AWS SDK created events
+    if (isAwsSdkRequest(options)) {
+      return originalRequest.apply(coreModule, arguments);
+    }
 
-    if (skipTracingResult.skip || shouldBeBypassed(skipTracingResult.parentSpan, options, awsSdkRequest)) {
+    if (skipTracingResult.skip || shouldBeBypassed(skipTracingResult.parentSpan, options)) {
       let traceLevelHeaderHasBeenAdded = false;
       if (skipTracingResult.suppressed) {
         traceLevelHeaderHasBeenAdded = tryToAddTraceLevelAddHeaderToOpts(options, '0', w3cTraceContext);
@@ -202,11 +192,6 @@ function instrument(coreModule, forceHttps) {
       }
 
       return clientRequest;
-    }
-
-    // Note: There is no need to create http EXIT spans for AWS SDK created events
-    if (awsSdkRequest) {
-      return originalRequest.apply(coreModule, arguments);
     }
 
     cls.ns.run(() => {

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -270,7 +270,7 @@ function instrument(coreModule, forceHttps) {
 
       let instanaHeadersHaveBeenAdded = false;
       try {
-        instanaHeadersHaveBeenAdded = tryToAddHeadersToOpts(options, span, w3cTraceContext, awsSdkRequest);
+        instanaHeadersHaveBeenAdded = tryToAddHeadersToOpts(options, span, w3cTraceContext);
         clientRequest = originalRequest.apply(coreModule, originalArgs);
         removeInstanaHeadersFromOpts(options);
       } catch (e) {
@@ -288,7 +288,7 @@ function instrument(coreModule, forceHttps) {
 
       cls.ns.bindEmitter(clientRequest);
       if (!instanaHeadersHaveBeenAdded) {
-        instanaHeadersHaveBeenAdded = setHeadersOnRequest(clientRequest, span, w3cTraceContext, awsSdkRequest);
+        instanaHeadersHaveBeenAdded = setHeadersOnRequest(clientRequest, span, w3cTraceContext);
       }
 
       let isTimeout = false;

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -99,22 +99,14 @@ function evaluateHeaderValue(headerValue, validator) {
  * @return {boolean} true, if the HTTP request that is about to happen should _not_ create a span.
  */
 /**
- * Returns true if the User-Agent identifies the request as originating from the aws-sdk (v2 or v3).
- * Used both to bypass span creation and to skip Instana header injection for AWS SigV4-signed requests.
+ * Returns true if the request options originate from the aws-sdk (v2 or v3), identified by the
+ * User-Agent header. Used to skip Instana header injection for SigV4-signed requests.
  * @param {Object} options
  * @returns {boolean}
  */
-function isAwsSdkRequest(options) {
+function isAWSdkHeader(options) {
   const headers = options && options.headers;
   const userAgent = (headers && headers['User-Agent']) || (headers && headers['user-agent']);
-  return isAWSNodeJSHeader(userAgent);
-}
-
-/**
- * @param {string | string[] | undefined} userAgent
- * @returns {boolean}
- */
-function isAWSNodeJSHeader(userAgent) {
   return evaluateHeaderValue(
     userAgent,
     header => header.toLowerCase().indexOf('aws-sdk-nodejs') > -1 || header.toLowerCase().indexOf('aws-sdk-js') > -1
@@ -125,7 +117,7 @@ function shouldBeBypassed(parentSpan, options) {
   const headers = options && options.headers;
   const userAgent = (headers && headers['User-Agent']) || (headers && headers['user-agent']);
 
-  const awsSdkHeader = isAWSNodeJSHeader(userAgent);
+  const awsSdkHeader = isAWSdkHeader(options);
 
   const hostInfo = (headers && headers.Host) || (headers && headers.host);
 
@@ -198,7 +190,7 @@ function instrument(coreModule, forceHttps) {
 
     const parentSpan = skipTracingResult.parentSpan;
 
-    const awsSdkRequest = isAwsSdkRequest(options);
+    const awsSdkRequest = isAWSdkHeader(options);
 
     // aws-sdk requests that are being skipped/bypassed must be returned completely untouched —
     // no suppression or W3C headers either, as nothing must disturb the signed request because

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -172,7 +172,8 @@ function instrument(coreModule, forceHttps) {
 
     const parentSpan = skipTracingResult.parentSpan;
 
-    // Note: There is no need to create http EXIT spans for AWS SDK created events
+    // Note: There is no need to create http EXIT spans for AWS SDK operations. They have their own AWS instrumentations and spans.
+    // Note: There was a case in the past where customers hit SignatureDoesNotMatch from AWS, because we have attached Instana headers to outgoing AWS SDK requests. We could only reproduce these in a script - see https://github.com/instana/nodejs/tree/main/packages/collector/test/bin/reproduce-scripts
     if (isAwsSdkRequest(options)) {
       return originalRequest.apply(coreModule, arguments);
     }

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -204,7 +204,7 @@ function instrument(coreModule, forceHttps) {
       return clientRequest;
     }
 
-    // "Note: There is no need to create http EXIT spans for AWS SDK created events"
+    // Note: There is no need to create http EXIT spans for AWS SDK created events
     if (awsSdkRequest) {
       return originalRequest.apply(coreModule, arguments);
     }

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -198,15 +198,11 @@ function instrument(coreModule, forceHttps) {
 
     const parentSpan = skipTracingResult.parentSpan;
 
-    // aws-sdk requests (identified by User-Agent) must not have Instana headers injected —
-    // the request is already SigV4-signed and adding headers would cause SignatureDoesNotMatch on retries.
-    // A node.http.client span is still created for observability; only header injection is skipped.
     const awsSdkRequest = isAwsSdkRequest(options);
 
-    // CASE 1: skip due to tracing being inactive / reduced span / etc.
-    // CASE 2: shouldBeBypassed covers special cases like SQS polling from an SQS entry span.
-    // For aws-sdk requests in either case: return the original request completely untouched
-    // (no suppression headers, no W3C headers — nothing must disturb the signed request).
+    // aws-sdk requests that are being skipped/bypassed must be returned completely untouched —
+    // no suppression or W3C headers either, as nothing must disturb the signed request because
+    // adding headers would cause SignatureDoesNotMatch on retries.
     if (skipTracingResult.skip || shouldBeBypassed(skipTracingResult.parentSpan, options, awsSdkRequest)) {
       if (awsSdkRequest) {
         return originalRequest.apply(coreModule, arguments);

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -495,7 +495,13 @@ function isItSafeToModifiyHeadersInOptions(options) {
       // instrumented Lambda function behind an API gateway and the user is using
       // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/APIGateway.html to invoke this Gateway/Lambda
       // combination, which _would_ benefit from tracing headers.)
-      return false;
+
+      // Exception: when the request comes from axios (e.g. via aws4-axios), the signing library re-signs
+      // the request fresh on every call, so adding trace headers is safe. The receiving end is also likely
+      // an instrumented service (e.g. a Lambda behind API Gateway) that benefits from receiving trace headers.
+      if (!isAxiosRequest(options.headers)) {
+        return false;
+      }
     }
   }
   return true;
@@ -503,8 +509,32 @@ function isItSafeToModifiyHeadersInOptions(options) {
 
 function isItSafeToModifiyHeadersForRequest(clientRequest) {
   const authHeader = clientRequest.getHeader('Authorization');
-  // see comment in isItSafeToModifiyHeadersInOptions
-  return !authHeader || authHeader.indexOf('AWS') !== 0;
+  if (!authHeader || authHeader.indexOf('AWS') !== 0) {
+    return true;
+  }
+  // See comment in isItSafeToModifiyHeadersInOptions. Allow header injection only for axios requests.
+  const userAgent = clientRequest.getHeader('User-Agent');
+  return isAxiosUserAgent(userAgent);
+}
+
+/**
+ * Returns true if the headers object contains a User-Agent indicating the request was made by axios
+ * (e.g. via the aws4-axios interceptor). Only the presence of "axios" in the User-Agent is checked;
+ * no version matching is performed.
+ * @param {Object} headers
+ * @returns {boolean}
+ */
+function isAxiosRequest(headers) {
+  const userAgent = headers['User-Agent'] || headers['user-agent'];
+  return isAxiosUserAgent(userAgent);
+}
+
+/**
+ * @param {string | string[] | undefined} userAgent
+ * @returns {boolean}
+ */
+function isAxiosUserAgent(userAgent) {
+  return evaluateHeaderValue(userAgent, header => header.toLowerCase().indexOf('axios') > -1);
 }
 
 function captureRequestHeaders(options, clientRequest, response) {

--- a/packages/core/src/tracing/instrumentation/protocols/httpClient.js
+++ b/packages/core/src/tracing/instrumentation/protocols/httpClient.js
@@ -189,10 +189,6 @@ function instrument(coreModule, forceHttps) {
     const awsSdkRequest = isAWSdkHeader(options);
 
     if (skipTracingResult.skip || shouldBeBypassed(skipTracingResult.parentSpan, options, awsSdkRequest)) {
-      if (awsSdkRequest) {
-        return originalRequest.apply(coreModule, arguments);
-      }
-
       let traceLevelHeaderHasBeenAdded = false;
       if (skipTracingResult.suppressed) {
         traceLevelHeaderHasBeenAdded = tryToAddTraceLevelAddHeaderToOpts(options, '0', w3cTraceContext);
@@ -206,6 +202,11 @@ function instrument(coreModule, forceHttps) {
       }
 
       return clientRequest;
+    }
+
+    // Note: The aws sdk instr will create its own span, so no need to create again an http client span
+    if (awsSdkRequest) {
+      return originalRequest.apply(coreModule, arguments);
     }
 
     cls.ns.run(() => {
@@ -382,7 +383,7 @@ function isUrlObject(argument) {
   return URL && argument instanceof url.URL;
 }
 
-function tryToAddHeadersToOpts(options, span, w3cTraceContext, awsSdkRequest) {
+function tryToAddHeadersToOpts(options, span, w3cTraceContext) {
   // Some HTTP spec background: If the request has a header Expect: 100-continue, the client will first send the
   // request headers, without the body. The client is then ought to wait for the server to send a first, preliminary
   // response with the status code 100 Continue (if all is well). Only then will the client send the actual request
@@ -402,16 +403,6 @@ function tryToAddHeadersToOpts(options, span, w3cTraceContext, awsSdkRequest) {
   // (see setHeadersOnRequest).
 
   if (hasHeadersOption(options)) {
-    if (awsSdkRequest) {
-      // This is a signed AWS API request (from the aws-sdk package, identified by its User-Agent).
-      // Adding our headers to this request would trigger a SignatureDoesNotMatch error in case the request
-      // will be retried:
-      // "SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided.
-      // Check your key and signing method."
-      // See https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html
-
-      return true;
-    }
     options.headers[constants.spanIdHeaderName] = span.s;
     options.headers[constants.traceIdHeaderName] = span.t;
     options.headers[constants.traceLevelHeaderName] = '1';
@@ -459,11 +450,7 @@ function removeInstanaHeadersFromOpts(options) {
   delete options.headers[constants.w3cTraceState];
 }
 
-function setHeadersOnRequest(clientRequest, span, w3cTraceContext, awsSdkRequest) {
-  if (awsSdkRequest) {
-    return;
-  }
-
+function setHeadersOnRequest(clientRequest, span, w3cTraceContext) {
   if (span.shouldSuppressDownstream) {
     // Suppress trace propagation to downstream services.
     clientRequest.setHeader(constants.traceLevelHeaderName, '0');


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-100764

headers in the aws4-axios package triggered http calls:

>   'user-agent': 'axios/1.18.1',
>   'x-amz-date': '20260714T084817Z',