### PR TITLE
feat(log4js): added option to capture info logs

### DIFF
--- a/packages/collector/test/integration/currencies/logging/log4js/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/log4js/test_base.js
@@ -67,7 +67,7 @@ module.exports = function (name, version, isLatest) {
       }
 
       it(`must not trace info ${suffix}`, async () => {
-        await trigger({ level: 'info', message: 'Info message - must not be traced.', useLogMethod });
+        await trigger({ level: 'info', message: 'Info message - must not be traced by default.', useLogMethod });
         return retry(async () => {
           const spans = await agentControls.getSpans();
           const entrySpan = expectAtLeastOneMatching(spans, [
@@ -130,6 +130,139 @@ module.exports = function (name, version, isLatest) {
         }));
     }
 
+    describe('log span capture configuration via INSTANA_TRACING_CAPTURE_LOG_LEVEL', () => {
+      let customControls;
+
+      describe('when INSTANA_TRACING_CAPTURE_LOG_LEVEL=error', () => {
+        before(async () => {
+          customControls = new ProcessControls({
+            dirname: __dirname,
+            useGlobalAgent: true,
+            env: {
+              INSTANA_TRACING_CAPTURE_LOG_LEVEL: 'error',
+              LIBRARY_LATEST: isLatest,
+              LIBRARY_VERSION: version,
+              LIBRARY_NAME: name
+            }
+          });
+
+          await customControls.startAndWaitForAgentConnection();
+        });
+
+        beforeEach(async () => {
+          await agentControls.clearReceivedTraceData();
+        });
+
+        after(async () => {
+          await customControls.stop();
+        });
+
+        it('should trace error', async () => {
+          await trigger({
+            level: 'error',
+            message: 'Error message',
+            useLogMethod: false,
+            controls: customControls
+          });
+
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            const logSpans = getSpansByName(spans, 'log.log4js');
+
+            expect(logSpans).to.have.length(1);
+            expect(logSpans[0].data.log.message).to.equal('Error message');
+          });
+        });
+
+        it('should not trace warn', async () => {
+          await trigger({
+            level: 'warn',
+            message: 'Warn message',
+            useLogMethod: false,
+            controls: customControls
+          });
+
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            expect(getSpansByName(spans, 'log.log4js')).to.be.empty;
+          });
+        });
+      });
+
+      describe('when INSTANA_TRACING_CAPTURE_LOG_LEVEL=info', () => {
+        before(async () => {
+          customControls = new ProcessControls({
+            dirname: __dirname,
+            useGlobalAgent: true,
+            env: {
+              INSTANA_TRACING_CAPTURE_LOG_LEVEL: 'info',
+              LIBRARY_LATEST: isLatest,
+              LIBRARY_VERSION: version,
+              LIBRARY_NAME: name
+            }
+          });
+
+          await customControls.startAndWaitForAgentConnection();
+        });
+
+        beforeEach(async () => {
+          await agentControls.clearReceivedTraceData();
+        });
+
+        after(async () => {
+          await customControls.stop();
+        });
+
+        it('should trace info', async () => {
+          await trigger({
+            level: 'info',
+            message: 'Info message',
+            useLogMethod: false,
+            controls: customControls
+          });
+
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            const logSpans = getSpansByName(spans, 'log.log4js');
+
+            expect(logSpans).to.have.length(1);
+            expect(logSpans[0].data.log.message).to.equal('Info message');
+          });
+        });
+
+        it('should not trace debug', async () => {
+          await trigger({
+            level: 'debug',
+            message: 'Debug message',
+            useLogMethod: false,
+            controls: customControls
+          });
+
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            expect(getSpansByName(spans, 'log.log4js')).to.be.empty;
+          });
+        });
+
+        it('should trace error', async () => {
+          await trigger({
+            level: 'error',
+            message: 'Error message',
+            useLogMethod: false,
+            controls: customControls
+          });
+
+          await retry(async () => {
+            const spans = await agentControls.getSpans();
+            const logSpans = getSpansByName(spans, 'log.log4js');
+
+            expect(logSpans).to.have.length(1);
+            expect(logSpans[0].data.log.message).to.equal('Error message');
+          });
+        });
+      });
+    });
+
     async function runTest({ level, message, useLogMethod, expectErroneous = false, multipleArguments = false }) {
       await trigger({ level, message, useLogMethod, multipleArguments });
       await retry(async () => {
@@ -176,18 +309,25 @@ module.exports = function (name, version, isLatest) {
       expect(span.n).to.equal('node.http.client');
     }
 
-    function trigger({ level, message, useLogMethod, multipleArguments = false }) {
+    function trigger({
+      level,
+      message,
+      useLogMethod,
+      multipleArguments = false,
+      controls: processControls = controls
+    }) {
       const query = {
         level,
         message,
         useLogMethod,
         multipleArguments
       };
+
       const queryString = Object.keys(query)
         .map(key => `${key}=${query[key]}`)
         .join('&');
 
-      return controls.sendRequest({
+      return processControls.sendRequest({
         method: 'POST',
         path: `/log?${queryString}`,
         simple: false

--- a/packages/core/src/tracing/instrumentation/logging/log4js.js
+++ b/packages/core/src/tracing/instrumentation/logging/log4js.js
@@ -8,12 +8,22 @@
 const util = require('util');
 const shimmer = require('../../shimmer');
 
+const { LOG_LEVEL } = require('../../../util/constants');
 const hook = require('../../../util/hook');
 const tracingUtil = require('../../tracingUtil');
 const constants = require('../../constants');
 const cls = require('../../cls');
 
 let isActive = false;
+
+const LEVEL_MAP = {
+  5000: LOG_LEVEL.TRACE,
+  10000: LOG_LEVEL.DEBUG,
+  20000: LOG_LEVEL.INFO,
+  30000: LOG_LEVEL.WARN,
+  40000: LOG_LEVEL.ERROR,
+  50000: LOG_LEVEL.FATAL
+};
 
 exports.init = function init() {
   hook.onFileLoad(/\/log4js\/lib\/logger\.js/, instrumentLog4jsLogger);
@@ -34,15 +44,20 @@ function shimLog(originalLog) {
       return originalLog.apply(this, arguments);
     }
 
-    if (level == null || typeof level.level !== 'number' || level.level < 30000) {
+    if (level == null || typeof level.level !== 'number') {
       return originalLog.apply(this, arguments);
     }
 
-    return instrumentedLog(this, data, originalLog, level.level >= 40000, level);
+    const resolvedLogLevel = resolveLogLevel(level.level);
+    if (!resolvedLogLevel || !tracingUtil.shouldCaptureLogSpan(resolvedLogLevel)) {
+      return originalLog.apply(this, arguments);
+    }
+
+    return instrumentedLog(this, data, originalLog, resolvedLogLevel);
   };
 }
 
-function instrumentedLog(ctx, data, originalLog, markAsError, level) {
+function instrumentedLog(ctx, data, originalLog, level) {
   return cls.ns.runAndReturn(() => {
     let message;
 
@@ -61,7 +76,7 @@ function instrumentedLog(ctx, data, originalLog, markAsError, level) {
     span.data.log = {
       message
     };
-    if (markAsError) {
+    if (tracingUtil.isLogLevelAnError(level)) {
       span.ec = 1;
     }
 
@@ -72,6 +87,10 @@ function instrumentedLog(ctx, data, originalLog, markAsError, level) {
       span.transmit();
     }
   });
+}
+
+function resolveLogLevel(level) {
+  return LEVEL_MAP[level];
 }
 
 exports.activate = function activate() {

--- a/packages/core/src/tracing/instrumentation/logging/pino.js
+++ b/packages/core/src/tracing/instrumentation/logging/pino.js
@@ -10,7 +10,7 @@
 const { inspect } = require('util');
 const shimmer = require('../../shimmer');
 
-const { LOG_LEVEL_PRIORITY, LOG_LEVEL } = require('../../../util/constants');
+const { LOG_LEVEL_PRIORITY } = require('../../../util/constants');
 const hook = require('../../../util/hook');
 const tracingUtil = require('../../tracingUtil');
 const constants = require('../../constants');
@@ -92,7 +92,7 @@ function shimGenLog(originalGenLog) {
             message
           };
 
-          if (levelName === LOG_LEVEL.ERROR || levelName === LOG_LEVEL.FATAL) {
+          if (tracingUtil.isLogLevelAnError(levelName)) {
             span.ec = 1;
           }
 

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -468,3 +468,11 @@ exports.shouldCaptureLogSpan = function shouldCaptureLogSpan(level) {
 
   return numericLevel !== undefined && numericLevel >= minLevel;
 };
+
+/**
+ * @param {string} level
+ * @returns {boolean}
+ */
+exports.isLogLevelAnError = function isLogLevelAnError(level) {
+  return level === LOG_LEVEL.ERROR || level === LOG_LEVEL.FATAL;
+};

--- a/packages/core/test/tracing/tracingUtil_test.js
+++ b/packages/core/test/tracing/tracingUtil_test.js
@@ -13,6 +13,7 @@ const util = require('util');
 
 const config = require('../config');
 const { isCI, createFakeLogger } = require('../test_util');
+const { LOG_LEVEL } = require('../../src/util/constants');
 
 const {
   findCallback,
@@ -1624,6 +1625,37 @@ describe('tracing/tracingUtil', () => {
       it('should return true for fatal', () => {
         expect(shouldCaptureLogSpan('fatal')).to.equal(true);
       });
+    });
+  });
+
+  describe('isLogLevelAnError', () => {
+    const { isLogLevelAnError } = tracingUtil;
+    before(() => {
+      tracingUtil.init({
+        logger: createFakeLogger(),
+        tracing: {
+          stackTraceLength: 10,
+          http: {
+            exit: {
+              classifyAll4xxAsErrors: false,
+              classifyAsErrors: []
+            }
+          },
+          captureLogLevel: 'warn'
+        }
+      });
+    });
+
+    it('should return true for ERROR and FATAL log levels', () => {
+      expect(isLogLevelAnError(LOG_LEVEL.ERROR)).to.be.true;
+      expect(isLogLevelAnError(LOG_LEVEL.FATAL)).to.be.true;
+    });
+
+    it('should return false for non-error log levels', () => {
+      expect(isLogLevelAnError(LOG_LEVEL.TRACE)).to.be.false;
+      expect(isLogLevelAnError(LOG_LEVEL.DEBUG)).to.be.false;
+      expect(isLogLevelAnError(LOG_LEVEL.INFO)).to.be.false;
+      expect(isLogLevelAnError(LOG_LEVEL.WARN)).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR adds support for capturing **info**-level logs for log4js. By default, log capture starts at **WARN** and above. When configured, **INFO** logs can also be captured.

Reference: https://github.com/log4js-node/log4js-node/blob/master/lib/levels.js#L96

https://log4js-node.github.io/log4js-node/api.html

## Configuration

The log capture level can be configured using either:

- Environment variable: `INSTANA_TRACING_CAPTURE_LOG_LEVEL`
- In-code configuration: `tracing.captureLogLevel`

Supported values:

- `INFO`
- `WARN` (default)
- `ERROR`
- `OFF`

## Log capture behavior

| Configuration | Captured log levels        |
| ------------- | -------------------------- |
| `INFO`        | INFO, WARN, ERROR, FATAL   |
| `WARN`        | WARN, ERROR, FATAL         |
| `ERROR`       | ERROR, FATAL               |
| `OFF`         | No log spans are captured. |

ref: https://jsw.ibm.com/browse/INSTA-101942
tech spec: https://github.ibm.com/instana/technical-documentation/blob/master/tracing/specification/README.md#log-spans