### PR TITLE
ci: pin @sonar/scan to v4.4.0

### DIFF
--- a/.tekton/tasks/tasks-results.yaml
+++ b/.tekton/tasks/tasks-results.yaml
@@ -69,7 +69,10 @@ spec:
           npx eslint packages/ -f json -o eslint-report.json || true
 
           echo "Installing SonarCloud scanner..."
-          npm install -g @sonar/scan
+          
+          # @sonar/scan v5 requires `sonar-scanner-npm`:
+          # https://github.com/SonarSource/sonar-scanner-npm/releases/tag/5.0.0
+          npm install -g @sonar/scan@4.4.0
 
           if [ -n "$(params.pr-number)" ]; then
             echo '$(params.pr-payload)' > pr.json


### PR DESCRIPTION
The latest @sonar/scan v5.0.0 introduces breaking changes:

Requires Node.js 22.12.0+ (previously Node.js 18+ for v4).
Removes the deprecated sonar and sonar-scanner CLI aliases in favour of `sonar-scanner-npm`.

This PR pins @sonar/scan to v4.4.0 until the CI pipeline is updated to use the new CLI and meets the new Node.js requirement.

see: https://github.com/SonarSource/sonar-scanner-npm/releases/tag/5.0.0