### PR TITLE
fix: captured missing log level in log spans 

### DIFF
--- a/packages/collector/test/integration/currencies/logging/bunyan/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/bunyan/test_base.js
@@ -69,20 +69,21 @@ module.exports = function (name, version, isLatest) {
         )
       ));
 
-    it('must trace warn', () => runTest('warn', false, 'Warn message - should be traced.', controls));
+    it('must trace warn', () => runTest('warn', false, 'Warn message - should be traced.', 'warn', controls));
 
-    it('must trace error', () => runTest('error', true, 'Error message - should be traced.', controls));
+    it('must trace error', () => runTest('error', true, 'Error message - should be traced.', 'error', controls));
 
-    it('must trace fatal', () => runTest('fatal', true, 'Fatal message - should be traced.', controls));
+    it('must trace fatal', () => runTest('fatal', true, 'Fatal message - should be traced.', 'fatal', controls));
 
     it("must capture an error object's message", () =>
-      runTest('error-object-only', true, 'Error: This is an error.', controls));
+      runTest('error-object-only', true, 'Error: This is an error.', 'error', controls));
 
     it("must capture a nested error object's message", async () => {
-      await runTest('nested-error-object-only', true, 'Error: This is a nested error.', controls);
+      await runTest('nested-error-object-only', true, 'Error: This is a nested error.', 'error', controls);
     });
 
-    it('must serialize random object', () => runTest('error-random-object-only', true, '{"foo":"[Object]"}', controls));
+    it('must serialize random object', () =>
+      runTest('error-random-object-only', true, '{"foo":"[Object]"}', 'error', controls));
 
     it('must serialize large object', () =>
       runTest(
@@ -90,6 +91,7 @@ module.exports = function (name, version, isLatest) {
         true,
         // eslint-disable-next-line max-len
         '{"_id":"638dea148cff492d47e792ea","index":0,"guid":"01b61bfa-fe4c-4d75-9224-389c4c04de10","isActive":false,"balance":"$1,919.18","picture":"http://placehold.it/32x32","age":37,"eyeColor":"blue","name":"Manning Brady","gender":"male","company":"ZYTRAC","email":"manningbrady@zytrac.com","phone":"+1 (957) 538-2183","address":"146 Bushwick Court, Gilgo, New York, 2992","about":"Ullamco cillum reprehenderit eu proident veniam laboris tempor voluptate. Officia deserunt velit incididunt consequat la...',
+        'error',
         controls,
         500,
         3
@@ -100,6 +102,7 @@ module.exports = function (name, version, isLatest) {
         'error-object-and-string',
         true,
         'Error: This is an error. -- Error message - should be traced.',
+        'error',
         controls
       ));
 
@@ -109,6 +112,7 @@ module.exports = function (name, version, isLatest) {
         true,
         // eslint-disable-next-line max-len
         'Error: This is a nested error. -- Error message - should be traced.',
+        'error',
         controls
       ));
 
@@ -117,20 +121,22 @@ module.exports = function (name, version, isLatest) {
         'error-random-object-and-string',
         true,
         '{"foo":"[Object]"} - Error message - should be traced.',
+        'error',
         controls
       ));
 
     it('must trace child logger error', () =>
-      runTest('child-error', true, 'Child logger error message - should be traced.', controls));
+      runTest('child-error', true, 'Child logger error message - should be traced.', 'error', controls));
 
     it('must trace an error with cause property', () =>
-      runTest('error-with-cause', true, 'Error: This is the cause error', controls));
+      runTest('error-with-cause', true, 'Error: This is the cause error', 'error', controls));
 
     it('must trace an error with cause property and extra string', () =>
       runTest(
         'error-with-cause-and-extra-string',
         true,
         'Error: This is the cause error -- Error message - should be traced.',
+        'error',
         controls
       ));
 
@@ -139,6 +145,7 @@ module.exports = function (name, version, isLatest) {
         'nested-error-with-cause',
         true,
         'Error: This is the cause error -- Error message - should be traced.',
+        'error',
         controls
       ));
 
@@ -212,7 +219,8 @@ module.exports = function (name, version, isLatest) {
             })
           ));
 
-        it('should trace error', () => runTest('error', true, 'Error message - should be traced.', customControls));
+        it('should trace error', () =>
+          runTest('error', true, 'Error message - should be traced.', 'error', customControls));
       });
 
       describe('when the minimum log level is INFO', () => {
@@ -225,11 +233,13 @@ module.exports = function (name, version, isLatest) {
         });
 
         it('should trace info', () =>
-          runTest('info', false, 'Info message - must not be traced by default.', customControls));
+          runTest('info', false, 'Info message - must not be traced by default.', 'info', customControls));
 
-        it('should trace warn', () => runTest('warn', false, 'Warn message - should be traced.', customControls));
+        it('should trace warn', () =>
+          runTest('warn', false, 'Warn message - should be traced.', 'warn', customControls));
 
-        it('should trace error', () => runTest('error', true, 'Error message - should be traced.', customControls));
+        it('should trace error', () =>
+          runTest('error', true, 'Error message - should be traced.', 'error', customControls));
       });
 
       describe('when the minimum log level is OFF', () => {
@@ -282,7 +292,7 @@ module.exports = function (name, version, isLatest) {
     });
   });
 
-  function runTest(url, expectErroneous, message, controls, lengthOfMessage, numberOfSpans) {
+  function runTest(url, expectErroneous, message, level, controls, lengthOfMessage, numberOfSpans) {
     return trigger(url, controls).then(async () => {
       return retry(async () => {
         const spans = await agentControls.getSpans();
@@ -299,7 +309,7 @@ module.exports = function (name, version, isLatest) {
         ]);
 
         expectAtLeastOneMatching(spans, span => {
-          checkBunyanSpan(span, entrySpan, expectErroneous, message, controls, lengthOfMessage);
+          checkBunyanSpan(span, entrySpan, expectErroneous, message, level, controls, lengthOfMessage);
         });
 
         expectAtLeastOneMatching(spans, span => {
@@ -313,7 +323,7 @@ module.exports = function (name, version, isLatest) {
     });
   }
 
-  function checkBunyanSpan(span, parent, erroneous, message, controls, lengthOfMessage) {
+  function checkBunyanSpan(span, parent, erroneous, message, level, controls, lengthOfMessage) {
     expect(span.t).to.equal(parent.t);
     expect(span.p).to.equal(parent.s);
     expect(span.k).to.equal(constants.EXIT);
@@ -326,6 +336,7 @@ module.exports = function (name, version, isLatest) {
     expect(span.data).to.exist;
     expect(span.data.log).to.exist;
     expect(span.data.log.message).to.equal(message);
+    expect(span.data.log.level).to.equal(level);
 
     if (lengthOfMessage) {
       expect(span.data.log.message.length).to.equal(lengthOfMessage);

--- a/packages/collector/test/integration/currencies/logging/bunyan/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/bunyan/test_base.js
@@ -69,85 +69,137 @@ module.exports = function (name, version, isLatest) {
         )
       ));
 
-    it('must trace warn', () => runTest('warn', false, 'Warn message - should be traced.', 'warn', controls));
+    it('must trace warn', () =>
+      runTest({
+        url: 'warn',
+        expectErroneous: false,
+        message: 'Warn message - should be traced.',
+        level: 'warn',
+        controls
+      }));
 
-    it('must trace error', () => runTest('error', true, 'Error message - should be traced.', 'error', controls));
+    it('must trace error', () =>
+      runTest({
+        url: 'error',
+        expectErroneous: true,
+        message: 'Error message - should be traced.',
+        level: 'error',
+        controls
+      }));
 
-    it('must trace fatal', () => runTest('fatal', true, 'Fatal message - should be traced.', 'fatal', controls));
+    it('must trace fatal', () =>
+      runTest({
+        url: 'fatal',
+        expectErroneous: true,
+        message: 'Fatal message - should be traced.',
+        level: 'fatal',
+        controls
+      }));
 
     it("must capture an error object's message", () =>
-      runTest('error-object-only', true, 'Error: This is an error.', 'error', controls));
+      runTest({
+        url: 'error-object-only',
+        expectErroneous: true,
+        message: 'Error: This is an error.',
+        level: 'error',
+        controls
+      }));
 
     it("must capture a nested error object's message", async () => {
-      await runTest('nested-error-object-only', true, 'Error: This is a nested error.', 'error', controls);
+      await runTest({
+        url: 'nested-error-object-only',
+        expectErroneous: true,
+        message: 'Error: This is a nested error.',
+        level: 'error',
+        controls
+      });
     });
 
     it('must serialize random object', () =>
-      runTest('error-random-object-only', true, '{"foo":"[Object]"}', 'error', controls));
+      runTest({
+        url: 'error-random-object-only',
+        expectErroneous: true,
+        message: '{"foo":"[Object]"}',
+        level: 'error',
+        controls
+      }));
 
     it('must serialize large object', () =>
-      runTest(
-        'error-large-object-only',
-        true,
+      runTest({
+        url: 'error-large-object-only',
+        expectErroneous: true,
         // eslint-disable-next-line max-len
-        '{"_id":"638dea148cff492d47e792ea","index":0,"guid":"01b61bfa-fe4c-4d75-9224-389c4c04de10","isActive":false,"balance":"$1,919.18","picture":"http://placehold.it/32x32","age":37,"eyeColor":"blue","name":"Manning Brady","gender":"male","company":"ZYTRAC","email":"manningbrady@zytrac.com","phone":"+1 (957) 538-2183","address":"146 Bushwick Court, Gilgo, New York, 2992","about":"Ullamco cillum reprehenderit eu proident veniam laboris tempor voluptate. Officia deserunt velit incididunt consequat la...',
-        'error',
+        message:
+          '{"_id":"638dea148cff492d47e792ea","index":0,"guid":"01b61bfa-fe4c-4d75-9224-389c4c04de10","isActive":false,"balance":"$1,919.18","picture":"http://placehold.it/32x32","age":37,"eyeColor":"blue","name":"Manning Brady","gender":"male","company":"ZYTRAC","email":"manningbrady@zytrac.com","phone":"+1 (957) 538-2183","address":"146 Bushwick Court, Gilgo, New York, 2992","about":"Ullamco cillum reprehenderit eu proident veniam laboris tempor voluptate. Officia deserunt velit incididunt consequat la...',
+        level: 'error',
         controls,
-        500,
-        3
-      ));
+        lengthOfMessage: 500,
+        numberOfSpans: 3
+      }));
 
     it("must capture an error object's message and an additional string", () =>
-      runTest(
-        'error-object-and-string',
-        true,
-        'Error: This is an error. -- Error message - should be traced.',
-        'error',
+      runTest({
+        url: 'error-object-and-string',
+        expectErroneous: true,
+        message: 'Error: This is an error. -- Error message - should be traced.',
+        level: 'error',
         controls
-      ));
+      }));
 
     it("must capture a nested error object's message and an additional string", () =>
-      runTest(
-        'nested-error-object-and-string',
-        true,
+      runTest({
+        url: 'nested-error-object-and-string',
+        expectErroneous: true,
         // eslint-disable-next-line max-len
-        'Error: This is a nested error. -- Error message - should be traced.',
-        'error',
+        message: 'Error: This is a nested error. -- Error message - should be traced.',
+        level: 'error',
         controls
-      ));
+      }));
 
     it('must trace random object and string', () =>
-      runTest(
-        'error-random-object-and-string',
-        true,
-        '{"foo":"[Object]"} - Error message - should be traced.',
-        'error',
+      runTest({
+        url: 'error-random-object-and-string',
+        expectErroneous: true,
+        message: '{"foo":"[Object]"} - Error message - should be traced.',
+        level: 'error',
         controls
-      ));
+      }));
 
     it('must trace child logger error', () =>
-      runTest('child-error', true, 'Child logger error message - should be traced.', 'error', controls));
+      runTest({
+        url: 'child-error',
+        expectErroneous: true,
+        message: 'Child logger error message - should be traced.',
+        level: 'error',
+        controls
+      }));
 
     it('must trace an error with cause property', () =>
-      runTest('error-with-cause', true, 'Error: This is the cause error', 'error', controls));
+      runTest({
+        url: 'error-with-cause',
+        expectErroneous: true,
+        message: 'Error: This is the cause error',
+        level: 'error',
+        controls
+      }));
 
     it('must trace an error with cause property and extra string', () =>
-      runTest(
-        'error-with-cause-and-extra-string',
-        true,
-        'Error: This is the cause error -- Error message - should be traced.',
-        'error',
+      runTest({
+        url: 'error-with-cause-and-extra-string',
+        expectErroneous: true,
+        message: 'Error: This is the cause error -- Error message - should be traced.',
+        level: 'error',
         controls
-      ));
+      }));
 
     it('must trace a nested error with cause property and extra string', () =>
-      runTest(
-        'nested-error-with-cause',
-        true,
-        'Error: This is the cause error -- Error message - should be traced.',
-        'error',
+      runTest({
+        url: 'nested-error-with-cause',
+        expectErroneous: true,
+        message: 'Error: This is the cause error -- Error message - should be traced.',
+        level: 'error',
         controls
-      ));
+      }));
 
     it('[suppression] should not trace', async function () {
       await trigger('warn', controls, { 'X-INSTANA-L': '0' });
@@ -220,7 +272,13 @@ module.exports = function (name, version, isLatest) {
           ));
 
         it('should trace error', () =>
-          runTest('error', true, 'Error message - should be traced.', 'error', customControls));
+          runTest({
+            url: 'error',
+            expectErroneous: true,
+            message: 'Error message - should be traced.',
+            level: 'error',
+            controls: customControls
+          }));
       });
 
       describe('when the minimum log level is INFO', () => {
@@ -233,13 +291,31 @@ module.exports = function (name, version, isLatest) {
         });
 
         it('should trace info', () =>
-          runTest('info', false, 'Info message - must not be traced by default.', 'info', customControls));
+          runTest({
+            url: 'info',
+            expectErroneous: false,
+            message: 'Info message - must not be traced by default.',
+            level: 'info',
+            controls: customControls
+          }));
 
         it('should trace warn', () =>
-          runTest('warn', false, 'Warn message - should be traced.', 'warn', customControls));
+          runTest({
+            url: 'warn',
+            expectErroneous: false,
+            message: 'Warn message - should be traced.',
+            level: 'warn',
+            controls: customControls
+          }));
 
         it('should trace error', () =>
-          runTest('error', true, 'Error message - should be traced.', 'error', customControls));
+          runTest({
+            url: 'error',
+            expectErroneous: true,
+            message: 'Error message - should be traced.',
+            level: 'error',
+            controls: customControls
+          }));
       });
 
       describe('when the minimum log level is OFF', () => {
@@ -292,7 +368,7 @@ module.exports = function (name, version, isLatest) {
     });
   });
 
-  function runTest(url, expectErroneous, message, level, controls, lengthOfMessage, numberOfSpans) {
+  function runTest({ url, expectErroneous, message, level, controls, lengthOfMessage, numberOfSpans }) {
     return trigger(url, controls).then(async () => {
       return retry(async () => {
         const spans = await agentControls.getSpans();

--- a/packages/collector/test/integration/currencies/logging/log4js/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/log4js/test_base.js
@@ -101,7 +101,8 @@ module.exports = function (name, version, isLatest) {
         runTest({
           level: 'warn',
           message: 'Warn message - should be traced.',
-          useLogMethod
+          useLogMethod,
+          expectedLevel: 'warn'
         }));
 
       it(`must trace error ${suffix}`, () =>
@@ -109,7 +110,8 @@ module.exports = function (name, version, isLatest) {
           level: 'error',
           message: 'Error message - should be traced.',
           useLogMethod,
-          expectErroneous: true
+          expectErroneous: true,
+          expectedLevel: 'error'
         }));
 
       it(`must trace fatal ${suffix}`, () =>
@@ -117,7 +119,8 @@ module.exports = function (name, version, isLatest) {
           level: 'fatal',
           message: 'Fatal message - should be traced.',
           useLogMethod,
-          expectErroneous: true
+          expectErroneous: true,
+          expectedLevel: 'fatal'
         }));
 
       it(`must trace error ${suffix} with multiple log arguments`, () =>
@@ -126,7 +129,8 @@ module.exports = function (name, version, isLatest) {
           message: 'Error message - should be traced.',
           useLogMethod,
           expectErroneous: true,
-          multipleArguments: true
+          multipleArguments: true,
+          expectedLevel: 'error'
         }));
     }
 
@@ -171,6 +175,7 @@ module.exports = function (name, version, isLatest) {
 
             expect(logSpans).to.have.length(1);
             expect(logSpans[0].data.log.message).to.equal('Error message');
+            expect(logSpans[0].data.log.level).to.equal('error');
           });
         });
 
@@ -227,6 +232,7 @@ module.exports = function (name, version, isLatest) {
 
             expect(logSpans).to.have.length(1);
             expect(logSpans[0].data.log.message).to.equal('Info message');
+            expect(logSpans[0].data.log.level).to.equal('info');
           });
         });
 
@@ -258,12 +264,20 @@ module.exports = function (name, version, isLatest) {
 
             expect(logSpans).to.have.length(1);
             expect(logSpans[0].data.log.message).to.equal('Error message');
+            expect(logSpans[0].data.log.level).to.equal('error');
           });
         });
       });
     });
 
-    async function runTest({ level, message, useLogMethod, expectErroneous = false, multipleArguments = false }) {
+    async function runTest({
+      level,
+      message,
+      useLogMethod,
+      expectErroneous = false,
+      multipleArguments = false,
+      expectedLevel
+    }) {
       await trigger({ level, message, useLogMethod, multipleArguments });
       await retry(async () => {
         const spans = await agentControls.getSpans();
@@ -273,7 +287,7 @@ module.exports = function (name, version, isLatest) {
           span => expect(span.f.h).to.equal('agent-stub-uuid')
         ]);
         expectAtLeastOneMatching(spans, span => {
-          checkLog4jsSpan(span, entrySpan, expectErroneous, message, multipleArguments);
+          checkLog4jsSpan(span, entrySpan, expectErroneous, message, multipleArguments, expectedLevel);
         });
         expectAtLeastOneMatching(spans, span => {
           checkNextExitSpan(span, entrySpan);
@@ -281,7 +295,7 @@ module.exports = function (name, version, isLatest) {
       });
     }
 
-    function checkLog4jsSpan(span, parent, expectErroneous, message, multipleArguments) {
+    function checkLog4jsSpan(span, parent, expectErroneous, message, multipleArguments, expectedLevel) {
       expect(span.t).to.equal(parent.t);
       expect(span.p).to.equal(parent.s);
       expect(span.k).to.equal(constants.EXIT);
@@ -297,6 +311,9 @@ module.exports = function (name, version, isLatest) {
         expect(span.data.log.message).to.equal(`${message} more arguments`);
       } else {
         expect(span.data.log.message).to.equal(message);
+      }
+      if (expectedLevel) {
+        expect(span.data.log.level).to.equal(expectedLevel);
       }
     }
 

--- a/packages/collector/test/integration/currencies/logging/pino/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/pino/test_base.js
@@ -68,7 +68,15 @@ module.exports = function (name, version, isLatest) {
       });
 
       it('must trace error', () =>
-        runTest('error', false, true, 'Error message - should be traced.', 'error', controls, 4));
+        runTest({
+          level: 'error',
+          useExpressPino: false,
+          expectErroneous: true,
+          message: 'Error message - should be traced.',
+          expectedLevel: 'error',
+          controls,
+          expectedSpans: 4
+        }));
     });
 
     describe('with second pino instance', function () {
@@ -99,7 +107,15 @@ module.exports = function (name, version, isLatest) {
       });
 
       it('must trace error', () =>
-        runTest('error', false, true, 'Error message - should be traced.', 'error', controls, 4));
+        runTest({
+          level: 'error',
+          useExpressPino: false,
+          expectErroneous: true,
+          message: 'Error message - should be traced.',
+          expectedLevel: 'error',
+          controls,
+          expectedSpans: 4
+        }));
     });
 
     describe('with express-pino', function () {
@@ -213,7 +229,15 @@ module.exports = function (name, version, isLatest) {
           });
 
           traced.forEach(([level, erroneous, message]) => {
-            it(`should trace ${level}`, () => runTest(level, false, erroneous, message, level, controls));
+            it(`should trace ${level}`, () =>
+              runTest({
+                level,
+                useExpressPino: false,
+                expectErroneous: erroneous,
+                message,
+                expectedLevel: level,
+                controls
+              }));
           });
 
           notTraced.forEach(level => {
@@ -303,45 +327,35 @@ module.exports = function (name, version, isLatest) {
           });
       });
 
-      it(`must trace warn${suffix}`, () => runTest('warn', useExpressPino, false, 'Warn message - should be traced.', 'warn', controls));
+      it(`must trace warn${suffix}`, () => runTest({ level: 'warn', useExpressPino, expectErroneous: false, message: 'Warn message - should be traced.', expectedLevel: 'warn', controls }));
 
-      it(`must trace error${suffix}`, () => runTest('error', useExpressPino, true, 'Error message - should be traced.', 'error', controls));
+      it(`must trace error${suffix}`, () => runTest({ level: 'error', useExpressPino, expectErroneous: true, message: 'Error message - should be traced.', expectedLevel: 'error', controls }));
 
-      it(`must trace fatal${suffix}`, () => runTest('fatal', useExpressPino, true, 'Fatal message - should be traced.', 'fatal', controls));
+      it(`must trace fatal${suffix}`, () => runTest({ level: 'fatal', useExpressPino, expectErroneous: true, message: 'Fatal message - should be traced.', expectedLevel: 'fatal', controls }));
 
-      // prettier-ignore
-      it(`must trace error object without message${suffix}`, () =>
-                runTest('error-object-only', useExpressPino, true, 'This is an error.', 'error', controls)
-            );
+      it(`must trace error object without message${suffix}`, () => runTest({ level: 'error-object-only', useExpressPino, expectErroneous: true, message: 'This is an error.', expectedLevel: 'error', controls }));
 
-      // prettier-ignore
       it(`should serialize random objects one level deep${suffix}`, () =>
-                runTest(
-                    'error-random-object-only',
-                    useExpressPino,
-                    true,
-                    ['{ payload: ', 'statusCode: 404', "error: 'Not Found'", 'very: [Object'],
-                    'error',
-                    controls
-                )
-            );
+        runTest({
+          level: 'error-random-object-only',
+          useExpressPino,
+          expectErroneous: true,
+          message: ['{ payload: ', 'statusCode: 404', "error: 'Not Found'", 'very: [Object'],
+          expectedLevel: 'error',
+          controls
+        }));
 
-      // prettier-ignore
       it(`must trace error object and string${suffix}`, () =>
-                runTest(
-                    'error-object-and-string',
-                    useExpressPino,
-                    true,
-                    'This is an error. -- Error message - should be traced.',
-                    'error',
-                    controls
-                )
-            );
+        runTest({
+          level: 'error-object-and-string',
+          useExpressPino,
+          expectErroneous: true,
+          message: 'This is an error. -- Error message - should be traced.',
+          expectedLevel: 'error',
+          controls
+        }));
 
-      // prettier-ignore
-      it(`must trace random object and string${suffix}`, () =>
-                runTest('error-random-object-and-string', useExpressPino, true, 'Error message - should be traced.', 'error', controls)
-            );
+      it(`must trace random object and string${suffix}`, () => runTest({ level: 'error-random-object-and-string', useExpressPino, expectErroneous: true, message: 'Error message - should be traced.', expectedLevel: 'error', controls }));
 
       it(`must not trace custom info${suffix}`, () =>
         trigger('custom-info', useExpressPino, controls).then(() =>
@@ -359,17 +373,24 @@ module.exports = function (name, version, isLatest) {
           )
         ));
 
-      it(`must trace custom error${suffix}`, () => runTest('custom-error', useExpressPino, true, 'Custom error level message - should be traced.', 'error', controls));
+      it(`must trace custom error${suffix}`, () => runTest({ level: 'custom-error', useExpressPino, expectErroneous: true, message: 'Custom error level message - should be traced.', expectedLevel: 'error', controls }));
 
       it(`must trace child logger error${suffix}`, () => {
         if (useExpressPino) {
           return;
         }
-        return runTest('child-error', false, true, 'Child logger error message - should be traced.', 'error', controls);
+        return runTest({
+          level: 'child-error',
+          useExpressPino: false,
+          expectErroneous: true,
+          message: 'Child logger error message - should be traced.',
+          expectedLevel: 'error',
+          controls
+        });
       });
     }
 
-    function runTest(level, useExpressPino, expectErroneous, message, expectedLevel, controls, expectedSpans = 3) {
+    function runTest({ level, useExpressPino, expectErroneous, message, expectedLevel, controls, expectedSpans = 3 }) {
       return trigger(level, useExpressPino, controls).then(() =>
         testUtils.retry(() =>
           agentControls.getSpans().then(spans => {

--- a/packages/collector/test/integration/currencies/logging/pino/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/pino/test_base.js
@@ -303,14 +303,11 @@ module.exports = function (name, version, isLatest) {
           });
       });
 
-      it(`must trace warn${suffix}`, () =>
-        runTest('warn', useExpressPino, false, 'Warn message - should be traced.', 'warn', controls));
+      it(`must trace warn${suffix}`, () => runTest('warn', useExpressPino, false, 'Warn message - should be traced.', 'warn', controls));
 
-      it(`must trace error${suffix}`, () =>
-        runTest('error', useExpressPino, true, 'Error message - should be traced.', 'error', controls));
+      it(`must trace error${suffix}`, () => runTest('error', useExpressPino, true, 'Error message - should be traced.', 'error', controls));
 
-      it(`must trace fatal${suffix}`, () =>
-        runTest('fatal', useExpressPino, true, 'Fatal message - should be traced.', 'fatal', controls));
+      it(`must trace fatal${suffix}`, () => runTest('fatal', useExpressPino, true, 'Fatal message - should be traced.', 'fatal', controls));
 
       // prettier-ignore
       it(`must trace error object without message${suffix}`, () =>
@@ -362,8 +359,7 @@ module.exports = function (name, version, isLatest) {
           )
         ));
 
-      it(`must trace custom error${suffix}`, () =>
-        runTest('custom-error', useExpressPino, true, 'Custom error level message - should be traced.', 'error', controls));
+      it(`must trace custom error${suffix}`, () => runTest('custom-error', useExpressPino, true, 'Custom error level message - should be traced.', 'error', controls));
 
       it(`must trace child logger error${suffix}`, () => {
         if (useExpressPino) {

--- a/packages/collector/test/integration/currencies/logging/pino/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/pino/test_base.js
@@ -67,7 +67,8 @@ module.exports = function (name, version, isLatest) {
         await controls.stop();
       });
 
-      it('must trace error', () => runTest('error', false, true, 'Error message - should be traced.', controls, 4));
+      it('must trace error', () =>
+        runTest('error', false, true, 'Error message - should be traced.', 'error', controls, 4));
     });
 
     describe('with second pino instance', function () {
@@ -97,7 +98,8 @@ module.exports = function (name, version, isLatest) {
         await controls.stop();
       });
 
-      it('must trace error', () => runTest('error', false, true, 'Error message - should be traced.', controls, 4));
+      it('must trace error', () =>
+        runTest('error', false, true, 'Error message - should be traced.', 'error', controls, 4));
     });
 
     describe('with express-pino', function () {
@@ -144,6 +146,7 @@ module.exports = function (name, version, isLatest) {
         const logSpan = spans.find(s => s.n === 'log.pino');
         expect(logSpan).to.exist;
         expect(logSpan.data.log.message).to.equal('Pino worker test error log');
+        expect(logSpan.data.log.level).to.equal('error');
 
         const httpSpan = spans.find(s => s.n === 'node.http.server');
         expect(httpSpan).to.exist;
@@ -210,7 +213,7 @@ module.exports = function (name, version, isLatest) {
           });
 
           traced.forEach(([level, erroneous, message]) => {
-            it(`should trace ${level}`, () => runTest(level, false, erroneous, message, controls));
+            it(`should trace ${level}`, () => runTest(level, false, erroneous, message, level, controls));
           });
 
           notTraced.forEach(level => {
@@ -300,15 +303,18 @@ module.exports = function (name, version, isLatest) {
           });
       });
 
-      it(`must trace warn${suffix}`, () => runTest('warn', useExpressPino, false, 'Warn message - should be traced.', controls));
+      it(`must trace warn${suffix}`, () =>
+        runTest('warn', useExpressPino, false, 'Warn message - should be traced.', 'warn', controls));
 
-      it(`must trace error${suffix}`, () => runTest('error', useExpressPino, true, 'Error message - should be traced.', controls));
+      it(`must trace error${suffix}`, () =>
+        runTest('error', useExpressPino, true, 'Error message - should be traced.', 'error', controls));
 
-      it(`must trace fatal${suffix}`, () => runTest('fatal', useExpressPino, true, 'Fatal message - should be traced.', controls));
+      it(`must trace fatal${suffix}`, () =>
+        runTest('fatal', useExpressPino, true, 'Fatal message - should be traced.', 'fatal', controls));
 
       // prettier-ignore
       it(`must trace error object without message${suffix}`, () =>
-                runTest('error-object-only', useExpressPino, true, 'This is an error.', controls)
+                runTest('error-object-only', useExpressPino, true, 'This is an error.', 'error', controls)
             );
 
       // prettier-ignore
@@ -318,6 +324,7 @@ module.exports = function (name, version, isLatest) {
                     useExpressPino,
                     true,
                     ['{ payload: ', 'statusCode: 404', "error: 'Not Found'", 'very: [Object'],
+                    'error',
                     controls
                 )
             );
@@ -329,13 +336,14 @@ module.exports = function (name, version, isLatest) {
                     useExpressPino,
                     true,
                     'This is an error. -- Error message - should be traced.',
+                    'error',
                     controls
                 )
             );
 
       // prettier-ignore
       it(`must trace random object and string${suffix}`, () =>
-                runTest('error-random-object-and-string', useExpressPino, true, 'Error message - should be traced.', controls)
+                runTest('error-random-object-and-string', useExpressPino, true, 'Error message - should be traced.', 'error', controls)
             );
 
       it(`must not trace custom info${suffix}`, () =>
@@ -354,17 +362,18 @@ module.exports = function (name, version, isLatest) {
           )
         ));
 
-      it(`must trace custom error${suffix}`, () => runTest('custom-error', useExpressPino, true, 'Custom error level message - should be traced.', controls));
+      it(`must trace custom error${suffix}`, () =>
+        runTest('custom-error', useExpressPino, true, 'Custom error level message - should be traced.', 'error', controls));
 
       it(`must trace child logger error${suffix}`, () => {
         if (useExpressPino) {
           return;
         }
-        return runTest('child-error', false, true, 'Child logger error message - should be traced.', controls);
+        return runTest('child-error', false, true, 'Child logger error message - should be traced.', 'error', controls);
       });
     }
 
-    function runTest(level, useExpressPino, expectErroneous, message, controls, expectedSpans = 3) {
+    function runTest(level, useExpressPino, expectErroneous, message, expectedLevel, controls, expectedSpans = 3) {
       return trigger(level, useExpressPino, controls).then(() =>
         testUtils.retry(() =>
           agentControls.getSpans().then(spans => {
@@ -374,7 +383,10 @@ module.exports = function (name, version, isLatest) {
               span => expect(span.f.h).to.equal('agent-stub-uuid')
             ]);
 
-            testUtils.expectAtLeastOneMatching(spans, checkPinoSpan(entrySpan, expectErroneous, message, controls));
+            testUtils.expectAtLeastOneMatching(
+              spans,
+              checkPinoSpan(entrySpan, expectErroneous, message, expectedLevel, controls)
+            );
             testUtils.expectAtLeastOneMatching(spans, checkNextExitSpan(entrySpan, controls));
 
             // entry + exit + pino log
@@ -390,7 +402,7 @@ module.exports = function (name, version, isLatest) {
       return controls.sendRequest({ path: `/${(useExpressPino ? 'express-pino-' : '') + level}` });
     }
 
-    function checkPinoSpan(parent, expectErroneous, message, controls) {
+    function checkPinoSpan(parent, expectErroneous, message, expectedLevel, controls) {
       const expectations = [
         span => expect(span.t).to.equal(parent.t),
         span => expect(span.p).to.equal(parent.s),
@@ -411,6 +423,7 @@ module.exports = function (name, version, isLatest) {
       } else {
         expectations.push(span => expect(span.data.log.message).to.equal(message));
       }
+      expectations.push(span => expect(span.data.log.level).to.equal(expectedLevel));
       return expectations;
     }
 

--- a/packages/collector/test/integration/currencies/logging/winston/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/winston/test_base.js
@@ -251,9 +251,7 @@ module.exports = function (name, version, isLatest, mode) {
     expect(span.data).to.exist;
     expect(span.data.log).to.exist;
     expect(span.data.log.message).to.equal(message);
-    if (level) {
-      expect(span.data.log.level).to.equal(level);
-    }
+    expect(span.data.log.level).to.equal(level);
     verifyStackTrace(span);
   }
 

--- a/packages/collector/test/integration/currencies/logging/winston/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/winston/test_base.js
@@ -212,7 +212,13 @@ module.exports = function (name, version, isLatest, mode) {
               ]);
               if (shouldTrace) {
                 expectAtLeastOneMatching(spans, span => {
-                  checkWinstonSpan(span, entrySpan, expectErroneous, expectedMessage, level);
+                  checkWinstonSpan({
+                    span,
+                    parent: entrySpan,
+                    erroneous: expectErroneous,
+                    message: expectedMessage,
+                    level
+                  });
                 });
 
                 // entry + exit + winston log
@@ -232,7 +238,7 @@ module.exports = function (name, version, isLatest, mode) {
     );
   }
 
-  function checkWinstonSpan(span, parent, erroneous, message, level) {
+  function checkWinstonSpan({ span, parent, erroneous, message, level }) {
     expect(span.t).to.equal(parent.t);
     expect(span.p).to.equal(parent.s);
     expect(span.k).to.equal(constants.EXIT);

--- a/packages/collector/test/integration/currencies/logging/winston/test_base.js
+++ b/packages/collector/test/integration/currencies/logging/winston/test_base.js
@@ -212,7 +212,7 @@ module.exports = function (name, version, isLatest, mode) {
               ]);
               if (shouldTrace) {
                 expectAtLeastOneMatching(spans, span => {
-                  checkWinstonSpan(span, entrySpan, expectErroneous, expectedMessage);
+                  checkWinstonSpan(span, entrySpan, expectErroneous, expectedMessage, level);
                 });
 
                 // entry + exit + winston log
@@ -232,7 +232,7 @@ module.exports = function (name, version, isLatest, mode) {
     );
   }
 
-  function checkWinstonSpan(span, parent, erroneous, message) {
+  function checkWinstonSpan(span, parent, erroneous, message, level) {
     expect(span.t).to.equal(parent.t);
     expect(span.p).to.equal(parent.s);
     expect(span.k).to.equal(constants.EXIT);
@@ -245,6 +245,9 @@ module.exports = function (name, version, isLatest, mode) {
     expect(span.data).to.exist;
     expect(span.data.log).to.exist;
     expect(span.data.log.message).to.equal(message);
+    if (level) {
+      expect(span.data.log.level).to.equal(level);
+    }
     verifyStackTrace(span);
   }
 

--- a/packages/core/src/tracing/instrumentation/logging/bunyan.js
+++ b/packages/core/src/tracing/instrumentation/logging/bunyan.js
@@ -118,7 +118,8 @@ function instrumentedLog(ctx, originalLog, originalArgs, level) {
     }
 
     span.data.log = {
-      message
+      message,
+      level
     };
 
     if (tracingUtil.isLogLevelAnError(level)) {

--- a/packages/core/src/tracing/instrumentation/logging/log4js.js
+++ b/packages/core/src/tracing/instrumentation/logging/log4js.js
@@ -74,7 +74,8 @@ function instrumentedLog(ctx, data, originalLog, level) {
     });
     span.stack = tracingUtil.getStackTrace(instrumentedLog);
     span.data.log = {
-      message
+      message,
+      level
     };
     if (tracingUtil.isLogLevelAnError(level)) {
       span.ec = 1;

--- a/packages/core/src/tracing/instrumentation/logging/pino.js
+++ b/packages/core/src/tracing/instrumentation/logging/pino.js
@@ -89,7 +89,8 @@ function shimGenLog(originalGenLog) {
           }
 
           span.data.log = {
-            message
+            message,
+            level: levelName
           };
 
           if (tracingUtil.isLogLevelAnError(levelName)) {

--- a/packages/core/src/tracing/instrumentation/logging/winston.js
+++ b/packages/core/src/tracing/instrumentation/logging/winston.js
@@ -193,7 +193,8 @@ function createSpan(ctx, originalMethod, originalArgs, message, level) {
     });
     span.stack = tracingUtil.getStackTrace(createSpan);
     span.data.log = {
-      message
+      message,
+      level
     };
     if (tracingUtil.isLogLevelAnError(level)) {
       span.ec = 1;


### PR DESCRIPTION
For some instrumentations, we're only sending the log message and not the log level. In the backend, if no log level is provided and ec != 0, the log is treated as WARN by default.

This means that if an INFO log span is sent without a level, the backend incorrectly classifies it as a WARN log, which doesn't seem right.

see: https://github.ibm.com/instana/backend/blob/develop/forge/src/main/java/com/instana/forge/connection/LogSpan.java#L116

Since we're already capturing the log level in our instrumentation, I think we should send it as part of the log span as well. The console instrumentation already includes the log level in span.data, so we could follow the same approach here.

UI: https://instana.io/s/RfyXRzHfRlGabC1AYVTaKg