### PR TITLE
chore(ci): use npm ci --ignore-scripts in Tekton install task

### DIFF
--- a/.tekton/tasks/install-project-dependencies.yaml
+++ b/.tekton/tasks/install-project-dependencies.yaml
@@ -49,7 +49,7 @@ spec:
           echo "Skipping npm cache..."
 
           echo "Installing npm dependencies..."
-          npm install --loglevel verbose --foreground-scripts
+          npm ci --loglevel verbose --ignore-scripts
         else
           echo "Restoring node_modules cache..."
           curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
@@ -100,7 +100,7 @@ spec:
             echo "npm install: $npmInstall"
 
             if [ "$npmInstall" == true ]; then
-              npm install --loglevel verbose --foreground-scripts
+              npm ci --loglevel verbose --ignore-scripts
 
               rm -rf node-modules.tar.zst
               rm -rf node-modules.tar
@@ -146,13 +146,13 @@ spec:
               rm -rf node-modules.tar
 
               if [ "$npmInstall" == true ]; then
-                npm install --loglevel verbose --foreground-scripts
+                npm ci --loglevel verbose --ignore-scripts
               fi
 
               echo "Restored node_modules cache..."
             else
               echo "Download from main was not successful. Installing node_modules..."
-              npm install --loglevel verbose --foreground-scripts
+              npm ci --loglevel verbose --ignore-scripts
             fi
           fi
         fi

--- a/bin/create-preinstalled-zip.sh
+++ b/bin/create-preinstalled-zip.sh
@@ -57,7 +57,7 @@ echo "Running: 'cd $TMPDIR/package'"
 cd "$TMPDIR/package"
 
 echo "Running: 'npm install --omit=optional --omit=dev' in $TMPDIR/package"
-npm install --omit=optional --omit=dev
+npm install --omit=optional --omit=dev --ignore-scripts
 
 CORE_TGZ="$TMPDIR/core.tgz"
 SHARED_TGZ="$TMPDIR/shared-metrics.tgz"
@@ -75,14 +75,14 @@ else
 fi
 
 if [ ${#INSTALL_ARGS[@]} -gt 0 ]; then
-  echo -n "Running: npm install --omit=optional --omit=dev ${INSTALL_ARGS[@]}"
+  echo -n "Running: npm install --omit=optional --omit=dev --ignore-scripts ${INSTALL_ARGS[@]}"
 
   for _p in "${INSTALL_ARGS[@]}"; do
     echo -n " $_p"
   done
   echo
 
-  npm install --omit=optional --omit=dev "${INSTALL_ARGS[@]}"
+  npm install --omit=optional --omit=dev --ignore-scripts "${INSTALL_ARGS[@]}"
 else
   echo "No additional tgz packages to install"
 fi

--- a/bin/create-version-test-folders.js
+++ b/bin/create-version-test-folders.js
@@ -245,8 +245,8 @@ ${
 }      log('[INFO] Running npm install for ${suiteName}@${displayVersion}...');
       const npmCmd = process.env.CI ?
         'npm install --cache ${rootDir}/.npm-offline-cache --prefer-offline ' +
-        '${hasLockFile ? '' : '--no-package-lock '}--no-audit --prefix ./ --no-progress' :
-        'npm install ${hasLockFile ? '' : '--no-package-lock '}--no-audit --prefix ./ --no-progress';
+        '${hasLockFile ? '' : '--no-package-lock '}--no-audit --ignore-scripts --prefix ./ --no-progress' :
+        'npm install ${hasLockFile ? '' : '--no-package-lock '}--no-audit --ignore-scripts --prefix ./ --no-progress';
 
       for (let attempt = 0; attempt < maxRetries; attempt++) {
         const timeout = 5 * 60 * 1000;


### PR DESCRIPTION
Replace `npm install --foreground-scripts` with `npm ci --ignore-scripts` for dependency installs in the Tekton pipeline.

- `npm ci` installs strictly from package-lock.json, preventing a  compromised newer version from silently resolving in
- `--ignore-scripts` blocks preinstall/postinstall/install lifecycle hooks from running in CI, closing the exact execution vector used  by the CHAINDROP/Shai-Hulud npm supply chain worm (Aug 2026)

ref : https://nodejs.org/learn/getting-started/security-best-practices#supply-chain-attacks

https://www.elastic.co/security-labs/shai-hulud-chaindrop-npm-supply-chain#recommendations-how-to-respond-to-the-shai-hulud-compromise