### PR TITLE
fix: respected W3C disable shorthand via in-code config

### DIFF
--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -181,6 +181,7 @@ let defaults = {
     stackTraceLength: DEFAULT_STACK_TRACE_LENGTH,
     disable: {},
     spanBatchingEnabled: false,
+    disableW3c: false,
     disableW3cCorrelation: false,
     disableW3cTraceCorrelation: false,
     disableW3cPropagation: false,

--- a/packages/core/src/config/index.js
+++ b/packages/core/src/config/index.js
@@ -70,6 +70,7 @@ let currentConfig;
  * @property {HTTPTracingOptions} [http]
  * @property {import('../config/types').Disable} [disable]
  * @property {boolean} [spanBatchingEnabled]
+ * @property {boolean} [disableW3c]
  * @property {boolean} [disableW3cCorrelation]
  * @property {boolean} [disableW3cTraceCorrelation]
  * @property {boolean} [disableW3cPropagation]
@@ -941,10 +942,11 @@ function normalizeDisableW3cPropagation({ userConfig = {}, defaultConfig = {}, f
 /**
  * @param {{ userConfig?: InstanaConfig|null, defaultConfig?: InstanaConfig, finalConfig?: InstanaConfig }} [options]
  */
-function normalizeDisableW3c({ finalConfig = {} } = {}) {
+function normalizeDisableW3c({ userConfig = {}, finalConfig = {} } = {}) {
   const { value, source } = util.resolve(
     {
       envValue: 'INSTANA_TRACING_DISABLE_W3C',
+      inCodeValue: userConfig.tracing.disableW3c,
       defaultValue: undefined
     },
     [validators.validateTruthyBoolean]

--- a/packages/core/test/config/normalizeConfig_test.js
+++ b/packages/core/test/config/normalizeConfig_test.js
@@ -1214,6 +1214,25 @@ describe('config.normalizeConfig', () => {
         expect(config.tracing.disableW3cPropagation).to.be.false;
       });
 
+      it('should disable W3C correlation and propagation via config.tracing.disableW3c', () => {
+        const config = coreConfig.normalize({ userConfig: { tracing: { disableW3c: true } } });
+        expect(config.tracing.disableW3cCorrelation).to.be.true;
+        expect(config.tracing.disableW3cPropagation).to.be.true;
+      });
+
+      it('should not disable W3C correlation and propagation via config.tracing.disableW3c when false', () => {
+        const config = coreConfig.normalize({ userConfig: { tracing: { disableW3c: false } } });
+        expect(config.tracing.disableW3cCorrelation).to.be.false;
+        expect(config.tracing.disableW3cPropagation).to.be.false;
+      });
+
+      it('should give precedence to INSTANA_TRACING_DISABLE_W3C env var over config.tracing.disableW3c', () => {
+        process.env.INSTANA_TRACING_DISABLE_W3C = 'true';
+        const config = coreConfig.normalize({ userConfig: { tracing: { disableW3c: false } } });
+        expect(config.tracing.disableW3cCorrelation).to.be.true;
+        expect(config.tracing.disableW3cPropagation).to.be.true;
+      });
+
       it('should use default (false) for disableW3cPropagation when neither env nor config is set', () => {
         const config = coreConfig.normalize({});
         expect(config.tracing.disableW3cPropagation).to.be.false;


### PR DESCRIPTION
refs https://jsw.ibm.com/browse/INSTA-93111

I noticed this is not respected.