### PR TITLE
feat(pino): added option to capture info logs

### DIFF
--- a/packages/collector/test/integration/currencies/logging/pino/app.js
+++ b/packages/collector/test/integration/currencies/logging/pino/app.js
@@ -74,7 +74,7 @@ app.get('/', (req, res) => {
 });
 
 app.get('/info', (req, res) => {
-  plainVanillaPino.info('Info message - must not be traced.');
+  plainVanillaPino.info('Info message - must not be traced by default.');
   finish(res);
 });
 

--- a/packages/collector/test/integration/currencies/logging/pino/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/pino/test_base.js
@@ -175,6 +175,12 @@ module.exports = function (name, version, isLatest) {
         notTraced: []
       });
 
+      runCaptureTests({
+        captureLevel: 'off',
+        traced: [],
+        notTraced: ['warn', 'info', 'error', 'fatal']
+      });
+
       function runCaptureTests({ captureLevel, traced, notTraced }) {
         describe(`when INSTANA_LOG_LEVEL_CAPTURE=${captureLevel}`, function () {
           let controls;

--- a/packages/collector/test/integration/currencies/logging/pino/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/pino/test_base.js
@@ -154,6 +154,81 @@ module.exports = function (name, version, isLatest) {
       });
     });
 
+    describe('log span capture configuration via INSTANA_LOG_LEVEL_CAPTURE', function () {
+      runCaptureTests({
+        captureLevel: 'error',
+        traced: [
+          ['error', true, 'Error message - should be traced.'],
+          ['fatal', true, 'Fatal message - should be traced.']
+        ],
+        notTraced: ['warn', 'info']
+      });
+
+      runCaptureTests({
+        captureLevel: 'info',
+        traced: [
+          ['info', false, 'Info message - must not be traced by default.'],
+          ['warn', false, 'Warn message - should be traced.'],
+          ['error', true, 'Error message - should be traced.'],
+          ['fatal', true, 'Fatal message - should be traced.']
+        ],
+        notTraced: []
+      });
+
+      function runCaptureTests({ captureLevel, traced, notTraced }) {
+        describe(`when INSTANA_LOG_LEVEL_CAPTURE=${captureLevel}`, function () {
+          let controls;
+
+          before(async () => {
+            controls = new ProcessControls({
+              dirname: __dirname,
+              useGlobalAgent: true,
+              env: {
+                INSTANA_LOG_LEVEL_CAPTURE: captureLevel,
+                LIBRARY_LATEST: isLatest,
+                LIBRARY_VERSION: version,
+                LIBRARY_NAME: name,
+                PINO_EXPRESS: 'false'
+              }
+            });
+
+            await controls.startAndWaitForAgentConnection();
+          });
+
+          beforeEach(async () => {
+            await agentControls.clearReceivedTraceData();
+          });
+
+          after(async () => {
+            await controls.stop();
+          });
+
+          traced.forEach(([level, erroneous, message]) => {
+            it(`should trace ${level}`, () => runTest(level, false, erroneous, message, controls));
+          });
+
+          notTraced.forEach(level => {
+            it(`should not trace ${level}`, () =>
+              trigger(level, false, controls).then(() =>
+                testUtils.retry(() =>
+                  agentControls.getSpans().then(spans => {
+                    const entrySpan = testUtils.expectAtLeastOneMatching(spans, [
+                      span => expect(span.n).to.equal('node.http.server'),
+                      span => expect(span.f.e).to.equal(String(controls.getPid())),
+                      span => expect(span.f.h).to.equal('agent-stub-uuid')
+                    ]);
+
+                    testUtils.expectAtLeastOneMatching(spans, checkNextExitSpan(entrySpan, controls));
+
+                    expect(testUtils.getSpansByName(spans, 'log.pino')).to.be.empty;
+                  })
+                )
+              ));
+          });
+        });
+      }
+    });
+
     function runTests(pinoVersion, useExpressPino) {
       const suffix = useExpressPino ? ' (express-pino)' : '';
 

--- a/packages/core/src/tracing/instrumentation/logging/pino.js
+++ b/packages/core/src/tracing/instrumentation/logging/pino.js
@@ -10,13 +10,17 @@
 const { inspect } = require('util');
 const shimmer = require('../../shimmer');
 
-const { LOG_LEVEL } = require('../../../util/constants');
+const { LOG_LEVEL_PRIORITY } = require('../../../util/constants');
 const hook = require('../../../util/hook');
 const tracingUtil = require('../../tracingUtil');
 const constants = require('../../constants');
 const cls = require('../../cls');
 
 let isActive = false;
+
+// Reverse the log level mapping once for numeric-to-name lookups.
+// Pino internally represents log levels as numbers (for example, 30 -> "info").
+const LEVEL_NAMES = Object.fromEntries(Object.entries(LOG_LEVEL_PRIORITY).map(([name, value]) => [value, name]));
 
 exports.init = function init() {
   // TODO: Fix the issue with Pino instrumentation. If Pino is required multiple times,
@@ -105,27 +109,10 @@ function shimGenLog(originalGenLog) {
 }
 
 function resolveLogLevel(level) {
-  if (typeof level === 'string') {
-    return level.toLowerCase();
-  }
-
-  if (level >= 60) {
-    return LOG_LEVEL.FATAL;
-  }
-  if (level >= 50) {
-    return LOG_LEVEL.ERROR;
-  }
-  if (level >= 40) {
-    return LOG_LEVEL.WARN;
-  }
-  if (level >= 30) {
-    return LOG_LEVEL.INFO;
-  }
-  if (level >= 20) {
-    return LOG_LEVEL.DEBUG;
-  }
-
-  return LOG_LEVEL.TRACE;
+  // `logLevelCapture` only accepts the standard log level names. Round custom
+  // Pino numeric levels (e.g. 35, 55) down to the nearest standard level.
+  const rounded = Math.floor(level / 10) * 10;
+  return LEVEL_NAMES[rounded];
 }
 
 exports.activate = function activate() {

--- a/packages/core/src/tracing/instrumentation/logging/pino.js
+++ b/packages/core/src/tracing/instrumentation/logging/pino.js
@@ -10,7 +10,7 @@
 const { inspect } = require('util');
 const shimmer = require('../../shimmer');
 
-const { LOG_LEVEL_PRIORITY } = require('../../../util/constants');
+const { LOG_LEVEL_PRIORITY, LOG_LEVEL } = require('../../../util/constants');
 const hook = require('../../../util/hook');
 const tracingUtil = require('../../tracingUtil');
 const constants = require('../../constants');
@@ -92,7 +92,7 @@ function shimGenLog(originalGenLog) {
             message
           };
 
-          if (level >= 50) {
+          if (levelName === LOG_LEVEL.ERROR || levelName === LOG_LEVEL.FATAL) {
             span.ec = 1;
           }
 

--- a/packages/core/src/tracing/instrumentation/logging/pino.js
+++ b/packages/core/src/tracing/instrumentation/logging/pino.js
@@ -10,6 +10,7 @@
 const { inspect } = require('util');
 const shimmer = require('../../shimmer');
 
+const { LOG_LEVEL } = require('../../../util/constants');
 const hook = require('../../../util/hook');
 const tracingUtil = require('../../tracingUtil');
 const constants = require('../../constants');
@@ -30,9 +31,9 @@ function instrumentPinoTools(toolsModule) {
 
 function shimGenLog(originalGenLog) {
   return function (level) {
-    // pino uses numerical log levels, 40 is 'warn', level increases with severity.
-    if (!level || level < 40) {
-      // we are not interested in anything below warn
+    const levelName = resolveLogLevel(level);
+
+    if (!levelName || !tracingUtil.shouldCaptureLogSpan(levelName)) {
       return originalGenLog.apply(this, arguments);
     } else {
       const originalLoggingFunction = originalGenLog.apply(this, arguments);
@@ -101,6 +102,30 @@ function shimGenLog(originalGenLog) {
       };
     }
   };
+}
+
+function resolveLogLevel(level) {
+  if (typeof level === 'string') {
+    return level.toLowerCase();
+  }
+
+  if (level >= 60) {
+    return LOG_LEVEL.FATAL;
+  }
+  if (level >= 50) {
+    return LOG_LEVEL.ERROR;
+  }
+  if (level >= 40) {
+    return LOG_LEVEL.WARN;
+  }
+  if (level >= 30) {
+    return LOG_LEVEL.INFO;
+  }
+  if (level >= 20) {
+    return LOG_LEVEL.DEBUG;
+  }
+
+  return LOG_LEVEL.TRACE;
 }
 
 exports.activate = function activate() {

--- a/packages/core/src/tracing/instrumentation/logging/pino.js
+++ b/packages/core/src/tracing/instrumentation/logging/pino.js
@@ -19,7 +19,7 @@ const cls = require('../../cls');
 let isActive = false;
 
 // Reverse the log level mapping once for numeric-to-name lookups.
-// Pino internally represents log levels as numbers (for example, 30 -> "info").
+// pino uses numerical log levels (for example, 30 -> "info").
 const LEVEL_NAMES = Object.fromEntries(Object.entries(LOG_LEVEL_PRIORITY).map(([name, value]) => [value, name]));
 
 exports.init = function init() {


### PR DESCRIPTION
## Summary

This PR adds support for capturing **info**-level logs for Pino. By default, log capture starts at **WARN** and above. When configured, **INFO** logs can also be captured.

Reference: https://github.com/pinojs/pino/blob/HEAD/docs/api.md#opt-customlevels

## Configuration

The log capture level can be configured using either:

- Environment variable: `INSTANA_LOG_LEVEL_CAPTURE`
- In-code configuration: `tracing.logLevelCapture`

Supported values:

- `INFO`
- `WARN` (default)
- `ERROR`
- `OFF`

## Log capture behavior

| Configuration | Captured log levels        |
| ------------- | -------------------------- |
| `INFO`        | INFO, WARN, ERROR, FATAL   |
| `WARN`        | WARN, ERROR, FATAL         |
| `ERROR`       | ERROR, FATAL               |
| `OFF`         | No log spans are captured. |

ref: https://jsw.ibm.com/browse/INSTA-101942
tech spec: https://github.ibm.com/instana/technical-documentation/blob/master/tracing/specification/README.md#log-spans