### PR TITLE
chore(log4js): shim _log instead of log 

### DIFF
--- a/packages/core/src/tracing/instrumentation/logging/log4js.js
+++ b/packages/core/src/tracing/instrumentation/logging/log4js.js
@@ -15,25 +15,16 @@ const cls = require('../../cls');
 
 let isActive = false;
 
-let levels;
-
 exports.init = function init() {
-  hook.onFileLoad(/\/log4js\/lib\/levels\.js/, saveLevelsRef);
   hook.onFileLoad(/\/log4js\/lib\/logger\.js/, instrumentLog4jsLogger);
 };
 
-function saveLevelsRef(levelsModule) {
-  if (typeof levelsModule.getLevel === 'function' && levelsModule.INFO != null) {
-    levels = levelsModule;
-  }
-}
-
 function instrumentLog4jsLogger(loggerModule) {
-  shimmer.wrap(loggerModule.prototype, 'log', shimLog);
+  shimmer.wrap(loggerModule.prototype, '_log', shimLog);
 }
 
 function shimLog(originalLog) {
-  return function (level) {
+  return function (level, data) {
     // The __instana attribute identifies the Instana logger, so prevent these logs from being traced.
     if (this.__instana) {
       return originalLog.apply(this, arguments);
@@ -43,31 +34,23 @@ function shimLog(originalLog) {
       return originalLog.apply(this, arguments);
     }
 
-    const actualLevel = levels && levels.getLevel(level, levels.INFO);
-    if (actualLevel == null || typeof actualLevel.level !== 'number' || actualLevel.level < 30000) {
+    if (level == null || typeof level.level !== 'number' || level.level < 30000) {
       return originalLog.apply(this, arguments);
     }
 
-    const originalArgs = new Array(arguments.length);
-    for (let i = 0; i < arguments.length; i++) {
-      originalArgs[i] = arguments[i];
-    }
-
-    return instrumentedLog(this, originalArgs, originalLog, actualLevel.level >= 40000);
+    return instrumentedLog(this, data, originalLog, level.level >= 40000, level);
   };
 }
 
-function instrumentedLog(ctx, originalArgs, originalLog, markAsError) {
+function instrumentedLog(ctx, data, originalLog, markAsError, level) {
   return cls.ns.runAndReturn(() => {
     let message;
 
-    // fast path for single string log call
-    if (originalArgs.length === 2 && typeof originalArgs[1] === 'string') {
-      message = originalArgs[1];
+    // _log receives data as an array of the message arguments (no level prefix).
+    if (data.length === 1 && typeof data[0] === 'string') {
+      message = data[0];
     } else {
-      // The original log4js log method takes (level, ...data) as arguments and creates the actually logged message via
-      // util.format(...data).
-      message = util.format(...originalArgs.slice(1));
+      message = util.format(...data);
     }
 
     const span = cls.startSpan({
@@ -81,8 +64,9 @@ function instrumentedLog(ctx, originalArgs, originalLog, markAsError) {
     if (markAsError) {
       span.ec = 1;
     }
+
     try {
-      return originalLog.apply(ctx, originalArgs);
+      return originalLog.apply(ctx, [level, data]);
     } finally {
       span.d = Date.now() - span.ts;
       span.transmit();


### PR DESCRIPTION
The old shim wrapped `log()`, which received the raw value passed by the user (for example, `"ERROR"` or `3`). So we needed `getLevel()` to convert it into a `Level` object.

Now we're wrapping `_log()`, which log4js calls **after** it has already resolved the level. That means `level` is always a `Level` object, so `getLevel()` is no longer needed.

This also lets us remove the extra mapping logic (`LEVEL_MAP`, `LOG_LEVEL`, `shouldCaptureLogSpan`, and `resolveLogLevel`), since we can use the resolved `Level` object directly.

