### PR TITLE
chore: removed unused env variable

### DIFF
--- a/packages/collector/package.json
+++ b/packages/collector/package.json
@@ -35,9 +35,9 @@
   },
   "scripts": {
     "audit": "npm audit --omit=dev",
-    "test": "USE_OPENTRACING_DEBUG_IMPL=true mocha --config=test/.mocharc.js --require test/hooks.js --sort $(find test -iname '*.test.js' -not -path '*/_v*/*')",
+    "test": "mocha --config=test/.mocharc.js --require test/hooks.js --sort $(find test -iname '*.test.js' -not -path '*/_v*/*')",
     "test:debug": "WITH_STDOUT=true npm run test --",
-    "test:debug:files": "WITH_STDOUT=true USE_OPENTRACING_DEBUG_IMPL=true mocha --config=test/.mocharc.js --require test/hooks.js --sort",
+    "test:debug:files": "WITH_STDOUT=true mocha --config=test/.mocharc.js --require test/hooks.js --sort",
     "test:ci": "mocha --config=test/.mocharc.js --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json --require test/hooks.js $TEST_FILES",
     "test:ci:long-running": "mocha --config=test/.mocharc.js --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json --require test/hooks.js 'test/integration/misc/long_*/**/*.test.js'",
     "lint": "eslint src test",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "audit": "npm audit --omit=dev",
-    "test": "USE_OPENTRACING_DEBUG_IMPL=true mocha --config=test/.mocharc.js --sort $(find test -iname '*test.js')",
+    "test": "mocha --config=test/.mocharc.js --sort $(find test -iname '*test.js')",
     "test:debug": "WITH_STDOUT=true npm run test --",
     "test:ci": "mocha --config=test/.mocharc.js --reporter mocha-multi-reporters --reporter-options configFile=reporter-config.json 'test/**/*test.js'",
     "lint": "eslint src test",


### PR DESCRIPTION
I couldn’t find any real usage or references for these environment variable. It looks like they no longer be used, as I couldn’t find any active references in the codebase or documentation.
