### PR TITLE
feat(winston): added option to capture info logs

### DIFF
--- a/packages/collector/test/integration/currencies/logging/winston/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/winston/test_base.js
@@ -95,7 +95,7 @@ module.exports = function (name, version, isLatest, mode) {
     })
   );
 
-  describe('log span capture respects INSTANA_LOG_LEVEL_CAPTURE', () => {
+  describe('log span capture respects INSTANA_TRACING_CAPTURE_LOG_LEVEL', () => {
     let customControls;
 
     async function start(level) {
@@ -103,7 +103,7 @@ module.exports = function (name, version, isLatest, mode) {
         dirname: __dirname,
         useGlobalAgent: true,
         env: {
-          INSTANA_LOG_LEVEL_CAPTURE: level,
+          INSTANA_TRACING_CAPTURE_LOG_LEVEL: level,
           LIBRARY_LATEST: isLatest,
           LIBRARY_VERSION: version,
           LIBRARY_NAME: name

--- a/packages/collector/test/integration/currencies/logging/winston/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/winston/test_base.js
@@ -95,6 +95,66 @@ module.exports = function (name, version, isLatest, mode) {
     })
   );
 
+  describe('log span capture respects INSTANA_LOG_LEVEL_CAPTURE', () => {
+    let customControls;
+
+    async function start(level) {
+      customControls = new ProcessControls({
+        dirname: __dirname,
+        useGlobalAgent: true,
+        env: {
+          INSTANA_LOG_LEVEL_CAPTURE: level,
+          LIBRARY_LATEST: isLatest,
+          LIBRARY_VERSION: version,
+          LIBRARY_NAME: name
+        }
+      });
+
+      await customControls.startAndWaitForAgentConnection();
+    }
+
+    beforeEach(async () => {
+      await agentControls.clearReceivedTraceData();
+    });
+
+    afterEach(async () => {
+      if (customControls) {
+        await customControls.stop();
+        customControls = null;
+      }
+    });
+
+    describe('when the minimum log level is ERROR', () => {
+      before(() => start('error'));
+
+      it('should not trace info', () => runTests(customControls, 'info', false));
+
+      it('should not trace warn', () => runTests(customControls, 'warn', false));
+
+      it('should trace error', () => runTests(customControls, 'error', true));
+    });
+
+    describe('when the minimum log level is INFO', () => {
+      before(() => start('info'));
+
+      it('should trace info', () => runTests(customControls, 'info', true));
+
+      it('should trace warn', () => runTests(customControls, 'warn', true));
+
+      it('should trace error', () => runTests(customControls, 'error', true));
+    });
+
+    describe('when the minimum log level is OFF', () => {
+      before(() => start('off'));
+
+      it('should not trace info', () => runTests(customControls, 'info', false));
+
+      it('should not trace warn', () => runTests(customControls, 'warn', false));
+
+      it('should not trace error', () => runTests(customControls, 'error', false));
+    });
+  });
+
   function runTests(useGlobalLogger, useLevelMethod, variant, level) {
     let testName;
     const shouldTrace = level !== 'info';

--- a/packages/core/src/tracing/instrumentation/logging/winston.js
+++ b/packages/core/src/tracing/instrumentation/logging/winston.js
@@ -61,31 +61,31 @@ function instrumentWinston3(createLogger) {
     const derivedLogger = createLogger.apply(this, arguments);
 
     // npm levels
-    shimLevelMethod(derivedLogger, 'error', true);
-    shimLevelMethod(derivedLogger, 'warn', false);
-    shimLevelMethod(derivedLogger, 'info', false);
+    shimLevelMethod(derivedLogger, 'error');
+    shimLevelMethod(derivedLogger, 'warn');
+    shimLevelMethod(derivedLogger, 'info');
 
     // syslog levels (RFC5424)
-    shimLevelMethod(derivedLogger, 'emerg', true);
-    shimLevelMethod(derivedLogger, 'alert', true);
-    shimLevelMethod(derivedLogger, 'crit', true);
-    shimLevelMethod(derivedLogger, 'warning', false);
-    shimLevelMethod(derivedLogger, 'notice', false);
+    shimLevelMethod(derivedLogger, 'emerg');
+    shimLevelMethod(derivedLogger, 'alert');
+    shimLevelMethod(derivedLogger, 'crit');
+    shimLevelMethod(derivedLogger, 'warning');
+    shimLevelMethod(derivedLogger, 'notice');
 
     shimLogMethod(derivedLogger);
     return derivedLogger;
   }
 }
 
-function shimLevelMethod(derivedLogger, level, markAsError) {
+function shimLevelMethod(derivedLogger, level) {
   const originalMethod = derivedLogger[level];
   if (typeof originalMethod !== 'function') {
     return;
   }
-  derivedLogger[level] = instrumentedLevelMethod(originalMethod, markAsError, level);
+  derivedLogger[level] = instrumentedLevelMethod(originalMethod, level);
 }
 
-function instrumentedLevelMethod(originalMethod, markAsError, level) {
+function instrumentedLevelMethod(originalMethod, level) {
   return function (message) {
     // CASE: Customer is using a custom winston logger (instana.setLogger(winstonLogger)).
     //       We create a winston child logger for all instana internal logs.
@@ -126,7 +126,7 @@ function instrumentedLevelMethod(originalMethod, markAsError, level) {
     }
 
     const ctx = this;
-    return createSpan(ctx, originalMethod, originalArgs, message, markAsError);
+    return createSpan(ctx, originalMethod, originalArgs, message, normalizedLogLevel);
   };
 }
 

--- a/packages/core/src/tracing/instrumentation/logging/winston.js
+++ b/packages/core/src/tracing/instrumentation/logging/winston.js
@@ -98,7 +98,9 @@ function instrumentedLevelMethod(originalMethod, markAsError, level) {
       return originalMethod.apply(this, arguments);
     }
 
-    if (!tracingUtil.shouldCaptureLogSpan(resolveLogLevel(level))) {
+    const normalizedLogLevel = resolveLogLevel(level);
+
+    if (!tracingUtil.shouldCaptureLogSpan(normalizedLogLevel)) {
       return originalMethod.apply(this, arguments);
     }
 
@@ -164,7 +166,9 @@ function instrumentedLog(originalMethod) {
       }
     }
 
-    if (cls.skipExitTracing({ isActive }) || !tracingUtil.shouldCaptureLogSpan(resolveLogLevel(level))) {
+    const normalizedLogLevel = resolveLogLevel(level);
+
+    if (cls.skipExitTracing({ isActive }) || !tracingUtil.shouldCaptureLogSpan(normalizedLogLevel)) {
       return originalMethod.apply(this, arguments);
     }
 
@@ -173,7 +177,7 @@ function instrumentedLog(originalMethod) {
       originalArgs[j] = arguments[j];
     }
     const ctx = this;
-    return createSpan(ctx, originalMethod, originalArgs, message, levelIsError(level));
+    return createSpan(ctx, originalMethod, originalArgs, message, levelIsError(normalizedLogLevel));
   };
 }
 
@@ -181,9 +185,8 @@ function resolveLogLevel(level) {
   return LEVEL_MAP[level];
 }
 
-function levelIsError(level) {
-  const resolvedLevel = resolveLogLevel(level);
-  return resolvedLevel === LOG_LEVEL.ERROR || resolvedLevel === LOG_LEVEL.FATAL;
+function levelIsError(normalizedLogLevel) {
+  return normalizedLogLevel === LOG_LEVEL.ERROR || normalizedLogLevel === LOG_LEVEL.FATAL;
 }
 
 function createSpan(ctx, originalMethod, originalArgs, message, markAsError) {

--- a/packages/core/src/tracing/instrumentation/logging/winston.js
+++ b/packages/core/src/tracing/instrumentation/logging/winston.js
@@ -177,7 +177,7 @@ function instrumentedLog(originalMethod) {
       originalArgs[j] = arguments[j];
     }
     const ctx = this;
-    return createSpan(ctx, originalMethod, originalArgs, message, levelIsError(normalizedLogLevel));
+    return createSpan(ctx, originalMethod, originalArgs, message, normalizedLogLevel);
   };
 }
 
@@ -185,11 +185,7 @@ function resolveLogLevel(level) {
   return LEVEL_MAP[level];
 }
 
-function levelIsError(normalizedLogLevel) {
-  return normalizedLogLevel === LOG_LEVEL.ERROR || normalizedLogLevel === LOG_LEVEL.FATAL;
-}
-
-function createSpan(ctx, originalMethod, originalArgs, message, markAsError) {
+function createSpan(ctx, originalMethod, originalArgs, message, level) {
   return cls.ns.runAndReturn(() => {
     const span = cls.startSpan({
       spanName: 'log.winston',
@@ -199,7 +195,7 @@ function createSpan(ctx, originalMethod, originalArgs, message, markAsError) {
     span.data.log = {
       message
     };
-    if (markAsError) {
+    if (tracingUtil.shouldMarkErrorForLogLevel(level)) {
       span.ec = 1;
     }
     try {

--- a/packages/core/src/tracing/instrumentation/logging/winston.js
+++ b/packages/core/src/tracing/instrumentation/logging/winston.js
@@ -195,7 +195,7 @@ function createSpan(ctx, originalMethod, originalArgs, message, level) {
     span.data.log = {
       message
     };
-    if (tracingUtil.shouldMarkErrorForLogLevel(level)) {
+    if (tracingUtil.isLogLevelAnError(level)) {
       span.ec = 1;
     }
     try {

--- a/packages/core/src/tracing/instrumentation/logging/winston.js
+++ b/packages/core/src/tracing/instrumentation/logging/winston.js
@@ -98,7 +98,7 @@ function instrumentedLevelMethod(originalMethod, markAsError, level) {
       return originalMethod.apply(this, arguments);
     }
 
-    if (!tracingUtil.shouldCaptureLogSpan(level)) {
+    if (!tracingUtil.shouldCaptureLogSpan(resolveLogLevel(level))) {
       return originalMethod.apply(this, arguments);
     }
 

--- a/packages/core/src/tracing/instrumentation/logging/winston.js
+++ b/packages/core/src/tracing/instrumentation/logging/winston.js
@@ -77,12 +77,12 @@ function instrumentWinston3(createLogger) {
   }
 }
 
-function shimLevelMethod(derivedLogger, key, markAsError) {
-  const originalMethod = derivedLogger[key];
+function shimLevelMethod(derivedLogger, level, markAsError) {
+  const originalMethod = derivedLogger[level];
   if (typeof originalMethod !== 'function') {
     return;
   }
-  derivedLogger[key] = instrumentedLevelMethod(originalMethod, markAsError, key);
+  derivedLogger[level] = instrumentedLevelMethod(originalMethod, markAsError, level);
 }
 
 function instrumentedLevelMethod(originalMethod, markAsError, level) {

--- a/packages/core/src/tracing/instrumentation/logging/winston.js
+++ b/packages/core/src/tracing/instrumentation/logging/winston.js
@@ -9,8 +9,26 @@ const hook = require('../../../util/hook');
 const tracingUtil = require('../../tracingUtil');
 const constants = require('../../constants');
 const cls = require('../../cls');
+const { LOG_LEVEL } = require('../../../util/constants');
 
 let isActive = false;
+
+const LEVEL_MAP = {
+  // npm levels
+  error: LOG_LEVEL.ERROR,
+  warn: LOG_LEVEL.WARN,
+  info: LOG_LEVEL.INFO,
+  debug: LOG_LEVEL.DEBUG,
+  verbose: LOG_LEVEL.TRACE,
+  silly: LOG_LEVEL.TRACE,
+
+  // RFC 5424 syslog levels
+  emerg: LOG_LEVEL.FATAL,
+  alert: LOG_LEVEL.FATAL,
+  crit: LOG_LEVEL.ERROR,
+  warning: LOG_LEVEL.WARN,
+  notice: LOG_LEVEL.INFO
+};
 
 exports.init = function init() {
   // Winston 2.x
@@ -45,12 +63,14 @@ function instrumentWinston3(createLogger) {
     // npm levels
     shimLevelMethod(derivedLogger, 'error', true);
     shimLevelMethod(derivedLogger, 'warn', false);
+    shimLevelMethod(derivedLogger, 'info', false);
 
     // syslog levels (RFC5424)
     shimLevelMethod(derivedLogger, 'emerg', true);
     shimLevelMethod(derivedLogger, 'alert', true);
     shimLevelMethod(derivedLogger, 'crit', true);
     shimLevelMethod(derivedLogger, 'warning', false);
+    shimLevelMethod(derivedLogger, 'notice', false);
 
     shimLogMethod(derivedLogger);
     return derivedLogger;
@@ -62,10 +82,10 @@ function shimLevelMethod(derivedLogger, key, markAsError) {
   if (typeof originalMethod !== 'function') {
     return;
   }
-  derivedLogger[key] = instrumentedLevelMethod(originalMethod, markAsError);
+  derivedLogger[key] = instrumentedLevelMethod(originalMethod, markAsError, key);
 }
 
-function instrumentedLevelMethod(originalMethod, markAsError) {
+function instrumentedLevelMethod(originalMethod, markAsError, level) {
   return function (message) {
     // CASE: Customer is using a custom winston logger (instana.setLogger(winstonLogger)).
     //       We create a winston child logger for all instana internal logs.
@@ -75,6 +95,10 @@ function instrumentedLevelMethod(originalMethod, markAsError) {
     }
 
     if (cls.skipExitTracing({ isActive, skipAllowRootExitSpanPresence: true })) {
+      return originalMethod.apply(this, arguments);
+    }
+
+    if (!tracingUtil.shouldCaptureLogSpan(level)) {
       return originalMethod.apply(this, arguments);
     }
 
@@ -140,7 +164,7 @@ function instrumentedLog(originalMethod) {
       }
     }
 
-    if (cls.skipExitTracing({ isActive }) || !levelIsTraced(level)) {
+    if (cls.skipExitTracing({ isActive }) || !tracingUtil.shouldCaptureLogSpan(resolveLogLevel(level))) {
       return originalMethod.apply(this, arguments);
     }
 
@@ -153,12 +177,13 @@ function instrumentedLog(originalMethod) {
   };
 }
 
-function levelIsTraced(level) {
-  return levelIsError(level) || level === 'warn' || level === 'warning';
+function resolveLogLevel(level) {
+  return LEVEL_MAP[level];
 }
 
 function levelIsError(level) {
-  return level === 'error' || level === 'emerg' || level === 'alert' || level === 'crit';
+  const resolvedLevel = resolveLogLevel(level);
+  return resolvedLevel === LOG_LEVEL.ERROR || resolvedLevel === LOG_LEVEL.FATAL;
 }
 
 function createSpan(ctx, originalMethod, originalArgs, message, markAsError) {


### PR DESCRIPTION
## Summary

This PR adds support for capturing **info**-level logs for Winston. By default, log capture starts at **WARN** and above. When configured, **INFO** logs can also be captured.

Reference: https://github.com/winstonjs/winston#logging-levels

## Configuration

The log capture level can be configured using either:

- Environment variable: `INSTANA_TRACING_CAPTURE_LOG_LEVEL`
- In-code configuration: `tracing.captureLogLevel`

Supported values:

- `INFO`
- `WARN` (default)
- `ERROR`
- `OFF`

## Log capture behavior

| Configuration | Captured log levels        |
| ------------- | -------------------------- |
| `INFO`        | INFO, WARN, ERROR, FATAL   |
| `WARN`        | WARN, ERROR, FATAL         |
| `ERROR`       | ERROR, FATAL               |
| `OFF`         | No log spans are captured. |

ref: https://jsw.ibm.com/browse/INSTA-101942
tech spec: https://github.ibm.com/instana/technical-documentation/blob/master/tracing/specification/README.md#log-spans