### PR TITLE
chore(otlp-exporter): added faas.name resource mapping

### DIFF
--- a/packages/core/src/otlpExporter/common/semconv/base/mappings.js
+++ b/packages/core/src/otlpExporter/common/semconv/base/mappings.js
@@ -15,7 +15,8 @@ const MAPPINGS = {
     HOST_NAME: 'host.name',
     HOST_ID: 'host.id',
     PROCESS_PID: 'process.pid',
-    OS_TYPE: 'os.type'
+    OS_TYPE: 'os.type',
+    FAAS_NAME: 'faas.name'
   },
 
   metadata: {

--- a/packages/core/src/otlpExporter/common/transformers/resource.js
+++ b/packages/core/src/otlpExporter/common/transformers/resource.js
@@ -34,6 +34,19 @@ const INSTRUMENTATION_SCOPE = {
  * @property {Record<string, any>} [f]
  */
 
+/**
+ * Extracts faas.name from provider-specific span data fields.
+ *
+ * @param {RawPayload} rawPayload
+ * @returns {string | undefined}
+ */
+function getFaasNameFromSpanData(rawPayload) {
+  return (
+    // AWS Lambda
+    rawPayload.data?.lambda?.functionName
+  );
+}
+
 const resourceMapper = {
   /**
    * @param {RawPayload} rawPayload
@@ -119,6 +132,16 @@ const resourceMapper = {
 
     return resource[RESOURCE.HOST_ID] || metadata.h;
   },
+
+  /**
+   * @param {RawPayload} rawPayload
+   * @returns {string | undefined}
+   */
+  faasName(rawPayload) {
+    const resource = rawPayload.data?.resource || rawPayload.resource || {};
+    return resource[RESOURCE.FAAS_NAME] || getFaasNameFromSpanData(rawPayload) || undefined;
+  },
+
   /**
    * @param {RawPayload} rawPayload
    * @returns {string | undefined}
@@ -179,6 +202,11 @@ function extractResourceAttributes(rawPayload) {
     {
       otlp: OTLP.resource.HOST_NAME,
       transform: resourceMapper.hostName,
+      valueType: 'string'
+    },
+    {
+      otlp: OTLP.resource.FAAS_NAME,
+      transform: resourceMapper.faasName,
       valueType: 'string'
     }
   ];

--- a/packages/core/test/otlpExporter/common/transformers/resource_test.js
+++ b/packages/core/test/otlpExporter/common/transformers/resource_test.js
@@ -201,6 +201,24 @@ describe('otlpExporter/common/transformers/resource', () => {
     });
   });
 
+  describe('faas.name', () => {
+    it('uses data.lambda.functionName from AWS Lambda span', () => {
+      const span = makeSpan({ data: { lambda: { functionName: 'my-lambda' } } });
+      expectStr(extract(span), 'faas.name', 'my-lambda');
+    });
+
+    it('prefers resource["faas.name"] override over span data', () => {
+      const span = makeSpan({
+        data: { resource: { 'faas.name': 'override-fn' }, lambda: { functionName: 'my-lambda' } }
+      });
+      expectStr(extract(span), 'faas.name', 'override-fn');
+    });
+
+    it('omits faas.name when no FaaS span data is present', () => {
+      expectAbsent(extract(makeSpan()), 'faas.name');
+    });
+  });
+
   describe('required attributes always present', () => {
     it('emits all required attributes on every span', () => {
       const attrs = extract(makeSpan());


### PR DESCRIPTION
At the moment, we only map `faas.name`, as it is the only Required FaaS resource attribute in the OpenTelemetry specification.

Otel spec: https://opentelemetry.io/docs/specs/semconv/resource/faas/

ref: https://jsw.ibm.com/browse/INSTA-100980