### PR TITLE
fix: added guard against non-string level in log span

### DIFF
--- a/packages/core/src/tracing/instrumentation/logging/bunyan.js
+++ b/packages/core/src/tracing/instrumentation/logging/bunyan.js
@@ -44,7 +44,7 @@ function shimLog(level) {
         return originalLog.apply(this, arguments);
       }
 
-      if (!tracingUtil.shouldCaptureLogSpan(level)) {
+      if (!level || !tracingUtil.shouldCaptureLogSpan(level)) {
         return originalLog.apply(this, arguments);
       }
 

--- a/packages/core/src/tracing/instrumentation/logging/console.js
+++ b/packages/core/src/tracing/instrumentation/logging/console.js
@@ -39,7 +39,7 @@ function shimLog(options) {
         return originalLog.apply(this, arguments);
       }
 
-      if (!tracingUtil.shouldCaptureLogSpan(options.level)) {
+      if (!options.level || !tracingUtil.shouldCaptureLogSpan(options.level)) {
         return originalLog.apply(this, arguments);
       }
 

--- a/packages/core/src/tracing/instrumentation/logging/winston.js
+++ b/packages/core/src/tracing/instrumentation/logging/winston.js
@@ -100,7 +100,7 @@ function instrumentedLevelMethod(originalMethod, level) {
 
     const normalizedLogLevel = resolveLogLevel(level);
 
-    if (!tracingUtil.shouldCaptureLogSpan(normalizedLogLevel)) {
+    if (!normalizedLogLevel || !tracingUtil.shouldCaptureLogSpan(normalizedLogLevel)) {
       return originalMethod.apply(this, arguments);
     }
 
@@ -168,7 +168,11 @@ function instrumentedLog(originalMethod) {
 
     const normalizedLogLevel = resolveLogLevel(level);
 
-    if (cls.skipExitTracing({ isActive }) || !tracingUtil.shouldCaptureLogSpan(normalizedLogLevel)) {
+    if (
+      cls.skipExitTracing({ isActive }) ||
+      !normalizedLogLevel ||
+      !tracingUtil.shouldCaptureLogSpan(normalizedLogLevel)
+    ) {
       return originalMethod.apply(this, arguments);
     }
 

--- a/packages/core/src/tracing/tracingUtil.js
+++ b/packages/core/src/tracing/tracingUtil.js
@@ -462,6 +462,9 @@ exports.shouldCaptureLogSpan = function shouldCaptureLogSpan(level) {
   if (logLevelConfig === LOG_LEVEL.OFF) {
     return false;
   }
+  if (typeof level !== 'string') {
+    return false;
+  }
   const minLevel = LOG_LEVEL_PRIORITY[logLevelConfig];
 
   const numericLevel = LOG_LEVEL_PRIORITY[level.toLowerCase()];

--- a/packages/core/test/tracing/tracingUtil_test.js
+++ b/packages/core/test/tracing/tracingUtil_test.js
@@ -1583,6 +1583,18 @@ describe('tracing/tracingUtil', () => {
       it('should return false for an unknown log level', () => {
         expect(shouldCaptureLogSpan('INVALID')).to.equal(false);
       });
+
+      it('should return false for undefined without throwing', () => {
+        expect(shouldCaptureLogSpan(undefined)).to.equal(false);
+      });
+
+      it('should return false for null without throwing', () => {
+        expect(shouldCaptureLogSpan(null)).to.equal(false);
+      });
+
+      it('should return false for a numeric level without throwing', () => {
+        expect(shouldCaptureLogSpan(42)).to.equal(false);
+      });
     });
 
     describe('when captureLogLevel is WARN(default)', () => {


### PR DESCRIPTION
When a third-party logger calls winston's .log() with a custom level name that has no entry in `LEVEL_MAP` (e.g. 'bla'), `resolveLogLevel` returns undefined. Passing undefined to `shouldCaptureLogSpan` then crashes with:

> TypeError: Cannot read properties of undefined (reading 'toLowerCase')

Add a typeof guard so shouldCaptureLogSpan returns false immediately for any non-string argument instead of throwing.

REF https://ibmsf.lightning.force.com/lightning/r/Case/500gJ00000EywFjQAJ/view

