### PR TITLE
feat(console): added option to capture info logs

### DIFF
--- a/packages/collector/test/integration/currencies/logging/console/app.js
+++ b/packages/collector/test/integration/currencies/logging/console/app.js
@@ -43,7 +43,7 @@ app.get('/log', (req, res) => {
 });
 
 app.get('/info', (req, res) => {
-  console.info('console.info - should not be traced');
+  console.info('console.info - should not be traced by default');
   finish(res);
 });
 

--- a/packages/collector/test/integration/currencies/logging/console/app.mjs
+++ b/packages/collector/test/integration/currencies/logging/console/app.mjs
@@ -43,7 +43,7 @@ app.get('/log', (req, res) => {
 });
 
 app.get('/info', (req, res) => {
-  console.info('console.info - should not be traced');
+  console.info('console.info - should not be traced by default');
   finish(res);
 });
 

--- a/packages/collector/test/integration/currencies/logging/console/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/console/test_base.js
@@ -148,6 +148,169 @@ module.exports = function (name, version, isLatest) {
       ));
   });
 
+  describe('log span capture configuration via INSTANA_LOG_LEVEL_CAPTURE', () => {
+    let customAgentControls;
+    describe('when INSTANA_LOG_LEVEL_CAPTURE=error', () => {
+      before(async () => {
+        customAgentControls = new ProcessControls({
+          useGlobalAgent: true,
+          dirname: __dirname,
+          env: {
+            INSTANA_LOG_LEVEL_CAPTURE: 'error',
+            LIBRARY_LATEST: isLatest,
+            LIBRARY_VERSION: version,
+            LIBRARY_NAME: name
+          }
+        });
+        await customAgentControls.startAndWaitForAgentConnection();
+      });
+
+      after(async () => {
+        await customAgentControls.stop();
+      });
+
+      it('should trace console.error calls', async () => {
+        await customAgentControls.sendRequest({ path: '/error' });
+
+        await testUtils.retry(async () => {
+          const spans = await agentControls.getSpans();
+          console.log('spans', JSON.stringify(spans));
+          const httpEntrySpan = verifyHttpRootEntry({
+            spans,
+            apiPath: '/error',
+            pid: String(customAgentControls.getPid())
+          });
+
+          verifyHttpExit({
+            spans,
+            parent: httpEntrySpan,
+            pid: String(customAgentControls.getPid())
+          });
+
+          const consoleLogSpans = testUtils.getSpansByName(spans, 'log.console');
+          expect(consoleLogSpans.length).to.equal(1);
+          expect(consoleLogSpans[0].data.log.level).to.equal('error');
+          expect(consoleLogSpans[0].data.log.message).to.equal('console.error - should be traced');
+        });
+      });
+
+      it('should not trace console.warn calls', async () => {
+        await customAgentControls.sendRequest({ path: '/warn' });
+
+        await testUtils.retry(async () => {
+          const spans = await agentControls.getSpans();
+          const httpEntrySpan = verifyHttpRootEntry({
+            spans,
+            apiPath: '/warn',
+            pid: String(customAgentControls.getPid())
+          });
+
+          verifyHttpExit({
+            spans,
+            parent: httpEntrySpan,
+            pid: String(customAgentControls.getPid())
+          });
+
+          const consoleLogSpans = testUtils.getSpansByName(spans, 'log.console');
+          expect(consoleLogSpans).to.be.empty;
+        });
+      });
+    });
+
+    describe('when INSTANA_LOG_LEVEL_CAPTURE=info', () => {
+      before(async () => {
+        customAgentControls = new ProcessControls({
+          useGlobalAgent: true,
+          dirname: __dirname,
+          env: {
+            INSTANA_LOG_LEVEL_CAPTURE: 'info',
+            LIBRARY_LATEST: isLatest,
+            LIBRARY_VERSION: version,
+            LIBRARY_NAME: name
+          }
+        });
+        await customAgentControls.startAndWaitForAgentConnection();
+      });
+
+      after(async () => {
+        await customAgentControls.stop();
+      });
+
+      it('should trace console.info calls', async () => {
+        await customAgentControls.sendRequest({ path: '/info' });
+
+        await testUtils.retry(async () => {
+          const spans = await agentControls.getSpans();
+          console.log('spans', JSON.stringify(spans));
+          const httpEntrySpan = verifyHttpRootEntry({
+            spans,
+            apiPath: '/info',
+            pid: String(customAgentControls.getPid())
+          });
+
+          verifyHttpExit({
+            spans,
+            parent: httpEntrySpan,
+            pid: String(customAgentControls.getPid())
+          });
+
+          const consoleLogSpans = testUtils.getSpansByName(spans, 'log.console');
+          expect(consoleLogSpans.length).to.equal(1);
+          expect(consoleLogSpans[0].data.log.level).to.equal('info');
+          expect(consoleLogSpans[0].data.log.message).to.equal('console.info - should not be traced by default');
+        });
+      });
+
+      it('should trace console.error calls', async () => {
+        await customAgentControls.sendRequest({ path: '/error' });
+
+        await testUtils.retry(async () => {
+          const spans = await agentControls.getSpans();
+          console.log('spans', JSON.stringify(spans));
+          const httpEntrySpan = verifyHttpRootEntry({
+            spans,
+            apiPath: '/error',
+            pid: String(customAgentControls.getPid())
+          });
+
+          verifyHttpExit({
+            spans,
+            parent: httpEntrySpan,
+            pid: String(customAgentControls.getPid())
+          });
+
+          const consoleLogSpans = testUtils.getSpansByName(spans, 'log.console');
+          expect(consoleLogSpans.length).to.equal(1);
+          expect(consoleLogSpans[0].data.log.level).to.equal('error');
+          expect(consoleLogSpans[0].data.log.message).to.equal('console.error - should be traced');
+        });
+      });
+
+      it('should not trace console.log calls', async () => {
+        await customAgentControls.sendRequest({ path: '/log' });
+
+        await testUtils.retry(async () => {
+          const spans = await agentControls.getSpans();
+          console.log('spans', JSON.stringify(spans));
+          const httpEntrySpan = verifyHttpRootEntry({
+            spans,
+            apiPath: '/log',
+            pid: String(customAgentControls.getPid())
+          });
+
+          verifyHttpExit({
+            spans,
+            parent: httpEntrySpan,
+            pid: String(customAgentControls.getPid())
+          });
+
+          const consoleLogSpans = testUtils.getSpansByName(spans, 'log.console');
+          expect(consoleLogSpans.length).to.equal(0);
+        });
+      });
+    });
+  });
+
   describe('when logging is disabled', () => {
     describe('through environment variables', () => {
       let envVarControls;

--- a/packages/core/src/tracing/instrumentation/logging/console.js
+++ b/packages/core/src/tracing/instrumentation/logging/console.js
@@ -17,6 +17,7 @@ let isActive = false;
 exports.init = function init() {
   shimmer.wrap(console, 'warn', shimLog({ markAsError: false, level: 'warn' }));
   shimmer.wrap(console, 'error', shimLog({ markAsError: true, level: 'error' }));
+  shimmer.wrap(console, 'info', shimLog({ markAsError: false, level: 'info' }));
 };
 
 // ATTENTION: Do not use console.warn or console.error in this file, otherwise it could run into endless loop
@@ -35,6 +36,10 @@ function shimLog(options) {
       }
 
       if (cls.skipExitTracing({ isActive, skipAllowRootExitSpanPresence: true })) {
+        return originalLog.apply(this, arguments);
+      }
+
+      if (!tracingUtil.shouldCaptureLogSpan(options.level)) {
         return originalLog.apply(this, arguments);
       }
 

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -10,7 +10,7 @@ const path = require('path');
 const StringDecoder = require('string_decoder').StringDecoder;
 
 const stackTrace = require('../util/stackTrace');
-const { STACK_TRACE_MODES, LOG_LEVEL_PRIORITY, DEFAULT_LOG_LEVEL, LOG_LEVEL } = require('../util/constants');
+const { STACK_TRACE_MODES, LOG_LEVEL_PRIORITY, LOG_LEVEL } = require('../util/constants');
 
 /** @type {import('../core').GenericLogger} */
 let logger;
@@ -463,10 +463,6 @@ exports.shouldCaptureLogSpan = function shouldCaptureLogSpan(level) {
     return false;
   }
   const minLevel = LOG_LEVEL_PRIORITY[logLevelConfig];
-
-  if (typeof level === 'number') {
-    return level >= minLevel;
-  }
 
   const numericLevel = LOG_LEVEL_PRIORITY[level?.toLowerCase()];
 

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -52,7 +52,6 @@ exports.activate = function activate(_config) {
   stackTraceLength = _config.tracing.stackTraceLength;
   stackTraceMode = _config.tracing.stackTrace;
   httpExitConfig = _config.tracing.http.exit;
-  logLevelConfig = _config.tracing.logLevelCapture;
 };
 
 /**

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -464,7 +464,7 @@ exports.shouldCaptureLogSpan = function shouldCaptureLogSpan(level) {
   }
   const minLevel = LOG_LEVEL_PRIORITY[logLevelConfig];
 
-  const numericLevel = LOG_LEVEL_PRIORITY[level?.toLowerCase()];
+  const numericLevel = LOG_LEVEL_PRIORITY[level.toLowerCase()];
 
   return numericLevel !== undefined && numericLevel >= minLevel;
 };

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -10,7 +10,7 @@ const path = require('path');
 const StringDecoder = require('string_decoder').StringDecoder;
 
 const stackTrace = require('../util/stackTrace');
-const { STACK_TRACE_MODES, LOG_LEVEL_PRIORITY, DEFAULT_LOG_LEVEL } = require('../util/constants');
+const { STACK_TRACE_MODES, LOG_LEVEL_PRIORITY, DEFAULT_LOG_LEVEL, LOG_LEVEL } = require('../util/constants');
 
 /** @type {import('../core').GenericLogger} */
 let logger;
@@ -459,7 +459,7 @@ exports.handleUnexpectedReturnValue = function handleUnexpectedReturnValue(retur
  * @returns {boolean}
  */
 exports.shouldCaptureLogSpan = function shouldCaptureLogSpan(level) {
-  if (logLevelConfig === 'off') {
+  if (logLevelConfig === LOG_LEVEL.OFF) {
     return false;
   }
   const minLevel = LOG_LEVEL_PRIORITY[logLevelConfig];

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -10,7 +10,7 @@ const path = require('path');
 const StringDecoder = require('string_decoder').StringDecoder;
 
 const stackTrace = require('../util/stackTrace');
-const { STACK_TRACE_MODES } = require('../util/constants');
+const { STACK_TRACE_MODES, LOG_LEVEL_PRIORITY, DEFAULT_LOG_LEVEL } = require('../util/constants');
 
 /** @type {import('../core').GenericLogger} */
 let logger;
@@ -29,6 +29,11 @@ let stackTraceMode;
  * @type {import("../config").HTTPExitTracingOptions | undefined}
  */
 let httpExitConfig;
+
+/**
+ * @type {string}
+ */
+let logLevelConfig = DEFAULT_LOG_LEVEL;
 /**
  * @param {import('../config').InstanaConfig} config
  */
@@ -37,6 +42,7 @@ exports.init = function (config) {
   stackTraceLength = config?.tracing?.stackTraceLength;
   stackTraceMode = config?.tracing?.stackTrace;
   httpExitConfig = config.tracing.http.exit;
+  logLevelConfig = config.tracing.logLevelCapture;
 };
 
 /**
@@ -46,6 +52,7 @@ exports.activate = function activate(_config) {
   stackTraceLength = _config.tracing.stackTraceLength;
   stackTraceMode = _config.tracing.stackTrace;
   httpExitConfig = _config.tracing.http.exit;
+  logLevelConfig = _config.tracing.logLevelCapture;
 };
 
 /**
@@ -446,4 +453,23 @@ exports.handleUnexpectedReturnValue = function handleUnexpectedReturnValue(retur
   );
 
   return true;
+};
+
+/**
+ * @param {string} level
+ * @returns {boolean}
+ */
+exports.shouldCaptureLogSpan = function shouldCaptureLogSpan(level) {
+  if (logLevelConfig === 'off') {
+    return false;
+  }
+  const minLevel = LOG_LEVEL_PRIORITY[logLevelConfig];
+
+  if (typeof level === 'number') {
+    return level >= minLevel;
+  }
+
+  const numericLevel = LOG_LEVEL_PRIORITY[level?.toLowerCase()];
+
+  return numericLevel !== undefined && numericLevel >= minLevel;
 };

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -33,7 +33,7 @@ let httpExitConfig;
 /**
  * @type {string}
  */
-let logLevelConfig = DEFAULT_LOG_LEVEL;
+let logLevelConfig;
 /**
  * @param {import('../config').InstanaConfig} config
  */

--- a/packages/core/src/util/constants.js
+++ b/packages/core/src/util/constants.js
@@ -35,4 +35,13 @@ exports.LOG_LEVEL = {
   OFF: 'off'
 };
 
+exports.LOG_LEVEL_PRIORITY = {
+  [exports.LOG_LEVEL.TRACE]: 10,
+  [exports.LOG_LEVEL.DEBUG]: 20,
+  [exports.LOG_LEVEL.INFO]: 30,
+  [exports.LOG_LEVEL.WARN]: 40,
+  [exports.LOG_LEVEL.ERROR]: 50,
+  [exports.LOG_LEVEL.FATAL]: 60
+};
+
 exports.DEFAULT_LOG_LEVEL = exports.LOG_LEVEL.WARN;

--- a/packages/core/test/tracing/tracingUtil_test.js
+++ b/packages/core/test/tracing/tracingUtil_test.js
@@ -13,6 +13,7 @@ const util = require('util');
 
 const config = require('../config');
 const { isCI, createFakeLogger } = require('../test_util');
+const { LOG_LEVEL_PRIORITY, LOG_LEVEL } = require('../../src/util/constants');
 
 const {
   findCallback,
@@ -1501,6 +1502,146 @@ describe('tracing/tracingUtil', () => {
 
       it('should return false for 399', () => {
         expect(shouldMarkAsError(399)).to.equal(false);
+      });
+    });
+  });
+
+  describe('shouldCaptureLogSpan', () => {
+    const { shouldCaptureLogSpan } = tracingUtil;
+
+    describe('when logLevelCapture is OFF', () => {
+      before(() => {
+        tracingUtil.init({
+          logger: createFakeLogger(),
+          tracing: {
+            stackTraceLength: 10,
+            http: {
+              exit: {
+                classifyAll4xxAsErrors: false,
+                classifyAsErrors: []
+              }
+            },
+            logLevelCapture: 'off'
+          }
+        });
+      });
+
+      ['TRACE', 'DEBUG', 'INFO', 'WARN', 'error', 'fatal'].forEach(level => {
+        it(`should return false for ${level}`, () => {
+          expect(shouldCaptureLogSpan(level)).to.equal(false);
+        });
+      });
+    });
+
+    describe('when logLevelCapture is INFO', () => {
+      before(() => {
+        tracingUtil.init({
+          logger: createFakeLogger(),
+          tracing: {
+            stackTraceLength: 10,
+            http: {
+              exit: {
+                classifyAll4xxAsErrors: false,
+                classifyAsErrors: []
+              }
+            },
+            logLevelCapture: 'info'
+          }
+        });
+      });
+
+      it('should return false for TRACE', () => {
+        expect(shouldCaptureLogSpan('TRACE')).to.equal(false);
+      });
+
+      it('should return false for DEBUG', () => {
+        expect(shouldCaptureLogSpan('DEBUG')).to.equal(false);
+      });
+
+      it('should return true for INFO', () => {
+        expect(shouldCaptureLogSpan('INFO')).to.equal(true);
+      });
+
+      it('should return true for WARN', () => {
+        expect(shouldCaptureLogSpan('WARN')).to.equal(true);
+      });
+
+      it('should return true for error', () => {
+        expect(shouldCaptureLogSpan('error')).to.equal(true);
+      });
+
+      it('should return true for fatal', () => {
+        expect(shouldCaptureLogSpan('fatal')).to.equal(true);
+      });
+
+      it('should be case-insensitive', () => {
+        expect(shouldCaptureLogSpan('info')).to.equal(true);
+        expect(shouldCaptureLogSpan('Warn')).to.equal(true);
+        expect(shouldCaptureLogSpan('error')).to.equal(true);
+      });
+
+      it('should return false for an unknown log level', () => {
+        expect(shouldCaptureLogSpan('INVALID')).to.equal(false);
+      });
+    });
+
+    describe('when logLevelCapture is WARN(default)', () => {
+      before(() => {
+        tracingUtil.init({
+          logger: createFakeLogger(),
+          tracing: {
+            stackTraceLength: 10,
+            http: {
+              exit: {
+                classifyAll4xxAsErrors: false,
+                classifyAsErrors: []
+              }
+            },
+            logLevelCapture: 'warn'
+          }
+        });
+      });
+
+      it('should return false for TRACE', () => {
+        expect(shouldCaptureLogSpan('TRACE')).to.equal(false);
+      });
+
+      it('should return false for DEBUG', () => {
+        expect(shouldCaptureLogSpan('DEBUG')).to.equal(false);
+      });
+
+      it('should return false for INFO', () => {
+        expect(shouldCaptureLogSpan('INFO')).to.equal(false);
+      });
+
+      it('should return true for WARN', () => {
+        expect(shouldCaptureLogSpan('WARN')).to.equal(true);
+      });
+
+      it('should return true for error', () => {
+        expect(shouldCaptureLogSpan('error')).to.equal(true);
+      });
+
+      it('should return true for fatal', () => {
+        expect(shouldCaptureLogSpan('fatal')).to.equal(true);
+      });
+
+      it('should return false for numeric levels below WARN', () => {
+        expect(shouldCaptureLogSpan(LOG_LEVEL_PRIORITY[LOG_LEVEL.TRACE])).to.equal(false);
+        expect(shouldCaptureLogSpan(LOG_LEVEL_PRIORITY[LOG_LEVEL.DEBUG])).to.equal(false);
+        expect(shouldCaptureLogSpan(LOG_LEVEL_PRIORITY[LOG_LEVEL.INFO])).to.equal(false);
+      });
+
+      it('should return true for numeric WARN level', () => {
+        expect(shouldCaptureLogSpan(LOG_LEVEL_PRIORITY[LOG_LEVEL.WARN])).to.equal(true);
+      });
+
+      it('should return true for numeric error level', () => {
+        expect(shouldCaptureLogSpan(LOG_LEVEL_PRIORITY[LOG_LEVEL.ERROR])).to.equal(true);
+      });
+
+      it('should return true for numeric fatal level', () => {
+        expect(shouldCaptureLogSpan(LOG_LEVEL_PRIORITY[LOG_LEVEL.FATAL])).to.equal(true);
       });
     });
   });

--- a/packages/core/test/tracing/tracingUtil_test.js
+++ b/packages/core/test/tracing/tracingUtil_test.js
@@ -13,7 +13,6 @@ const util = require('util');
 
 const config = require('../config');
 const { isCI, createFakeLogger } = require('../test_util');
-const { LOG_LEVEL_PRIORITY, LOG_LEVEL } = require('../../src/util/constants');
 
 const {
   findCallback,
@@ -1624,24 +1623,6 @@ describe('tracing/tracingUtil', () => {
 
       it('should return true for fatal', () => {
         expect(shouldCaptureLogSpan('fatal')).to.equal(true);
-      });
-
-      it('should return false for numeric levels below WARN', () => {
-        expect(shouldCaptureLogSpan(LOG_LEVEL_PRIORITY[LOG_LEVEL.TRACE])).to.equal(false);
-        expect(shouldCaptureLogSpan(LOG_LEVEL_PRIORITY[LOG_LEVEL.DEBUG])).to.equal(false);
-        expect(shouldCaptureLogSpan(LOG_LEVEL_PRIORITY[LOG_LEVEL.INFO])).to.equal(false);
-      });
-
-      it('should return true for numeric WARN level', () => {
-        expect(shouldCaptureLogSpan(LOG_LEVEL_PRIORITY[LOG_LEVEL.WARN])).to.equal(true);
-      });
-
-      it('should return true for numeric error level', () => {
-        expect(shouldCaptureLogSpan(LOG_LEVEL_PRIORITY[LOG_LEVEL.ERROR])).to.equal(true);
-      });
-
-      it('should return true for numeric fatal level', () => {
-        expect(shouldCaptureLogSpan(LOG_LEVEL_PRIORITY[LOG_LEVEL.FATAL])).to.equal(true);
       });
     });
   });


### PR DESCRIPTION
Previously, console log spans were created only for logs at WARN level and above. With this change, users can configure the minimum log level that should generate log spans.

### Configuration
The log capture level can be configured using either:

**Environment variable**: INSTANA_LOG_LEVEL_CAPTURE
**In-code configuration**: tracing.logLevelCapture

#### Supported values:

- INFO
- WARN (default)
- ERROR
- OFF

ref: https://jsw.ibm.com/browse/INSTA-101942
tech spec: https://github.ibm.com/instana/technical-documentation/blob/master/tracing/specification/README.md#log-spans
