### PR TITLE
chore(otlp-exporter): added missing resource mapping

### DIFF
--- a/packages/core/src/otlpExporter/common/context.js
+++ b/packages/core/src/otlpExporter/common/context.js
@@ -15,8 +15,6 @@ class OtlpConfigContext {
     /** @type {any} */
     this._compiledSemConv = null;
     /** @type {string | null} */
-    this._hostId = null;
-    /** @type {string | null} */
     this._pid = null;
     /** @type {string | null} */
     this._serviceName = null;

--- a/packages/core/src/otlpExporter/common/context.js
+++ b/packages/core/src/otlpExporter/common/context.js
@@ -20,6 +20,8 @@ class OtlpConfigContext {
     this._pid = null;
     /** @type {string | null} */
     this._serviceName = null;
+    /** @type {string | null} */
+    this._serviceVersion = null;
   }
 
   /**
@@ -54,6 +56,20 @@ class OtlpConfigContext {
 
   get serviceName() {
     return this._serviceName;
+  }
+
+  /**
+   * @param {string} serviceVersion
+   */
+  setServiceVersion(serviceVersion) {
+    if (!serviceVersion || this._serviceVersion === serviceVersion) {
+      return;
+    }
+    this._serviceVersion = serviceVersion;
+  }
+
+  get serviceVersion() {
+    return this._serviceVersion;
   }
 }
 

--- a/packages/core/src/otlpExporter/common/context.js
+++ b/packages/core/src/otlpExporter/common/context.js
@@ -18,8 +18,6 @@ class OtlpConfigContext {
     this._pid = null;
     /** @type {string | null} */
     this._serviceName = null;
-    /** @type {string | null} */
-    this._serviceVersion = null;
   }
 
   /**
@@ -54,20 +52,6 @@ class OtlpConfigContext {
 
   get serviceName() {
     return this._serviceName;
-  }
-
-  /**
-   * @param {string} serviceVersion
-   */
-  setServiceVersion(serviceVersion) {
-    if (!serviceVersion || this._serviceVersion === serviceVersion) {
-      return;
-    }
-    this._serviceVersion = serviceVersion;
-  }
-
-  get serviceVersion() {
-    return this._serviceVersion;
   }
 }
 

--- a/packages/core/src/otlpExporter/common/semconv/base/mappings.js
+++ b/packages/core/src/otlpExporter/common/semconv/base/mappings.js
@@ -9,17 +9,13 @@
 const MAPPINGS = {
   resource: {
     SERVICE_NAME: 'service.name',
-    SERVICE_VERSION: 'service.version',
-    SERVICE_INSTANCE_ID: 'service.instance.id',
     SDK_LANGUAGE: 'telemetry.sdk.language',
     SDK_NAME: 'telemetry.sdk.name',
     SDK_VERSION: 'telemetry.sdk.version',
     HOST_NAME: 'host.name',
     HOST_ID: 'host.id',
     PROCESS_PID: 'process.pid',
-    OS_TYPE: 'os.type',
-    CONTAINER_ID: 'container.id',
-    K8S_POD_UID: 'k8s.pod.uid'
+    OS_TYPE: 'os.type'
   },
 
   metadata: {

--- a/packages/core/src/otlpExporter/common/semconv/base/mappings.js
+++ b/packages/core/src/otlpExporter/common/semconv/base/mappings.js
@@ -9,12 +9,17 @@
 const MAPPINGS = {
   resource: {
     SERVICE_NAME: 'service.name',
+    SERVICE_VERSION: 'service.version',
+    SERVICE_INSTANCE_ID: 'service.instance.id',
     SDK_LANGUAGE: 'telemetry.sdk.language',
     SDK_NAME: 'telemetry.sdk.name',
     SDK_VERSION: 'telemetry.sdk.version',
     HOST_NAME: 'host.name',
     HOST_ID: 'host.id',
-    PROCESS_PID: 'process.pid'
+    PROCESS_PID: 'process.pid',
+    OS_TYPE: 'os.type',
+    CONTAINER_ID: 'container.id',
+    K8S_POD_UID: 'k8s.pod.uid'
   },
 
   metadata: {

--- a/packages/core/src/otlpExporter/common/transformers/resource.js
+++ b/packages/core/src/otlpExporter/common/transformers/resource.js
@@ -5,8 +5,6 @@
 'use strict';
 
 const os = require('os');
-const { randomUUID } = require('crypto');
-
 const ctx = require('../context');
 const { INSTRUMENTATION_SCOPE_NAME } = require('../constants');
 const { MAPPINGS } = require('../semconv/base/mappings');
@@ -21,7 +19,6 @@ try {
   // ignore the error
 }
 
-const generatedServiceInstanceId = randomUUID();
 const SDK_LANGUAGE = 'nodejs';
 const SDK_NAME = 'instana';
 
@@ -35,7 +32,6 @@ const INSTRUMENTATION_SCOPE = {
  * @property {Record<string, any>} [data]
  * @property {Record<string, any>} [resource]
  * @property {Record<string, any>} [f]
- * @property {string} [version]
  */
 
 const resourceMapper = {
@@ -46,24 +42,6 @@ const resourceMapper = {
   serviceName(rawPayload) {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
     return resource[RESOURCE.SERVICE_NAME] || ctx.serviceName;
-  },
-
-  /**
-   * @param {RawPayload} rawPayload
-   * @returns {string | undefined}
-   */
-  serviceVersion(rawPayload) {
-    const resource = rawPayload.data?.resource || rawPayload.resource || {};
-    return resource[RESOURCE.SERVICE_VERSION] || ctx.serviceVersion || undefined;
-  },
-
-  /**
-   * @param {RawPayload} rawPayload
-   * @returns {string | undefined}
-   */
-  serviceInstanceId(rawPayload) {
-    const resource = rawPayload.data?.resource || rawPayload.resource || {};
-    return resource[RESOURCE.SERVICE_INSTANCE_ID] || generatedServiceInstanceId;
   },
 
   /**
@@ -141,7 +119,6 @@ const resourceMapper = {
 
     return resource[RESOURCE.HOST_ID] || metadata.h;
   },
-
   /**
    * @param {RawPayload} rawPayload
    * @returns {string | undefined}
@@ -154,24 +131,6 @@ const resourceMapper = {
     }
 
     return normalizeOsType(os.platform());
-  },
-
-  /**
-   * @param {RawPayload} rawPayload
-   * @returns {string | undefined}
-   */
-  containerId(rawPayload) {
-    const resource = rawPayload.data?.resource || rawPayload.resource || {};
-    return resource[RESOURCE.CONTAINER_ID];
-  },
-
-  /**
-   * @param {RawPayload} rawPayload
-   * @returns {string | undefined}
-   */
-  k8sPodUid(rawPayload) {
-    const resource = rawPayload.data?.resource || rawPayload.resource || {};
-    return resource[RESOURCE.K8S_POD_UID];
   }
 };
 
@@ -190,16 +149,6 @@ function extractResourceAttributes(rawPayload) {
     {
       otlp: OTLP.resource.SERVICE_NAME,
       transform: resourceMapper.serviceName,
-      valueType: 'string'
-    },
-    {
-      otlp: OTLP.resource.SERVICE_VERSION,
-      transform: resourceMapper.serviceVersion,
-      valueType: 'string'
-    },
-    {
-      otlp: OTLP.resource.SERVICE_INSTANCE_ID,
-      transform: resourceMapper.serviceInstanceId,
       valueType: 'string'
     },
     {
@@ -230,21 +179,6 @@ function extractResourceAttributes(rawPayload) {
     {
       otlp: OTLP.resource.HOST_NAME,
       transform: resourceMapper.hostName,
-      valueType: 'string'
-    },
-    {
-      otlp: OTLP.resource.HOST_ID,
-      transform: resourceMapper.hostId,
-      valueType: 'string'
-    },
-    {
-      otlp: OTLP.resource.CONTAINER_ID,
-      transform: resourceMapper.containerId,
-      valueType: 'string'
-    },
-    {
-      otlp: OTLP.resource.K8S_POD_UID,
-      transform: resourceMapper.k8sPodUid,
       valueType: 'string'
     }
   ];

--- a/packages/core/src/otlpExporter/common/transformers/resource.js
+++ b/packages/core/src/otlpExporter/common/transformers/resource.js
@@ -127,7 +127,7 @@ const resourceMapper = {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
 
     if (resource[RESOURCE.OS_TYPE]) {
-      return String(resource[RESOURCE.OS_TYPE]);
+      return resource[RESOURCE.OS_TYPE];
     }
 
     return normalizeOsType(os.platform());

--- a/packages/core/src/otlpExporter/common/transformers/resource.js
+++ b/packages/core/src/otlpExporter/common/transformers/resource.js
@@ -5,8 +5,13 @@
 'use strict';
 
 const os = require('os');
+const { randomUUID } = require('crypto');
+
 const ctx = require('../context');
 const { INSTRUMENTATION_SCOPE_NAME } = require('../constants');
+const { MAPPINGS } = require('../semconv/base/mappings');
+
+const RESOURCE = MAPPINGS.resource;
 
 let SDK_VERSION = '1.0.0';
 try {
@@ -16,6 +21,7 @@ try {
   // ignore the error
 }
 
+const generatedServiceInstanceId = randomUUID();
 const SDK_LANGUAGE = 'nodejs';
 const SDK_NAME = 'instana';
 
@@ -39,7 +45,7 @@ const resourceMapper = {
    */
   serviceName(rawPayload) {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
-    return resource['service.name'] || ctx.serviceName;
+    return resource[RESOURCE.SERVICE_NAME] || ctx.serviceName;
   },
 
   /**
@@ -48,7 +54,7 @@ const resourceMapper = {
    */
   serviceVersion(rawPayload) {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
-    return resource['service.version'] || ctx.serviceVersion || undefined;
+    return resource[RESOURCE.SERVICE_VERSION] || ctx.serviceVersion || undefined;
   },
 
   /**
@@ -57,15 +63,7 @@ const resourceMapper = {
    */
   serviceInstanceId(rawPayload) {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
-    const metadata = rawPayload.f || {};
-    return (
-      resource['service.instance.id'] ||
-      resource['container.id'] ||
-      resource['k8s.pod.uid'] ||
-      resource['host.id'] ||
-      metadata.h ||
-      ctx._hostId
-    );
+    return resource[RESOURCE.SERVICE_INSTANCE_ID] || generatedServiceInstanceId;
   },
 
   /**
@@ -74,7 +72,7 @@ const resourceMapper = {
    */
   sdkLanguage(rawPayload) {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
-    return resource['telemetry.sdk.language'] || SDK_LANGUAGE;
+    return resource[RESOURCE.SDK_LANGUAGE] || SDK_LANGUAGE;
   },
 
   /**
@@ -83,7 +81,7 @@ const resourceMapper = {
    */
   sdkName(rawPayload) {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
-    return resource['telemetry.sdk.name'] || SDK_NAME;
+    return resource[RESOURCE.SDK_NAME] || SDK_NAME;
   },
 
   /**
@@ -92,7 +90,7 @@ const resourceMapper = {
    */
   sdkVersion(rawPayload) {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
-    return resource['telemetry.sdk.version'] || SDK_VERSION;
+    return resource[RESOURCE.SDK_VERSION] || SDK_VERSION;
   },
 
   /**
@@ -103,7 +101,7 @@ const resourceMapper = {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
     const metadata = rawPayload.f || {};
 
-    const pid = resource['process.pid'] || metadata.e || ctx._pid;
+    const pid = resource[RESOURCE.PROCESS_PID] || metadata.e || ctx._pid;
 
     if (pid === null || pid === undefined) {
       return undefined;
@@ -119,7 +117,7 @@ const resourceMapper = {
    */
   hostName(rawPayload) {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
-    let hostName = resource['host.name'];
+    let hostName = resource[RESOURCE.HOST_NAME];
 
     if (!hostName) {
       try {
@@ -141,7 +139,7 @@ const resourceMapper = {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
     const metadata = rawPayload.f || {};
 
-    return resource['host.id'] || metadata.h || ctx._hostId;
+    return resource[RESOURCE.HOST_ID] || metadata.h;
   },
 
   /**
@@ -151,8 +149,8 @@ const resourceMapper = {
   osType(rawPayload) {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
 
-    if (resource['os.type']) {
-      return String(resource['os.type']);
+    if (resource[RESOURCE.OS_TYPE]) {
+      return String(resource[RESOURCE.OS_TYPE]);
     }
 
     return normalizeOsType(os.platform());
@@ -164,7 +162,7 @@ const resourceMapper = {
    */
   containerId(rawPayload) {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
-    return resource['container.id'];
+    return resource[RESOURCE.CONTAINER_ID];
   },
 
   /**
@@ -173,7 +171,7 @@ const resourceMapper = {
    */
   k8sPodUid(rawPayload) {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
-    return resource['k8s.pod.uid'];
+    return resource[RESOURCE.K8S_POD_UID];
   }
 };
 

--- a/packages/core/src/otlpExporter/common/transformers/resource.js
+++ b/packages/core/src/otlpExporter/common/transformers/resource.js
@@ -29,6 +29,7 @@ const INSTRUMENTATION_SCOPE = {
  * @property {Record<string, any>} [data]
  * @property {Record<string, any>} [resource]
  * @property {Record<string, any>} [f]
+ * @property {string} [version]
  */
 
 const resourceMapper = {
@@ -39,6 +40,32 @@ const resourceMapper = {
   serviceName(rawPayload) {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
     return resource['service.name'] || ctx.serviceName;
+  },
+
+  /**
+   * @param {RawPayload} rawPayload
+   * @returns {string | undefined}
+   */
+  serviceVersion(rawPayload) {
+    const resource = rawPayload.data?.resource || rawPayload.resource || {};
+    return resource['service.version'] || ctx.serviceVersion || undefined;
+  },
+
+  /**
+   * @param {RawPayload} rawPayload
+   * @returns {string | undefined}
+   */
+  serviceInstanceId(rawPayload) {
+    const resource = rawPayload.data?.resource || rawPayload.resource || {};
+    const metadata = rawPayload.f || {};
+    return (
+      resource['service.instance.id'] ||
+      resource['container.id'] ||
+      resource['k8s.pod.uid'] ||
+      resource['host.id'] ||
+      metadata.h ||
+      ctx._hostId
+    );
   },
 
   /**
@@ -114,9 +141,39 @@ const resourceMapper = {
     const resource = rawPayload.data?.resource || rawPayload.resource || {};
     const metadata = rawPayload.f || {};
 
-    const hostId = resource['host.id'] || metadata.h || ctx._hostId;
+    return resource['host.id'] || metadata.h || ctx._hostId;
+  },
 
-    return typeof hostId === 'string' ? hostId : undefined;
+  /**
+   * @param {RawPayload} rawPayload
+   * @returns {string | undefined}
+   */
+  osType(rawPayload) {
+    const resource = rawPayload.data?.resource || rawPayload.resource || {};
+
+    if (resource['os.type']) {
+      return String(resource['os.type']);
+    }
+
+    return normalizeOsType(os.platform());
+  },
+
+  /**
+   * @param {RawPayload} rawPayload
+   * @returns {string | undefined}
+   */
+  containerId(rawPayload) {
+    const resource = rawPayload.data?.resource || rawPayload.resource || {};
+    return resource['container.id'];
+  },
+
+  /**
+   * @param {RawPayload} rawPayload
+   * @returns {string | undefined}
+   */
+  k8sPodUid(rawPayload) {
+    const resource = rawPayload.data?.resource || rawPayload.resource || {};
+    return resource['k8s.pod.uid'];
   }
 };
 
@@ -135,6 +192,16 @@ function extractResourceAttributes(rawPayload) {
     {
       otlp: OTLP.resource.SERVICE_NAME,
       transform: resourceMapper.serviceName,
+      valueType: 'string'
+    },
+    {
+      otlp: OTLP.resource.SERVICE_VERSION,
+      transform: resourceMapper.serviceVersion,
+      valueType: 'string'
+    },
+    {
+      otlp: OTLP.resource.SERVICE_INSTANCE_ID,
+      transform: resourceMapper.serviceInstanceId,
       valueType: 'string'
     },
     {
@@ -158,8 +225,28 @@ function extractResourceAttributes(rawPayload) {
       valueType: 'int'
     },
     {
+      otlp: OTLP.resource.OS_TYPE,
+      transform: resourceMapper.osType,
+      valueType: 'string'
+    },
+    {
       otlp: OTLP.resource.HOST_NAME,
       transform: resourceMapper.hostName,
+      valueType: 'string'
+    },
+    {
+      otlp: OTLP.resource.HOST_ID,
+      transform: resourceMapper.hostId,
+      valueType: 'string'
+    },
+    {
+      otlp: OTLP.resource.CONTAINER_ID,
+      transform: resourceMapper.containerId,
+      valueType: 'string'
+    },
+    {
+      otlp: OTLP.resource.K8S_POD_UID,
+      transform: resourceMapper.k8sPodUid,
       valueType: 'string'
     }
   ];
@@ -180,6 +267,20 @@ function extractResourceAttributes(rawPayload) {
   }, /** @type {Array<{ key: string, value: { intValue?: number, stringValue?: string } }>} */ ([]));
 
   return { attributes };
+}
+
+/**
+ * @param {string} nodePlatform
+ */
+function normalizeOsType(nodePlatform) {
+  switch (nodePlatform) {
+    case 'win32':
+      return 'windows';
+    case 'sunos':
+      return 'solaris';
+    default:
+      return nodePlatform;
+  }
 }
 
 module.exports = {

--- a/packages/core/src/otlpExporter/metrics/converter.js
+++ b/packages/core/src/otlpExporter/metrics/converter.js
@@ -23,9 +23,12 @@ function init(config) {
 /**
  * @param {any} metrics
  */
-function resolveServiceName(metrics) {
+function resolveServiceIdentity(metrics) {
   if (metrics?.name && typeof metrics.name === 'string' && !otlpCtx.serviceName) {
     otlpCtx.setServiceName(metrics.name);
+  }
+  if (metrics?.version && typeof metrics.version === 'string' && !otlpCtx.serviceVersion) {
+    otlpCtx.setServiceVersion(metrics.version);
   }
 }
 
@@ -41,8 +44,9 @@ function convert(metrics) {
       return { resourceMetrics: [] };
     }
 
-    // Service name resolution, it not come from first metric once it set it will be used for all metrics
-    resolveServiceName(metrics);
+    // Service identity(name + version) resolution, it not come from first metric once it set it
+    // will be used for all metrics
+    resolveServiceIdentity(metrics);
 
     // All metrics share the same resource, so we can extract the attributes from the first one
     const resource = transformers.resource.extractResourceAttributes(/** @type {any} */ (metricsArray[0]));

--- a/packages/core/src/otlpExporter/metrics/converter.js
+++ b/packages/core/src/otlpExporter/metrics/converter.js
@@ -23,12 +23,9 @@ function init(config) {
 /**
  * @param {any} metrics
  */
-function resolveServiceIdentity(metrics) {
+function resolveServiceName(metrics) {
   if (metrics?.name && typeof metrics.name === 'string' && !otlpCtx.serviceName) {
     otlpCtx.setServiceName(metrics.name);
-  }
-  if (metrics?.version && typeof metrics.version === 'string' && !otlpCtx.serviceVersion) {
-    otlpCtx.setServiceVersion(metrics.version);
   }
 }
 
@@ -44,9 +41,8 @@ function convert(metrics) {
       return { resourceMetrics: [] };
     }
 
-    // Service identity(name + version) resolution, it not come from first metric once it set it
-    // will be used for all metrics
-    resolveServiceIdentity(metrics);
+    // Service name resolution, it not come from first metric once it set it will be used for all metrics
+    resolveServiceName(metrics);
 
     // All metrics share the same resource, so we can extract the attributes from the first one
     const resource = transformers.resource.extractResourceAttributes(/** @type {any} */ (metricsArray[0]));

--- a/packages/core/src/otlpExporter/metrics/util.js
+++ b/packages/core/src/otlpExporter/metrics/util.js
@@ -5,15 +5,6 @@
 'use strict';
 
 /**
- * @param {Record<string, any>} from
- * @returns {string}
- */
-function getResourceKey(from) {
-  if (!from) return 'h:empty|e:empty';
-  return `h:${from.h || 'empty'}|e:${from.e || 'empty'}`;
-}
-
-/**
  * @param {Record<string, any>} obj
  * @param {string} [prefix]
  * @returns {Record<string, any>}
@@ -90,6 +81,5 @@ function normalizeObject(metricsObj) {
 
 module.exports = {
   flattenObject,
-  normalizeMetrics,
-  getResourceKey
+  normalizeMetrics
 };

--- a/packages/core/test/otlpExporter/common/transformers/resource_test.js
+++ b/packages/core/test/otlpExporter/common/transformers/resource_test.js
@@ -109,32 +109,6 @@ describe('otlpExporter/common/transformers/resource', () => {
     });
   });
 
-  describe('service.version', () => {
-    it('uses resource["service.version"] from span data', () => {
-      const span = makeSpan({ data: { resource: { 'service.version': '3.1.4' } } });
-      expectStr(extract(span), 'service.version', '3.1.4');
-    });
-
-    it('omits service.version when no source is set', () => {
-      expectAbsent(extract(makeSpan()), 'service.version');
-    });
-  });
-
-  describe('service.instance.id', () => {
-    it('uses resource["service.instance.id"] when explicitly present', () => {
-      const span = makeSpan({ data: { resource: { 'service.instance.id': 'explicit-id' } } });
-      expectStr(extract(span), 'service.instance.id', 'explicit-id');
-    });
-
-    it('derives from resource["container.id"]', () => {
-      const span = makeSpan({ data: { resource: { 'container.id': 'ctr-abc123' } } });
-      const attrs = extract(span);
-      const attr = attrs.find(a => a.key === 'service.instance.id');
-      expect(attr).to.exist;
-      expect(attr.value.stringValue).to.match(/^[0-9a-f-]{36}$/);
-    });
-  });
-
   describe('telemetry.sdk.*', () => {
     it('emits hardcoded sdk.language "nodejs"', () => {
       expectStr(extract(makeSpan()), 'telemetry.sdk.language', 'nodejs');
@@ -224,40 +198,6 @@ describe('otlpExporter/common/transformers/resource', () => {
 
     it('falls back to os.hostname() when not in span data', () => {
       expectStr(extract(makeSpan()), 'host.name', 'stub.hostname.test');
-    });
-  });
-
-  describe('host.id', () => {
-    it('uses resource["host.id"] from span data', () => {
-      const span = makeSpan({ data: { resource: { 'host.id': 'explicit-host-id' } } });
-      expectStr(extract(span), 'host.id', 'explicit-host-id');
-    });
-
-    it('derives from span metadata f.h', () => {
-      const span = makeSpan({ f: { e: '1', h: 'metadata-host-id' } });
-      expectStr(extract(span), 'host.id', 'metadata-host-id');
-    });
-  });
-
-  describe('container.id', () => {
-    it('emits container.id when present in span resource data', () => {
-      const span = makeSpan({ data: { resource: { 'container.id': 'sha256-deadbeef' } } });
-      expectStr(extract(span), 'container.id', 'sha256-deadbeef');
-    });
-
-    it('omits container.id when absent', () => {
-      expectAbsent(extract(makeSpan()), 'container.id');
-    });
-  });
-
-  describe('k8s.pod.uid', () => {
-    it('emits k8s.pod.uid when present in span resource data', () => {
-      const span = makeSpan({ data: { resource: { 'k8s.pod.uid': 'uid-abcdef' } } });
-      expectStr(extract(span), 'k8s.pod.uid', 'uid-abcdef');
-    });
-
-    it('omits k8s.pod.uid when neither span data nor env var is set', () => {
-      expectAbsent(extract(makeSpan()), 'k8s.pod.uid');
     });
   });
 

--- a/packages/core/test/otlpExporter/common/transformers/resource_test.js
+++ b/packages/core/test/otlpExporter/common/transformers/resource_test.js
@@ -74,7 +74,6 @@ describe('otlpExporter/common/transformers/resource', () => {
     ctx._config = null;
     ctx._semConvVersion = null;
     ctx._compiledSemConv = null;
-    ctx._hostId = null;
     ctx._pid = null;
     ctx._serviceName = null;
     ctx._serviceVersion = null;
@@ -129,28 +128,10 @@ describe('otlpExporter/common/transformers/resource', () => {
 
     it('derives from resource["container.id"]', () => {
       const span = makeSpan({ data: { resource: { 'container.id': 'ctr-abc123' } } });
-      expectStr(extract(span), 'service.instance.id', 'ctr-abc123');
-    });
-
-    it('derives from resource["k8s.pod.uid"]', () => {
-      const span = makeSpan({ data: { resource: { 'k8s.pod.uid': 'pod-uid-xyz' } } });
-      expectStr(extract(span), 'service.instance.id', 'pod-uid-xyz');
-    });
-
-    it('derives from span metadata f.h as last resort', () => {
-      const span = makeSpan({ f: { e: '1234', h: 'metadata-host-fallback' } });
-      expectStr(extract(span), 'service.instance.id', 'metadata-host-fallback');
-    });
-
-    it('prefers container.id over k8s.pod.uid', () => {
-      const span = makeSpan({ data: { resource: { 'container.id': 'ctr-wins', 'k8s.pod.uid': 'pod-loses' } } });
-      expectStr(extract(span), 'service.instance.id', 'ctr-wins');
-    });
-
-    it('prefers k8s.pod.uid over MY_POD_UID env var', () => {
-      process.env.MY_POD_UID = 'env-loses';
-      const span = makeSpan({ data: { resource: { 'k8s.pod.uid': 'pod-uid-wins' } } });
-      expectStr(extract(span), 'service.instance.id', 'pod-uid-wins');
+      const attrs = extract(span);
+      const attr = attrs.find(a => a.key === 'service.instance.id');
+      expect(attr).to.exist;
+      expect(attr.value.stringValue).to.match(/^[0-9a-f-]{36}$/);
     });
   });
 

--- a/packages/core/test/otlpExporter/common/transformers/resource_test.js
+++ b/packages/core/test/otlpExporter/common/transformers/resource_test.js
@@ -1,0 +1,299 @@
+/*
+ * (c) Copyright IBM Corp. 2026
+ */
+
+'use strict';
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const os = require('node:os');
+const proxyquire = require('proxyquire');
+
+const mockPackageJson = { version: '6.0.0' };
+
+function loadResource() {
+  return proxyquire('../../../../src/otlpExporter/common/transformers/resource', {
+    '../../../../package.json': Object.assign({ '@noCallThru': true }, mockPackageJson)
+  });
+}
+
+const ctx = require('../../../../src/otlpExporter/common/context');
+const otlp = require('../../../../src/otlpExporter');
+
+const INIT_CONFIG = {
+  serviceName: 'resource-test-service',
+  logger: console,
+  tracing: { otlp: { enabled: true, semConvVersion: '1.23' } }
+};
+
+const resource = loadResource();
+
+function extract(span) {
+  return resource.extractResourceAttributes(span).attributes;
+}
+
+function find(attrs, key) {
+  return attrs.find(a => a.key === key);
+}
+
+function expectStr(attrs, key, value) {
+  expect(find(attrs, key), `Missing attribute "${key}"`).to.deep.equal({
+    key,
+    value: { stringValue: value }
+  });
+}
+
+function expectInt(attrs, key, value) {
+  expect(find(attrs, key), `Missing attribute "${key}"`).to.deep.equal({
+    key,
+    value: { intValue: value }
+  });
+}
+
+function expectAbsent(attrs, key) {
+  expect(find(attrs, key), `Attribute "${key}" should be absent`).to.be.undefined;
+}
+
+function makeSpan(overrides = {}) {
+  return {
+    f: { e: '1234', h: 'default-host-id', ...(overrides.f || {}) },
+    data: { ...(overrides.data || {}) }
+  };
+}
+
+describe('otlpExporter/common/transformers/resource', () => {
+  let hostnameStub;
+
+  before(() => {
+    hostnameStub = sinon.stub(os, 'hostname').returns('stub.hostname.test');
+    otlp.init(INIT_CONFIG);
+  });
+
+  after(() => {
+    hostnameStub.restore();
+    ctx._config = null;
+    ctx._semConvVersion = null;
+    ctx._compiledSemConv = null;
+    ctx._hostId = null;
+    ctx._pid = null;
+    ctx._serviceName = null;
+    ctx._serviceVersion = null;
+  });
+
+  describe('extractResourceAttributes', () => {
+    it('returns empty attributes for a null payload', () => {
+      expect(resource.extractResourceAttributes(null)).to.deep.equal({ attributes: [] });
+    });
+
+    it('returns empty attributes for an undefined payload', () => {
+      expect(resource.extractResourceAttributes(undefined)).to.deep.equal({ attributes: [] });
+    });
+  });
+
+  describe('INSTRUMENTATION_SCOPE', () => {
+    it('exposes name and version', () => {
+      expect(resource.INSTRUMENTATION_SCOPE).to.deep.equal({
+        name: '@instana/collector',
+        version: '6.0.0'
+      });
+    });
+  });
+
+  describe('service.name', () => {
+    it('uses resource["service.name"] from span data', () => {
+      const span = makeSpan({ data: { resource: { 'service.name': 'from-span-data' } } });
+      expectStr(extract(span), 'service.name', 'from-span-data');
+    });
+
+    it('uses ctx.serviceName set by otlp.init', () => {
+      expectStr(extract(makeSpan()), 'service.name', 'resource-test-service');
+    });
+  });
+
+  describe('service.version', () => {
+    it('uses resource["service.version"] from span data', () => {
+      const span = makeSpan({ data: { resource: { 'service.version': '3.1.4' } } });
+      expectStr(extract(span), 'service.version', '3.1.4');
+    });
+
+    it('omits service.version when no source is set', () => {
+      expectAbsent(extract(makeSpan()), 'service.version');
+    });
+  });
+
+  describe('service.instance.id', () => {
+    it('uses resource["service.instance.id"] when explicitly present', () => {
+      const span = makeSpan({ data: { resource: { 'service.instance.id': 'explicit-id' } } });
+      expectStr(extract(span), 'service.instance.id', 'explicit-id');
+    });
+
+    it('derives from resource["container.id"]', () => {
+      const span = makeSpan({ data: { resource: { 'container.id': 'ctr-abc123' } } });
+      expectStr(extract(span), 'service.instance.id', 'ctr-abc123');
+    });
+
+    it('derives from resource["k8s.pod.uid"]', () => {
+      const span = makeSpan({ data: { resource: { 'k8s.pod.uid': 'pod-uid-xyz' } } });
+      expectStr(extract(span), 'service.instance.id', 'pod-uid-xyz');
+    });
+
+    it('derives from span metadata f.h as last resort', () => {
+      const span = makeSpan({ f: { e: '1234', h: 'metadata-host-fallback' } });
+      expectStr(extract(span), 'service.instance.id', 'metadata-host-fallback');
+    });
+
+    it('prefers container.id over k8s.pod.uid', () => {
+      const span = makeSpan({ data: { resource: { 'container.id': 'ctr-wins', 'k8s.pod.uid': 'pod-loses' } } });
+      expectStr(extract(span), 'service.instance.id', 'ctr-wins');
+    });
+
+    it('prefers k8s.pod.uid over MY_POD_UID env var', () => {
+      process.env.MY_POD_UID = 'env-loses';
+      const span = makeSpan({ data: { resource: { 'k8s.pod.uid': 'pod-uid-wins' } } });
+      expectStr(extract(span), 'service.instance.id', 'pod-uid-wins');
+    });
+  });
+
+  describe('telemetry.sdk.*', () => {
+    it('emits hardcoded sdk.language "nodejs"', () => {
+      expectStr(extract(makeSpan()), 'telemetry.sdk.language', 'nodejs');
+    });
+
+    it('emits hardcoded sdk.name "instana"', () => {
+      expectStr(extract(makeSpan()), 'telemetry.sdk.name', 'instana');
+    });
+
+    it('emits sdk.version from package.json (mocked to 6.0.0)', () => {
+      expectStr(extract(makeSpan()), 'telemetry.sdk.version', '6.0.0');
+    });
+
+    it('allows span data to override sdk.language', () => {
+      const span = makeSpan({ data: { resource: { 'telemetry.sdk.language': 'python' } } });
+      expectStr(extract(span), 'telemetry.sdk.language', 'python');
+    });
+
+    it('allows span data to override sdk.name', () => {
+      const span = makeSpan({ data: { resource: { 'telemetry.sdk.name': 'opentelemetry' } } });
+      expectStr(extract(span), 'telemetry.sdk.name', 'opentelemetry');
+    });
+
+    it('allows span data to override sdk.version', () => {
+      const span = makeSpan({ data: { resource: { 'telemetry.sdk.version': '99.0.0' } } });
+      expectStr(extract(span), 'telemetry.sdk.version', '99.0.0');
+    });
+  });
+
+  describe('process.pid', () => {
+    it('uses metadata f.e field as pid', () => {
+      const span = makeSpan({ f: { e: '9999', h: 'h' } });
+      expectInt(extract(span), 'process.pid', 9999);
+    });
+
+    it('uses resource["process.pid"] from span data', () => {
+      const span = makeSpan({ data: { resource: { 'process.pid': 1234 } } });
+      expectInt(extract(span), 'process.pid', 1234);
+    });
+
+    it('omits process.pid for non-numeric values', () => {
+      const span = { f: { e: 'not-a-number' }, data: {} };
+      expectAbsent(extract(span), 'process.pid');
+    });
+  });
+
+  describe('os.type', () => {
+    let platformStub;
+
+    beforeEach(() => {
+      platformStub = sinon.stub(process, 'platform').value('linux');
+    });
+
+    afterEach(() => {
+      if (platformStub) {
+        platformStub.restore();
+        platformStub = null;
+      }
+    });
+
+    function stubPlatform(value) {
+      platformStub.value(value);
+    }
+
+    it('uses resource["os.type"] from span data, overriding process.platform', () => {
+      stubPlatform('linux');
+      const span = makeSpan({ data: { resource: { 'os.type': 'windows' } } });
+      expectStr(extract(span), 'os.type', 'windows');
+    });
+
+    it('maps win32 → "windows"', () => {
+      stubPlatform('win32');
+      expectStr(extract(makeSpan()), 'os.type', 'windows');
+    });
+
+    it('passes unknown platforms through as-is', () => {
+      stubPlatform('freebsd');
+      expectStr(extract(makeSpan()), 'os.type', 'freebsd');
+    });
+  });
+
+  describe('host.name', () => {
+    it('uses resource["host.name"] from span data', () => {
+      const span = makeSpan({ data: { resource: { 'host.name': 'custom-host.example' } } });
+      expectStr(extract(span), 'host.name', 'custom-host.example');
+    });
+
+    it('falls back to os.hostname() when not in span data', () => {
+      expectStr(extract(makeSpan()), 'host.name', 'stub.hostname.test');
+    });
+  });
+
+  describe('host.id', () => {
+    it('uses resource["host.id"] from span data', () => {
+      const span = makeSpan({ data: { resource: { 'host.id': 'explicit-host-id' } } });
+      expectStr(extract(span), 'host.id', 'explicit-host-id');
+    });
+
+    it('derives from span metadata f.h', () => {
+      const span = makeSpan({ f: { e: '1', h: 'metadata-host-id' } });
+      expectStr(extract(span), 'host.id', 'metadata-host-id');
+    });
+  });
+
+  describe('container.id', () => {
+    it('emits container.id when present in span resource data', () => {
+      const span = makeSpan({ data: { resource: { 'container.id': 'sha256-deadbeef' } } });
+      expectStr(extract(span), 'container.id', 'sha256-deadbeef');
+    });
+
+    it('omits container.id when absent', () => {
+      expectAbsent(extract(makeSpan()), 'container.id');
+    });
+  });
+
+  describe('k8s.pod.uid', () => {
+    it('emits k8s.pod.uid when present in span resource data', () => {
+      const span = makeSpan({ data: { resource: { 'k8s.pod.uid': 'uid-abcdef' } } });
+      expectStr(extract(span), 'k8s.pod.uid', 'uid-abcdef');
+    });
+
+    it('omits k8s.pod.uid when neither span data nor env var is set', () => {
+      expectAbsent(extract(makeSpan()), 'k8s.pod.uid');
+    });
+  });
+
+  describe('required attributes always present', () => {
+    it('emits all required attributes on every span', () => {
+      const attrs = extract(makeSpan());
+      const required = [
+        'service.name',
+        'telemetry.sdk.language',
+        'telemetry.sdk.name',
+        'telemetry.sdk.version',
+        'process.pid',
+        'os.type'
+      ];
+      required.forEach(key => {
+        expect(find(attrs, key), `Required attribute "${key}" must be present`).to.exist;
+      });
+    });
+  });
+});

--- a/packages/core/test/otlpExporter/metrics/converter_test.js
+++ b/packages/core/test/otlpExporter/metrics/converter_test.js
@@ -57,13 +57,6 @@ describe('metrics/converters/otlp', () => {
 
         const result = converter.transform(input);
 
-        const attrs = result.resourceMetrics[0].resource.attributes;
-        const instanceIdAttr = attrs.find(a => a.key === 'service.instance.id');
-        expect(instanceIdAttr, 'service.instance.id should be present').to.exist;
-        expect(instanceIdAttr.value.stringValue).to.match(/^[0-9a-f-]{36}$/);
-
-        result.resourceMetrics[0].resource.attributes = attrs.filter(a => a.key !== 'service.instance.id');
-
         expect(result).to.deep.equal(expectedOutput);
       });
 

--- a/packages/core/test/otlpExporter/metrics/converter_test.js
+++ b/packages/core/test/otlpExporter/metrics/converter_test.js
@@ -57,6 +57,13 @@ describe('metrics/converters/otlp', () => {
 
         const result = converter.transform(input);
 
+        const attrs = result.resourceMetrics[0].resource.attributes;
+        const instanceIdAttr = attrs.find(a => a.key === 'service.instance.id');
+        expect(instanceIdAttr, 'service.instance.id should be present').to.exist;
+        expect(instanceIdAttr.value.stringValue).to.match(/^[0-9a-f-]{36}$/);
+
+        result.resourceMetrics[0].resource.attributes = attrs.filter(a => a.key !== 'service.instance.id');
+
         expect(result).to.deep.equal(expectedOutput);
       });
 

--- a/packages/core/test/otlpExporter/metrics/converter_test.js
+++ b/packages/core/test/otlpExporter/metrics/converter_test.js
@@ -37,13 +37,16 @@ function loadOutputFixture(filename) {
 
 describe('metrics/converters/otlp', () => {
   let hostnameStub;
+  let platformStub;
 
   before(() => {
     hostnameStub = sinon.stub(os, 'hostname').returns('test-hostname');
+    platformStub = sinon.stub(process, 'platform').value('linux');
   });
 
   after(() => {
     hostnameStub.restore();
+    platformStub.restore();
   });
 
   describe('converter', () => {

--- a/packages/core/test/otlpExporter/metrics/fixtures/output/metrics-output.json
+++ b/packages/core/test/otlpExporter/metrics/fixtures/output/metrics-output.json
@@ -4,7 +4,6 @@
       "resource": {
         "attributes": [
           { "key": "service.name", "value": { "stringValue": "otel-exporter-test" } },
-          { "key": "service.version", "value": { "stringValue": "1.0.0" } },
           { "key": "telemetry.sdk.language", "value": { "stringValue": "nodejs" } },
           { "key": "telemetry.sdk.name", "value": { "stringValue": "instana" } },
           { "key": "telemetry.sdk.version", "value": { "stringValue": "6.0.0" } },

--- a/packages/core/test/otlpExporter/metrics/fixtures/output/metrics-output.json
+++ b/packages/core/test/otlpExporter/metrics/fixtures/output/metrics-output.json
@@ -4,9 +4,11 @@
       "resource": {
         "attributes": [
           { "key": "service.name", "value": { "stringValue": "otel-exporter-test" } },
+          { "key": "service.version", "value": { "stringValue": "1.0.0" } },
           { "key": "telemetry.sdk.language", "value": { "stringValue": "nodejs" } },
           { "key": "telemetry.sdk.name", "value": { "stringValue": "instana" } },
           { "key": "telemetry.sdk.version", "value": { "stringValue": "6.0.0" } },
+          { "key": "os.type", "value": { "stringValue": "linux" } },
           { "key": "host.name", "value": { "stringValue": "test-hostname" } }
         ]
       },

--- a/packages/core/test/otlpExporter/metrics/util_test.js
+++ b/packages/core/test/otlpExporter/metrics/util_test.js
@@ -6,72 +6,9 @@
 
 const expect = require('chai').expect;
 
-const { flattenObject, normalizeMetrics, getResourceKey } = require('../../../src/otlpExporter/metrics/util');
+const { flattenObject, normalizeMetrics } = require('../../../src/otlpExporter/metrics/util');
 
 describe('otlpExporter/metrics/util', () => {
-  describe('getResourceKey', () => {
-    it('should generate key from host and entity', () => {
-      const from = { h: 'host123', e: 'entity456' };
-      const key = getResourceKey(from);
-
-      expect(key).to.equal('h:host123|e:entity456');
-    });
-
-    it('should handle missing host', () => {
-      const from = { e: 'entity456' };
-      const key = getResourceKey(from);
-
-      expect(key).to.equal('h:empty|e:entity456');
-    });
-
-    it('should handle missing entity', () => {
-      const from = { h: 'host123' };
-      const key = getResourceKey(from);
-
-      expect(key).to.equal('h:host123|e:empty');
-    });
-
-    it('should handle both missing', () => {
-      const from = {};
-      const key = getResourceKey(from);
-
-      expect(key).to.equal('h:empty|e:empty');
-    });
-
-    it('should handle null input', () => {
-      const key = getResourceKey(null);
-
-      expect(key).to.equal('h:empty|e:empty');
-    });
-
-    it('should handle undefined input', () => {
-      const key = getResourceKey(undefined);
-
-      expect(key).to.equal('h:empty|e:empty');
-    });
-
-    it('should handle numeric values', () => {
-      const from = { h: 123, e: 456 };
-      const key = getResourceKey(from);
-
-      expect(key).to.equal('h:123|e:456');
-    });
-
-    it('should create unique keys for different resources', () => {
-      const key1 = getResourceKey({ h: 'host1', e: 'entity1' });
-      const key2 = getResourceKey({ h: 'host2', e: 'entity2' });
-
-      expect(key1).to.not.equal(key2);
-    });
-
-    it('should create same key for identical resources', () => {
-      const key1 = getResourceKey({ h: 'host1', e: 'entity1' });
-      const key2 = getResourceKey({ h: 'host1', e: 'entity1' });
-
-      expect(key1).to.equal(key2);
-    });
-  });
-
   describe('flattenObject', () => {
     describe('basic flattening', () => {
       it('should flatten simple nested object', () => {


### PR DESCRIPTION
Some resource mapping were not added earlier, added those.
**Whats not included**

Faas resource mapping can be handlied in a different PR


Future:

There are some rc candidates(not added in the tracer spec), can be extended later


1. [process.runtime.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/process/)/
2. [process.runtime.version](https://opentelemetry.io/docs/specs/semconv/registry/attributes/process/)
---
Tracer spec: https://github.ibm.com/instana/technical-documentation/blob/master/tracing/specification/otlp-exporter.md#resource-attribute-mapping

otel spec https://opentelemetry.io/docs/specs/semconv/resource/


ref https://jsw.ibm.com/browse/INSTA-100980