### PR TITLE
chore: added support for INSTANA_LOG_LEVEL_CAPTURE env variable

### DIFF
--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -7,7 +7,12 @@
 
 const normalizers = require('./normalizers');
 const deepMerge = require('../util/deepMerge');
-const { DEFAULT_STACK_TRACE_LENGTH, DEFAULT_STACK_TRACE_MODE, CONFIG_SOURCES } = require('../util/constants');
+const {
+  DEFAULT_STACK_TRACE_LENGTH,
+  DEFAULT_STACK_TRACE_MODE,
+  CONFIG_SOURCES,
+  DEFAULT_LOG_LEVEL
+} = require('../util/constants');
 const util = require('./util');
 const validators = require('./validator');
 const { validateStackTraceMode, validateStackTraceLength } = validators;
@@ -74,6 +79,7 @@ let currentConfig;
  * @property {boolean} [disableEOLEvents]
  * @property {globalStackTraceConfig} [global]
  * @property {otlpExporterOptions} [otlp]
+ * @property {string} [logLevelCapture]
  */
 
 /**
@@ -181,6 +187,7 @@ let defaults = {
     ignoreEndpoints: {},
     ignoreEndpointsDisableSuppression: false,
     disableEOLEvents: false,
+    logLevelCapture: DEFAULT_LOG_LEVEL,
     otlp: {
       enabled: false,
       // Currently, we only have http protocol support and default to 4318
@@ -371,6 +378,7 @@ function normalizeTracingConfig({ userConfig = {}, defaultConfig = {}, finalConf
   normalizeIgnoreEndpointsDisableSuppression({ userConfig, defaultConfig, finalConfig });
   normalizeDisableEOLEvents({ userConfig, defaultConfig, finalConfig });
   normalizeOtlpExporter({ userConfig, defaultConfig, finalConfig });
+  normalizeLogLevelCapture({ userConfig, defaultConfig, finalConfig });
 }
 
 /**
@@ -1206,6 +1214,31 @@ function normalizeDisableEOLEvents({ userConfig = {}, defaultConfig = {}, finalC
     source,
     value,
     envVarName: 'INSTANA_TRACING_DISABLE_EOL_EVENTS'
+  });
+}
+
+/**
+ * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
+ */
+function normalizeLogLevelCapture({ userConfig = {}, defaultConfig = {}, finalConfig = {} } = {}) {
+  const { value, source } = util.resolve(
+    {
+      envValue: 'INSTANA_LOG_LEVEL_CAPTURE',
+      inCodeValue: userConfig.tracing?.logLevelCapture,
+      defaultValue: defaultConfig.tracing.logLevelCapture
+    },
+    [validators.logLevelValidator]
+  );
+
+  configStore.set('config.tracing.logLevelCapture', { source });
+
+  finalConfig.tracing.logLevelCapture = value;
+
+  util.log({
+    configPath: 'config.tracing.logLevelCapture',
+    source,
+    value,
+    envVarName: 'INSTANA_LOG_LEVEL_CAPTURE'
   });
 }
 

--- a/packages/core/src/config/validator.js
+++ b/packages/core/src/config/validator.js
@@ -167,7 +167,7 @@ exports.logLevelValidator = function logLevelValidator(value) {
   if (value == null) {
     return undefined;
   }
-  const VALID_LOG_LEVEL_CAPTURE_VALUES = [LOG_LEVEL.INFO, LOG_LEVEL.WARN, LOG_LEVEL.ERROR, 'off'];
+  const VALID_LOG_LEVEL_CAPTURE_VALUES = [LOG_LEVEL.INFO, LOG_LEVEL.WARN, LOG_LEVEL.ERROR, LOG_LEVEL.OFF];
 
   if (typeof value !== 'string') {
     logger?.debug(

--- a/packages/core/src/config/validator.js
+++ b/packages/core/src/config/validator.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const { validStackTraceModes } = require('../util/constants');
+const { validStackTraceModes, LOG_LEVEL } = require('../util/constants');
 
 /** @type {import('../core').GenericLogger} */
 let logger;
@@ -157,4 +157,37 @@ exports.httpExitErrorCodeValidator = function httpExitErrorCodeValidator(value) 
 
     return result;
   }, []);
+};
+
+/**
+ * @param {any} value
+ * @returns {string|undefined}
+ */
+exports.logLevelValidator = function logLevelValidator(value) {
+  if (value == null) {
+    return undefined;
+  }
+  const VALID_LOG_LEVEL_CAPTURE_VALUES = [LOG_LEVEL.INFO, LOG_LEVEL.WARN, LOG_LEVEL.ERROR, 'off'];
+
+  if (typeof value !== 'string') {
+    logger?.debug(
+      `Ignoring invalid log level capture value "${value}". Expected one of: ${VALID_LOG_LEVEL_CAPTURE_VALUES.join(
+        ', '
+      )}.`
+    );
+    return undefined;
+  }
+
+  const normalized = value.toLowerCase();
+
+  if (!VALID_LOG_LEVEL_CAPTURE_VALUES.includes(normalized)) {
+    logger?.debug(
+      `Ignoring invalid log level capture value "${value}". Expected one of: ${VALID_LOG_LEVEL_CAPTURE_VALUES.join(
+        ', '
+      )}.`
+    );
+    return undefined;
+  }
+
+  return normalized;
 };

--- a/packages/core/src/util/constants.js
+++ b/packages/core/src/util/constants.js
@@ -24,3 +24,23 @@ exports.CONFIG_SOURCES = {
   AGENT: 3,
   DEFAULT: 4
 };
+
+exports.LOG_LEVEL = {
+  TRACE: 'trace',
+  DEBUG: 'debug',
+  INFO: 'info',
+  WARN: 'warn',
+  ERROR: 'error',
+  FATAL: 'fatal'
+};
+
+exports.LOG_LEVEL_PRIORITY = {
+  [exports.LOG_LEVEL.TRACE]: 10,
+  [exports.LOG_LEVEL.DEBUG]: 20,
+  [exports.LOG_LEVEL.INFO]: 30,
+  [exports.LOG_LEVEL.WARN]: 40,
+  [exports.LOG_LEVEL.ERROR]: 50,
+  [exports.LOG_LEVEL.FATAL]: 60
+};
+
+exports.DEFAULT_LOG_LEVEL = exports.LOG_LEVEL.WARN;

--- a/packages/core/src/util/constants.js
+++ b/packages/core/src/util/constants.js
@@ -31,7 +31,8 @@ exports.LOG_LEVEL = {
   INFO: 'info',
   WARN: 'warn',
   ERROR: 'error',
-  FATAL: 'fatal'
+  FATAL: 'fatal',
+  OFF: 'off'
 };
 
 exports.LOG_LEVEL_PRIORITY = {

--- a/packages/core/src/util/constants.js
+++ b/packages/core/src/util/constants.js
@@ -35,13 +35,4 @@ exports.LOG_LEVEL = {
   OFF: 'off'
 };
 
-exports.LOG_LEVEL_PRIORITY = {
-  [exports.LOG_LEVEL.TRACE]: 10,
-  [exports.LOG_LEVEL.DEBUG]: 20,
-  [exports.LOG_LEVEL.INFO]: 30,
-  [exports.LOG_LEVEL.WARN]: 40,
-  [exports.LOG_LEVEL.ERROR]: 50,
-  [exports.LOG_LEVEL.FATAL]: 60
-};
-
 exports.DEFAULT_LOG_LEVEL = exports.LOG_LEVEL.WARN;

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -642,7 +642,7 @@ describe('config.normalizeConfig', () => {
       });
 
       it('should normalize stack trace mode to lowercase from config', () => {
-        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: 'error' } } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: 'ERROR' } } } });
         expect(config.tracing.stackTrace).to.equal('error');
       });
 

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -49,6 +49,7 @@ describe('config.normalizeConfig', () => {
     delete process.env.INSTANA_TRACING_OTLP_ENABLED;
     delete process.env.INSTANA_TRACING_HTTP_EXIT_CLASSIFY_ALL_4XX_AS_ERRORS;
     delete process.env.INSTANA_TRACING_HTTP_EXIT_CLASSIFY_AS_ERRORS;
+    delete process.env.INSTANA_LOG_LEVEL_CAPTURE;
   }
 
   describe('default configuration', () => {
@@ -641,7 +642,7 @@ describe('config.normalizeConfig', () => {
       });
 
       it('should normalize stack trace mode to lowercase from config', () => {
-        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: 'ERROR' } } } });
+        const config = coreConfig.normalize({ userConfig: { tracing: { global: { stackTrace: 'error' } } } });
         expect(config.tracing.stackTrace).to.equal('error');
       });
 
@@ -2675,4 +2676,74 @@ describe('config.normalizeConfig', () => {
       }
     });
   }
+
+  describe('log level capture configuration (INSTANA_LOG_LEVEL_CAPTURE)', () => {
+    it('should default to warn when not set', () => {
+      const config = coreConfig.normalize();
+      expect(config.tracing.logLevelCapture).to.equal('warn');
+    });
+
+    it('should accept warn from env var', () => {
+      process.env.INSTANA_LOG_LEVEL_CAPTURE = 'warn';
+      const config = coreConfig.normalize();
+      expect(config.tracing.logLevelCapture).to.equal('warn');
+    });
+
+    it('should accept info from env var', () => {
+      process.env.INSTANA_LOG_LEVEL_CAPTURE = 'info';
+      const config = coreConfig.normalize();
+      expect(config.tracing.logLevelCapture).to.equal('info');
+    });
+
+    it('should accept error from env var', () => {
+      process.env.INSTANA_LOG_LEVEL_CAPTURE = 'error';
+      const config = coreConfig.normalize();
+      expect(config.tracing.logLevelCapture).to.equal('error');
+    });
+
+    it('should accept off from env var', () => {
+      process.env.INSTANA_LOG_LEVEL_CAPTURE = 'off';
+      const config = coreConfig.normalize();
+      expect(config.tracing.logLevelCapture).to.equal('off');
+    });
+
+    it('should normalize env var value to uppercase (lowercase "warn")', () => {
+      process.env.INSTANA_LOG_LEVEL_CAPTURE = 'warn';
+      const config = coreConfig.normalize();
+      expect(config.tracing.logLevelCapture).to.equal('warn');
+    });
+
+    it('should normalize env var value to uppercase (mixed case "Info")', () => {
+      process.env.INSTANA_LOG_LEVEL_CAPTURE = 'Info';
+      const config = coreConfig.normalize();
+      expect(config.tracing.logLevelCapture).to.equal('info');
+    });
+
+    it('should fall back to warn for an invalid env var value', () => {
+      process.env.INSTANA_LOG_LEVEL_CAPTURE = 'VERBOSE';
+      const config = coreConfig.normalize();
+      expect(config.tracing.logLevelCapture).to.equal('warn');
+    });
+
+    it('should accept info from in-code config', () => {
+      const config = coreConfig.normalize({ userConfig: { tracing: { logLevelCapture: 'info' } } });
+      expect(config.tracing.logLevelCapture).to.equal('info');
+    });
+
+    it('should accept off from in-code config', () => {
+      const config = coreConfig.normalize({ userConfig: { tracing: { logLevelCapture: 'off' } } });
+      expect(config.tracing.logLevelCapture).to.equal('off');
+    });
+
+    it('should fall back to warn for an invalid in-code config value', () => {
+      const config = coreConfig.normalize({ userConfig: { tracing: { logLevelCapture: 'INVALID' } } });
+      expect(config.tracing.logLevelCapture).to.equal('warn');
+    });
+
+    it('should give precedence to env var over in-code config', () => {
+      process.env.INSTANA_LOG_LEVEL_CAPTURE = 'error';
+      const config = coreConfig.normalize({ userConfig: { tracing: { logLevelCapture: 'info' } } });
+      expect(config.tracing.logLevelCapture).to.equal('error');
+    });
+  });
 });

--- a/packages/core/test/config/validator_test.js
+++ b/packages/core/test/config/validator_test.js
@@ -517,4 +517,59 @@ describe('config.validator', () => {
       expect(validator.httpExitErrorCodeValidator(['abc', {}, [], 500, 399])).to.deep.equal([]);
     });
   });
+
+  describe('logLevelValidator', () => {
+    it('should return undefined for null', () => {
+      expect(validator.logLevelValidator(null)).to.be.undefined;
+    });
+
+    it('should return undefined for undefined', () => {
+      expect(validator.logLevelValidator(undefined)).to.be.undefined;
+    });
+
+    it('should accept "info"', () => {
+      expect(validator.logLevelValidator('info')).to.equal('info');
+    });
+
+    it('should accept "warn"', () => {
+      expect(validator.logLevelValidator('warn')).to.equal('warn');
+    });
+
+    it('should accept "error"', () => {
+      expect(validator.logLevelValidator('error')).to.equal('error');
+    });
+
+    it('should accept "off"', () => {
+      expect(validator.logLevelValidator('off')).to.equal('off');
+    });
+
+    it('should normalize mixed-case input to lowercase', () => {
+      expect(validator.logLevelValidator('INFO')).to.equal('info');
+      expect(validator.logLevelValidator('Warn')).to.equal('warn');
+      expect(validator.logLevelValidator('ERROR')).to.equal('error');
+      expect(validator.logLevelValidator('OFF')).to.equal('off');
+    });
+
+    it('should return undefined for an invalid string value', () => {
+      expect(validator.logLevelValidator('debug')).to.be.undefined;
+      expect(validator.logLevelValidator('verbose')).to.be.undefined;
+      expect(validator.logLevelValidator('trace')).to.be.undefined;
+      expect(validator.logLevelValidator('INVALID')).to.be.undefined;
+    });
+
+    it('should return undefined for a number', () => {
+      expect(validator.logLevelValidator(1)).to.be.undefined;
+      expect(validator.logLevelValidator(0)).to.be.undefined;
+    });
+
+    it('should return undefined for a boolean', () => {
+      expect(validator.logLevelValidator(true)).to.be.undefined;
+      expect(validator.logLevelValidator(false)).to.be.undefined;
+    });
+
+    it('should return undefined for an object', () => {
+      expect(validator.logLevelValidator({})).to.be.undefined;
+      expect(validator.logLevelValidator([])).to.be.undefined;
+    });
+  });
 });


### PR DESCRIPTION
introduced a new configuration option to control the minimum log level for log span capture.

Previously, log spans were created only for logs at **WARN** level and above. With this change, users can configure the minimum log level that should generate log spans.

## Configuration

The log capture level can be configured using either:

- Environment variable: `INSTANA_LOG_LEVEL_CAPTURE`
- In-code configuration: `tracing.logLevelCapture`

Supported values:

- `INFO`
- `WARN` (default)
- `ERROR`
- `OFF`

## Log capture behavior

| Configuration | Captured log levels |
|---------------|---------------------|
| `INFO` | INFO, WARN, ERROR, FATAL |
| `WARN` (default) | WARN, ERROR, FATAL |
| `ERROR` | ERROR, FATAL |
| `OFF` | No log spans are captured |


ref: https://jsw.ibm.com/browse/INSTA-101942
tech spec: https://github.ibm.com/instana/technical-documentation/blob/master/tracing/specification/README.md#log-spans